### PR TITLE
perf: pre-size string concatenation with String::with_capacity

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -383,7 +383,12 @@ fn eval_binop(op: &BinOp, left: &Value, right: &Value) -> Result<Value> {
             }
         }
         // String concatenation with +
-        (BinOp::Add, Value::Text(a), Value::Text(b)) => Ok(Value::Text(format!("{}{}", a, b))),
+        (BinOp::Add, Value::Text(a), Value::Text(b)) => {
+            let mut out = String::with_capacity(a.len() + b.len());
+            out.push_str(a);
+            out.push_str(b);
+            Ok(Value::Text(out))
+        }
         // Comparisons on numbers
         (BinOp::GreaterThan, Value::Number(a), Value::Number(b)) => Ok(Value::Bool(a > b)),
         (BinOp::LessThan, Value::Number(a), Value::Number(b)) => Ok(Value::Bool(a < b)),

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -1232,7 +1232,10 @@ impl<'a> VM<'a> {
                             // pointers with live RC counts (loaded from valid registers).
                             let sb = match bv.as_heap_ref() { HeapObj::Str(s) => s, _ => unreachable!() };
                             let sc = match cv.as_heap_ref() { HeapObj::Str(s) => s, _ => unreachable!() };
-                            NanVal::heap_string(format!("{}{}", sb, sc))
+                            let mut out = String::with_capacity(sb.len() + sc.len());
+                            out.push_str(sb);
+                            out.push_str(sc);
+                            NanVal::heap_string(out)
                         };
                         reg_set!(a, result);
                     } else {


### PR DESCRIPTION
## Summary
- Replaces `format!("{}{}", sb, sc)` in `OP_ADD` hot path with `String::with_capacity(sb.len() + sc.len())` + `push_str`
- Same fix in interpreter's `eval_binop` for `BinOp::Add` on strings

## Why
`format!` cannot predict output size and may allocate more than needed. Pre-sizing with `with_capacity` does a single allocation of exactly the right size.

## Test plan
- [ ] `cargo test` — all 13 tests pass
- [ ] `cargo build` — no warnings