### PR TITLE
fix: assert on register overflow in alloc_reg

### DIFF
--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -203,6 +203,7 @@ impl RegCompiler {
     }
 
     fn alloc_reg(&mut self) -> u8 {
+        assert!(self.next_reg < 255, "register overflow: function uses more than 255 registers");
         let r = self.next_reg;
         self.next_reg += 1;
         if self.next_reg > self.max_reg {


### PR DESCRIPTION
## Summary
- `alloc_reg` increments `next_reg: u8` with no bounds check
- At 255 registers it wraps to 0, silently overwriting function parameter registers and producing broken bytecode
- Added `assert!(self.next_reg < 255)` to catch this at compile time with a clear message

## Test plan
- [ ] All 13 existing tests pass
- [ ] Functions with ≤255 registers are unaffected