### PR TITLE
Fix unary negation -x parsing

### DIFF
--- a/research/TODO.md
+++ b/research/TODO.md
@@ -13,7 +13,7 @@
 - [ ] List literals `[a, b, c]` — `Expr::List` and `OP_LISTNEW` exist, parser has no `[` production
   - Homogeneous typed only: `L n`, `L t`, `L order` etc.
   - No mixed/untyped lists for now
-- [ ] Unary negation `-x` — `UnaryOp::Negate` in AST, but `-` always parsed as binary subtract
+- [x] Unary negation `-x` — `UnaryOp::Negate` in AST, parser now disambiguates: `-x` = negate, `-x y` = subtract
 - [ ] Logical NOT `!x` — blocked on sigil change above
 
 ### Missing fundamental operators

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -1938,6 +1938,28 @@ mod tests {
     }
 
     #[test]
+    fn vm_unary_negate() {
+        let source = "f x:n>n;-x";
+        assert_eq!(
+            vm_run(source, Some("f"), vec![Value::Number(5.0)]),
+            Value::Number(-5.0)
+        );
+        assert_eq!(
+            vm_run(source, Some("f"), vec![Value::Number(-3.0)]),
+            Value::Number(3.0)
+        );
+    }
+
+    #[test]
+    fn vm_unary_negate_in_expr() {
+        let source = "f x:n>n;y=-x;+y 10";
+        assert_eq!(
+            vm_run(source, Some("f"), vec![Value::Number(5.0)]),
+            Value::Number(5.0)
+        );
+    }
+
+    #[test]
     fn vm_record_and_field() {
         let source = "f x:n>n;r=point x:x y:10;r.y";
         let result = vm_run(source, Some("f"), vec![Value::Number(5.0)]);


### PR DESCRIPTION
## Summary
- Parser now disambiguates `-` as unary negation vs binary subtract based on whether one or two atoms follow
- `-x` → `UnaryOp::Negate` (one atom = unary)
- `-x y` → `BinOp::Subtract` (two atoms = binary prefix, as before)
- All existing AST/VM/interpreter/JIT/Python codegen already supported `UnaryOp::Negate` — only the parser was missing the production

## Test plan
- [x] 3 new parser tests: `parse_unary_negate`, `parse_unary_negate_in_let`, `parse_binary_subtract_still_works`
- [x] 2 new VM tests: `vm_unary_negate`, `vm_unary_negate_in_expr`
- [x] All 105 existing tests still pass