### PR TITLE
feat: migrate Err-wrap sigil from ! to ^

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ tot p:n q:n r:n>n;s=*p q;t=*s r;+s t
 1. **Token-conservative** — every choice evaluated against total token cost across the full loop: generation, retries, error feedback, context loading.
 2. **Constrained** — small vocabulary, closed world, one way to do things. Fewer valid next-tokens = fewer wrong choices = fewer retries.
 3. **Self-contained** — each unit carries its own context: deps, types, rules. The spec travels with the program.
-4. **Language-agnostic** — structural tokens (`@`, `>`, `?`, `!`, `~`) over English words.
+4. **Language-agnostic** — structural tokens (`@`, `>`, `?`, `^`, `~`, `!`) over English words.
 5. **Graph-native** — programs express relationships (calls, depends-on, has-type). Navigable as a graph, not just readable as linear text.
 
 See [MANIFESTO.md](MANIFESTO.md) for the full rationale.

--- a/SPEC.md
+++ b/SPEC.md
@@ -134,7 +134,7 @@ xs.2     # third element
 | `?{arms}` | match last result |
 | `@v list{body}` | iterate list |
 | `~expr` | return ok |
-| `!expr` | return err |
+| `^expr` | return err |
 
 ---
 
@@ -145,7 +145,7 @@ xs.2     # third element
 | `"gold":body` | literal text |
 | `42:body` | literal number |
 | `~v:body` | ok — bind inner value to `v` |
-| `!e:body` | err — bind inner value to `e` |
+| `^e:body` | err — bind inner value to `e` |
 | `_:body` | wildcard |
 
 Arms separated by `;`. First match wins.
@@ -155,7 +155,7 @@ cls sp:n>t;>=sp 1000{"gold"};>=sp 500{"silver"};"bronze"
 ```
 
 ```
-?r{!e:!+"failed: "e;~v:v}
+?r{^e:^+"failed: "e;~v:v}
 ```
 
 ---
@@ -214,13 +214,13 @@ tool get-user"Retrieve user by ID" uid:t>R profile t timeout:5,retry:2
 `R ok err` return type. Call then match:
 
 ```
-get-user uid;?{!e:!+"Lookup failed: "e;~d:use d}
+get-user uid;?{^e:^+"Lookup failed: "e;~d:use d}
 ```
 
 Compensate/rollback inline:
 
 ```
-charge pid amt;?{!e:release rid;!+"Payment failed: "e;~cid:continue}
+charge pid amt;?{^e:release rid;^+"Payment failed: "e;~cid:continue}
 ```
 
 ---
@@ -231,5 +231,5 @@ charge pid amt;?{!e:release rid;!+"Payment failed: "e;~cid:continue}
 tool get-user"Retrieve user by ID" uid:t>R profile t timeout:5,retry:2
 tool send-email"Send an email" to:t subject:t body:t>R _ t timeout:10,retry:1
 type profile{id:t;name:t;email:t;verified:b}
-ntf uid:t msg:t>R _ t;get-user uid;?{!e:!+"Lookup failed: "e;~d:!d.verified{!"Email not verified"};send-email d.email "Notification" msg;?{!e:!+"Send failed: "e;~_:~_}}
+ntf uid:t msg:t>R _ t;get-user uid;?{^e:^+"Lookup failed: "e;~d:!d.verified{^"Email not verified"};send-email d.email "Notification" msg;?{^e:^+"Send failed: "e;~_:~_}}
 ```

--- a/research/TODO.md
+++ b/research/TODO.md
@@ -2,9 +2,9 @@
 
 ## Sigil changes (do first — unblocks other work)
 
-- [ ] Decide Err-wrap sigil to replace `!` (candidates: `\x`, `^x`)
+- [x] Decide Err-wrap sigil to replace `!` → chose `^` (caret)
 - [ ] Reassign `!x` → logical NOT (`UnaryOp::Not`, `OP_NOT` already in AST/VM)
-- [ ] Update SPEC.md, example `.ilo` files, README with new sigils
+- [x] Update SPEC.md, example `.ilo` files, README with new sigils
 
 ## Basics — complete what's already there
 

--- a/research/explorations/idea8-ultra-dense/02-with-dependencies.ilo
+++ b/research/explorations/idea8-ultra-dense/02-with-dependencies.ilo
@@ -1,1 +1,1 @@
-process order:order>R order t;validate order.addr;?{!_:!"Invalid shipping address"};ship=shipping order.weight order.addr.country;disc=discount order.subtotal order.code;final=+(-order.subtotal disc)ship;~order with total:final cost:ship
+process order:order>R order t;validate order.addr;?{^_:^"Invalid shipping address"};ship=shipping order.weight order.addr.country;disc=discount order.subtotal order.code;final=+(-order.subtotal disc)ship;~order with total:final cost:ship

--- a/research/explorations/idea8-ultra-dense/04-tool-interaction.ilo
+++ b/research/explorations/idea8-ultra-dense/04-tool-interaction.ilo
@@ -1,1 +1,1 @@
-notify uid:t msg:t>R _ t;get-user uid;?{!e:!+"Lookup failed: "e;~data:!data.verified{!"Email not verified"};send-email data.email "Notification" msg;?{!e:!+"Send failed: "e;~_:~_}}
+notify uid:t msg:t>R _ t;get-user uid;?{^e:^+"Lookup failed: "e;~data:!data.verified{^"Email not verified"};send-email data.email "Notification" msg;?{^e:^+"Send failed: "e;~_:~_}}

--- a/research/explorations/idea8-ultra-dense/05-workflow.ilo
+++ b/research/explorations/idea8-ultra-dense/05-workflow.ilo
@@ -1,1 +1,1 @@
-checkout pid:t amt:n items:L item>R receipt t;reserve items;?{!e:!+"Inventory unavailable: "e;~rid:charge pid amt;?{!e:release rid;!+"Payment failed: "e;~cid:oid=make-id();~receipt oid:oid cid:cid rid:rid}}
+checkout pid:t amt:n items:L item>R receipt t;reserve items;?{^e:^+"Inventory unavailable: "e;~rid:charge pid amt;?{^e:release rid;^+"Payment failed: "e;~cid:oid=make-id();~receipt oid:oid cid:cid rid:rid}}

--- a/research/explorations/idea8-ultra-dense/SPEC.md
+++ b/research/explorations/idea8-ultra-dense/SPEC.md
@@ -13,13 +13,13 @@ ilo pushed to minimum characters AND tokens. Every keyword shortened to 1 char. 
 | `result T E` | `R T E` | result type |
 | `call(name:val name:val)` | `call val val` | positional args (drop names, parens) |
 | `fn(p:type p:type)>` | `fn p:type p:type>` | no parens in declarations |
-| `x=call(...);match x{err e:;ok v:}` | `call val;?{!e:;~v:}` | implicit last-result match |
+| `x=call(...);match x{err e:;ok v:}` | `call val;?{^e:;~v:}` | implicit last-result match |
 | `match x{"a":1;"b":2}` | `?x{"a":1;"b":2}` | value match |
 | `for c in list` | `@c list` | iteration |
 | `if <cond>{...}` | `<cond>{...}` | conditional (drop `if`) |
 | `not x` | `!x` | negation guard |
 | `concat"a"b` | `+"a"b` | string concat |
-| `err <expr>` | `!<expr>` | construct error |
+| `err <expr>` | `^<expr>` | construct error |
 | `ok <expr>` | `~<expr>` | construct ok |
 
 ## Declarations
@@ -90,11 +90,11 @@ Prefix notation. `+` doubles as string concat. All comparison operators: `>`, `<
 | Bind | `<var>=<expr>` |
 | Conditional | `<cond>{<body>}` (no `if` keyword) |
 | Negation guard | `!<expr>{<body>}` |
-| Match last result | `?{!<e>:<body>;~<v>:<body>}` |
-| Match named | `?<var>{!<e>:<body>;~<v>:<body>}` |
+| Match last result | `?{^<e>:<body>;~<v>:<body>}` |
+| Match named | `?<var>{^<e>:<body>;~<v>:<body>}` |
 | Match values | `?<var>{"gold":20;"silver":10}` |
 | Iteration | `@<var> <list>{<body>}` |
-| Return error | `!<expr>` |
+| Return error | `^<expr>` |
 | Return ok | `~<expr>` |
 
 `?` with no argument matches the last expression's result. `?x` matches a named variable.
@@ -104,13 +104,13 @@ Prefix notation. `+` doubles as string concat. All comparison operators: `>`, `<
 `R T E` return types. Call then match:
 
 ```
-get-user uid;?{!e:!+"Lookup failed: "e;~data:use data}
+get-user uid;?{^e:^+"Lookup failed: "e;~data:use data}
 ```
 
 Compensate/rollback inline:
 
 ```
-charge pid amt;?{!e:release rid;!+"Payment failed: "e;~cid:continue}
+charge pid amt;?{^e:release rid;^+"Payment failed: "e;~cid:continue}
 ```
 
 ## Object Construction and Update
@@ -156,5 +156,5 @@ Function names and field names in constructors keep their full form (they define
 tool get-user"Retrieve user by ID" uid:t>R profile t timeout:5,retry:2
 tool send-email"Send an email" to:t subject:t body:t>R _ t timeout:10,retry:1
 type profile{id:t;name:t;email:t;verified:b}
-notify uid:t msg:t>R _ t;get-user uid;?{!e:!+"Lookup failed: "e;~data:!data.verified{!"Email not verified"};send-email data.email "Notification" msg;?{!e:!+"Send failed: "e;~_:~_}}
+notify uid:t msg:t>R _ t;get-user uid;?{^e:^+"Lookup failed: "e;~data:!data.verified{^"Email not verified"};send-email data.email "Notification" msg;?{^e:^+"Send failed: "e;~_:~_}}
 ```

--- a/research/explorations/idea9-ultra-dense-short/02-with-dependencies.ilo
+++ b/research/explorations/idea9-ultra-dense-short/02-with-dependencies.ilo
@@ -1,1 +1,1 @@
-prc ord:order>R order t;vld ord.addr;?{!_:!"Invalid shipping address"};sh=shipping ord.weight ord.addr.country;dc=discount ord.subtotal ord.code;fin=+(-ord.subtotal dc)sh;~ord with total:fin cost:sh
+prc ord:order>R order t;vld ord.addr;?{^_:^"Invalid shipping address"};sh=shipping ord.weight ord.addr.country;dc=discount ord.subtotal ord.code;fin=+(-ord.subtotal dc)sh;~ord with total:fin cost:sh

--- a/research/explorations/idea9-ultra-dense-short/04-tool-interaction.ilo
+++ b/research/explorations/idea9-ultra-dense-short/04-tool-interaction.ilo
@@ -1,1 +1,1 @@
-ntf uid:t msg:t>R _ t;get-user uid;?{!e:!+"Lookup failed: "e;~d:!d.verified{!"Email not verified"};send-email d.email "Notification" msg;?{!e:!+"Send failed: "e;~_:~_}}
+ntf uid:t msg:t>R _ t;get-user uid;?{^e:^+"Lookup failed: "e;~d:!d.verified{^"Email not verified"};send-email d.email "Notification" msg;?{^e:^+"Send failed: "e;~_:~_}}

--- a/research/explorations/idea9-ultra-dense-short/05-workflow.ilo
+++ b/research/explorations/idea9-ultra-dense-short/05-workflow.ilo
@@ -1,1 +1,1 @@
-chk pid:t amt:n its:L item>R receipt t;reserve its;?{!e:!+"Inventory unavailable: "e;~rid:charge pid amt;?{!e:release rid;!+"Payment failed: "e;~cid:oid=make-id();~receipt oid:oid cid:cid rid:rid}}
+chk pid:t amt:n its:L item>R receipt t;reserve its;?{^e:^+"Inventory unavailable: "e;~rid:charge pid amt;?{^e:release rid;^+"Payment failed: "e;~cid:oid=make-id();~receipt oid:oid cid:cid rid:rid}}

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -85,7 +85,7 @@ pub struct MatchArm {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Pattern {
-    /// `!e:` — binds error value
+    /// `^e:` — binds error value
     Err(String),
     /// `~v:` — binds ok value
     Ok(String),
@@ -131,7 +131,7 @@ pub enum Expr {
     /// Ok constructor: `~expr`
     Ok(Box<Expr>),
 
-    /// Err constructor: `!expr`
+    /// Err constructor: `^expr`
     Err(Box<Expr>),
 
     /// List literal

--- a/src/codegen/python.rs
+++ b/src/codegen/python.rs
@@ -368,7 +368,7 @@ mod tests {
 
     #[test]
     fn emit_err_expr() {
-        let py = parse_and_emit(r#"f x:n>R n t;!"bad""#);
+        let py = parse_and_emit(r#"f x:n>R n t;^"bad""#);
         assert!(py.contains("return (\"err\", \"bad\")"));
     }
 

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -43,7 +43,7 @@ impl std::fmt::Display for Value {
                 write!(f, "}}")
             }
             Value::Ok(v) => write!(f, "~{}", v),
-            Value::Err(v) => write!(f, "!{}", v),
+            Value::Err(v) => write!(f, "^{}", v),
         }
     }
 }
@@ -656,14 +656,14 @@ mod tests {
 
     #[test]
     fn interpret_err_constructor() {
-        let source = r#"f x:n>R n t;!"bad""#;
+        let source = r#"f x:n>R n t;^"bad""#;
         let result = run_str(source, Some("f"), vec![Value::Number(0.0)]);
         assert_eq!(result, Value::Err(Box::new(Value::Text("bad".to_string()))));
     }
 
     #[test]
     fn interpret_match_ok_err_patterns() {
-        let source = r#"f x:R n t>n;?x{!e:0;~v:v}"#;
+        let source = r#"f x:R n t>n;?x{^e:0;~v:v}"#;
         let ok_result = run_str(
             source,
             Some("f"),

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -65,6 +65,8 @@ pub enum Token {
     At,
     #[token("!")]
     Bang,
+    #[token("^")]
+    Caret,
     #[token("~")]
     Tilde,
 
@@ -184,10 +186,10 @@ mod tests {
 
     #[test]
     fn lex_special_tokens() {
-        let source = "?@!~";
+        let source = "?@!^~";
         let tokens = lex(source).unwrap();
         let types: Vec<_> = tokens.iter().map(|(t, _)| t.clone()).collect();
-        assert_eq!(types, vec![Token::Question, Token::At, Token::Bang, Token::Tilde]);
+        assert_eq!(types, vec![Token::Question, Token::At, Token::Bang, Token::Caret, Token::Tilde]);
     }
 
     #[test]

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -2162,14 +2162,14 @@ mod tests {
 
     #[test]
     fn vm_err_constructor() {
-        let source = r#"f x:n>R n t;!"bad""#;
+        let source = r#"f x:n>R n t;^"bad""#;
         let result = vm_run(source, Some("f"), vec![Value::Number(0.0)]);
         assert_eq!(result, Value::Err(Box::new(Value::Text("bad".to_string()))));
     }
 
     #[test]
     fn vm_match_ok_err_patterns() {
-        let source = r#"f x:R n t>n;?x{!e:0;~v:v}"#;
+        let source = r#"f x:R n t>n;?x{^e:0;~v:v}"#;
         let ok_result = vm_run(
             source,
             Some("f"),


### PR DESCRIPTION
## Summary
- Migrates all Err-related syntax from `!` to `^` sigil (`^"bad"`, `^e:` patterns)
- Adds `Caret` token to lexer, updates parser to use `Token::Caret` for Err contexts
- Simplifies `parse_bang_stmt` to only handle negated guards (`!cond{body}`)
- Adds `parse_caret_stmt` for `^expr` Err constructor at statement position
- Updates all tests, example `.ilo` files, SPEC.md, and docs

This unblocks PR B: adding `!x` as logical NOT expression.

## Test plan
- [x] `cargo clippy -- -W clippy::all` — clean
- [x] `cargo test` — all 171 tests pass (158 unit + 13 integration)
- [x] Negated guard `!cond{body}` still works unchanged
- [x] `^"bad"` parses as Err constructor
- [x] `^e:` parses as Err pattern in match arms