### PR TITLE
feat: support nested prefix operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ ilo program.ilo --bench tot 10 20 30  # benchmark
 cargo test
 ```
 
-176 tests: lexer, parser, interpreter, VM, codegen, and CLI integration tests.
+192 tests: lexer, parser, interpreter, VM, codegen, and CLI integration tests.
 
 ## Documentation
 

--- a/src/codegen/python.rs
+++ b/src/codegen/python.rs
@@ -549,4 +549,11 @@ mod tests {
         let py = parse_and_emit("f n:n>n;cel n");
         assert!(py.contains("__import__('math').ceil(n)"));
     }
+
+    #[test]
+    fn emit_nested_prefix() {
+        // +*a b c → (a * b) + c
+        let py = parse_and_emit("f a:n b:n c:n>n;+*a b c");
+        assert!(py.contains("((a * b) + c)"), "got: {}", py);
+    }
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -935,4 +935,36 @@ mod tests {
         let result = run_str(source, Some("f"), vec![Value::Number(5.0)]);
         assert_eq!(result, Value::Number(10.0));
     }
+
+    #[test]
+    fn interpret_nested_multiply_add() {
+        // +*a b c → (a * b) + c
+        let source = "f a:n b:n c:n>n;+*a b c";
+        let result = run_str(source, Some("f"), vec![Value::Number(2.0), Value::Number(3.0), Value::Number(4.0)]);
+        assert_eq!(result, Value::Number(10.0));
+    }
+
+    #[test]
+    fn interpret_nested_compare() {
+        // >=+x y 100 → (x + y) >= 100
+        let source = "f x:n y:n>b;>=+x y 100";
+        let result = run_str(source, Some("f"), vec![Value::Number(60.0), Value::Number(50.0)]);
+        assert_eq!(result, Value::Bool(true));
+    }
+
+    #[test]
+    fn interpret_not_as_and_operand() {
+        // &!x y → (!x) & y
+        let source = "f x:b y:b>b;&!x y";
+        let result = run_str(source, Some("f"), vec![Value::Bool(false), Value::Bool(true)]);
+        assert_eq!(result, Value::Bool(true));
+    }
+
+    #[test]
+    fn interpret_negate_product() {
+        // -*a b → -(a * b)
+        let source = "f a:n b:n>n;-*a b";
+        let result = run_str(source, Some("f"), vec![Value::Number(3.0), Value::Number(4.0)]);
+        assert_eq!(result, Value::Number(-12.0));
+    }
 }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -2565,6 +2565,38 @@ mod tests {
     }
 
     #[test]
+    fn vm_nested_multiply_add() {
+        // +*a b c → (a * b) + c
+        let source = "f a:n b:n c:n>n;+*a b c";
+        let result = vm_run(source, Some("f"), vec![Value::Number(2.0), Value::Number(3.0), Value::Number(4.0)]);
+        assert_eq!(result, Value::Number(10.0));
+    }
+
+    #[test]
+    fn vm_nested_compare() {
+        // >=+x y 100 → (x + y) >= 100
+        let source = "f x:n y:n>b;>=+x y 100";
+        let result = vm_run(source, Some("f"), vec![Value::Number(60.0), Value::Number(50.0)]);
+        assert_eq!(result, Value::Bool(true));
+    }
+
+    #[test]
+    fn vm_not_as_and_operand() {
+        // &!x y → (!x) & y
+        let source = "f x:b y:b>b;&!x y";
+        let result = vm_run(source, Some("f"), vec![Value::Bool(false), Value::Bool(true)]);
+        assert_eq!(result, Value::Bool(true));
+    }
+
+    #[test]
+    fn vm_negate_product() {
+        // -*a b → -(a * b)
+        let source = "f a:n b:n>n;-*a b";
+        let result = vm_run(source, Some("f"), vec![Value::Number(3.0), Value::Number(4.0)]);
+        assert_eq!(result, Value::Number(-12.0));
+    }
+
+    #[test]
     fn nanval_roundtrip() {
         // Number
         let v = Value::Number(42.5);

--- a/tests/eval_inline.rs
+++ b/tests/eval_inline.rs
@@ -130,6 +130,18 @@ fn file_no_args_outputs_ast() {
     assert!(stdout.contains("\"name\""), "expected AST JSON, got: {}", stdout);
 }
 
+// --- Nested prefix operators ---
+
+#[test]
+fn inline_nested_prefix() {
+    let out = ilo()
+        .args(["f a:n b:n c:n>n;+*a b c", "2", "3", "4"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "10");
+}
+
 // --- Legacy -e flag ---
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds `parse_operand()` method to parser, sitting between `parse_atom` (terminals only) and `parse_expr_inner` (includes greedy function calls)
- Prefix binary ops, `parse_minus`, and `!` now call `parse_operand` instead of `parse_atom`, enabling nesting
- Expressions like `+*a b c`, `>=+x y 100`, `&!x y`, `-*a b` now work as documented in SPEC.md

## Test plan
- [x] 16 new tests across parser (6), interpreter (4), VM (4), codegen (1), CLI (1)
- [x] All 192 tests pass (was 176)
- [x] `cargo clippy -- -W clippy::all` clean
- [x] Manual: `ilo 'f a:n b:n c:n>n;+*a b c' 2 3 4` → `10`
- [x] Manual: `ilo 'f x:n y:n>b;>=+x y 100' 60 50` → `true`