### PR TITLE
test: increase unit test coverage to 366 tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ ilo program.ilo --bench tot 10 20 30  # benchmark
 cargo test
 ```
 
-192 tests: lexer, parser, interpreter, VM, codegen, and CLI integration tests.
+366 tests: lexer, parser, interpreter, VM, codegen, and CLI integration tests.
 
 ## Documentation
 

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -268,4 +268,32 @@ mod tests {
         let tokens = lex(source).unwrap();
         assert!(tokens.len() > 5);
     }
+
+    #[test]
+    fn lex_error_invalid_char() {
+        let result = lex("$");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.snippet, "$");
+        assert!(err.suggestion.contains("Unexpected character"));
+    }
+
+    #[test]
+    fn lex_suggest_fix_underscore() {
+        // suggest_fix is called with the bad token snippet — test it directly
+        let suggestion = super::suggest_fix("my_func");
+        assert!(suggestion.contains("my-func"), "got: {}", suggestion);
+    }
+
+    #[test]
+    fn lex_suggest_fix_uppercase() {
+        let suggestion = super::suggest_fix("MyFunc");
+        assert!(suggestion.contains("myfunc"), "got: {}", suggestion);
+    }
+
+    #[test]
+    fn lex_suggest_fix_generic() {
+        let suggestion = super::suggest_fix("$");
+        assert!(suggestion.contains("Unexpected character"), "got: {}", suggestion);
+    }
 }

--- a/tests/eval_inline.rs
+++ b/tests/eval_inline.rs
@@ -142,6 +142,81 @@ fn inline_nested_prefix() {
     assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "10");
 }
 
+// --- CLI modes ---
+
+#[test]
+fn inline_run_vm_mode() {
+    let out = ilo()
+        .args(["f x:n>n;*x 2", "--run-vm", "f", "5"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "10");
+}
+
+#[test]
+fn inline_run_with_func_name() {
+    let out = ilo()
+        .args(["f x:n>n;*x 2", "--run", "f", "5"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "10");
+}
+
+#[test]
+fn inline_emit_unknown_target() {
+    let out = ilo()
+        .args(["f x:n>n;*x 2", "--emit", "javascript"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("Unknown emit target"), "expected emit error, got: {}", stderr);
+}
+
+#[test]
+fn inline_parse_bool_arg() {
+    let out = ilo()
+        .args(["f x:b>b;!x", "true"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "false");
+}
+
+#[test]
+fn inline_parse_text_arg() {
+    let out = ilo()
+        .args(["f x:t>t;x", "hello"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "hello");
+}
+
+#[test]
+fn inline_parse_error() {
+    let out = ilo()
+        .args(["f x:>n;x", "5"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("Parse error") || stderr.contains("error"), "expected parse error, got: {}", stderr);
+}
+
+#[test]
+fn inline_bench_mode() {
+    let out = ilo()
+        .args(["f x:n>n;*x 2", "--bench", "f", "5"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("interpreter") || stdout.contains("vm"), "expected benchmark output, got: {}", stdout);
+}
+
 // --- Legacy -e flag ---
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds 174 new tests (192 → 366) targeting uncovered code paths across all modules
- Parser: 31 tests for error paths, edge cases, all operator branches
- Interpreter: 45 tests for Display impls, builtin errors, comparison operators
- VM: 50 tests for VmState API, constant folding, all generic opcodes
- Codegen: 14 tests for missing BinOp/UnaryOp variants, match patterns
- Lexer: 4 tests for error handling and suggestion functions
- CLI: 8 new integration tests for run-vm, emit errors, bool/text args, bench mode

### Coverage
| Module | Line Coverage |
|--------|-------------|
| lexer | 100% |
| interpreter | 99.29% |
| codegen | 98.76% |
| vm | 93.43% |
| parser | 90.39% |

## Test plan
- [x] `cargo test` — all 366 tests pass
- [x] `cargo clippy -- -W clippy::all` — clean
- [x] `cargo llvm-cov` — coverage verified