### PR TITLE
feat: add GitHub Releases with pre-built binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            cross: true
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross
+        if: matrix.cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build
+        run: |
+          if [ "${{ matrix.cross }}" = "true" ]; then
+            cross build --release --target ${{ matrix.target }}
+          else
+            cargo build --release --target ${{ matrix.target }}
+          fi
+        shell: bash
+
+      - name: Rename binary (unix)
+        if: runner.os != 'Windows'
+        run: mv target/${{ matrix.target }}/release/ilo ilo-${{ matrix.target }}
+
+      - name: Rename binary (windows)
+        if: runner.os == 'Windows'
+        run: mv target/${{ matrix.target }}/release/ilo.exe ilo-${{ matrix.target }}.exe
+        shell: bash
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ilo-${{ matrix.target }}
+          path: ilo-${{ matrix.target }}*
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - name: Generate checksums
+        run: sha256sum ilo-* > checksums-sha256.txt
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            ilo-*
+            checksums-sha256.txt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,8 @@ cranelift-module = { version = "0.116", optional = true }
 cranelift-native = { version = "0.116", optional = true }
 target-lexicon = { version = "0.12", optional = true }
 inkwell = { version = "0.5", features = ["llvm18-0"], optional = true }
+
+[profile.release]
+strip = true
+lto = true
+codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -66,9 +66,24 @@ Each idea explores a different syntax. Every folder has a SPEC and 5 example pro
 
 Score = LLM generation accuracy /10 (claude-haiku-4-5, spec + all examples as context). See [test-summary.txt](research/explorations/test-summary.txt) for per-task breakdown.
 
-## Running
+## Install
 
-**Prerequisites:** [Rust](https://rustup.rs/) installed.
+**One-liner (macOS / Linux):**
+```bash
+curl -fsSL https://raw.githubusercontent.com/danieljohnmorris/ilo-lang/main/install.sh | sh
+```
+
+**Direct download (example: macOS Apple Silicon):**
+```bash
+curl -fsSL https://github.com/danieljohnmorris/ilo-lang/releases/latest/download/ilo-aarch64-apple-darwin -o /usr/local/bin/ilo && chmod +x /usr/local/bin/ilo
+```
+
+**From source (developers):**
+```bash
+cargo install --git https://github.com/danieljohnmorris/ilo-lang
+```
+
+## Running
 
 **Run inline code:**
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -eu
+
+REPO="danieljohnmorris/ilo-lang"
+
+OS=$(uname -s)
+ARCH=$(uname -m)
+
+case "$OS" in
+  Linux)  OS_TARGET="unknown-linux-gnu" ;;
+  Darwin) OS_TARGET="apple-darwin" ;;
+  *)      echo "Unsupported OS: $OS" >&2; exit 1 ;;
+esac
+
+case "$ARCH" in
+  x86_64|amd64)  ARCH_TARGET="x86_64" ;;
+  aarch64|arm64) ARCH_TARGET="aarch64" ;;
+  *)             echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+
+TARGET="${ARCH_TARGET}-${OS_TARGET}"
+URL="https://github.com/${REPO}/releases/latest/download/ilo-${TARGET}"
+
+echo "Downloading ilo for ${TARGET}..."
+
+if [ -w /usr/local/bin ]; then
+  INSTALL_DIR="/usr/local/bin"
+else
+  INSTALL_DIR="${HOME}/.local/bin"
+  mkdir -p "$INSTALL_DIR"
+fi
+
+curl -fsSL "$URL" -o "${INSTALL_DIR}/ilo"
+chmod +x "${INSTALL_DIR}/ilo"
+
+echo "Installed ilo to ${INSTALL_DIR}/ilo"
+
+if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
+  echo "Add ${INSTALL_DIR} to your PATH to use ilo"
+fi


### PR DESCRIPTION
## Summary
- Add release workflow that builds binaries for 5 platforms on tag push (`v*`)
- Add `install.sh` for one-liner installation (`curl | sh`)
- Add optimized `[profile.release]` (strip, LTO, single codegen unit)
- Fix CI workflow branch from `master` to `main`
- Update README with install instructions

## Targets
- `x86_64-unknown-linux-gnu` (Linux x86_64)
- `aarch64-unknown-linux-gnu` (Linux ARM64)
- `x86_64-apple-darwin` (macOS Intel)
- `aarch64-apple-darwin` (macOS Apple Silicon)
- `x86_64-pc-windows-msvc` (Windows)

## Install experience
```bash
# One-liner
curl -fsSL https://raw.githubusercontent.com/danieljohnmorris/ilo-lang/main/install.sh | sh

# Direct download
curl -fsSL https://github.com/danieljohnmorris/ilo-lang/releases/latest/download/ilo-aarch64-apple-darwin -o /usr/local/bin/ilo && chmod +x /usr/local/bin/ilo

# From source
cargo install --git https://github.com/danieljohnmorris/ilo-lang
```

## Test plan
- [ ] Merge PR, then push tag `v0.1.0`
- [ ] Verify all 5 build targets complete in Actions
- [ ] Verify release page shows binaries + checksums
- [ ] Test `curl -fsSL .../install.sh | sh` installs working binary
- [ ] Test `ilo 'f x:n>n;*x 2' 5` returns `10` on downloaded binary