### PR TITLE
feat: add ilo help and ilo help lang commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            src
+            Cargo.toml
+            Cargo.lock
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ ilo 'dbl x:n>n;s=*x 2;+s 0 tot p:n q:n r:n>n;s=*p q;t=*s r;+s t' tot 10 20 30
 ilo program.ilo 10 20 30
 ```
 
+**Help & language spec:**
+```bash
+ilo help                     # usage and examples
+ilo help lang                # print the full language specification
+```
+
 **Other modes:**
 ```bash
 ilo 'code' --emit python     # transpile to Python

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,30 @@ fn main() {
 
     if args.len() < 2 {
         eprintln!("Usage: ilo <file-or-code> [args... | --run func args... | --bench func args... | --emit python]");
+        eprintln!("       ilo help          Show usage and examples");
+        eprintln!("       ilo help lang     Show language specification");
         std::process::exit(1);
+    }
+
+    if args[1] == "help" {
+        if args.len() > 2 && args[2] == "lang" {
+            print!("{}", include_str!("../SPEC.md"));
+        } else {
+            println!("ilo — a constructed language for AI agents\n");
+            println!("Usage:");
+            println!("  ilo <code> [args...]              Run inline code");
+            println!("  ilo <file.ilo> [args...]          Run from file");
+            println!("  ilo <code> func [args...]         Run a specific function");
+            println!("  ilo <code> --emit python          Transpile to Python");
+            println!("  ilo <code>                        Print AST as JSON (no args)");
+            println!("  ilo <code> --bench func [args...] Benchmark a function");
+            println!("  ilo help lang                     Show language specification\n");
+            println!("Examples:");
+            println!("  ilo 'f x:n>n;*x 2' 5             Define and call f(5) → 10");
+            println!("  ilo program.ilo 10 20             Run file with arguments");
+            println!("  ilo 'f x:n>n;*x 2' --emit python Transpile to Python");
+        }
+        std::process::exit(0);
     }
 
     // If args[1] is a file that exists, read it. Otherwise treat it as inline code.


### PR DESCRIPTION
## Summary
- Add `ilo help` — shows usage, flags, and examples
- Add `ilo help lang` — prints the full language spec (embedded at compile time via `include_str!`)
- Add sparse checkout to release workflow (skips `research/` during CI)
- Update README with help commands

## Test plan
- [x] `ilo help` prints usage and examples
- [x] `ilo help lang` prints SPEC.md content
- [ ] CI passes