### PR TITLE
feat: braceless guard ambiguity detection (ILO-P016, ILO-T027)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -199,13 +199,13 @@ ilo operators have fixed arity, so the parser always knows when a condition expr
 - [x] Interpreter: no changes — guard body evaluation is the same regardless of brace syntax
 - [x] VM: no changes — same compilation path
 - [x] Formatter: `--fmt` emits braceless form for single-expression guards; `--fmt-expanded` emits braced form
-- [ ] **Ambiguity detection & hints (critical — prevents retries):**
-  - [ ] Detect dangling tokens after braceless guard body: if parser consumes a single identifier as guard body but the next token is NOT `;`, `}`, or EOF, emit a hint
-  - [ ] Hint text: `"function calls in braceless guards need braces: >=sp 1000{classify sp}"` — uses `error_hint()` infrastructure (already exists for `&&`→`&`, `->`→`>`, etc.)
-  - [ ] Verifier cross-check: if braceless guard body is a single identifier that matches a known function name, emit warning `"did you mean to call '<name>'? Use braces: cond{<name> args}"` — reuses existing Levenshtein/scope-aware suggestion system
-  - [ ] JSON error output: hint appears in `suggestion` field so agent tooling can auto-fix
-  - [ ] `--explain` entry for the error code: show braceless vs braced examples, explain when braces are required
-  - [ ] Test: `>=sp 1000 classify sp` → error with hint mentioning braces. `>=sp 1000 classify;` → valid (classify is a variable ref, not a call). Agent gets actionable fix on first error, no retry needed
+- [x] **Ambiguity detection & hints (critical — prevents retries):**
+  - [x] Detect dangling tokens after braceless guard body: if parser consumes a single identifier as guard body but the next token is NOT `;`, `}`, or EOF, emit a hint
+  - [x] Hint text: `"function calls in braceless guards need braces: >=sp 1000{classify sp}"` — uses `error_hint()` infrastructure (already exists for `&&`→`&`, `->`→`>`, etc.)
+  - [x] Verifier cross-check: if braceless guard body is a single identifier that matches a known function name, emit warning `"did you mean to call '<name>'? Use braces: cond{<name> args}"` — reuses existing Levenshtein/scope-aware suggestion system
+  - [x] JSON error output: hint appears in `suggestion` field so agent tooling can auto-fix
+  - [x] `--explain` entry for the error code: show braceless vs braced examples, explain when braces are required
+  - [x] Test: `>=sp 1000 classify sp` → error with hint mentioning braces. `>=sp 1000 classify;` → valid (classify is a variable ref, not a call). Agent gets actionable fix on first error, no retry needed
 - [x] Tests: braceless guard with literal, with operator expression, with ok/err wrap, with variable ref; multi-statement still requires braces; negated braceless guard; mixed braceless and braced in same function
 - [x] SPEC.md: document optional braces for single-expression guards, with explicit note on when braces are required
 

--- a/src/diagnostic/registry.rs
+++ b/src/diagnostic/registry.rs
@@ -214,6 +214,33 @@ A `tool` declaration requires a string literal as its description.
     tool my-tool "does things" with { ... }  -- correct
 "#,
     },
+    ErrorEntry {
+        code: "ILO-P016",
+        short: "unexpected token after braceless guard body",
+        long: r#"## ILO-P016: unexpected token after braceless guard body
+
+Braceless guards allow a single expression as the body without braces.
+If you need a function call as the guard body, use braces.
+
+**Wrong:**
+
+    cls sp:n>t;>=sp 1000 classify sp
+
+The parser reads `classify` as the guard body and `sp` is left dangling.
+
+**Correct:**
+
+    cls sp:n>t;>=sp 1000{classify sp}
+
+Braces are required when the guard body is a function call, because the
+parser cannot know the function's arity to determine where the body ends.
+
+Single-expression bodies (literals, variables, operators, ok/err wraps)
+do not need braces:
+
+    cls sp:n>t;>=sp 1000 "gold";>=sp 500 "silver";"bronze"
+"#,
+    },
 
     // ── Type / Verifier ──────────────────────────────────────────────────────
     ErrorEntry {
@@ -536,6 +563,28 @@ function, so the enclosing function must return a Result type
     outer x:n>n;inner! x   -- error: outer returns n, not R
 
 **Fix:** Change the enclosing function's return type to `R`.
+"#,
+    },
+    ErrorEntry {
+        code: "ILO-T027",
+        short: "braceless guard body looks like a function name",
+        long: r#"## ILO-T027: braceless guard body looks like a function name
+
+A braceless guard's body is a single identifier that matches a known
+function name. This usually means you intended to call the function
+but forgot to wrap it in braces.
+
+**Wrong:**
+
+    cls sp:n>t;>=sp 1000 classify
+
+`classify` is treated as a variable reference, not a function call.
+
+**Correct:**
+
+    cls sp:n>t;>=sp 1000{classify sp}
+
+Use braces when the guard body is a function call.
 "#,
     },
 


### PR DESCRIPTION
## Summary

- Parser uses `parse_operand` instead of `parse_expr` for braceless guard bodies, preventing greedy function call consumption
- **ILO-P016**: Dangling tokens after braceless guard body emit error with hint: "function calls in braceless guards need braces"
- **ILO-T027**: Verifier warns when braceless guard body is a single identifier matching a known function/builtin name
- Both codes have `--explain` entries and JSON `suggestion` output for agent auto-fix

## Test plan

- [x] `>=sp 1000 classify sp` → ILO-P016 with braces hint
- [x] `>=sp 1000 classify;` → valid (variable ref, semicolon terminates)
- [x] Verifier T027 fires for user-defined function names in braceless guard body
- [x] Verifier T027 fires for builtin names (e.g. `len`)
- [x] No false positive when guard body is a plain variable
- [x] All 851 existing tests pass (no regressions)