### PR TITLE
feat: add 7 builtins (cat, has, hd, tl, rev, srt, slc) + ternary guard-else

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -121,6 +121,14 @@ Called like functions, compiled to dedicated opcodes.
 | `flr n` | floor (round toward negative infinity) | `n` |
 | `cel n` | ceiling (round toward positive infinity) | `n` |
 | `get url` | HTTP GET | `R t t` |
+| `spl t sep` | split text by separator | `L t` |
+| `cat xs sep` | join list of text with separator | `t` |
+| `has xs v` | membership test (list: element, text: substring) | `b` |
+| `hd xs` | head (first element/char) of list or text | element / `t` |
+| `tl xs` | tail (all but first) of list or text | `L` / `t` |
+| `rev xs` | reverse list or text | same type |
+| `srt xs` | sort list (all-number or all-text) or text chars | same type |
+| `slc xs a b` | slice list or text from index a to b | same type |
 
 `get` returns `Ok(body)` on success, `Err(message)` on failure (connection error, timeout, DNS failure, etc). `$` is a terse alias:
 
@@ -169,8 +177,10 @@ ilo 'f xs:L t>t;xs.0' 'a,b,c'       → a
 | `x=expr` | bind |
 | `cond{body}` | guard: return body if cond true |
 | `cond expr` | braceless guard (single-expression body) |
+| `cond{then}{else}` | ternary: evaluate then or else (no early return) |
 | `!cond{body}` | guard: return body if cond false |
 | `!cond expr` | braceless negated guard |
+| `!cond{then}{else}` | negated ternary |
 | `?x{arms}` | match named value |
 | `?{arms}` | match last result |
 | `@v list{body}` | iterate list |
@@ -207,6 +217,22 @@ cls sp:n>t;>=sp 1000 "gold";>=sp 500 "silver";"bronze"
 Equivalent to `>=sp 1000{"gold"}` — saves 2 tokens per guard. Both forms produce identical AST.
 
 Negated braceless guards also work: `!<=n 0 ^"must be positive"`.
+
+### Ternary (Guard-Else)
+
+A guard followed by a second brace block becomes a ternary — it produces a value without early return:
+
+```
+f x:n>t;=x 1{"yes"}{"no"}
+```
+
+Unlike guards, ternary does **not** return from the function. Code after the ternary continues executing:
+
+```
+f x:n>n;=x 0{10}{20};+x 1   -- always returns x+1, ternary value is discarded
+```
+
+Negated ternary: `!=x 1{"not one"}{"one"}`.
 
 Use braces when the body has multiple statements:
 

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -129,11 +129,13 @@ pub enum Stmt {
     /// `name=expr`
     Let { name: String, value: Expr },
 
-    /// `cond{body}` or `!cond{body}`
+    /// `cond{body}` or `!cond{body}` — guard (early return)
+    /// `cond{then}{else}` — ternary (value, no early return)
     Guard {
         condition: Expr,
         negated: bool,
         body: Vec<Spanned<Stmt>>,
+        else_body: Option<Vec<Spanned<Stmt>>>,
     },
 
     /// `?expr{arms}` or `?{arms}`

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -400,7 +400,7 @@ impl RegCompiler {
                 None
             }
 
-            Stmt::Guard { condition, negated, body } => {
+            Stmt::Guard { condition, negated, body, else_body } => {
                 let saved_next = self.next_reg;
                 let cond_reg = self.compile_expr(condition);
                 let jump = if *negated {
@@ -408,17 +408,51 @@ impl RegCompiler {
                 } else {
                     self.emit_jmpf(cond_reg)
                 };
-                let body_result = self.compile_body(body);
-                let ret_reg = body_result.unwrap_or_else(|| {
-                    let r = self.alloc_reg();
-                    let ki = self.current.add_const(Value::Nil);
-                    self.emit_abx(OP_LOADK, r, ki);
-                    r
-                });
-                self.emit_abx(OP_RET, ret_reg, 0);
-                self.current.patch_jump(jump);
-                self.next_reg = saved_next;
-                None
+
+                if let Some(else_b) = else_body {
+                    // Ternary: cond{then}{else} — produce value, no early return
+                    let result_reg = self.alloc_reg();
+                    let then_result = self.compile_body(body);
+                    let then_reg = then_result.unwrap_or_else(|| {
+                        let r = self.alloc_reg();
+                        let ki = self.current.add_const(Value::Nil);
+                        self.emit_abx(OP_LOADK, r, ki);
+                        r
+                    });
+                    if then_reg != result_reg {
+                        self.emit_abc(OP_MOVE, result_reg, then_reg, 0);
+                    }
+                    let jump_over_else = self.emit_jmp_placeholder();
+                    self.current.patch_jump(jump);
+
+                    self.next_reg = result_reg + 1;
+                    let else_result = self.compile_body(else_b);
+                    let else_reg = else_result.unwrap_or_else(|| {
+                        let r = self.alloc_reg();
+                        let ki = self.current.add_const(Value::Nil);
+                        self.emit_abx(OP_LOADK, r, ki);
+                        r
+                    });
+                    if else_reg != result_reg {
+                        self.emit_abc(OP_MOVE, result_reg, else_reg, 0);
+                    }
+                    self.current.patch_jump(jump_over_else);
+                    self.next_reg = result_reg + 1;
+                    Some(result_reg)
+                } else {
+                    // Guard: cond{body} — early return
+                    let body_result = self.compile_body(body);
+                    let ret_reg = body_result.unwrap_or_else(|| {
+                        let r = self.alloc_reg();
+                        let ki = self.current.add_const(Value::Nil);
+                        self.emit_abx(OP_LOADK, r, ki);
+                        r
+                    });
+                    self.emit_abx(OP_RET, ret_reg, 0);
+                    self.current.patch_jump(jump);
+                    self.next_reg = saved_next;
+                    None
+                }
             }
 
             Stmt::Match { subject, arms } => {
@@ -4286,5 +4320,24 @@ mod tests {
     fn vm_slc_text() {
         let source = r#"f>t;slc "hello" 1 4"#;
         assert_eq!(vm_run(source, Some("f"), vec![]), Value::Text("ell".into()));
+    }
+
+    #[test]
+    fn vm_ternary_true() {
+        let source = r#"f x:n>t;=x 1{"yes"}{"no"}"#;
+        assert_eq!(vm_run(source, Some("f"), vec![Value::Number(1.0)]), Value::Text("yes".into()));
+    }
+
+    #[test]
+    fn vm_ternary_false() {
+        let source = r#"f x:n>t;=x 1{"yes"}{"no"}"#;
+        assert_eq!(vm_run(source, Some("f"), vec![Value::Number(2.0)]), Value::Text("no".into()));
+    }
+
+    #[test]
+    fn vm_ternary_no_early_return() {
+        let source = r#"f x:n>n;=x 0{10}{20};+x 1"#;
+        assert_eq!(vm_run(source, Some("f"), vec![Value::Number(0.0)]), Value::Number(1.0));
+        assert_eq!(vm_run(source, Some("f"), vec![Value::Number(5.0)]), Value::Number(6.0));
     }
 }


### PR DESCRIPTION
## Summary
- **7 new builtins**: `cat`, `has`, `hd`, `tl`, `rev`, `srt`, `slc` (opcodes 49-55)
- **Ternary guard-else**: `cond{then}{else}` — produces a value without early return
- Each builtin has verifier type checks, interpreter implementation, VM opcode, and tests
- SPEC.md updated with all new builtins and ternary syntax

### Builtins
| Builtin | Signature | Description |
|---------|-----------|-------------|
| `cat xs sep` | `L t, t → t` | Join list of text with separator |
| `has xs v` | `list_or_text, any → b` | Membership test |
| `hd xs` | `list_or_text → any` | Head (first element/char) |
| `tl xs` | `list_or_text → list_or_text` | Tail (all but first) |
| `rev xs` | `list_or_text → list_or_text` | Reverse |
| `srt xs` | `list_or_text → list_or_text` | Sort (numbers/text) |
| `slc xs a b` | `list_or_text, n, n → list_or_text` | Slice from a to b |

### Ternary
```
f x:n>t;=x 1{"yes"}{"no"}    -- returns "yes" or "no"
f x:n>n;=x 0{10}{20};+x 1    -- ternary value discarded, returns x+1
```

## Test plan
- [x] 917 tests pass (805 unit + 112 integration)
- [x] Verifier, interpreter, and VM tests for each builtin
- [x] Ternary tests: true/false branches, no-early-return, negated, guard unchanged
- [x] Parser test for ternary AST structure
- [x] No new clippy warnings

Supersedes PRs #49-#55 (which had opcode collisions from parallel development).