### PR TITLE
feat: while loop `wh cond{body}` (F6)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -188,6 +188,7 @@ ilo 'f xs:L t>t;xs.0' 'a,b,c'       → a
 | `~expr` | return ok |
 | `^expr` | return err |
 | `func! args` | call + auto-unwrap Result |
+| `wh cond{body}` | while loop |
 | `expr>>func` | pipe: pass result as last arg to func |
 
 ---
@@ -246,6 +247,17 @@ f xs:L n>n;@x xs{>=x 10{ret x}};0  -- return first element >= 10
 ```
 
 Guards already provide early return for simple cases. Use `ret` when you need early return inside a loop or deeply nested block.
+
+### While Loop
+
+`wh cond{body}` loops while condition is truthy:
+
+```
+f>n;i=0;s=0;wh <i 5{i=+i 1;s=+s i};s    -- sum 1..5 = 15
+f>n;i=0;wh true{i=+i 1;>=i 3{ret i}};0   -- early return from loop
+```
+
+Variable rebinding (`i=+i 1`) inside while loops updates the existing variable rather than creating a new binding.
 
 ### Pipe Operator
 

--- a/TODO.md
+++ b/TODO.md
@@ -330,21 +330,23 @@ Explicit return from anywhere in function body.
 - [x] Tests: parser, interpreter, VM, verifier, codegen
 - [x] SPEC.md: documented `ret` syntax
 
-##### F6. While loop — `wh cond{body}` (medium priority — new capability)
+##### F6. While loop — `wh cond{body}` ✅
 
 `@` only iterates lists. While enables polling, convergence, and stateful loops.
 
-- [ ] Syntax: `wh cond{body}` — evaluate condition; if truthy, execute body; repeat
-- [ ] Parser: recognise `wh` keyword, parse condition expression + brace body
-- [ ] AST: add `Stmt::While { condition: Expr, body: Vec<Spanned<Stmt>> }`
-- [ ] Interpreter: loop while `is_truthy(eval_expr(condition))`, execute body each iteration, return last body value
-- [ ] VM: compile as `loop_top: eval cond → reg; JMPF reg → exit; <body>; JMP loop_top; exit:`
-- [ ] Verifier: condition must be truthy-compatible; body type is the loop's result type
+- [x] Syntax: `wh cond{body}` — evaluate condition; if truthy, execute body; repeat
+- [x] Parser: recognise `wh` keyword, parse condition expression + brace body
+- [x] AST: `Stmt::While { condition: Expr, body: Vec<Spanned<Stmt>> }`
+- [x] Interpreter: loop while `is_truthy(eval_expr(condition))`, execute body each iteration
+- [x] VM: compile as `loop_top: eval cond → reg; JMPF reg → exit; <body>; JMP loop_top; exit:`
+- [x] VM fix: `Stmt::Let` re-binding writes to existing register (needed for loop counters)
+- [x] Verifier: condition + body type checked
 - [ ] Cranelift JIT: standard loop with conditional back-edge
 - [ ] Interaction with break/continue (F9): `brk` jumps to exit, `cnt` jumps to loop_top
-- [ ] Python codegen: emit as `while <cond>: <body>`
-- [ ] Tests: basic while, while with accumulator, infinite loop guard (max iterations?), while + break
-- [ ] SPEC.md: document `wh` syntax
+- [x] Python codegen: emit as `while <cond>: <body>`
+- [x] Formatter: emit as `wh cond{body}`
+- [x] Tests: parser, interpreter (basic, zero-iter, ret), VM (basic, zero-iter, ret)
+- [x] SPEC.md: documented `wh` syntax
 
 ##### F7. Range iteration — `@i 0..n{body}` (medium priority)
 

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -151,6 +151,12 @@ pub enum Stmt {
         body: Vec<Spanned<Stmt>>,
     },
 
+    /// `wh cond{body}` — while loop
+    While {
+        condition: Expr,
+        body: Vec<Spanned<Stmt>>,
+    },
+
     /// `ret expr` — early return from function
     Return(Expr),
 

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -633,6 +633,10 @@ impl VerifyContext {
                 scope.pop();
                 body_ty
             }
+            Stmt::While { condition, body } => {
+                self.infer_expr(func, scope, condition, span);
+                self.verify_body(func, scope, body)
+            }
             Stmt::Return(expr) => self.infer_expr(func, scope, expr, span),
             Stmt::Expr(expr) => self.infer_expr(func, scope, expr, span),
         }
@@ -2465,6 +2469,11 @@ mod tests {
         let result = parse_and_verify("f x:L n s:t>L n;slc x s 2");
         let errors = result.unwrap_err();
         assert!(errors.iter().any(|e| e.code == "ILO-T013" && e.message.contains("slc")));
+    }
+
+    #[test]
+    fn while_valid() {
+        assert!(parse_and_verify("f>n;i=0;wh <i 5{i=+i 1};i").is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `wh cond{body}` while loop statement
- AST: `Stmt::While { condition, body }`
- Parser: `wh` keyword recognition
- Interpreter + VM: loop while condition is truthy, supports `ret` for early exit
- VM fix: variable rebinding (`i=+i 1`) reuses existing register instead of allocating new ones
- Formatter, Python codegen, verifier all handle `Stmt::While`
- 950 tests passing (10 new tests)

## Test plan
- [x] Parser: while loop AST structure
- [x] Interpreter: basic sum, zero iterations, early return with ret
- [x] VM: basic sum, zero iterations, early return with ret
- [x] Verifier: valid while loop
- [x] Formatter: dense/expanded, round-trip
- [x] Python codegen: emits `while cond:`