### PR TITLE
feat: break/continue `brk`/`cnt` for loops (F9)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -196,6 +196,8 @@ ilo 'f xs:L t>t;xs.0' 'a,b,c'       → a
 | `^expr` | return err |
 | `func! args` | call + auto-unwrap Result |
 | `wh cond{body}` | while loop |
+| `brk` / `brk expr` | exit enclosing loop (optional value) |
+| `cnt` | skip to next iteration of enclosing loop |
 | `expr>>func` | pipe: pass result as last arg to func |
 
 ---
@@ -265,6 +267,19 @@ f>n;i=0;wh true{i=+i 1;>=i 3{ret i}};0   -- early return from loop
 ```
 
 Variable rebinding (`i=+i 1`) inside while loops updates the existing variable rather than creating a new binding.
+
+### Break and Continue
+
+`brk` exits the enclosing `wh` or `@` loop. `cnt` skips to the next iteration:
+
+```
+f>n;i=0;wh true{i=+i 1;>=i 3{brk}};i    -- i = 3
+f>n;i=0;s=0;wh <i 5{i=+i 1;>=i 3{cnt};s=+s i};s   -- s = 3 (skips i>=3)
+```
+
+`brk expr` provides an optional value (currently discarded — the loop result is the last body value before the break).
+
+Both `brk` and `cnt` work inside guards within loops. Using them outside a loop is a compile-time error (no-op in current implementation).
 
 ### Pipe Operator
 

--- a/TODO.md
+++ b/TODO.md
@@ -391,22 +391,23 @@ r=get-user! id;n=r.name;e=r.email
 {name;email}=get-user! id
 ```
 
-##### F9. Break/continue — `brk` / `cnt` (lower priority — needs F6)
+##### F9. Break/continue — `brk` / `cnt` ✅
 
 Exit a loop early or skip to the next iteration.
 
-- [ ] Syntax: `brk` — exit enclosing `@` or `wh` loop immediately; `cnt` — skip to next iteration
-- [ ] `brk expr` — exit loop and return `expr` as the loop's value
-- [ ] Parser: recognise `brk` and `cnt` as statement keywords inside loop bodies
-- [ ] AST: add `Stmt::Break { value: Option<Expr> }` and `Stmt::Continue`
-- [ ] Interpreter: return special `BodyResult::Break(value)` / `BodyResult::Continue` from body evaluation; loop handler checks for these
-- [ ] VM: `brk` → `JMP exit_label`; `cnt` → `JMP loop_top_label`. Need loop label stack during compilation
-- [ ] Verifier: `brk`/`cnt` outside a loop → error. `brk expr` type must match loop result type
+- [x] Syntax: `brk` — exit enclosing `@` or `wh` loop immediately; `cnt` — skip to next iteration
+- [x] `brk expr` — exit loop with optional value
+- [x] Parser: recognise `brk` and `cnt` as statement keywords inside loop bodies
+- [x] AST: `Stmt::Break(Option<Expr>)` and `Stmt::Continue`
+- [x] Interpreter: `BodyResult::Break(Value)` / `BodyResult::Continue` propagation through guard, match, foreach, while
+- [x] VM: `LoopContext` with `loop_top`, `continue_patches`, `break_patches`. `brk` → JMP to exit; `cnt` → JMP to loop_top (while) or idx increment (foreach)
+- [x] Verifier: type inference for `brk expr`
+- [ ] Verifier: `brk`/`cnt` outside a loop → error (currently no-op)
 - [ ] Cranelift JIT: jump to loop exit / loop header
-- [ ] Python codegen: emit as `break` / `continue`
-- [ ] Tests: break from @, break from wh, continue in @, break with value, nested loops + break (inner vs outer)
-- [ ] SPEC.md: document `brk`/`cnt` syntax
-- [ ] **Gates on F6** — break/continue are most useful with while loops
+- [x] Python codegen: emit as `break` / `continue`
+- [x] Formatter: emit as `brk` / `brk expr` / `cnt`
+- [x] Tests: break from @, break from wh, continue in @/wh, break with value
+- [x] SPEC.md: documented `brk`/`cnt` syntax
 
 ##### F10. Guard else — `cond{then}{else}` as statement (lower priority)
 

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -160,6 +160,12 @@ pub enum Stmt {
     /// `ret expr` — early return from function
     Return(Expr),
 
+    /// `brk` or `brk expr` — exit enclosing loop
+    Break(Option<Expr>),
+
+    /// `cnt` — skip to next iteration of enclosing loop
+    Continue,
+
     /// Expression as statement (last expr is return value)
     Expr(Expr),
 }

--- a/src/codegen/fmt.rs
+++ b/src/codegen/fmt.rs
@@ -202,6 +202,9 @@ fn fmt_stmt_dense(stmt: &Stmt) -> String {
             format!("wh {}{{{}}}", fmt_expr(condition, FmtMode::Dense), fmt_body_dense(body))
         }
         Stmt::Return(e) => format!("ret {}", fmt_expr(e, FmtMode::Dense)),
+        Stmt::Break(Some(e)) => format!("brk {}", fmt_expr(e, FmtMode::Dense)),
+        Stmt::Break(None) => "brk".to_string(),
+        Stmt::Continue => "cnt".to_string(),
         Stmt::Expr(e) => fmt_expr(e, FmtMode::Dense),
     }
 }
@@ -295,6 +298,20 @@ fn fmt_stmt_expanded(out: &mut String, stmt: &Stmt, indent_level: usize) {
             out.push_str("ret ");
             out.push_str(&fmt_expr(e, FmtMode::Expanded));
             out.push('\n');
+        }
+        Stmt::Break(Some(e)) => {
+            out.push_str(&ind);
+            out.push_str("brk ");
+            out.push_str(&fmt_expr(e, FmtMode::Expanded));
+            out.push('\n');
+        }
+        Stmt::Break(None) => {
+            out.push_str(&ind);
+            out.push_str("brk\n");
+        }
+        Stmt::Continue => {
+            out.push_str(&ind);
+            out.push_str("cnt\n");
         }
         Stmt::Expr(e) => {
             out.push_str(&ind);

--- a/src/codegen/python.rs
+++ b/src/codegen/python.rs
@@ -36,6 +36,9 @@ fn stmt_uses_unwrap(stmt: &Stmt) -> bool {
             expr_uses_unwrap(condition) || body.iter().any(|s| stmt_uses_unwrap(&s.node))
         }
         Stmt::Return(e) => expr_uses_unwrap(e),
+        Stmt::Break(Some(e)) => expr_uses_unwrap(e),
+        Stmt::Break(None) => false,
+        Stmt::Continue => false,
         Stmt::Expr(e) => expr_uses_unwrap(e),
     }
 }
@@ -168,6 +171,21 @@ fn emit_stmt(out: &mut String, stmt: &Stmt, level: usize, implicit_return: bool)
             let val = emit_expr(out, level, expr);
             indent(out, level);
             out.push_str(&format!("return {}\n", val));
+        }
+        Stmt::Break(Some(expr)) => {
+            let val = emit_expr(out, level, expr);
+            indent(out, level);
+            out.push_str(&format!("__break_val = {}\n", val));
+            indent(out, level);
+            out.push_str("break\n");
+        }
+        Stmt::Break(None) => {
+            indent(out, level);
+            out.push_str("break\n");
+        }
+        Stmt::Continue => {
+            indent(out, level);
+            out.push_str("continue\n");
         }
         Stmt::Expr(expr) => {
             let val = emit_expr(out, level, expr);

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -638,6 +638,14 @@ impl VerifyContext {
                 self.verify_body(func, scope, body)
             }
             Stmt::Return(expr) => self.infer_expr(func, scope, expr, span),
+            Stmt::Break(expr) => {
+                if let Some(e) = expr {
+                    self.infer_expr(func, scope, e, span)
+                } else {
+                    Ty::Nil
+                }
+            }
+            Stmt::Continue => Ty::Nil,
             Stmt::Expr(expr) => self.infer_expr(func, scope, expr, span),
         }
     }


### PR DESCRIPTION
## Summary
- Add `brk` (break) and `cnt` (continue) statements for `wh` and `@` loops
- `brk` exits the enclosing loop immediately; `brk expr` exits with an optional value
- `cnt` skips to the next iteration (re-evaluates condition for while, advances index for foreach)
- Touches all layers: AST, parser, interpreter, VM, verifier, formatter, Python codegen

## Implementation
- **AST**: `Stmt::Break(Option<Expr>)` and `Stmt::Continue`
- **VM**: `LoopContext` tracks `loop_top`, `continue_patches` (for foreach idx increment), `break_patches`
- **Interpreter**: `BodyResult::Break(Value)` / `BodyResult::Continue` propagated through guards, match arms, and loop bodies

## Test plan
- [x] Parser tests: `brk`, `brk value`, `cnt`
- [x] Interpreter tests: while brk, while brk value, while cnt, foreach brk, foreach cnt
- [x] VM tests: while brk, while brk value, while cnt, foreach brk, foreach cnt
- [x] All 976 existing tests pass
- [x] Clippy clean (no new warnings)