### PR TITLE
test: add 41 coverage tests for uncovered lines

### DIFF
--- a/src/codegen/fmt.rs
+++ b/src/codegen/fmt.rs
@@ -1002,4 +1002,52 @@ mod tests {
     fn round_trip_alias_with_function() {
         assert_round_trip("alias res R n t\nf x:n>res;~x");
     }
+
+    // ---- Coverage tests for newer features ----
+
+    #[test]
+    fn dense_brk_value() {
+        let s = dense("f>n;wh true{brk 99}");
+        assert!(s.contains("brk 99"), "got: {s}");
+    }
+
+    #[test]
+    fn expanded_brk_value() {
+        let s = expanded("f>n;wh true{brk 99}");
+        assert!(s.contains("brk 99"), "got: {s}");
+    }
+
+    #[test]
+    fn dense_cnt() {
+        let s = dense("f>n;wh true{cnt}");
+        assert!(s.contains("cnt"), "got: {s}");
+    }
+
+    #[test]
+    fn expanded_cnt() {
+        let s = expanded("f>n;wh true{cnt}");
+        assert!(s.contains("cnt"), "got: {s}");
+    }
+
+    #[test]
+    fn dense_nil_coalesce() {
+        let s = dense("f x:n>n;x??42");
+        assert!(s.contains("??"), "got: {s}");
+    }
+
+    #[test]
+    fn round_trip_nil_coalesce() {
+        assert_round_trip("f x:n>n;x??42");
+    }
+
+    #[test]
+    fn dense_safe_field() {
+        let s = dense("f x:n>n;x.?name");
+        assert!(s.contains(".?name"), "got: {s}");
+    }
+
+    #[test]
+    fn round_trip_safe_field() {
+        assert_round_trip("f x:n>n;x.?name");
+    }
 }

--- a/src/codegen/python.rs
+++ b/src/codegen/python.rs
@@ -1139,4 +1139,55 @@ mod tests {
         // Output should contain the function body, not any error artifacts
         assert!(py.contains("return"), "missing return in: {py}");
     }
+
+    // ---- Coverage tests for newer features ----
+
+    #[test]
+    fn emit_for_range() {
+        let py = parse_and_emit("f>n;@i 0..5{i}");
+        assert!(py.contains("for i in range("), "got: {py}");
+    }
+
+    #[test]
+    fn emit_nil_coalesce() {
+        let py = parse_and_emit("f x:n>n;x??42");
+        assert!(py.contains("is not None else"), "got: {py}");
+    }
+
+    #[test]
+    fn emit_break_no_value() {
+        let py = parse_and_emit("f>n;wh true{brk}");
+        assert!(py.contains("break"), "got: {py}");
+    }
+
+    #[test]
+    fn emit_break_with_value() {
+        let py = parse_and_emit("f>n;wh true{brk 99}");
+        assert!(py.contains("__break_val = 99"), "got: {py}");
+        assert!(py.contains("break"), "got: {py}");
+    }
+
+    #[test]
+    fn emit_continue() {
+        let py = parse_and_emit("f>n;wh true{cnt}");
+        assert!(py.contains("continue"), "got: {py}");
+    }
+
+    #[test]
+    fn emit_alias() {
+        let py = parse_and_emit("alias res R n t\nf x:n>res;~x");
+        assert!(py.contains("# alias res"), "got: {py}");
+    }
+
+    #[test]
+    fn emit_safe_field() {
+        let py = parse_and_emit("f x:n>n;x.?name");
+        assert!(py.contains("is not None else None"), "got: {py}");
+    }
+
+    #[test]
+    fn emit_safe_index() {
+        let py = parse_and_emit("f xs:L n>n;xs.?0");
+        assert!(py.contains("is not None else None"), "got: {py}");
+    }
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -2442,4 +2442,139 @@ mod tests {
         // i=0: 0, i=1: 1, i=2: 4 → last = 4
         assert_eq!(run_str(source, Some("f"), vec![]), Value::Number(4.0));
     }
+
+    // ---- Builtin error-path coverage tests ----
+
+    #[test]
+    fn err_spl_non_text_first() {
+        let err = run_str_err("f x:n y:t>L t;spl x y", Some("f"), vec![Value::Number(1.0), Value::Text("a".into())]);
+        assert!(err.contains("spl requires two text args"), "got: {err}");
+    }
+
+    #[test]
+    fn err_spl_non_text_second() {
+        let err = run_str_err("f x:t y:n>L t;spl x y", Some("f"), vec![Value::Text("a-b".into()), Value::Number(1.0)]);
+        assert!(err.contains("spl requires two text args"), "got: {err}");
+    }
+
+    #[test]
+    fn err_cat_non_text_items() {
+        let err = run_str_err("f>t;cat [1,2,3] \",\"", Some("f"), vec![]);
+        assert!(err.contains("cat: list items must be text"), "got: {err}");
+    }
+
+    #[test]
+    fn err_cat_wrong_arg_types() {
+        let err = run_str_err("f x:n y:n>t;cat x y", Some("f"), vec![Value::Number(1.0), Value::Number(2.0)]);
+        assert!(err.contains("cat requires a list and text separator"), "got: {err}");
+    }
+
+    #[test]
+    fn err_has_text_non_text_needle() {
+        let err = run_str_err("f x:t y:n>b;has x y", Some("f"), vec![Value::Text("hello".into()), Value::Number(1.0)]);
+        assert!(err.contains("text search requires text needle"), "got: {err}");
+    }
+
+    #[test]
+    fn err_has_wrong_first_arg() {
+        let err = run_str_err("f x:n y:n>b;has x y", Some("f"), vec![Value::Number(1.0), Value::Number(2.0)]);
+        assert!(err.contains("has requires a list or text"), "got: {err}");
+    }
+
+    #[test]
+    fn err_hd_empty_list() {
+        let err = run_str_err("f>n;hd []", Some("f"), vec![]);
+        assert!(err.contains("hd: empty list"), "got: {err}");
+    }
+
+    #[test]
+    fn err_hd_empty_text() {
+        let err = run_str_err("f>t;hd \"\"", Some("f"), vec![]);
+        assert!(err.contains("hd: empty text"), "got: {err}");
+    }
+
+    #[test]
+    fn err_hd_wrong_type() {
+        let err = run_str_err("f x:n>n;hd x", Some("f"), vec![Value::Number(1.0)]);
+        assert!(err.contains("hd requires a list or text"), "got: {err}");
+    }
+
+    #[test]
+    fn err_tl_empty_list() {
+        let err = run_str_err("f>L n;tl []", Some("f"), vec![]);
+        assert!(err.contains("tl: empty list"), "got: {err}");
+    }
+
+    #[test]
+    fn err_tl_empty_text() {
+        let err = run_str_err("f>t;tl \"\"", Some("f"), vec![]);
+        assert!(err.contains("tl: empty text"), "got: {err}");
+    }
+
+    #[test]
+    fn err_tl_wrong_type() {
+        let err = run_str_err("f x:n>n;tl x", Some("f"), vec![Value::Number(1.0)]);
+        assert!(err.contains("tl requires a list or text"), "got: {err}");
+    }
+
+    #[test]
+    fn err_rev_wrong_type() {
+        let err = run_str_err("f x:n>n;rev x", Some("f"), vec![Value::Number(1.0)]);
+        assert!(err.contains("rev requires a list or text"), "got: {err}");
+    }
+
+    #[test]
+    fn err_srt_mixed_types() {
+        let err = run_str_err("f>L n;srt [1,\"a\"]", Some("f"), vec![]);
+        assert!(err.contains("srt: list must contain all numbers or all text"), "got: {err}");
+    }
+
+    #[test]
+    fn err_srt_wrong_type() {
+        let err = run_str_err("f x:n>n;srt x", Some("f"), vec![Value::Number(1.0)]);
+        assert!(err.contains("srt requires a list or text"), "got: {err}");
+    }
+
+    #[test]
+    fn err_slc_wrong_first_arg() {
+        let err = run_str_err("f x:n>n;slc x 0 1", Some("f"), vec![Value::Number(1.0)]);
+        assert!(err.contains("slc requires a list or text"), "got: {err}");
+    }
+
+    #[test]
+    fn err_slc_non_number_start() {
+        let err = run_str_err("f x:t y:t>t;slc x y 1", Some("f"), vec![Value::Text("hi".into()), Value::Text("a".into())]);
+        assert!(err.contains("slc: start index must be a number"), "got: {err}");
+    }
+
+    #[test]
+    fn err_slc_non_number_end() {
+        let err = run_str_err("f x:t y:t>t;slc x 0 y", Some("f"), vec![Value::Text("hi".into()), Value::Text("a".into())]);
+        assert!(err.contains("slc: end index must be a number"), "got: {err}");
+    }
+
+    #[test]
+    fn err_rnd_lower_gt_upper() {
+        let err = run_str_err("f>n;rnd 10 1", Some("f"), vec![]);
+        assert!(err.contains("rnd: lower bound"), "got: {err}");
+        assert!(err.contains("upper bound"), "got: {err}");
+    }
+
+    #[test]
+    fn err_rnd_wrong_arg_types() {
+        let err = run_str_err("f x:t y:t>n;rnd x y", Some("f"), vec![Value::Text("a".into()), Value::Text("b".into())]);
+        assert!(err.contains("rnd requires two numbers"), "got: {err}");
+    }
+
+    #[test]
+    fn err_get_non_text_arg() {
+        let err = run_str_err("f x:n>R t t;get x", Some("f"), vec![Value::Number(1.0)]);
+        assert!(err.contains("get requires text"), "got: {err}");
+    }
+
+    #[test]
+    fn ok_srt_empty_list() {
+        let source = "f>L n;srt []";
+        assert_eq!(run_str(source, Some("f"), vec![]), Value::List(vec![]));
+    }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3152,4 +3152,19 @@ mod tests {
             _ => panic!("expected function"),
         }
     }
+
+    #[test]
+    fn parse_dollar_in_operand() {
+        // $ in operand position (inside a binary op)
+        let prog = parse_str(r#"f url:t>R t t;cat [$url] ",""#);
+        match &prog.declarations[0] {
+            Decl::Function { body, .. } => match &body[0].node {
+                Stmt::Expr(Expr::Call { function, .. }) => {
+                    assert_eq!(function, "cat");
+                }
+                other => panic!("expected Call, got {:?}", other),
+            },
+            _ => panic!("expected function"),
+        }
+    }
 }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -4837,4 +4837,18 @@ mod tests {
         // 2+3+4 = 9
         assert_eq!(vm_run(source, Some("f"), vec![]), Value::Number(9.0));
     }
+
+    #[test]
+    fn vm_safe_index_on_nil() {
+        // .?0 on nil returns nil
+        let source = "mk x:n>n;>=x 1{x}\nf>n;v=mk 0;v.?0??99";
+        assert_eq!(vm_run(source, Some("f"), vec![]), Value::Number(99.0));
+    }
+
+    #[test]
+    fn vm_safe_index_on_value() {
+        // .?0 on a list returns the element
+        let source = "f>n;xs=[10,20,30];xs.?0";
+        assert_eq!(vm_run(source, Some("f"), vec![]), Value::Number(10.0));
+    }
 }


### PR DESCRIPTION
## Summary
- 22 interpreter tests covering builtin error paths (spl, cat, has, hd, tl, rev, srt, slc, rnd, get)
- 8 Python codegen tests for range, nil-coalesce, brk/cnt, alias, safe field/index
- 8 formatter tests for brk-value, cnt, nil-coalesce, safe-field
- 2 VM tests for safe index (.?0) on nil and on value
- 1 parser test for $ in operand position

## Test plan
- [x] `cargo test` — 1091 tests pass (up from 1050)
- [x] `cargo clippy -- -W clippy::all` — no new warnings
- [x] `cargo llvm-cov --summary-only` — line coverage 95.68% → 96.38%