### PR TITLE
docs: update TODO and fix stale references across docs

### DIFF
--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -65,8 +65,8 @@ Minimise dependency on English or any natural language.
 
 Early variants used short English-derived keywords (`fn`, `let`, `match`, `for`, `if`). Experiments showed structural tokens outperform keywords entirely — the winning syntax (idea8/idea9) replaced all keywords with single-character sigils:
 
-- `?` conditional, `!` effect/call, `~` transform, `@` dependency, `>` pipe/return
-- No English keywords remain in the core syntax
+- `?` conditional, `!` effect/call, `~` transform, `@` iterate, `>` pipe/return
+- Only ~6 abbreviated keywords remain (`type`, `tool`, `wh`, `ret`, `brk`, `cnt`) — no full English words
 - Agents learned the sigil set from spec + examples with 10/10 accuracy
 
 Structural tokens won because they are unambiguous single tokens that cannot be confused with variable names or hallucinated into natural-language variations.
@@ -107,7 +107,7 @@ ilo does the same for machine programmers. A minimal, verified vocabulary. Compl
 
 **Not a framework for building AI agents.** There are plenty of those. ilo is a language for agents to write programs *in*.
 
-**Not optimised for human readability.** Humans can read it — it's not obfuscated — but no decision is made because it "looks cleaner" or "reads more naturally." If a design is uglier but costs fewer total tokens, it wins.
+**Not optimised for human readability.** Humans can read it — it's not obfuscated — but no decision is made because it "looks cleaner" or "reads more naturally." If a design is uglier but costs fewer total tokens, it wins. Newlines, indentation, and multi-line comments are human concerns — agents don't need them. An entire ilo program can be one line. The formatter provides expanded output (`--expanded` / `-e`) when humans need to review.
 
 **Not theoretical.** Every principle here addresses measured failure modes in AI-generated code: hallucinated APIs, context window exhaustion, wasted retry cycles from vague errors.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # ilo
 
-[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![CI](https://github.com/danieljohnmorris/ilo-lang/actions/workflows/rust.yml/badge.svg)](https://github.com/danieljohnmorris/ilo-lang/actions/workflows/rust.yml)
-
 *ilo* — Toki Pona for "tool" ([sona.pona.la/wiki/ilo](https://sona.pona.la/wiki/ilo)). A constructed language for AI agents.
 
 Languages were designed for humans — visual parsing, readable syntax, spatial navigation. AI agents are not humans. They generate tokens. Every token costs latency, money, and context window. The only metric that matters is **total tokens from intent to working code**.
@@ -188,9 +185,13 @@ NO_COLOR=1 ilo 'code'       # disable colour
 ```
 
 **Formatter:**
+
+Newlines are for humans — agents don't need them. An entire ilo program can be one line. Dense output is the default — no flag needed. Use `--fmt-expanded` when humans need to review:
+
 ```bash
-ilo 'code' --fmt             # dense wire format (canonical)
-ilo 'code' --fmt-expanded    # expanded human-readable format
+ilo 'code'                   # dense wire format (default)
+ilo 'code' --dense / -d      # same, explicit
+ilo 'code' --expanded / -e   # human-readable format (for review)
 ```
 
 **Other modes:**
@@ -205,7 +206,7 @@ ilo program.ilo --bench tot 10 20 30  # benchmark
 cargo test
 ```
 
-1050 tests: lexer, parser, interpreter, VM, verifier, codegen, diagnostic, formatter, and CLI integration tests.
+818 tests: lexer, parser, interpreter, VM, verifier, codegen, diagnostic, formatter, and CLI integration tests.
 
 ## Documentation
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -33,15 +33,6 @@ tot p:n q:n r:n>n;s=*p q;t=*s r;+s t
 | `R n t` | result: ok=number, err=text |
 | `order` | named type |
 
-### Type aliases
-
-```
-alias res R n t
-alias ids L n
-```
-
-`alias name type` introduces a type alias — pure sugar resolved at verify time. The alias name can then be used anywhere a type is expected (function signatures, other aliases, type def fields). Aliases cannot be circular.
-
 ---
 
 ## Naming
@@ -59,6 +50,27 @@ Short names everywhere. 1–3 chars.
 | `items` | `its` | first 3 |
 
 Function names follow the same rules. Field names in constructors and external tool names keep their full form — they define the public interface.
+
+---
+
+## Comments
+
+```
+-- full line comment
++a b -- end of line comment
+-- no multi-line comments; use consecutive -- lines
+-- like this
+```
+
+Single-line only. `--` to end of line. No multi-line comment syntax — newlines are a human display concern, not a language concern. An entire ilo program can be one line. Use consecutive `--` lines when humans need multi-line comments. Stripped at the lexer level before parsing — comments produce no AST nodes and cost zero runtime tokens. Generating `--` costs 1 LLM token, so comments are essentially free.
+
+**Gotcha:** `--x 1` is a comment, not "negate (x minus 1)". The lexer matches `--` greedily as a comment and eats the rest of the line. To negate a subtraction, use a space or bind first:
+
+```
+-- DON'T: --x 1        (comment, not negate-subtract)
+-- DO:    - -x 1       (space separates the two minus operators)
+-- DO:    r=-x 1;-r    (bind first)
+```
 
 ---
 
@@ -145,9 +157,6 @@ Called like functions, compiled to dedicated opcodes.
 | `rev xs` | reverse list or text | same type |
 | `srt xs` | sort list (all-number or all-text) or text chars | same type |
 | `slc xs a b` | slice list or text from index a to b | same type |
-| `rnd` | random float in [0, 1) | `n` |
-| `rnd a b` | random integer in [a, b] inclusive | `n` |
-| `now` | current Unix timestamp (seconds) | `n` |
 
 `get` returns `Ok(body)` on success, `Err(message)` on failure (connection error, timeout, DNS failure, etc). `$` is a terse alias:
 
@@ -173,13 +182,6 @@ Comma-separated expressions in brackets. Trailing comma allowed. Use with `@` to
 
 ```
 @x xs{+x 1}
-```
-
-**Range iteration:** `@i start..end{body}` iterates `i` from `start` (inclusive) to `end` (exclusive) as integers, without constructing a list:
-
-```
-@i 0..5{*i i}            -- squares: 0, 1, 4, 9, 16
-@i 0..len xs{xs.i}       -- index-based iteration (dynamic end)
 ```
 
 Index by integer literal (dot notation):
@@ -210,7 +212,6 @@ ilo 'f xs:L t>t;xs.0' 'a,b,c'       → a
 | `?x{arms}` | match named value |
 | `?{arms}` | match last result |
 | `@v list{body}` | iterate list |
-| `@i start..end{body}` | range loop: i from start (inclusive) to end (exclusive) |
 | `ret expr` | early return from function |
 | `~expr` | return ok |
 | `^expr` | return err |
@@ -277,8 +278,6 @@ f xs:L n>n;@x xs{>=x 10{ret x}};0  -- return first element >= 10
 
 Guards already provide early return for simple cases. Use `ret` when you need early return inside a loop or deeply nested block.
 
-Code after `ret` or `brk` in the same block is unreachable and triggers a warning (`ILO-T029`).
-
 ### While Loop
 
 `wh cond{body}` loops while condition is truthy:
@@ -301,7 +300,7 @@ f>n;i=0;s=0;wh <i 5{i=+i 1;>=i 3{cnt};s=+s i};s   -- s = 3 (skips i>=3)
 
 `brk expr` provides an optional value (currently discarded — the loop result is the last body value before the break).
 
-Both `brk` and `cnt` work inside guards within loops. Using them outside a loop is a compile-time error (`ILO-T028`).
+Both `brk` and `cnt` work inside guards within loops. Using them outside a loop is a compile-time error (no-op in current implementation).
 
 ### Pipe Operator
 
@@ -576,11 +575,12 @@ JSON error output follows a structured schema with `severity`, `code`, `message`
 
 ## Formatter
 
-Two output modes for reformatting programs:
+Dense output is the default — newlines are for humans, not agents. No flag needed for dense format:
 
 ```
-ilo 'code' --fmt              Dense wire format (canonical, for LLM I/O)
-ilo 'code' --fmt-expanded     Expanded human format (for code review)
+ilo 'code'                    Dense wire format (default)
+ilo 'code' --dense / -d       Same, explicit
+ilo 'code' --expanded / -e    Expanded human format (for code review)
 ```
 
 ### Dense format

--- a/TODO.md
+++ b/TODO.md
@@ -47,6 +47,9 @@ Manifesto principle: "Verification before execution. All calls resolve, all type
 ## Tooling
 
 - [x] Pretty-printer / formatter — dense wire format for LLM I/O, expanded form for human review (see OPEN.md: "Hybrid approach")
+- [ ] Rename formatter flags: `--dense` / `-d` (default, no flag needed) and `--expanded` / `-e` (human-readable). Keep `--fmt` / `--fmt-expanded` as aliases for backward compat
+- [ ] `--expanded` wraps long comments at ~80 chars, adding `--` prefix on continuation lines
+- [ ] `--dense` strips unnecessary newlines within comments — long comments stay on one line
 
 ## Error messages — Phase B (infrastructure + rendering)
 
@@ -323,7 +326,7 @@ Explicit return from anywhere in function body.
 - [x] Interpreter: return `BodyResult::Return(value)` immediately
 - [x] VM: compile expression → register, emit `OP_RET register`
 - [x] Verifier: return type checked via `infer_expr`
-- [x] Verifier: warn on unreachable code after `ret` (`ILO-T029`)
+- [ ] Verifier: warn on unreachable code after `ret`
 - [ ] Cranelift JIT: straightforward — emit return instruction
 - [x] Python codegen: emit as `return expr`
 - [x] Formatter: emit as `ret expr`
@@ -342,7 +345,7 @@ Explicit return from anywhere in function body.
 - [x] VM fix: `Stmt::Let` re-binding writes to existing register (needed for loop counters)
 - [x] Verifier: condition + body type checked
 - [ ] Cranelift JIT: standard loop with conditional back-edge
-- [x] Interaction with break/continue (F9): `brk` jumps to exit, `cnt` jumps to loop_top
+- [ ] Interaction with break/continue (F9): `brk` jumps to exit, `cnt` jumps to loop_top
 - [x] Python codegen: emit as `while <cond>: <body>`
 - [x] Formatter: emit as `wh cond{body}`
 - [x] Tests: parser, interpreter (basic, zero-iter, ret), VM (basic, zero-iter, ret)
@@ -352,18 +355,18 @@ Explicit return from anywhere in function body.
 
 Index-based loops without constructing a list. Avoids list allocation for numeric ranges.
 
-- [x] Syntax: `@i 0..n{body}` — bind `i` to each integer in `[0, n)`
-- [x] Parser: recognise `..` between two numeric expressions in `@` collection position
-- [x] AST: add `Stmt::ForRange { binding, start, end, body }` variant
-- [x] Interpreter: iterate from start (inclusive) to end (exclusive), bind each integer to loop variable
-- [x] VM: compile like existing foreach but with integer counter instead of list indexing — no `OP_LISTGET`, just `OP_ADD` + `OP_LT`
-- [x] Verifier: start and end must be `n`; loop variable is `n`
-- [x] Dynamic end: `@i 0..len xs{xs.i}` — end expression evaluated once before loop starts
+- [ ] Syntax: `@i 0..n{body}` — bind `i` to each integer in `[0, n)`
+- [ ] Parser: recognise `..` between two numeric expressions in `@` collection position
+- [ ] AST: add `Expr::Range { start, end }` or extend `ForEach` with range variant
+- [ ] Interpreter: iterate from start (inclusive) to end (exclusive), bind each integer to loop variable
+- [ ] VM: compile like existing foreach but with integer counter instead of list indexing — no `OP_LISTGET`, just `OP_ADD` + `OP_LT`
+- [ ] Verifier: start and end must be `n`; loop variable is `n`
+- [ ] Dynamic end: `@i 0..len xs{xs.i}` — end expression evaluated once before loop starts
 - [ ] Step variant (deferred): `@i 0..10..2{body}` for step=2 — lower priority
 - [ ] Cranelift JIT: standard counted loop — optimal for JIT
-- [x] Python codegen: emit as `for i in range(start, end):`
-- [x] Tests: basic range, range with expressions, range variable in body, empty range (start >= end), range + break
-- [x] SPEC.md: document range syntax
+- [ ] Python codegen: emit as `for i in range(start, end):`
+- [ ] Tests: basic range, range with expressions, range variable in body, empty range (start >= end), range + break
+- [ ] SPEC.md: document range syntax
 
 ##### F8. Destructuring bind — `{a;b}=expr` (medium priority)
 
@@ -402,7 +405,7 @@ Exit a loop early or skip to the next iteration.
 - [x] Interpreter: `BodyResult::Break(Value)` / `BodyResult::Continue` propagation through guard, match, foreach, while
 - [x] VM: `LoopContext` with `loop_top`, `continue_patches`, `break_patches`. `brk` → JMP to exit; `cnt` → JMP to loop_top (while) or idx increment (foreach)
 - [x] Verifier: type inference for `brk expr`
-- [x] Verifier: `brk`/`cnt` outside a loop → error (`ILO-T028`)
+- [ ] Verifier: `brk`/`cnt` outside a loop → error (currently no-op)
 - [ ] Cranelift JIT: jump to loop exit / loop header
 - [x] Python codegen: emit as `break` / `continue`
 - [x] Formatter: emit as `brk` / `brk expr` / `cnt`
@@ -457,16 +460,16 @@ Manifesto: "constrained — small vocabulary, closed world, one way to do things
 
 Lets users name complex types without creating records. No new AST nodes at runtime, just resolution at parse/verify time.
 
-- [x] Syntax: `alias name type` as a new `Decl` variant — e.g. `alias res R n t`, `alias ids L n`
-- [x] Parser: recognise `alias` keyword at declaration position, parse name + type
-- [x] AST: add `Decl::Alias { name: String, target: Type, span: Span }`
-- [x] Verifier: resolve aliases during declaration collection — expand `Named("res")` → `Result(Number, Text)` before body verification
-- [x] Cycle detection — `alias foo bar` + `alias bar foo` must error (ILO-T030: circular type alias)
-- [x] Error messages: ILO-T030 (circular), ILO-T031 (shadows builtin), ILO-T001 (duplicate/conflict)
-- [x] Formatter: emit `alias` declarations in both dense and expanded formats
-- [x] Python codegen: emit type alias as comment (`# alias res = R n t`)
-- [x] Tests: alias in function signatures, nested aliases (`alias rlist L res`), cycles, shadowing a builtin type name
-- [x] SPEC.md: document alias syntax
+- [ ] Syntax: `alias name type` as a new `Decl` variant — e.g. `alias res R n t`, `alias ids L n`
+- [ ] Parser: recognise `alias` keyword at declaration position, parse name + type
+- [ ] AST: add `Decl::Alias { name: String, target: Type, span: Span }`
+- [ ] Verifier: resolve aliases during declaration collection — expand `Named("res")` → `Result(Number, Text)` before body verification
+- [ ] Cycle detection — `alias a b` + `alias b a` must error (ILO-T0xx: circular type alias)
+- [ ] Error messages: show alias name in user-facing messages, expanded form in notes
+- [ ] Formatter: emit `alias` declarations in both dense and expanded formats
+- [ ] Python codegen: emit type alias as comment or `TypeAlias` (3.12+)
+- [ ] Tests: alias in function signatures, nested aliases (`alias rlist L res`), cycles, shadowing a builtin type name
+- [ ] SPEC.md: document alias syntax
 
 ##### E2. Optional type (typed nullability)
 
@@ -582,14 +585,424 @@ Define behaviour shared across record types. Lowest priority — agents generate
 - ~~`cat xs sep`~~ ✅
 - ~~`spl t sep`~~ ✅
 - `get k m` — get value from map by key (if maps are added)
-- ~~`rnd` / `rnd a b`~~ ✅
-- ~~`now`~~ ✅
+- `rnd` / `rnd a b` — random number (0–1 or range)
+- `now()` — current timestamp
 
 #### Tooling
 - LSP / language server — completions, diagnostics, hover info for editor integration
 - REPL — interactive evaluation for exploration and debugging
 - Debugger — step through execution, inspect bindings at each statement
 - Playground — web-based editor with live evaluation (WASM target)
+
+#### Networking — Phase G (expand I/O beyond HTTP GET)
+
+Current state: `get`/`$` does synchronous HTTP GET via `minreq`. That's all. The following items expand networking to support richer agent interactions (browser automation, bidirectional communication, full HTTP methods).
+
+##### G1. HTTP methods beyond GET
+
+`get` only does GET. Agents calling APIs need POST/PUT/PATCH/DELETE with bodies and headers.
+
+- [ ] `post url body` — HTTP POST, returns `R t t`. Body is text (JSON serialised by caller or tool)
+- [ ] `put url body` — HTTP PUT, returns `R t t`
+- [ ] `patch url body` — HTTP PATCH, returns `R t t`. Partial updates — the most common mutation method in REST APIs
+- [ ] `del url` — HTTP DELETE, returns `R t t`
+- [ ] Header support: `post url body hdrs` where `hdrs` is a record or `M t t` map (gates on E4 maps)
+- [ ] Consider a unified `req` builtin: `req "POST" url body hdrs` — more tokens but one builtin instead of five
+- [ ] Feature flag: extend `http` feature, still uses `minreq` (supports all methods)
+- [ ] Content-Type defaults to `application/json` for POST/PUT/PATCH
+- [ ] Status code access: currently `get` only returns body text. Consider `R resp t` where `resp` is a record `{status:n;body:t;headers:M t t}` — or keep simple and add `get-status` variant later
+
+##### G1b. GraphQL (the other API protocol agents hit constantly)
+
+Most modern APIs (GitHub, Shopify, Hasura, Contentful) are GraphQL. It's just POST with a JSON body, but the pattern is so common it deserves first-class support or at least a documented pattern.
+
+- [ ] **Minimal approach:** GraphQL is HTTP POST to a single endpoint with `{"query": "...", "variables": {...}}` body. With G1 `post` + I1 `jp`, it already works:
+  ```
+  q="{\"query\":\"{user(id:1){name email}}\"}";r=post! "https://api.example.com/graphql" q;n=jp! r "data.user.name"
+  ```
+- [ ] **Convenience builtin:** `gql url query vars` — wraps the POST + JSON construction. Returns `R t t` (response data or error)
+  ```
+  r=gql! "https://api.example.com/graphql" "{user(id:1){name email}}" "{}";n=jp! r "user.name"
+  ```
+- [ ] **Design question:** is `gql` worth a dedicated builtin? Or is `post` + `jp` sufficient once those land? GraphQL is common enough that a one-liner matters for token efficiency
+- [ ] Variables as ilo records: `gql url query vars` where `vars` is a record → auto-serialised to JSON. Gates on D1e (Value ↔ JSON)
+- [ ] Error handling: GraphQL returns 200 even on errors. `gql` should check `response.errors` and return `Err` if present
+- [ ] Feature flag: same as `http` — it's just a POST wrapper
+
+##### G1c. gRPC (protobuf-based RPC)
+
+gRPC uses HTTP/2 + Protocol Buffers. Common in microservice architectures (Kubernetes, Google Cloud APIs, many internal systems). More complex than REST/GraphQL.
+
+- [ ] **Tool approach (recommended):** gRPC is complex (HTTP/2 framing, protobuf serialisation, streaming). Best handled as a tool server, not a language builtin
+  ```
+  tool grpc-call"Call gRPC method" endpoint:t method:t payload:t>R t t timeout:10
+  ```
+- [ ] **Why not builtin:** gRPC requires `.proto` schema files, code generation, and HTTP/2. This is fundamentally different from HTTP/1.1 text protocols. A gRPC tool server (in Go, Rust, or Python) translates between JSON and protobuf
+- [ ] **grpcurl pattern:** like `curl` for gRPC — the tool server wraps `grpcurl` or equivalent
+- [ ] **Reflection support:** `tool grpc-list"List gRPC services" endpoint:t>R t t` — discover available methods via gRPC reflection
+- [ ] Feature flag: none in ilo — this lives in a tool server
+- [ ] **If native eventually:** would need protobuf parsing (binary format), HTTP/2 support, and streaming. Massive scope. Gates on G5 (TCP), G6 (streams), G7 (binary data)
+
+##### G1d. Server-Sent Events / SSE (streaming responses)
+
+LLM APIs (OpenAI, Anthropic, etc.) use SSE for streaming responses. Agents calling other LLMs need this.
+
+- [ ] SSE is HTTP GET/POST with `text/event-stream` content type — server sends `data: ...\n\n` frames over a long-lived connection
+- [ ] `sse url` — open SSE connection, returns stream handle (like G6)
+- [ ] `sse-recv h` — receive next event, returns `R t t` (event data or connection error)
+- [ ] `sse-close h` — close SSE connection
+- [ ] **Or:** SSE as a special case of G6 streams — `get` with streaming flag returns a stream handle instead of the full body
+- [ ] **Use case:** agent calls OpenAI streaming API, processes tokens as they arrive, takes action before full response is complete
+- [ ] Feature flag: extend `http` feature — SSE is just HTTP with chunked transfer encoding
+- [ ] Gates on: G6 (streams) for the iteration model
+
+##### G2. WebSocket client (bidirectional communication)
+
+Required for browser automation (CDP), real-time APIs, and agent-to-agent communication. This is the big one.
+
+- [ ] `ws url` — open WebSocket connection, returns `R ws t` (connection handle or error)
+- [ ] `ws-send conn msg` — send text message, returns `R _ t`
+- [ ] `ws-recv conn` — receive next message (blocking), returns `R t t`
+- [ ] `ws-close conn` — close connection, returns `R _ t`
+- [ ] Connection handle: new `Value::Handle(u64)` — opaque reference to runtime-managed resource
+- [ ] Runtime resource table: `HashMap<u64, Box<dyn Resource>>` in interpreter/VM, handles get indices
+- [ ] Feature flag: `ws` feature, uses `tungstenite` (sync WebSocket, no tokio needed)
+- [ ] Timeout: `ws-recv conn 5` — optional timeout in seconds, returns `Err("timeout")` if exceeded
+- [ ] Binary frames: `ws-recv` returns text frames as `t`, binary frames as base64-encoded `t` (or a new `bytes` type — deferred)
+- [ ] **Design question:** blocking `ws-recv` means the program stalls waiting for messages. For CDP this is fine (request-response pattern). For event streams, may need callback/event model (deferred to G5)
+
+##### G3. Process spawning
+
+Required for launching browsers, running external tools, shell integration.
+
+- [ ] `spawn cmd args` — launch process, returns `R proc t` (process handle or error)
+- [ ] `proc-wait h` — wait for process to exit, returns `R n t` (exit code or error)
+- [ ] `proc-kill h` — kill process, returns `R _ t`
+- [ ] `proc-out h` — read stdout as text, returns `R t t`
+- [ ] Process handle: reuses `Value::Handle(u64)` from G2
+- [ ] Feature flag: `process` feature (uses `std::process`)
+- [ ] **Security:** sandboxing concern — process spawning is powerful. Consider allowlist of executables, or make it tool-provider-only (not a language builtin)
+- [ ] Environment variables: `spawn cmd args env` where `env` is `M t t` (gates on E4)
+
+##### G4. Async runtime (foundation for concurrent I/O)
+
+Current model is fully synchronous. Async unlocks parallel tool calls, non-blocking WebSocket, and multiplexed CDP communication.
+
+- [ ] Introduce `tokio` behind `async` feature flag
+- [ ] `ToolProvider` trait becomes async (already planned in D1d)
+- [ ] Async builtins: `get`, `post`, `ws-send`, `ws-recv` become non-blocking internally
+- [ ] **Language-level async:** deferred — the runtime handles async internally, ilo programs remain sequential from the agent's perspective
+- [ ] **Parallel tool calls:** `par{call1;call2;call3}` — execute tool calls concurrently, collect results. Sugar for runtime-managed parallelism
+- [ ] **Design question:** should ilo expose async to the language (promises, await) or keep it hidden in the runtime? Hidden is simpler and more constrained (manifesto: "one way to do things")
+
+##### G5. TCP/UDP sockets (raw network I/O)
+
+WebSocket and HTTP are application-level protocols. For lower-level networking — talking to databases, custom protocols, inter-process communication — ilo needs raw sockets.
+
+- [ ] `tcp-conn host port` — open TCP connection, returns `R handle t`
+- [ ] `tcp-send h data` — send text over TCP, returns `R n t` (bytes sent or error)
+- [ ] `tcp-recv h max` — receive up to `max` bytes, returns `R t t` (data or error)
+- [ ] `tcp-close h` — close connection, returns `R _ t`
+- [ ] `tcp-listen port` — bind and listen on port, returns `R handle t` (server socket)
+- [ ] `tcp-accept h` — accept incoming connection, returns `R handle t` (blocking)
+- [ ] `udp-bind port` — create UDP socket bound to port, returns `R handle t`
+- [ ] `udp-send h host port data` — send datagram, returns `R n t`
+- [ ] `udp-recv h max` — receive datagram, returns `R t t`
+- [ ] Connection handles: reuse `Value::Handle(u64)` from G2
+- [ ] Feature flag: `net` feature (uses `std::net`)
+- [ ] **Design question:** should raw sockets be language builtins or tool-provider-only? Raw sockets are powerful but dangerous. Builtins keep ilo self-contained; tool-provider-only keeps the sandbox tighter
+- [ ] **Use cases:** database drivers (Postgres wire protocol, Redis RESP), custom agent-to-agent communication, SMTP, DNS lookups
+
+##### G6. Streams and buffered I/O
+
+Current I/O model is request-response (send, then receive complete response). Streams handle continuous/chunked data — log tailing, large file transfer, SSE, streaming LLM responses.
+
+- [ ] `Value::Stream(u64)` — handle to a readable/writable stream (backed by runtime resource table)
+- [ ] `read s max` — read up to `max` bytes/chars from stream, returns `R t t` (data or error). Returns empty string `""` at EOF
+- [ ] `readln s` — read one line from stream (up to `\n`), returns `R t t`
+- [ ] `write s data` — write text to stream, returns `R n t` (bytes written or error)
+- [ ] `flush s` — flush buffered writes, returns `R _ t`
+- [ ] `close s` — close stream, returns `R _ t`
+- [ ] `eof s` — check if stream is at end, returns `b`
+- [ ] Streams wrap: TCP sockets, process stdin/stdout, file handles, WebSocket connections
+- [ ] Buffering: runtime manages read buffers internally (like `BufReader`), ilo programs don't manage buffer sizes
+- [ ] **Line-based iteration:** `@line stream{process line}` — iterate lines from a stream. Natural fit with `@` loop syntax
+- [ ] **Design question:** should streams be a distinct type or just handles that support read/write? Distinct type gives better verifier errors; handles are simpler
+
+##### G7. Buffers and binary data
+
+ilo currently has no binary data type. Everything is `n` (f64) or `t` (string). Binary data matters for: screenshots (PNG), file uploads, protocol framing, cryptographic operations.
+
+- [ ] New type: `B` (bytes / buffer) — raw byte sequence
+- [ ] `B` literals: deferred (no good syntax for binary literals in a token-minimal language)
+- [ ] `b64enc data` — bytes to base64 text, returns `t`
+- [ ] `b64dec text` — base64 text to bytes, returns `R B t`
+- [ ] `buf-new n` — allocate empty buffer of capacity `n`, returns `B`
+- [ ] `buf-len b` — length in bytes, returns `n`
+- [ ] `buf-slc b start end` — slice bytes, returns `B`
+- [ ] `buf-cat a b` — concatenate buffers, returns `B`
+- [ ] `to-buf t` — encode text as UTF-8 bytes, returns `B`
+- [ ] `to-txt b` — decode UTF-8 bytes as text, returns `R t t` (fails if invalid UTF-8)
+- [ ] Integration with streams: `read`/`write` work on `B` as well as `t`
+- [ ] Integration with WebSocket: binary frames return `B` instead of `t`
+- [ ] Integration with `shot` (screenshot): CDP returns base64 PNG — `b64dec` → `B` → file write
+- [ ] Feature flag: no feature flag needed — core type like `L` and `R`
+- [ ] **Design question:** is `B` worth the complexity? Alternative: everything stays as base64 `t`, tools handle encoding. Simpler but wastes memory (base64 is 33% larger)
+
+##### G8. File I/O
+
+ilo has no file system access. Agents need to read configs, write outputs, save screenshots.
+
+- [ ] `fread path` — read entire file as text, returns `R t t`
+- [ ] `fwrite path data` — write text to file (overwrite), returns `R _ t`
+- [ ] `fappend path data` — append text to file, returns `R _ t`
+- [ ] `fexists path` — check if file exists, returns `b`
+- [ ] `freadbin path` — read file as bytes, returns `R B t` (gates on G7 buffers)
+- [ ] `fwritebin path data` — write bytes to file, returns `R _ t` (gates on G7)
+- [ ] Feature flag: `fs` feature (uses `std::fs`)
+- [ ] **Security:** file system access is a sandbox escape. Options:
+  - Allowlist of directories (e.g. only `/tmp` and working directory)
+  - Read-only by default, write requires `--allow-write` flag
+  - Tool-provider-only (no builtins, file I/O via declared tools)
+- [ ] **Design question:** builtins vs tools? File I/O as builtins keeps ilo self-contained for scripting. As tools, it's more constrained but requires tool provider setup for basic file operations
+
+##### G9. Event/callback model (deferred — needs design)
+
+For WebSocket event streams, browser events, server-sent events. Currently out of scope but noting the design space.
+
+- [ ] Event loop concept: `on conn "event-name" {handler body}`
+- [ ] Or pull-based: `poll conns timeout` — wait on multiple connections, return first message
+- [ ] Or channel-based: `ch=chan();spawn-listener conn ch;msg=recv ch`
+- [ ] **Recommendation:** defer until a concrete use case forces the design. CDP's request-response pattern works with blocking `ws-recv`
+
+##### G10. Resource handles — unified design (foundation for G2-G8)
+
+G2-G8 all introduce "handles" — opaque references to runtime-managed resources (sockets, processes, files, streams). This needs a unified design.
+
+- [ ] `Value::Handle(u64)` — single opaque type for all external resources
+- [ ] Runtime resource table: `HashMap<u64, Box<dyn Resource>>` — indexed by handle ID
+- [ ] `Resource` trait: `close()`, `type_name()` — common interface for cleanup
+- [ ] Auto-cleanup: resources closed when handle goes out of scope (or program exits)
+- [ ] Verifier: handle types are opaque — can't do arithmetic on them, can only pass to handle-accepting builtins
+- [ ] **Typed handles vs untyped:** `ws` vs `tcp` vs `file` — should the verifier distinguish handle types? Typed catches "passing a file handle to ws-send" at verify time. Untyped is simpler
+- [ ] **Type syntax if typed:** `H ws`, `H tcp`, `H file` — or just `ws`, `tcp`, `file` as named types
+
+#### Browser automation — Phase H (Playwright-for-ilo)
+
+See [research/playwright-for-ilo.md](research/playwright-for-ilo.md) for full design exploration.
+
+Two approaches: **tool-server wrapper** (practical, near-term) vs **native CDP client** (ambitious, needs G2+G3+G4).
+
+##### H1. Playwright tool server (recommended first step)
+
+Wrap Playwright (Node.js) as an external tool server. ilo calls it via HTTP or stdio. Gets browser automation without any new language primitives.
+
+- [ ] Tool server: Node.js process running Playwright, exposing actions as HTTP endpoints or stdio JSON-RPC
+- [ ] Tool declarations in ilo:
+  ```
+  tool nav"Navigate to URL" url:t>R _ t timeout:30
+  tool click"Click element" sel:t>R _ t timeout:10
+  tool fill"Fill input" sel:t val:t>R _ t timeout:10
+  tool txt"Get text content" sel:t>R t t timeout:5
+  tool shot"Screenshot" path:t>R t t timeout:10
+  tool eval"Evaluate JS" code:t>R t t timeout:10
+  ```
+- [ ] Session management: tool server maintains browser state between calls
+- [ ] Gates on D1d (ToolProvider infrastructure)
+
+##### H2. Native CDP client (ambitious — needs G2, G3, G4)
+
+Direct Chrome DevTools Protocol communication from ilo. No Node.js dependency.
+
+- [ ] Launch Chromium with `--remote-debugging-port` via G3 process spawning
+- [ ] Connect via WebSocket (G2) to CDP endpoint
+- [ ] CDP message protocol: JSON request/response over WebSocket
+- [ ] Subset of CDP domains: Page, Runtime, DOM, Network, Input
+- [ ] **Massive scope** — CDP has dozens of domains with hundreds of methods. Start with ~10 essential operations
+- [ ] Gates on: G2 (WebSocket), G3 (process spawn), G4 (async for multiplexed CDP), E4 (maps for JSON)
+
+#### Agent essentials — Phase I (what agents actually need daily)
+
+Gap analysis: what do real AI agents do that ilo can't express today? Ordered by how often agents hit the wall without it.
+
+##### I1. JSON parsing (critical — agents live in JSON)
+
+Agents call APIs. APIs return JSON. ilo can fetch JSON (`get url`) but can't do anything with the response except pass it as raw text. This is the #1 gap.
+
+- [ ] `jp text key` — JSON path lookup, returns `R t t`. `jp body "name"` extracts `$.name` as text
+- [ ] `jp text key` on nested paths: `jp body "address.city"` or `jp body "items.0.name"`
+- [ ] `jparse text` — parse JSON text into ilo values (records, lists, numbers, text, bool, nil), returns `R <value> t`
+- [ ] `jdump value` — serialise ilo value to JSON text, returns `t`
+- [ ] **Minimal approach:** `jp` alone covers 80% of cases. Agent gets JSON string from API, picks out fields with `jp`, done. No full parse needed
+- [ ] **Design tension:** manifesto says "format parsing is a tool concern." But JSON is so fundamental to agent work that not having it is like a shell without `grep`. Consider making `jp` a builtin exception, or accept that every agent needs a `json-extract` tool
+- [ ] Feature flag: `json` feature (uses `serde_json` — already a dependency)
+- [ ] **Integration with records:** `jparse text "profile"` could map JSON to a declared record type, verified at parse time — combines D1e (Value ↔ JSON) with a language builtin
+- [ ] **Token comparison:**
+  ```
+  # Python: ~12 tokens
+  data = json.loads(response.text)
+  name = data["user"]["name"]
+
+  # ilo with jp: ~4 tokens
+  n=jp! body "user.name"
+
+  # ilo without (current): impossible without tool
+  ```
+
+##### I2. Shell/command execution (critical — agents shell out constantly)
+
+G3 covers low-level process spawning with handles. But agents need a simple "run this command, give me the output" — like backticks in Perl/Ruby/shell or `subprocess.run` in Python.
+
+**Two forms:** `run` (builtin, verbose) and `` ` `` (backtick syntax, terse). Same relationship as `get url` and `$url`.
+
+- [ ] `run cmd` — run system command, wait for completion, returns `R t t` (stdout or error). Stderr captured in error
+- [ ] `run!` — auto-unwrap variant: `o=run! "ls -la"`
+- [ ] `` `cmd` `` — terse alias for `run "cmd"`. Backtick-delimited string is executed as a shell command, returns `R t t`
+- [ ] `` `!cmd` `` — terse auto-unwrap: `` o=`!ls -la` `` (or `o=run! "ls -la"`)
+- [ ] Exit code: `run` returns `Err` if non-zero exit. Ok body is stdout text
+- [ ] **vs G3 spawn:** `run` is the simple one-shot version. `spawn` is for long-running processes you interact with. `run "ls"` vs `h=spawn "node" "server.js"`
+- [ ] **Cross-platform shell selection:**
+  - macOS/Linux: `/bin/sh -c "..."`
+  - Windows: `cmd.exe /C "..."` (or `powershell -Command "..."` — configurable)
+  - Agent writes `run "git status"` — works everywhere. Platform-specific commands (`ls` vs `dir`) are the agent's problem, not the language's
+- [ ] Feature flag: `shell` feature (uses `std::process::Command`)
+- [ ] **Security:** same concerns as G3. `--allow-shell` flag? Or sandbox to specific commands?
+- [ ] **Lexer changes for backticks:**
+  - New token: `Token::Backtick(String)` — contents between `` ` `` delimiters
+  - Escape: `` \` `` inside backticks for literal backtick (rare)
+  - Parser: desugar `` `cmd` `` to `Call("run", [StringLit("cmd")])` — same AST as `run "cmd"`
+  - `!` position: `` `!cmd` `` — `!` immediately after opening backtick, consistent with `$!url` pattern
+- [ ] **Precedent in ilo:** `$url` is terse alias for `get url`. `` `cmd` `` is terse alias for `run "cmd"`. Both are sigil-based shortcuts for common operations. Pattern: frequent operations get single-character syntax
+- [ ] **Token comparison:**
+  ```
+  # Python: ~8 tokens
+  result = subprocess.run(["ls", "-la"], capture_output=True, text=True)
+  output = result.stdout
+
+  # ilo with run: ~3 tokens
+  o=run! "ls -la"
+
+  # ilo with backticks: ~2 tokens
+  o=`ls -la`
+
+  # terse auto-unwrap: ~2 tokens
+  o=`!ls -la`
+  ```
+
+##### I3. Environment variables (critical — every agent needs config)
+
+API keys, base URLs, secrets, feature flags. Every agent program needs to read env vars. Currently impossible in ilo.
+
+- [ ] `env key` — read environment variable, returns `R t t` (value or "not set")
+- [ ] `env! key` — auto-unwrap: `k=env! "API_KEY"`
+- [ ] **No env-set:** writing env vars is rarely needed and creates side effects. Read-only
+- [ ] Feature flag: none needed — `std::env::var` is stdlib
+- [ ] **Token comparison:**
+  ```
+  # Python: ~4 tokens
+  key = os.environ["API_KEY"]
+
+  # ilo: ~2 tokens
+  k=env! "API_KEY"
+  ```
+
+##### I4. String interpolation / templating
+
+Building URLs, prompts, messages. Currently requires chains of `+` which is verbose and error-prone:
+`+++++"Hello " name ", your order " oid " is " status` — 11 tokens for a simple template.
+
+- [ ] **Option A:** Template syntax in strings: `fmt "Hello {name}, order {oid} is {status}"` — clear but needs lexer changes for `{}`-in-strings
+- [ ] **Option B:** Printf-style: `fmt "Hello %s, order %s is %s" name oid status` — no lexer changes, variadic
+- [ ] **Option C:** Stay with `+` — it works, agents generate it fine, and it's already 10/10 accuracy. Token cost is the tradeoff
+- [ ] **Recommendation:** `fmt` builtin with positional `%s` placeholders. No lexer changes, composes with existing types, `str` handles number→text conversion
+- [ ] `fmt pattern args...` — returns `t`. `%s` substitutes args in order. Type-aware: numbers auto-convert via `str`
+- [ ] **Token comparison:**
+  ```
+  # Current ilo: 11 tokens
+  +++++"Hello " name ", order " oid " is " status
+
+  # With fmt: 5 tokens
+  fmt "Hello %s, order %s is %s" name oid status
+  ```
+
+##### I5. Logging / debug output
+
+Agents need observability — what did it do, what's the current state, where did it fail. Currently ilo has no way to print debug output without it being the return value.
+
+- [ ] `log msg` — write to stderr, returns `_` (nil). Does NOT affect return value or program flow
+- [ ] `log` accepts any type — auto-converts via `str` for numbers, `jdump` for records/lists
+- [ ] Log levels: `log msg` (info), `logw msg` (warn), `loge msg` (error), `logd msg` (debug)
+- [ ] Or simpler: just `log msg` and `dbg expr` (debug-print with expression name + value, like Rust's `dbg!`)
+- [ ] `dbg x` — prints `x = <value>` to stderr, returns the value unchanged (transparent — can insert anywhere in a pipeline)
+- [ ] Feature flag: none — stderr is always available
+- [ ] **Design question:** does logging violate the "pure function" feel? No — it's a side effect on stderr, doesn't affect computation. Same as Haskell's `trace`
+
+##### I6. Time and timestamps
+
+Rate limiting, timeouts, cache expiry, audit logs, scheduling. Agents work in time.
+
+- [ ] `now()` — current Unix timestamp as `n` (seconds since epoch, float for sub-second precision)
+- [ ] `sleep n` — pause execution for `n` seconds, returns `_`. For rate limiting, polling loops
+- [ ] `fmt-time n pattern` — format timestamp as text. Deferred — complex, may be a tool concern
+- [ ] **Design question:** `sleep` is a side effect that breaks pure execution. But agents need rate limiting. Alternative: runtime-level rate limiting on tool calls (automatic backoff in ToolProvider)
+
+##### I7. Encoding/decoding (URL, HTML, base64)
+
+Agents build URLs with parameters, handle HTML content, pass binary data.
+
+- [ ] `urlencode t` — percent-encode text for URL parameters, returns `t`
+- [ ] `urldecode t` — decode percent-encoded text, returns `R t t`
+- [ ] `b64enc t` — encode text as base64, returns `t` (overlaps with G7 but works on text directly)
+- [ ] `b64dec t` — decode base64 to text, returns `R t t`
+- [ ] `htmlesc t` — escape HTML entities (`<>&"'`), returns `t`
+- [ ] `htmlunesc t` — unescape HTML entities, returns `R t t`
+- [ ] **Minimal set:** `urlencode` + `b64enc` + `b64dec` cover 90% of agent encoding needs
+- [ ] Feature flag: none — pure string transformations, no deps
+
+##### I8. Regex / pattern matching on text
+
+Extracting structured data from unstructured text — log parsing, HTML scraping, validation.
+
+- [ ] `match text pattern` — first regex match, returns `R t t` (matched text or no-match error)
+- [ ] `matchall text pattern` — all matches, returns `L t`
+- [ ] `sub text pattern replacement` — regex substitution, returns `t`
+- [ ] `suball text pattern replacement` — global substitution, returns `t`
+- [ ] Capture groups: `match text "(\d+)-(\w+)"` → access groups via `.0`, `.1` on result? Or return list of captures?
+- [ ] Feature flag: `regex` feature (uses `regex` crate)
+- [ ] **Design question:** regex is powerful but complex. Alternative: keep text processing as tool concern (a `regex` tool). But like JSON, it's so fundamental that agents hit the wall without it
+- [ ] **Simpler alternative:** just `has` (already exists) + `spl` (exists) + `slc` (exists) cover basic cases. Regex for the hard stuff
+
+##### I9. Hashing and checksums
+
+Content deduplication, cache keys, API signature verification, integrity checks.
+
+- [ ] `hash t` — SHA-256 hash of text, returns `t` (hex string). Single default algorithm
+- [ ] `hmac key msg` — HMAC-SHA256, returns `t`. For API authentication (AWS, Stripe, etc.)
+- [ ] Feature flag: `crypto` feature (uses `sha2` + `hmac` crates, or ring)
+- [ ] **Scope limit:** hashing only, not encryption. Encryption is a tool concern
+- [ ] **Use case:** many APIs require HMAC signatures: `sig=hmac secret (+method +path +timestamp)`
+
+##### I10. Standard output and program I/O
+
+Currently the only output is the return value of the main function. Agents need to write structured output, stream progress, and read input.
+
+- [ ] `print val` — write value to stdout followed by newline, returns `_`
+- [ ] `eprint val` — write to stderr (alias for `log`)
+- [ ] `input prompt` — read line from stdin, returns `R t t`. For interactive mode
+- [ ] **vs return value:** `print` is for streaming output during execution. Return value is the final result. Both matter for agent integration
+- [ ] **Design question:** does `print` conflict with ilo's "return value is the output" model? In agent mode (D4 `ilo serve`), stdout is the protocol channel. `print` would need to go to stderr or a separate channel
+
+##### I11. Sleep / delay / retry helpers
+
+Agents need to wait between API calls (rate limiting), retry on failure, and implement backoff.
+
+- [ ] `sleep n` — pause `n` seconds (also mentioned in I6)
+- [ ] `retry n f args` — call function `f` up to `n` times with exponential backoff, returns first `~` result or last `^` error
+- [ ] **Or:** retry as a pattern, not a builtin. `wh` loop + `sleep` + counter already works:
+  ```
+  poll url:t n:n>R t t;<=n 0{^"timeout"};r=get url;?r{~v:~v;^e:sleep 1;poll url -n 1}
+  ```
+- [ ] **Recommendation:** `sleep` as builtin, retry as a pattern. Keeps builtins minimal
 
 #### Codegen targets
 - JavaScript / TypeScript emit — like Python codegen but for JS ecosystem

--- a/research/BUILDING-A-LANGUAGE.md
+++ b/research/BUILDING-A-LANGUAGE.md
@@ -88,20 +88,23 @@ This is the key question. ilo has a unique position: it's a language for AI agen
 
 ### The Answer: Both (in phases)
 
-**Phase 1: Verifier + Transpiler (interpreted via host)**
-- The verifier is ilo's differentiator — build this first
-- Transpile to Python for immediate execution
-- Agent writes ilo → verifier checks it → transpiler emits Python → Python runs it
-- Fastest path to "I can run programs"
+**Phase 1: Verifier** — *completed*
+- The verifier is ilo's differentiator — built first
+- Originally planned to transpile to Python, but skipped directly to the bytecode VM
 
-**Phase 2: Bytecode VM (compiled to bytecode)**
-- Replace transpiler with a proper runtime
-- Custom bytecode VM gives full control over execution model
-- This matters for tool orchestration, typed-shell semantics
-- Lua's approach: small, embeddable, fast enough
+**Phase 2: Bytecode VM (compiled to bytecode)** — *completed*
+- Register-based bytecode VM with custom opcodes
+- Full control over execution model, tool orchestration, typed-shell semantics
+- See `research/jit-backends.md` for benchmark results (66ns/call interpreted)
 
-**Phase 3: Optional native compilation**
-- LLVM backend if performance matters
+**Phase 3: JIT compilation** — *in progress*
+- Cranelift JIT backend: 2ns/call for numeric functions
+- Custom ARM64 JIT backend: 2ns/call
+- Within 2x of LuaJIT (1ns) for pure-numeric workloads
+- See `research/jit-backends.md` for full benchmark comparison
+
+**Phase 4: Optional native compilation** — *future*
+- LLVM backend if performance matters beyond JIT
 - WASM target for portability
 - Only if the use case demands it
 
@@ -122,19 +125,22 @@ In ilo's model:
 
 The verifier is the product. The runtime is an implementation detail.
 
-## Recommended Path for ilo
+## Path Taken
 
-### Step 1: Lexer + Parser (~500-1000 lines)
-Hand-written recursive descent + Pratt parser. ilo's grammar is small and sigil-based — this is straightforward. Implementation language: Rust (long-term performance, strong ecosystem for language tooling) or TypeScript (faster prototyping). [createlang.rs](https://createlang.rs/) covers building a full compiler in Rust from lexer through LLVM JIT — useful reference for the Rust path.
+### Step 1: Lexer + Parser — *done*
+Hand-written recursive descent + Pratt parser in Rust. ilo's grammar is small and sigil-based. [createlang.rs](https://createlang.rs/) was a useful reference for the Rust path.
 
-### Step 2: Verifier
-Walk the AST. Check: all calls resolve to known functions, all types align, all dependencies exist. Return structured errors. This is ilo's core innovation.
+### Step 2: Verifier — *done*
+Walks the AST. Checks: all calls resolve to known functions, all types align, all dependencies exist. Returns structured errors. This is ilo's core innovation.
 
-### Step 3: Transpiler to Python
-Walk the AST, emit Python. Get execution working in days. This is throwaway code.
+### Step 3: Register VM — *done*
+Bytecode VM with register-based architecture. Skipped the transpiler-to-Python phase entirely.
 
-### Step 4: Ship and Learn
-Get agents writing and running ilo programs. Learn from real usage. Then decide if you need a bytecode VM, LLVM backend, or if the transpiler is good enough.
+### Step 4: JIT backends — *in progress*
+Cranelift and custom ARM64 backends. See `research/jit-backends.md` for benchmarks.
+
+### Step 5: Ship and Learn
+Get agents writing and running ilo programs. Learn from real usage.
 
 ## Key Resources
 

--- a/research/CONTROL-FLOW.md
+++ b/research/CONTROL-FLOW.md
@@ -20,6 +20,11 @@ Evaluated against the manifesto: **total tokens from intent to working code**. A
 | `func! args` | 1 sigil | Call + auto-unwrap Result |
 | `&a b` | 1 sigil | Short-circuit AND |
 | `\|a b` | 1 sigil | Short-circuit OR |
+| `cond{then}{else}` | 1 sigil | Ternary: value without early return |
+| `wh cond{body}` | 1 keyword | While loop |
+| `ret expr` | 1 keyword | Early return from function |
+| `brk` / `brk expr` | 1 keyword | Exit enclosing loop |
+| `cnt` | 1 keyword | Skip to next loop iteration |
 
 This is already terse. The question is: what common patterns still cost too many tokens?
 
@@ -317,22 +322,22 @@ Token savings: no variable names — values flow through the stack. Combinators 
 
 ## Synthesis: what ilo should add
 
-Ranked by **token savings × frequency of use**:
+Ranked by **token savings × frequency of use**. Features marked *done* are now in the language (see "What ilo has today" table above).
 
-| Priority | Feature | Token savings | Frequency | Source |
+| Priority | Feature | Token savings | Frequency | Status |
 |----------|---------|---------------|-----------|--------|
-| **1** | Ternary expression | 3-5 per use | Very high | Bash, Perl, Ruby, C |
-| **2** | Nil-coalescing `??` | 5-7 per use | High (tool results) | Perl `//`, Ruby `\|\|`, Kotlin `?:` |
-| **3** | Safe navigation `.?` | 5-10 per chain | High (nested records) | Ruby `&.`, Kotlin `?.`, TS `?.` |
-| **4** | Pipe operator | 2-3 per step | Medium | Elixir `\|>`, Bash `\|`, F# |
-| **5** | Early return | 2-4 per use | Medium | Rust, most languages |
-| **6** | While loop | N/A (new capability) | Low-medium | Perl, Ruby, Bash |
-| **7** | Destructuring bind | 2-3 per record | Medium | Rust, JS, Elixir |
-| **8** | Range iteration | 3-5 per range loop | Medium | Ruby `0..n`, Python `range()` |
-| **9** | Break/continue | 2-3 per use | Low | Most languages |
-| **10** | Reduce operator | 5-7 per use | Medium | APL `/`, K, Haskell `fold` |
-| **11** | Guard else | 1-2 per use | Low | Haskell, Elixir |
-| **12** | Type pattern match | N/A (new capability) | Low | Haskell, Scala |
+| **1** | Ternary expression | 3-5 per use | Very high | *done* — `cond{then}{else}` |
+| **2** | Nil-coalescing `??` | 5-7 per use | High (tool results) | *done* |
+| **3** | Safe navigation `.?` | 5-10 per chain | High (nested records) | *done* |
+| **4** | Pipe operator `>>` | 2-3 per step | Medium | *done* |
+| **5** | Early return | 2-4 per use | Medium | *done* — `ret expr` |
+| **6** | While loop | N/A (new capability) | Low-medium | *done* — `wh cond{body}` |
+| **7** | Destructuring bind | 2-3 per record | Medium | open |
+| **8** | Range iteration | 3-5 per range loop | Medium | open |
+| **9** | Break/continue | 2-3 per use | Low | *done* — `brk` / `cnt` |
+| **10** | Reduce operator | 5-7 per use | Medium | open (gates on generics) |
+| **11** | Guard else | 1-2 per use | Low | *done* — `cond{then}{else}` covers this |
+| **12** | Type pattern match | N/A (new capability) | Low | open |
 
 ---
 

--- a/research/OPEN.md
+++ b/research/OPEN.md
@@ -124,6 +124,38 @@ When the shape is unknown or too complex, the tool declares `>t` and the agent g
 
 No new types needed: `_` handles null, `t` is the escape hatch for untyped data, records handle known shapes, `R ok err` handles fallible tools.
 
+## The "Essential Packages" Principle
+
+Every mainstream language has packages so universally installed they're effectively part of the language: Python's `requests`, Node's `lodash`/`express`, Ruby's `rails`/`nokogiri`, Go's `gorilla/mux`, Rust's `serde`/`tokio`. .NET absorbed `Newtonsoft.Json` into `System.Text.Json` after years of universal dependency.
+
+The gap between what language designers thought was core and what developers actually install reveals what the language got wrong — or more charitably, what real-world usage demanded that the designers didn't anticipate.
+
+**This matters for ilo because agents cannot install packages.** There is no `pip install` or `npm install`. Whatever an ilo program needs must be either a builtin or a declared tool. The "essential packages" of other languages tell us exactly what builtins ilo needs from day one.
+
+Cross-language patterns that emerge:
+
+| Capability | Python | JS/TS | Rust | Go | Ruby |
+|-----------|--------|-------|------|-----|------|
+| HTTP client | `requests` | `axios` | `reqwest` | stdlib | `httparty`/`faraday` |
+| Data validation | `pydantic` | `zod` | `serde` | struct tags | Rails validators |
+| Env vars from file | `python-dotenv` | `dotenv` | `dotenvy` | `godotenv` | `dotenv` |
+| Date/time | stdlib (bad) | `dayjs`/`date-fns` | `chrono` | stdlib | `activesupport` |
+| UUID generation | `uuid` | `uuid` | `uuid` | `google/uuid` | `securerandom` |
+| CLI parsing | `click`/`typer` | `commander` | `clap` | `cobra` | `optparse` |
+| Structured logging | `structlog` | `pino`/`winston` | `tracing` | `zap`/`zerolog` | `logger` |
+| Testing | `pytest` | `jest`/`vitest` | built-in | `testify` | `rspec` |
+
+**Key observations:**
+- **HTTP client** is universally needed and universally underserved by stdlibs. ilo already has `get`/`$`; `post` is the obvious next builtin.
+- **Env loading** (`dotenv`) exists in every ecosystem — proof that env var access is a core agent need, not a niche feature.
+- **Data validation** (`pydantic`/`zod`/`serde`) is the most-installed category across languages. ilo's type system + tool declarations + verifier already serve this role — the type declaration IS the validation schema.
+- **CLI parsing** is a human concern — agents don't need `--help` text or subcommands. ilo's positional function params already handle this.
+- **Testing** is a human workflow concern. Agents don't write test suites; they generate correct programs verified before execution.
+
+**The design heuristic:** if a capability requires a near-universal third-party package in 3+ mainstream languages, it belongs in ilo's builtin set (or as a declared tool with a standard name). If it's universal but human-facing (CLI parsing, testing, formatting), it doesn't.
+
+See `research/essential-packages-analysis.md` for the full cross-language analysis.
+
 ## Syntax Questions (Resolved by Experiments)
 
 These were open questions that the syntax experiments have now answered:
@@ -145,8 +177,32 @@ Could the runtime accept multiple syntax levels — dense wire format for LLM ge
 
 ### Match exhaustiveness
 
-Should the verifier require all patterns to be covered? The experiments don't test this since there's no verifier yet.
+Should the verifier require all patterns to be covered? The verifier exists but exhaustiveness checking is not yet implemented.
 
 ### Compensation patterns
 
 The workflow examples show inline compensation (`charge pid amt;?{^e:release rid;^+"Payment failed"...}`). Should compensation be a first-class concept, or is inline error handling sufficient?
+
+### Builtin naming: competing proposals across research files
+
+Research files propose different names for the same operations. These need a single decision per capability. The table below shows proposals and emerging consensus:
+
+| Capability | Proposals | Source files | Emerging consensus |
+|-----------|-----------|-------------|-------------------|
+| File read | `fread`, `rd`, `read` | Go/Rust/Lua-Elixir, Python/Universal-gaps, JS-TS | `fread` (3 files) |
+| File write | `fwrite`, `wr`, `write` | Go/Rust/Lua-Elixir, Python/Universal-gaps, JS-TS | `fwrite` (3 files) |
+| Regex match | `rgx`, `rx`, `mtc`, `matchall` | Python/Essential/Universal-gaps, Ruby-PHP, JS-TS, Go | `rgx` (3 files) |
+| Regex all | `rga`, — | Python/Essential/Universal-gaps | `rga` (3 files) |
+| Regex sub | `rgs`, `rxr`, `rep`, `sub` | Python/Essential/Universal-gaps, Ruby-PHP, Rust, Go | `rgs` (3 files) |
+| String replace | `rpl`, `sub`, `rep` | Python/Essential/Universal-gaps, Go, Rust | `rpl` (3 files) |
+| JSON parse | `jsn`, `jp`, `jparse` | Python/Universal-gaps, Essential, Go | `jsn` (2 files) |
+| JSON dump | `ser`, `jdump` | Python/Universal-gaps, Go | `ser` (2 files) |
+| Hash | `sha`, `hash` | Python/Essential, Go | undecided |
+| HMAC | `hmac` | Python/Essential, Go | `hmac` (consensus) |
+| Sleep | `slp`, `sleep` | Python/Universal-gaps, Go | `slp` (2 files) |
+
+### File I/O: builtin vs tool
+
+Early research files (ruby-php-research, swift-kotlin-research) say "file I/O is a tool concern, not a language concern." Later files (go-stdlib, rust-capabilities, python-stdlib, essential-packages) propose file I/O builtins (`fread`/`fwrite` or `rd`/`wr`). This represents an evolving position: as the design matured, file I/O moved from "tool" to "builtin." The earlier files have not been updated to reflect this shift.
+
+The OPEN.md principle "format parsing is a tool concern" applies to format parsing (JSON, XML, HTML), not to raw file read/write. File I/O as a builtin is consistent with the principle — the builtin reads/writes bytes or text, while format-specific parsing remains a tool concern.

--- a/research/comment-syntax.md
+++ b/research/comment-syntax.md
@@ -1,0 +1,97 @@
+# Comment Syntax Exploration
+
+Current syntax: `--` to end of line. Should we change it?
+
+## Current: `--` (double dash)
+
+```
++a b -- add a and b
+```
+
+**Pros:**
+- SQL-style, familiar to many
+- 1 LLM token to generate
+- Stripped at lexer level (logos skip rule), zero runtime cost
+
+**Cons:**
+- Ambiguous with nested subtraction. `--x 1` is a comment, not "negate (x minus 1)". Must write `- -x 1` or `r=-x 1;-r`
+- This is a silent footgun — the lexer eats the rest of the line with no error
+
+## Option A: `#` (hash)
+
+```
++a b # add a and b
+```
+
+**Pros:**
+- 1 LLM token, 1 character (saves 1 char vs `--`)
+- No operator ambiguity — `#` isn't used as an operator
+- Familiar from Python, Ruby, shell, YAML, TOML
+
+**Cons:**
+- Heavily overloaded symbol: markdown headers, CSS selectors, hex colors, C preprocessor
+- ilo code inside markdown would need escaping or fencing
+- Could conflict if `#` is ever wanted for another purpose (e.g., map literals, tagged values)
+
+## Option B: `//` (double slash)
+
+```
++a b // add a and b
+```
+
+**Pros:**
+- C/Java/JS/Rust-style, very widely known
+- No operator ambiguity — `/` is division, but `//` can be lexed greedily as comment
+- 1 LLM token
+
+**Cons:**
+- Same greedy-lexer trick as `--`: `//x 1` would be a comment, not "divide divide x 1". But `//x 1` is unlikely to be intentional code anyway.
+- Could conflict if `//` is ever wanted for integer division (Python uses `//`)
+- 2 characters like `--`
+
+## Option C: `/* */` (C-style block comments)
+
+```
++a b /* add a and b */
+/* multi-line
+   comment */
+```
+
+**Pros:**
+- Enables multi-line comments
+- Very widely known
+- No line-scoped ambiguity
+
+**Cons:**
+- Missing `*/` silently eats the rest of the file — much worse than `--` eating one line
+- `/*` looks like `/` then `*` (divide then multiply) — real parsing ambiguity in prefix notation
+- More tokens to generate (at least 2: `/*` and `*/`)
+- Nesting `/* /* */ */` is a classic footgun (does inner `*/` close outer?)
+
+## Option D: Keep `--` but add `#` as single-line alternative
+
+Support both. `--` for backward compat, `#` as the shorter form.
+
+**Cons:**
+- Two ways to do the same thing — violates "one way to do things" principle
+- More lexer rules
+
+## The `--` ambiguity in practice
+
+How likely is `--x 1` in real ilo code? In prefix notation, nested operators are common:
+
+```
++*a b c     -- (a * b) + c       ✓ fine
+-*a b *c d  -- (a * b) - (c * d) ✓ fine
+--a b       -- COMMENT, not -(a - b)  ✗ gotcha
+```
+
+The pattern `-<op>` is fine for any operator except `-` itself. So the ambiguity only hits one specific case: negating a subtraction. Workarounds exist (`- -a b` or bind-first), but it's still surprising.
+
+## Recommendation
+
+`--` is good enough. The ambiguity is narrow (only `-` after `-`), the workarounds are simple, and changing comment syntax at this point would churn every example in the SPEC, README, and research docs.
+
+If the ambiguity proves painful in practice, `#` is the cleanest replacement — no operator conflicts, saves a character, widely understood.
+
+Multi-line comments (`/* */`) are not recommended due to the parsing ambiguity with `/*` in prefix notation and the unclosed-comment footgun.

--- a/research/error-messages-research.md
+++ b/research/error-messages-research.md
@@ -1028,3 +1028,10 @@ Given ilo's density, a single function might have 3-5 errors. Reporting all of t
 - [Error Detection and Recovery in Compilers (GeeksforGeeks)](https://www.geeksforgeeks.org/error-detection-recovery-compiler/)
 - [ANSI Escape Codes (Wikipedia)](https://en.wikipedia.org/wiki/ANSI_escape_code)
 - [GCC Diagnostic Message Formatting Options](https://gcc.gnu.org/onlinedocs/gcc/Diagnostic-Message-Formatting-Options.html)
+
+---
+
+## See Also
+
+- [rust-capabilities-research.md](rust-capabilities-research.md) — discusses ILO-T024 exhaustiveness checking and ilo's error code system
+- [CONTROL-FLOW.md](CONTROL-FLOW.md) — braceless guard section includes error hint design for ambiguous parses

--- a/research/jit-backends.md
+++ b/research/jit-backends.md
@@ -1,6 +1,6 @@
 # JIT Compilation: From 67ns to 2ns
 
-The ilo register VM runs `tot` at ~67ns/call. LuaJIT does ~1ns, V8 does ~16ns. The remaining gap is dispatch overhead — even with type-specialized opcodes, each instruction still pays for a u32 decode + match branch. JIT compilation eliminates dispatch entirely by emitting native machine code.
+The ilo register VM runs `tot` at ~67ns/call. LuaJIT does ~1ns, V8 does ~18ns. The remaining gap is dispatch overhead — even with type-specialized opcodes, each instruction still pays for a u32 decode + match branch. JIT compilation eliminates dispatch entirely by emitting native machine code.
 
 We built three JIT backends to compare approaches.
 
@@ -120,7 +120,7 @@ All measurements on Apple M4 Pro, `cargo build --release --features cranelift`, 
 
 Total speedup from interpreter to JIT: **~690x**.
 
-The Custom JIT (arm64) and Cranelift backends produce essentially identical performance for this function — both emit the same 4 floating-point instructions. ilo's JIT backends match Go and LuaJIT at ~2ns. Only C and Rust AOT beat them (0.4-0.5ns), where the compiler can eliminate the function call entirely.
+The Custom JIT (arm64) and Cranelift backends produce essentially identical performance for this function — both emit the same 4 floating-point instructions. ilo's JIT backends match Go at ~2ns and are within 2x of LuaJIT (~1ns). Only C and Rust AOT beat them (0.4-0.5ns), where the compiler can eliminate the function call entirely.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
Extracted from #63 (the sprawling exploration branch).

- **TODO.md**: Phase G (networking), Phase H (browser automation), Phase I (agent essentials), formatter flags, comment syntax items
- **MANIFESTO.md**: fix `@` sigil description, update formatter flag names, qualify "no English keywords"
- **SPEC.md**: document comment syntax, nested subtraction gotcha, "newlines are for humans"
- **README.md**: update formatter flag docs
- **Existing research docs**: fix stale references in BUILDING-A-LANGUAGE, CONTROL-FLOW, OPEN, jit-backends, error-messages
- **New**: `research/comment-syntax.md` exploration

## Test plan
- [x] No code changes — docs only