### PR TITLE
docs: add 15 research docs from language exploration

### DIFF
--- a/research/agent-framework-tool-mechanics.md
+++ b/research/agent-framework-tool-mechanics.md
@@ -1,0 +1,1318 @@
+# Agent Framework Tool-Calling Mechanics: A Comparative Analysis
+
+Research for ilo-lang — understanding universal patterns across all major agent
+frameworks to identify what a token-minimal agent language must support.
+
+---
+
+## Table of Contents
+
+1. [Anthropic Claude (Messages API + Agent SDK)](#1-anthropic-claude)
+2. [OpenAI (Responses API + Agents SDK)](#2-openai)
+3. [MCP (Model Context Protocol)](#3-mcp-model-context-protocol)
+4. [LangChain / LangGraph](#4-langchain--langgraph)
+5. [CrewAI](#5-crewai)
+6. [AutoGen (Microsoft)](#6-autogen-microsoft)
+7. [Vercel AI SDK](#7-vercel-ai-sdk)
+8. [Google A2A Protocol](#8-google-a2a-protocol)
+9. [Universal Patterns](#9-universal-patterns)
+10. [Implications for ilo-lang](#10-implications-for-ilo-lang)
+
+---
+
+## 1. Anthropic Claude
+
+### Tool Definition (Messages API)
+
+Tools are defined per-request via a `tools` array. Each tool uses JSON Schema for
+its `input_schema`:
+
+```json
+{
+  "model": "claude-opus-4-6",
+  "max_tokens": 1024,
+  "tools": [
+    {
+      "name": "get_weather",
+      "description": "Get current weather in a given location",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "location": {
+            "type": "string",
+            "description": "City and state, e.g. San Francisco, CA"
+          }
+        },
+        "required": ["location"]
+      }
+    }
+  ],
+  "messages": [
+    { "role": "user", "content": "What is the weather in SF?" }
+  ]
+}
+```
+
+Key field: `input_schema` (not `parameters` — Anthropic's naming diverges from
+OpenAI). Strict mode adds `"strict": true` at the tool level and requires
+`"additionalProperties": false` in the schema.
+
+### Tool Call (Model Output)
+
+Claude emits a `tool_use` content block inside the assistant message:
+
+```json
+{
+  "role": "assistant",
+  "content": [
+    {
+      "type": "tool_use",
+      "id": "toolu_01D7FLrfh4GYq7yT1ULFeyMV",
+      "name": "get_weather",
+      "input": { "location": "San Francisco, CA" }
+    }
+  ]
+}
+```
+
+Fields: `type` (always `"tool_use"`), `id` (Anthropic-generated, prefix `toolu_`),
+`name`, `input` (parsed JSON object, not a string).
+
+### Tool Result (Return to Model)
+
+Results are sent as a user message with `tool_result` content blocks:
+
+```json
+{
+  "role": "user",
+  "content": [
+    {
+      "type": "tool_result",
+      "tool_use_id": "toolu_01D7FLrfh4GYq7yT1ULFeyMV",
+      "content": "72°F, sunny"
+    }
+  ]
+}
+```
+
+The `content` field accepts either a plain string or an array of typed content
+blocks (`text`, `image`). Error results set `"is_error": true`:
+
+```json
+{
+  "type": "tool_result",
+  "tool_use_id": "toolu_01D7FLrfh4GYq7yT1ULFeyMV",
+  "is_error": true,
+  "content": "Error: Location 'Atlantis' not found."
+}
+```
+
+### Parallel Tool Use
+
+Claude can emit multiple `tool_use` blocks in a single assistant message. All
+corresponding `tool_result` blocks must appear in the subsequent user message.
+The matching is by `tool_use_id`, not by order.
+
+### Agent SDK Sandboxing
+
+The Claude Agent SDK (the engine behind Claude Code) uses OS-level sandboxing:
+
+- **Filesystem**: bubblewrap (Linux) / sandbox-exec (macOS). Default: read
+  entire filesystem, write only to working directory.
+- **Network**: removed network namespace (Linux) / Seatbelt profiles (macOS),
+  traffic routed through built-in proxy.
+- **Permission modes**: `default`, `accept_edits`, `plan`, `bypass_permissions`.
+- **Evaluation order**: PreToolUse Hook -> Deny Rules -> Allow Rules -> Ask Rules
+  -> Permission Mode -> canUseTool Callback -> PostToolUse Hook.
+- **Static analysis**: bash commands are analyzed pre-execution; risky operations
+  (system files, sensitive directories) require explicit approval.
+
+The Agent SDK reduced permission prompts by 84% through sandboxing.
+
+### Key Schema Properties
+
+| Property | Value |
+|---|---|
+| Schema location | `input_schema` (top-level tool field) |
+| Schema format | JSON Schema draft-compatible |
+| Arguments encoding | Parsed JSON object (not stringified) |
+| Call ID format | `toolu_` prefix + alphanumeric |
+| Result channel | `tool_result` in user message |
+| Error signaling | `is_error: true` flag |
+| Parallel calls | Multiple `tool_use` blocks in one message |
+
+---
+
+## 2. OpenAI
+
+### Tool Definition (Responses API)
+
+Tools are defined with `type: "function"` and use `parameters` (JSON Schema):
+
+```json
+{
+  "tools": [
+    {
+      "type": "function",
+      "name": "get_weather",
+      "description": "Get current temperature for a given location.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "location": {
+            "type": "string",
+            "description": "City and country"
+          }
+        },
+        "required": ["location"],
+        "additionalProperties": false
+      },
+      "strict": true
+    }
+  ]
+}
+```
+
+Key differences from Anthropic: field is `parameters` (not `input_schema`),
+tools have an explicit `type: "function"` wrapper, and `strict: true` is
+recommended by default.
+
+### Tool Call (Model Output — Responses API)
+
+The Responses API returns `function_call` output items:
+
+```json
+{
+  "type": "function_call",
+  "id": "fc_12345xyz",
+  "call_id": "call_12345xyz",
+  "name": "get_weather",
+  "arguments": "{\"location\": \"Paris, France\"}",
+  "status": "completed"
+}
+```
+
+Critical difference: `arguments` is a **JSON string** (not a parsed object).
+The caller must `JSON.parse()` / `json.loads()` it. This is a legacy design
+from the Chat Completions API that persists in the Responses API.
+
+### Tool Call (Model Output — Chat Completions API, legacy)
+
+```json
+{
+  "role": "assistant",
+  "tool_calls": [
+    {
+      "id": "call_abc123",
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "arguments": "{\"location\": \"Paris\"}"
+      }
+    }
+  ]
+}
+```
+
+Note the nested `function` object — another layer of wrapping.
+
+### Tool Result (Return to Model — Responses API)
+
+```json
+{
+  "type": "function_call_output",
+  "call_id": "call_12345xyz",
+  "output": "72°F, sunny"
+}
+```
+
+### Tool Result (Return to Model — Chat Completions API, legacy)
+
+```json
+{
+  "role": "tool",
+  "tool_call_id": "call_abc123",
+  "content": "72°F, sunny"
+}
+```
+
+### Parallel Tool Calls
+
+Enabled by default. Disable with `"parallel_tool_calls": false` for sequential
+execution (zero or one tool per turn).
+
+### Built-in Tools (Responses API)
+
+The Responses API has first-party tools that execute server-side:
+- `web_search` — web search
+- `file_search` — RAG over uploaded files
+- `code_interpreter` — sandboxed Python execution
+- `image_generation` — DALL-E
+- `computer_use` — screen interaction
+- Remote MCP servers (via `mcp` tool type)
+
+### Agents SDK Tools
+
+The OpenAI Agents SDK (Python) wraps function tools with type inference:
+
+```python
+from agents import Agent, function_tool
+
+@function_tool
+def get_weather(city: str) -> str:
+    """Get weather for a city."""
+    return f"72°F in {city}"
+
+agent = Agent(
+    name="Weather bot",
+    instructions="You help with weather.",
+    tools=[get_weather],
+)
+```
+
+Schema is auto-generated from type hints. The SDK also supports:
+- `codex_tool` — wraps Codex CLI for workspace-scoped tasks
+- MCP server integration
+- `is_enabled` parameter for runtime tool filtering
+
+### Codex CLI Sandboxing
+
+- **Sandbox modes**: workspace-write (default), read-only, full-access, YOLO
+- **Default**: no network access, write limited to working directory
+- **OS enforcement**: Linux namespace isolation, Windows sandbox
+- **Config**: `~/.codex/config.toml` and `.codex/config.toml` (project-scoped)
+- **Writable expansion**: `--add-dir` flag for multi-project coordination
+
+### Key Schema Properties
+
+| Property | Value |
+|---|---|
+| Schema location | `parameters` (under tool definition) |
+| Schema format | JSON Schema |
+| Arguments encoding | **JSON string** (must be parsed) |
+| Call ID format | `call_` prefix (Chat) / `fc_` prefix (Responses) |
+| Result channel | `function_call_output` (Responses) / `role: "tool"` (Chat) |
+| Error signaling | Return error string in output (no dedicated flag) |
+| Parallel calls | Default on, `parallel_tool_calls: false` to disable |
+
+---
+
+## 3. MCP (Model Context Protocol)
+
+MCP is the vertical protocol (agent-to-tools), complementing A2A's horizontal
+protocol (agent-to-agent). Both Anthropic and OpenAI support MCP natively.
+
+### Tool Definition
+
+Tools are defined on MCP servers and discovered via `tools/list`:
+
+```json
+{
+  "name": "read_file",
+  "description": "Read contents of a file at the given path.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "path": {
+        "type": "string",
+        "description": "Absolute path to the file"
+      }
+    },
+    "required": ["path"]
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "content": { "type": "string" },
+      "size": { "type": "integer" }
+    }
+  }
+}
+```
+
+Key naming: `inputSchema` (camelCase — differs from both Anthropic's
+`input_schema` and OpenAI's `parameters`). Optional `outputSchema` for
+structured result validation.
+
+### Tool Invocation (`tools/call`)
+
+MCP uses JSON-RPC 2.0 for all communication:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "read_file",
+    "arguments": {
+      "path": "/home/user/data.txt"
+    }
+  }
+}
+```
+
+### Tool Result
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "File contents here..."
+      }
+    ],
+    "structuredContent": {
+      "content": "File contents here...",
+      "size": 1234
+    },
+    "isError": false
+  }
+}
+```
+
+Dual-track output: `content` (unstructured, for display/LLM consumption) +
+`structuredContent` (typed, validated against `outputSchema`). For backward
+compatibility, structured results SHOULD also include serialized JSON in a
+`TextContent` block within `content`.
+
+### Tool Naming Rules
+
+- 1-128 characters, case-sensitive
+- Allowed: `[A-Za-z0-9_\-.]`
+- No spaces, commas, or special characters
+- Must be unique within a server
+
+### Transport
+
+JSON-RPC 2.0 over stdio (local) or HTTP+SSE (remote). Schema is defined in
+TypeScript first, published as JSON Schema for interop.
+
+### Key Schema Properties
+
+| Property | Value |
+|---|---|
+| Schema location | `inputSchema` (camelCase) |
+| Output schema | `outputSchema` (optional) |
+| Schema format | JSON Schema |
+| Arguments encoding | Parsed JSON object |
+| Transport | JSON-RPC 2.0 (stdio or HTTP+SSE) |
+| Result format | Dual: `content` (display) + `structuredContent` (typed) |
+| Error signaling | `isError: true` in result |
+| Discovery | `tools/list` method |
+
+---
+
+## 4. LangChain / LangGraph
+
+### Tool Definition — `@tool` Decorator
+
+```python
+from langchain_core.tools import tool
+
+@tool
+def search_database(query: str, limit: int = 10) -> str:
+    """Search the customer database for records matching the query.
+
+    Args:
+        query: Search terms to look for
+        limit: Maximum number of results to return
+    """
+    return f"Found {limit} results for '{query}'"
+```
+
+Schema is auto-generated from type hints + docstring. The decorator produces a
+`StructuredTool` with a JSON Schema `args_schema`.
+
+### Tool Definition — Pydantic Schema
+
+```python
+from langchain_core.tools import tool
+from pydantic import BaseModel, Field
+
+class SearchInput(BaseModel):
+    query: str = Field(description="Search terms")
+    limit: int = Field(default=10, ge=1, le=100, description="Max results")
+
+@tool(args_schema=SearchInput)
+def search_database(query: str, limit: int = 10) -> str:
+    """Search the customer database."""
+    return f"Found {limit} results for '{query}'"
+```
+
+### Tool Definition — BaseTool Subclass
+
+```python
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field
+from typing import Type
+
+class SearchInput(BaseModel):
+    query: str = Field(description="Search terms")
+
+class SearchTool(BaseTool):
+    name: str = "search_database"
+    description: str = "Search the customer database"
+    args_schema: Type[BaseModel] = SearchInput
+
+    def _run(self, query: str) -> str:
+        return f"Results for '{query}'"
+```
+
+### Binding Tools to Models
+
+```python
+from langchain_openai import ChatOpenAI
+
+llm = ChatOpenAI(model="gpt-4o")
+llm_with_tools = llm.bind_tools([search_database, other_tool])
+```
+
+`bind_tools` converts tool schemas to the provider's native format automatically
+(OpenAI format, Anthropic format, etc.). This is the key abstraction —
+LangChain is a **schema translator** layer.
+
+### Tool Call Message Format
+
+```python
+result = llm_with_tools.invoke([("user", "Find users named Alice")])
+result.tool_calls
+# [
+#   {
+#     "name": "search_database",
+#     "args": {"query": "Alice"},
+#     "id": "toolu_01Bfrz1Uhu84ggZd96Ae9De8"
+#   }
+# ]
+```
+
+The `.tool_calls` attribute is a normalized list of dicts with `name`, `args`
+(parsed dict, not JSON string), and `id`. This normalization is consistent
+regardless of which LLM provider is used.
+
+### Model-Specific Direct Binding
+
+```python
+model_with_tools = model.bind(
+    tools=[{
+        "type": "function",
+        "function": {
+            "name": "multiply",
+            "description": "Multiply two integers.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "a": {"type": "number"},
+                    "b": {"type": "number"}
+                },
+                "required": ["a", "b"]
+            }
+        }
+    }]
+)
+```
+
+This bypasses LangChain's schema translation and uses OpenAI's native format
+directly.
+
+### LangGraph Agent Loop
+
+```python
+from langgraph.graph import StateGraph, END
+from typing import TypedDict, Annotated, List
+import operator
+
+class AgentState(TypedDict):
+    messages: Annotated[List, operator.add]
+
+def call_model(state: AgentState):
+    response = llm_with_tools.invoke(state["messages"])
+    return {"messages": [response]}
+
+def should_continue(state: AgentState):
+    last = state["messages"][-1]
+    if last.tool_calls:
+        return "tools"
+    return "end"
+
+workflow = StateGraph(AgentState)
+workflow.add_node("agent", call_model)
+workflow.add_node("tools", tool_node)
+workflow.set_entry_point("agent")
+workflow.add_conditional_edges("agent", should_continue,
+                               {"tools": "tools", "end": END})
+workflow.add_edge("tools", "agent")
+app = workflow.compile()
+```
+
+The graph is cyclic: `agent -> tools -> agent -> ...` until no tool calls remain.
+This is the universal agent loop pattern.
+
+### Key Schema Properties
+
+| Property | Value |
+|---|---|
+| Schema source | Type hints + docstring / Pydantic BaseModel |
+| Internal format | JSON Schema (via `args_schema`) |
+| Wire format | Translated per-provider by `bind_tools` |
+| Arguments encoding | Parsed dict (normalized from provider format) |
+| Call ID | Passed through from provider |
+| Agent loop | LangGraph StateGraph with cyclic edges |
+| Multi-agent | Supervisor, peer-to-peer, sequential patterns |
+
+---
+
+## 5. CrewAI
+
+### Tool Definition — `@tool` Decorator
+
+```python
+from crewai.tools import tool
+
+@tool("web_search")
+def web_search(query: str) -> str:
+    """Search the web for information on the given query."""
+    return f"Results for: {query}"
+```
+
+Function name becomes tool name (or override via decorator arg). Docstring
+becomes description. Type hints define schema.
+
+### Tool Definition — BaseTool Subclass
+
+```python
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
+from typing import Type
+
+class SearchInput(BaseModel):
+    """Input schema for WebSearchTool."""
+    query: str = Field(..., description="Search query string")
+    max_results: int = Field(5, ge=1, le=50, description="Max results")
+
+class WebSearchTool(BaseTool):
+    name: str = "web_search"
+    description: str = "Search the web for current information."
+    args_schema: Type[BaseModel] = SearchInput
+
+    def _run(self, query: str, max_results: int = 5) -> str:
+        return f"Top {max_results} results for: {query}"
+```
+
+CrewAI's `BaseTool` mirrors LangChain's pattern (name, description,
+args_schema, _run), but is independent — CrewAI is 100% decoupled from
+LangChain.
+
+### Agent + Task + Crew Assembly
+
+```python
+from crewai import Agent, Task, Crew
+
+researcher = Agent(
+    role="Researcher",
+    goal="Find accurate information",
+    backstory="An expert research analyst...",
+    tools=[WebSearchTool()],
+    llm="gpt-4o"
+)
+
+writer = Agent(
+    role="Writer",
+    goal="Write compelling content",
+    backstory="A skilled technical writer..."
+)
+
+research_task = Task(
+    description="Research the topic: {topic}",
+    expected_output="A detailed summary of findings",
+    agent=researcher
+)
+
+writing_task = Task(
+    description="Write an article based on the research",
+    expected_output="A polished article",
+    agent=writer
+)
+
+crew = Crew(
+    agents=[researcher, writer],
+    tasks=[research_task, writing_task],
+    process="sequential"  # or "hierarchical"
+)
+
+result = crew.kickoff(inputs={"topic": "AI agents"})
+```
+
+### Orchestration Modes
+
+- **Sequential**: agents execute in order, each receiving prior agent's output
+- **Hierarchical**: a manager agent delegates tasks dynamically
+- **Flows**: event-driven pipelines with conditional branching, looping,
+  parallelism — the backbone for production orchestration
+
+### Tool Delegation
+
+In hierarchical mode, the manager agent can delegate tool access. Agents only
+have access to tools explicitly assigned to them. Tool results are always
+strings (serialized by the tool).
+
+### Key Schema Properties
+
+| Property | Value |
+|---|---|
+| Schema source | Pydantic BaseModel / type hints |
+| Schema format | JSON Schema (via Pydantic) |
+| Tool results | Always strings |
+| Tool assignment | Per-agent (explicit list) |
+| Orchestration | Sequential, hierarchical, flows |
+| Caching | Default on (key = tool name + input params) |
+| Memory | Short-term, long-term, entity, contextual |
+
+---
+
+## 6. AutoGen (Microsoft)
+
+### Tool Definition — FunctionTool (AutoGen 0.4+)
+
+```python
+from autogen_core.tools import FunctionTool
+from typing_extensions import Annotated
+
+async def get_stock_price(
+    ticker: str,
+    date: Annotated[str, "Date in YYYY/MM/DD"]
+) -> float:
+    import random
+    return random.uniform(10, 200)
+
+stock_tool = FunctionTool(
+    get_stock_price,
+    description="Fetch the stock price for a given ticker."
+)
+```
+
+Schema is auto-generated from type hints. `Annotated` types provide field-level
+descriptions (similar to Pydantic `Field(description=...)`).
+
+The `strict` parameter enforces structured output mode (no default values
+allowed, explicit args only).
+
+### Tool Execution
+
+```python
+import json
+from autogen_core import CancellationToken
+
+# Direct execution
+result = await stock_tool.run_json(
+    {"ticker": "AAPL", "date": "2021/01/01"},
+    CancellationToken()
+)
+print(stock_tool.return_value_as_string(result))
+```
+
+`run_json` takes a dict (parsed arguments) and returns the result. The
+`return_value_as_string` method serializes results for LLM consumption.
+
+### Tool Use with Model Client
+
+```python
+from autogen_core.models import UserMessage
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+model_client = OpenAIChatCompletionClient(model="gpt-4o-mini")
+user_msg = UserMessage(content="What is AAPL stock price?", source="user")
+
+create_result = await model_client.create(
+    messages=[user_msg],
+    tools=[stock_tool],
+    cancellation_token=CancellationToken()
+)
+
+# Parse the tool call
+arguments = json.loads(create_result.content[0].arguments)
+tool_result = await stock_tool.run_json(arguments, CancellationToken())
+```
+
+Note: `create_result.content[0].arguments` is a **JSON string** — the OpenAI
+format leaks through.
+
+### Legacy Tool Registration (AutoGen 0.2)
+
+```python
+import autogen
+
+autogen.register_function(
+    get_stock_price,
+    caller=assistant,      # agent that suggests calls
+    executor=user_proxy,   # agent that executes calls
+    name="get_stock_price",
+    description="Fetch stock price for a ticker."
+)
+```
+
+The 0.2 API separated caller (LLM agent) from executor (runtime agent) — a
+two-agent pattern where the assistant decides what to call and the user proxy
+actually runs it.
+
+### Agent-as-Tool (AgentTool)
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.tools import AgentTool
+
+math_expert = AssistantAgent(
+    "math_expert",
+    model_client=model_client,
+    system_message="You are a math expert."
+)
+
+math_tool = AgentTool(
+    agent=math_expert,
+    return_value_as_last_message=True
+)
+
+general_agent = AssistantAgent(
+    "assistant",
+    model_client=model_client,
+    tools=[math_tool]
+)
+```
+
+Agents can be wrapped as tools for other agents — the multi-agent equivalent
+of function composition.
+
+### Migration: AutoGen -> Microsoft Agent Framework
+
+Microsoft Agent Framework is the successor. It merges AutoGen and Semantic
+Kernel into a unified multi-language SDK. Same patterns, new namespace.
+
+### Key Schema Properties
+
+| Property | Value |
+|---|---|
+| Schema source | Type hints + `Annotated` descriptions |
+| Schema format | JSON Schema (auto-generated) |
+| Arguments encoding | JSON string (from model), parsed via `json.loads` |
+| Execution | `run_json(dict, CancellationToken)` |
+| Result serialization | `return_value_as_string(result)` |
+| Agent-as-tool | `AgentTool` wrapper |
+| Multi-agent | RoundRobinGroupChat, Swarm, custom topologies |
+
+---
+
+## 7. Vercel AI SDK
+
+### Tool Definition (AI SDK 5+)
+
+```typescript
+import { z } from "zod";
+import { tool, generateText } from "ai";
+
+const weatherTool = tool({
+  description: "Get weather for a location",
+  inputSchema: z.object({
+    location: z.string().describe("City name"),
+  }),
+  outputSchema: z.object({
+    temperature: z.number(),
+    condition: z.string(),
+  }),
+  execute: async ({ location }) => {
+    return { temperature: 72, condition: "sunny" };
+  },
+});
+```
+
+AI SDK 5 renamed `parameters` to `inputSchema` and added `outputSchema` to
+align with MCP naming conventions. The `execute` function is co-located with
+the schema definition.
+
+### Tool Definition (AI SDK 4, legacy)
+
+```typescript
+const weatherTool = tool({
+  description: "Get weather for a location",
+  parameters: z.object({
+    location: z.string().describe("City name"),
+  }),
+  execute: async ({ location }) => {
+    return { temperature: 72, condition: "sunny" };
+  },
+});
+```
+
+### Using Tools with generateText
+
+```typescript
+const result = await generateText({
+  model: openai("gpt-4o"),
+  tools: { weather: weatherTool },
+  prompt: "What is the weather in London?",
+});
+
+// result.toolCalls — array of tool invocations
+// result.toolResults — array of results
+```
+
+Tools are passed as a **named object** (not an array) — the key becomes the
+tool name.
+
+### Multi-Step Agent Loop
+
+```typescript
+const result = await generateText({
+  model: openai("gpt-4o"),
+  tools: { weather: weatherTool },
+  prompt: "What is the weather in London?",
+  stopWhen: stepCountIs(5),   // max 5 tool-call rounds
+});
+```
+
+The SDK orchestrates the loop automatically: call model -> extract tool calls ->
+execute tools -> append results -> call model again -> repeat until text
+response or step limit.
+
+### Human-in-the-Loop (AI SDK 6)
+
+```typescript
+const weatherTool = tool({
+  description: "Get weather",
+  inputSchema: z.object({ location: z.string() }),
+  needsApproval: true,  // requires human approval before execution
+  execute: async ({ location }) => { /* ... */ },
+});
+```
+
+### Strict Mode (AI SDK 6)
+
+Opt-in per tool — compatible tools use strict schema validation, others use
+regular mode. Both can coexist in the same call.
+
+### Key Schema Properties
+
+| Property | Value |
+|---|---|
+| Schema source | Zod objects |
+| Schema location | `inputSchema` (v5+) / `parameters` (v4) |
+| Output schema | `outputSchema` (optional, v5+) |
+| Schema format | Zod -> JSON Schema (auto-converted) |
+| Tool namespace | Object keys (not array) |
+| Execution | Co-located `execute` function |
+| Agent loop | Built-in via `stopWhen` / step counting |
+| Approval | `needsApproval: true` per tool |
+
+---
+
+## 8. Google A2A Protocol
+
+A2A is the **horizontal** protocol (agent-to-agent), complementing MCP's
+**vertical** protocol (agent-to-tools). It enables opaque agents from different
+vendors to communicate without sharing internal state.
+
+### Agent Card (Discovery)
+
+Published at `/.well-known/agent.json`:
+
+```json
+{
+  "name": "Recipe Agent",
+  "description": "Finds and suggests recipes based on ingredients.",
+  "url": "https://recipe-agent.example.com/a2a",
+  "version": "1.0.0",
+  "capabilities": {
+    "streaming": true,
+    "pushNotifications": false,
+    "stateTransitionHistory": false
+  },
+  "skills": [
+    {
+      "id": "find-recipe",
+      "name": "Find Recipe",
+      "description": "Finds recipes matching given ingredients",
+      "inputModes": ["text"],
+      "outputModes": ["text"]
+    }
+  ],
+  "defaultInputModes": ["text"],
+  "defaultOutputModes": ["text"],
+  "authentication": {
+    "schemes": ["Bearer"]
+  },
+  "provider": {
+    "organization": "Example Corp",
+    "url": "https://example.com"
+  }
+}
+```
+
+Required fields: `name`, `url`, `version`, `capabilities`, `skills`.
+All JSON field names use camelCase (protocol requirement).
+
+### Request — `message/send`
+
+A2A uses JSON-RPC 2.0 over HTTP(S):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-001",
+  "method": "message/send",
+  "params": {
+    "message": {
+      "role": "user",
+      "parts": [
+        {
+          "kind": "text",
+          "text": "Find me a pasta recipe with mushrooms"
+        }
+      ],
+      "messageId": "msg-001"
+    }
+  }
+}
+```
+
+First message omits `contextId` (server generates it). Subsequent messages
+include both `contextId` and `taskId` for continuity.
+
+### Response — Completed Task
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-001",
+  "result": {
+    "kind": "task",
+    "id": "task-uuid-001",
+    "contextId": "ctx-uuid-001",
+    "status": {
+      "state": "completed"
+    },
+    "artifacts": [
+      {
+        "artifactId": "artifact-001",
+        "name": "Recipe",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "Mushroom Pasta: Sauté mushrooms..."
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Response — Submitted (Async)
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-002",
+  "result": {
+    "id": "task-uuid-002",
+    "contextId": "ctx-uuid-002",
+    "status": {
+      "state": "submitted",
+      "timestamp": "2025-03-15T11:00:00Z"
+    }
+  }
+}
+```
+
+Task states: `submitted`, `working`, `input-required`, `completed`, `canceled`,
+`rejected`, `failed`. Terminal states cannot be restarted.
+
+### Streaming — `message/stream`
+
+Requires `capabilities.streaming: true`. Response uses SSE
+(`Content-Type: text/event-stream`). Each event is a JSON-RPC response fragment.
+
+### Error Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-001",
+  "error": {
+    "code": -32052,
+    "message": "Validation error - Invalid request data"
+  }
+}
+```
+
+Standard JSON-RPC error codes plus A2A-specific codes.
+
+### Key Architectural Differences from MCP
+
+| Aspect | MCP (Vertical) | A2A (Horizontal) |
+|---|---|---|
+| Purpose | Agent-to-tool | Agent-to-agent |
+| Participants | Client + server | Client agent + remote agent |
+| State | Stateless tool calls | Stateful task lifecycle |
+| Discovery | `tools/list` | `/.well-known/agent.json` |
+| Output | Tool results | Artifacts (multi-part) |
+| Transport | JSON-RPC (stdio/HTTP) | JSON-RPC (HTTP), gRPC (v0.3+) |
+| Content | Text, structured data | Multi-modal parts (text, data, file) |
+
+### Three-Layer Architecture
+
+1. **Canonical Data Model** (`a2a.proto`): Core types — messages, tasks, agents
+2. **Abstract Operations**: Capabilities independent of transport
+3. **Protocol Bindings**: JSON-RPC, gRPC, HTTP/REST mappings
+
+The proto file is the normative source. All SDKs and JSON schemas are generated
+from it.
+
+---
+
+## 9. Universal Patterns
+
+### Pattern 1: JSON Schema as the Universal Tool Schema
+
+Every framework uses JSON Schema (or generates it) for tool parameter
+definitions:
+
+| Framework | Schema Field Name | Source |
+|---|---|---|
+| Anthropic | `input_schema` | Hand-written or Pydantic |
+| OpenAI | `parameters` | Hand-written or Pydantic/Zod |
+| MCP | `inputSchema` | Hand-written |
+| LangChain | `args_schema` | Pydantic BaseModel |
+| CrewAI | `args_schema` | Pydantic BaseModel |
+| AutoGen | (auto-generated) | Type hints + Annotated |
+| Vercel AI SDK | `inputSchema` | Zod objects |
+| A2A | (skills, not tools) | Agent Card JSON |
+
+**Convergence**: JSON Schema `type: "object"` with `properties`, `required`,
+and optionally `additionalProperties: false`. The naming varies but the
+structure is identical.
+
+### Pattern 2: The Tool Call Lifecycle
+
+Every framework follows the same 4-step cycle:
+
+```
+1. DEFINE  — Register tool schemas with the model
+2. CALL    — Model emits tool call (name + arguments + ID)
+3. EXECUTE — Runtime executes the tool with parsed arguments
+4. RETURN  — Send result back to model with matching ID
+```
+
+This cycle repeats until the model produces a text response (no more tool
+calls). The loop is the core agent pattern.
+
+### Pattern 3: Call ID Matching
+
+Every framework generates a unique ID per tool call and requires the result to
+reference that ID:
+
+| Framework | Call ID | Result Reference |
+|---|---|---|
+| Anthropic | `id` (in `tool_use`) | `tool_use_id` (in `tool_result`) |
+| OpenAI | `call_id` / `id` | `call_id` (in `function_call_output`) |
+| MCP | JSON-RPC `id` | JSON-RPC `id` in response |
+| LangChain | `id` (in `tool_calls`) | Passed through from provider |
+| A2A | `taskId` | `taskId` in subsequent messages |
+
+### Pattern 4: Parallel Tool Execution
+
+Most frameworks support multiple tool calls per turn:
+
+- **Anthropic**: Multiple `tool_use` blocks in one assistant message
+- **OpenAI**: Multiple `function_call` items; `parallel_tool_calls` toggle
+- **LangChain**: Multiple entries in `tool_calls` list
+- **Vercel**: Multiple tools resolved per step
+- **MCP**: One `tools/call` per request (parallelism is client-side)
+- **A2A**: One task per `message/send` (parallelism is client-side)
+
+### Pattern 5: Error Signaling
+
+| Framework | Error Mechanism |
+|---|---|
+| Anthropic | `is_error: true` flag on `tool_result` |
+| OpenAI | Error string in `output` (no dedicated flag) |
+| MCP | `isError: true` in result |
+| LangChain | Exception handling in tool execution |
+| CrewAI | Exception handling, tool returns error string |
+| AutoGen | Exception in `run_json`, or error in return value |
+| Vercel | Exception in `execute` function |
+| A2A | JSON-RPC error object / task state `"failed"` |
+
+### Pattern 6: Schema Generation from Code
+
+Every Python/TS framework auto-generates JSON Schema from typed code:
+
+| Source | Generator |
+|---|---|
+| Python type hints | `FunctionTool` (AutoGen), `@tool` (LangChain/CrewAI) |
+| Pydantic BaseModel | LangChain `args_schema`, CrewAI `args_schema` |
+| Python `Annotated` | AutoGen field descriptions |
+| Zod objects | Vercel AI SDK `inputSchema` |
+| TypeScript types | Vercel AI SDK (via Zod) |
+
+### Pattern 7: Sandboxing Convergence
+
+Both Anthropic and OpenAI converge on the same sandboxing model:
+
+| Feature | Claude Agent SDK | Codex CLI |
+|---|---|---|
+| Default writes | Working directory only | Working directory only |
+| Default reads | Entire filesystem | Entire filesystem |
+| Network | Blocked by default | Blocked by default |
+| OS mechanism | bubblewrap/sandbox-exec | Namespace isolation/Windows sandbox |
+| Config levels | Rules + hooks + modes | TOML config + flags |
+| Expansion | Permission rules | `--add-dir` flag |
+
+### Pattern 8: Output Schema (Emerging)
+
+Newer frameworks add output validation alongside input validation:
+
+- **MCP**: `outputSchema` + dual `content`/`structuredContent` return
+- **Vercel AI SDK 5+**: `outputSchema` (Zod)
+- **OpenAI**: Structured Outputs (`strict: true`)
+- **Anthropic**: Structured Outputs (`strict: true` on tools)
+
+This trend toward bidirectional schema validation (input AND output) matches
+ilo's `tool name"desc" params>return` pattern.
+
+### Pattern 9: The Two Protocol Axes
+
+```
+                    Agent-to-Tool (Vertical)
+                           MCP
+                            |
+                            |
+Agent-to-Agent (Horizontal) +---- A2A Protocol
+                            |
+                            |
+                    Both use JSON-RPC 2.0
+                    Both use JSON Schema
+                    Both support streaming
+```
+
+MCP and A2A are complementary. An agent uses MCP to access tools and A2A to
+communicate with other agents. Both share JSON-RPC 2.0 transport and JSON
+Schema for structure.
+
+---
+
+## 10. Implications for ilo-lang
+
+### What ilo Must Support
+
+Based on the universal patterns above, ilo needs to handle these mechanical
+realities:
+
+**1. JSON Schema is the universal tool interface.**
+
+Every framework defines tools via JSON Schema. ilo's `tool` declarations must
+map bidirectionally to JSON Schema:
+
+```
+tool weather"Get weather" location:s > WeatherResult
+```
+
+This must generate:
+```json
+{
+  "name": "weather",
+  "description": "Get weather",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "location": { "type": "string" }
+    },
+    "required": ["location"]
+  }
+}
+```
+
+And ilo must consume tool schemas discovered via MCP `tools/list` and convert
+them back into ilo type signatures for verification.
+
+**2. The call-ID lifecycle is universal.**
+
+Every framework generates a call ID and expects results to reference it. ilo's
+runtime must track call IDs transparently. The agent never needs to see or
+generate IDs — the runtime manages them.
+
+**3. Arguments are always a flat JSON object.**
+
+Despite framework differences (parsed object vs JSON string), the arguments are
+always a JSON object with string keys mapping to typed values. ilo's positional
+args must serialize to `{"param1": value1, "param2": value2}` at the boundary.
+This is a naming/ordering convention, not a type problem.
+
+**4. Results are string-first, structured-second.**
+
+Most frameworks serialize tool results to strings for LLM consumption. MCP's
+dual-track (`content` + `structuredContent`) is the most sophisticated. ilo's
+`R ok err` result type covers this: `~v` for the structured value,
+`return_value_as_string()` equivalent for the text representation.
+
+**5. Error signaling is a boolean + message.**
+
+Whether it's `is_error: true` (Anthropic), a JSON-RPC error object (MCP/A2A),
+or an exception (Python frameworks), errors are always: did it fail? + what
+went wrong? ilo's `R ok err` with `^e` error path handles this natively.
+
+**6. Parallel tool calls require batch semantics.**
+
+When the model requests multiple tools simultaneously, the runtime must execute
+all and return all results in one message. ilo's runtime should support this as
+concurrent execution of independent tool calls.
+
+**7. Sandbox defaults converge on: write cwd, read all, no network.**
+
+Both major AI companies enforce the same default sandbox. ilo programs running
+as agent tools should assume these constraints and declare required permissions
+explicitly.
+
+**8. Output schemas are becoming standard.**
+
+The trend toward `outputSchema` / `structuredContent` means ilo's tool return
+types are not just documentation — they're protocol-level contracts. The
+`tool name"desc" params>return` syntax already captures this.
+
+**9. Discovery is a schema exchange.**
+
+MCP `tools/list` and A2A `/.well-known/agent.json` are both schema discovery
+mechanisms. ilo's verifier can consume discovered schemas the same way it
+consumes hand-written declarations — they're all JSON Schema at the wire level.
+
+### What ilo Can Ignore
+
+- **Framework-specific wrapper layers**: LangChain's `bind_tools`, CrewAI's
+  `Crew`/`Flow`, AutoGen's `AgentTool` — these are orchestration concerns
+  above the language level.
+- **Multi-agent orchestration patterns**: Supervisor, hierarchical, round-robin
+  — these are runtime topology decisions, not language features.
+- **Provider-specific field naming**: `input_schema` vs `parameters` vs
+  `inputSchema` — the runtime adapter handles naming translation.
+- **Agent personas/roles**: CrewAI's `role`/`goal`/`backstory`, AutoGen's
+  `system_message` — these are prompt-engineering concerns.
+
+### The Minimum Viable Protocol Surface
+
+For ilo to work with all frameworks, it needs exactly:
+
+1. **Tool declaration** -> JSON Schema (bidirectional)
+2. **Result type** -> success value + error (R ok err)
+3. **Type mapping** -> ilo types <-> JSON Schema types
+4. **Call semantics** -> positional args <-> named JSON object
+5. **Discovery ingestion** -> MCP tools/list -> ilo function signatures
+
+Everything else is runtime adapter code, not language design.
+
+---
+
+## See Also
+
+- [coding-agents-research.md](coding-agents-research.md) — comparative analysis of agent tools, sandboxing, and OS interaction patterns
+- [mcp-protocol-research.md](mcp-protocol-research.md) — MCP protocol specifics referenced in the discovery ingestion surface

--- a/research/coding-agents-research.md
+++ b/research/coding-agents-research.md
@@ -1,0 +1,937 @@
+# AI Coding Agent Mechanics: Tools, Protocols, and Sandboxing
+
+A comparative analysis of the six major AI coding agents, focused on their
+tool sets, file editing mechanisms, sandboxing models, OS interaction
+patterns, and MCP integration. Written for the ilo-lang project to
+understand what operations agents actually perform on codebases.
+
+Research date: March 2026.
+
+---
+
+## Table of Contents
+
+1. Claude Code (Anthropic)
+2. Codex CLI (OpenAI)
+3. Cursor
+4. Kilo Code
+5. VS Code Copilot (GitHub)
+6. OpenCode
+7. Cross-Agent Comparison Tables
+8. Implications for ilo-lang
+
+---
+
+## 1. Claude Code (Anthropic)
+
+Claude Code is a terminal-native CLI agent. It runs as an interactive
+tool in the user's shell, communicating with Claude models via the
+Anthropic API. Written in TypeScript/Node.js.
+
+### 1.1 Complete Tool List (18 tools)
+
+```
+ #  Tool              Category         Purpose
+ 1  Bash              execution        Run shell commands
+ 2  BashOutput        execution        Get output from running bash processes
+ 3  KillShell         execution        Kill running shell processes
+ 4  Read              file-read        Read file contents (with line range support)
+ 5  Edit              file-write       Search-and-replace in files
+ 6  Write             file-write       Create new files or full rewrites
+ 7  Glob              search           File pattern matching (e.g., **/*.ts)
+ 8  Grep              search           Regex content search (ripgrep-based)
+ 9  NotebookEdit      file-write       Edit Jupyter notebook cells
+10  WebFetch          web              Fetch URL + process with AI model
+11  WebSearch         web              Search the web, return links
+12  TodoWrite         planning         Create/manage structured task lists
+13  Task              agent            Launch sub-agents for complex tasks
+14  AskUserQuestion   interaction      Ask the user for clarification
+15  Skill             extensibility    Execute learned skills / slash commands
+16  SlashCommand      extensibility    Execute slash commands
+17  EnterPlanMode     planning         Switch to planning mode
+18  ExitPlanMode      planning         Switch back from planning mode
+```
+
+Sub-agents (launched via Task) get a subset: Bash, Glob, Grep, Read,
+Edit, MultiEdit, Write, NotebookRead, NotebookEdit, WebFetch, TodoRead,
+TodoWrite, WebSearch.
+
+### 1.2 File Editing Model
+
+Claude Code uses **exact string search-and-replace** for its Edit tool.
+The model provides an `old_string` (text to find in the file) and a
+`new_string` (replacement text). The edit fails if `old_string` is not
+found or is not unique in the file. A `replace_all` flag can change
+every occurrence.
+
+The Write tool does **full file creation or overwrite**. It is intended
+for new files; the system prompt enforces reading a file before writing
+to it, preferring Edit for modifications.
+
+Key design choices:
+- Edit requires a prior Read of the file (enforced by the tool).
+- `old_string` must be unique unless `replace_all` is true.
+- The model must match exact indentation (tabs/spaces).
+- No line-number-based editing; matching is purely by string content.
+
+This is a **search-replace** model, not a diff/patch model. The model
+never generates unified diffs or line numbers for edits.
+
+### 1.3 Bash Execution Model
+
+Bash commands run in a child process. Key properties:
+- Working directory persists between commands.
+- Shell state (variables, aliases) does NOT persist between calls.
+- The shell environment initializes from the user's profile.
+- Commands have a configurable timeout (default 120s, max 600s).
+- Background execution is supported via `run_in_background`.
+- No interactive mode support (no -i flags, no REPLs).
+
+The system prompt instructs the model to prefer specialized tools over
+shell equivalents: use Glob instead of `find`, Grep instead of `grep`,
+Read instead of `cat`, Edit instead of `sed`.
+
+### 1.4 Sandboxing Model
+
+Claude Code uses **OS-level sandboxing** applied to the Bash tool:
+
+**macOS (Seatbelt):**
+- Uses Apple's `sandbox-exec` (Seatbelt framework).
+- Enabled by default since v1.0.20.
+- Seatbelt profiles define allowed filesystem and network access.
+
+**Linux (Bubblewrap):**
+- Uses bubblewrap (bwrap), the same tool used by Flatpak.
+- Requires WSL2 for Windows (WSL1 not supported).
+- Pre-generated seccomp BPF filters for x86-64 and ARM.
+
+**Two isolation boundaries:**
+1. **Filesystem:** Read follows deny-only (allowed everywhere, deny
+   specific paths like ~/.ssh). Write follows allow-only (denied
+   everywhere, explicitly allow paths like `.` and `/tmp`).
+2. **Network:** Linux removes the network namespace entirely; all
+   traffic must go through Unix domain socket proxies (via socat).
+   macOS Seatbelt allows only specific localhost ports.
+
+All child processes inherit sandbox restrictions. Running `npm install`
+inside the sandbox means every postinstall script is also sandboxed.
+This reduces permission prompts by 84% with <15ms latency overhead.
+
+The sandbox is open-sourced as `@anthropic-ai/sandbox-runtime`.
+
+### 1.5 MCP Integration
+
+Claude Code supports MCP as a client. MCP servers extend the tool set
+with external capabilities. Configuration happens via project-level
+`.mcp.json` files or through the `/mcp` slash command. Claude Code
+can also run AS an MCP server, exposing its tools to other clients.
+
+### 1.6 Notable Patterns
+
+- **Tool preference hierarchy:** Specialized tools over Bash. The
+  system prompt explicitly says "use Grep, not grep."
+- **Read-before-write enforcement:** Edit and Write tools fail if the
+  file has not been Read first in the conversation.
+- **Sub-agent isolation:** Task tool launches child agents with scoped
+  tool access and independent context windows.
+- **Web tools are split:** WebFetch (known URL -> content) vs.
+  WebSearch (query -> links). WebSearch intentionally returns only
+  titles and URLs, not page content.
+- **TodoWrite as a planning primitive:** Used for structured task
+  tracking with states (pending/in_progress/completed).
+
+---
+
+## 2. Codex CLI (OpenAI)
+
+Codex CLI is a terminal-native coding agent from OpenAI. Written in
+TypeScript, it uses the Responses API with GPT-5 family models. Its
+execution model is a single-agent ReAct loop.
+
+### 2.1 Complete Tool List
+
+```
+ #  Tool              Category         Purpose
+ 1  shell             execution        Run shell commands (default)
+ 2  apply_patch       file-write       Create/update/delete files via V4A diffs
+ 3  read_file         file-read        Read file contents
+ 4  update_plan       planning         Manage TODO/plan items
+ 5  web_search        web              Search the web (from OpenAI cache)
+ 6  exec_command      execution        Launch long-lived PTY sessions (experimental)
+ 7  write_stdin       execution        Feed input to exec_command sessions
+ 8  spawn_agent       agent            Multi-agent: launch child agent (experimental)
+ 9  send_input        agent            Multi-agent: send input to child agent
+10  resume_agent      agent            Multi-agent: resume paused agent
+11  wait              agent            Multi-agent: wait for agent completion
+12  close_agent       agent            Multi-agent: terminate child agent
+```
+
+Plus MCP-provided tools from configured servers.
+
+### 2.2 File Editing Model: apply_patch with V4A Diffs
+
+Codex uses a **structured diff format called V4A** (Version 4A patches).
+This is distinct from unified diffs or search-replace:
+
+```
+Operations:
+- create_file: Create a new file with specified content
+- update_file: Apply V4A diff to existing file
+- delete_file: Remove a file at specified path
+```
+
+V4A diffs use **contextual anchors** to identify edit regions rather
+than line numbers or exact string matches. The model has been heavily
+trained on this format. OpenAI states: "We strongly recommend using our
+exact apply_patch implementation as the model has been trained to excel
+at this diff format."
+
+Key properties:
+- GPT-family models are trained specifically on V4A (not unified diff).
+- The format supports file creation, updates, and deletion.
+- Patches use context lines to anchor changes (similar to unified diff
+  but with a custom format).
+- Known edge case: parser does not correctly handle multiple
+  `change_context` operations in a single patch (reported by Warp).
+
+The system prompt instructs: "If a tool exists for an action, prefer
+to use the tool instead of shell commands (e.g., read_file over cat)."
+
+### 2.3 Bash Execution Model
+
+Two shell tools:
+- `shell`: Runs a command, returns output. On Windows, uses PowerShell.
+  The prompt says "always fill in workdir; avoid using cd in the command
+  string."
+- `exec_command` (experimental): Launches a long-lived PTY for
+  streaming output, REPLs, or interactive sessions. `write_stdin`
+  sends additional input.
+
+### 2.4 Sandboxing Model
+
+Codex uses **OS-level sandboxing** with two mechanisms on Linux:
+
+**Landlock (kernel 5.13+):**
+- Capability-based filesystem restrictions.
+- Configurable writable roots (workspace directory).
+- Read-anywhere, write-only to whitelisted directories.
+
+**seccomp-BPF:**
+- System call filtering at the kernel level.
+- Blocks network-related syscalls unless explicitly allowed.
+- Granular control (e.g., allow `recvfrom` for local IPC, deny
+  `connect`).
+
+**macOS:** Uses Seatbelt (same framework as Claude Code).
+
+**Alternative pipeline (opt-in):**
+- `features.use_linux_sandbox_bwrap = true` enables Bubblewrap.
+- Vendored bwrap compiled as part of the Linux build.
+- In managed proxy mode, routes egress through proxy-only bridge.
+
+**Network isolation:**
+- Default `workspace-write` mode has NO network access.
+- Must explicitly enable via config or flags.
+- Cloud Codex uses two-phase runtime: setup phase has network
+  (for `npm install` etc.), agent phase runs offline by default.
+
+**Sandbox modes:**
+- `read-only`: Browse files only, no changes.
+- `workspace-write` (default): Read anywhere, write to workspace.
+- `danger-full-access`: No restrictions (for isolated runners).
+
+**ReadOnlyAccess policy (v0.100.0+):** Configurable policy for
+granular read access control, restricting which directories Codex
+can read from.
+
+Debug tool: `codex debug landlock` shows applied rules and filters.
+
+### 2.5 MCP Integration
+
+Codex supports MCP via STDIO or streaming HTTP servers configured in
+`~/.codex/config.toml`. Servers launch automatically at session start.
+MCP tools appear alongside built-ins. Codex can also run AS an MCP
+server. Managed via `codex mcp` CLI commands.
+
+### 2.6 Notable Patterns
+
+- **Minimal tool surface:** Only 2 core tools (shell + apply_patch)
+  for the default configuration. The philosophy is that shell can do
+  almost everything.
+- **V4A is a training artifact:** The diff format exists because the
+  model was trained on it, not because it is inherently superior. It
+  is model-specific.
+- **Parallel tool calling:** When enabled, the model batches multiple
+  tool calls using `multi_tool_use.parallel`.
+- **Git worktrees for isolation:** Multiple agents can work on the
+  same repo in isolated worktrees.
+- **ReAct loop bias:** The system prompt encodes "keep working until
+  done" — read, edit, test, iterate.
+- **Organization policy enforcement:** `requirements.toml` can lock
+  down approval policies and sandbox modes across a team.
+
+---
+
+## 3. Cursor
+
+Cursor is an IDE-integrated agent built as a VS Code fork. It uses a
+proprietary two-model architecture with a fine-tuned Mixture-of-Experts
+model (Composer) and a specialized apply model.
+
+### 3.1 Tool List
+
+```
+ #  Tool               Category         Purpose
+ 1  codebase_search    search           Semantic search over indexed codebase
+ 2  grep_search        search           Exact keyword/pattern search
+ 3  read_file          file-read        Read file contents (250-750 line limit)
+ 4  list_dir           search           List directory structure
+ 5  edit_file          file-write       Suggest and apply edits
+ 6  delete_file        file-write       Delete files
+ 7  terminal_command   execution        Execute terminal commands
+ 8  web_search         web              Real-time web search
+ 9  recent_changes     context          Track recent file modifications
+10  MCP tools          extensibility    External services via MCP
+```
+
+Agent mode is limited to 25 tool calls per session (extendable via
+"Continue").
+
+### 3.2 File Editing: Two-Model Architecture
+
+Cursor's most distinctive feature is its **two-stage edit pipeline:**
+
+**Stage 1: Planning (Frontier Model)**
+A large model (Claude Sonnet, GPT-4o, or Composer) generates "lazy
+diffs" — high-level descriptions of what should change. The model
+may output search-and-replace blocks or partial file rewrites.
+
+**Stage 2: Applying (Fast Apply Model)**
+A fine-tuned 70B model applies the planned changes to the actual
+file at ~1000 tokens/second using **speculative edits** (a variant
+of speculative decoding). Rather than having the LLM generate diffs,
+the apply model **rewrites the entire file** because:
+- LLMs struggle with diff formats (rare in training data).
+- Line number accuracy is poor across tokenizers.
+- Full rewrite lets the model use more tokens for "thinking."
+- Only Claude Opus could output accurate diffs consistently.
+
+**Speculative Edits:**
+Since most of the output will be identical to the existing code, a
+deterministic algorithm speculates future tokens (unchanged code
+lines), achieving up to 9x speedup over vanilla inference. This is
+NOT standard draft-model speculative decoding — it exploits the
+prior that edits are sparse within a file.
+
+Cursor found that full file rewrites outperform aider-style diffs
+for files under 400 lines.
+
+### 3.3 Tool Protocol
+
+Cursor uses **XML-based tool calling** in its system prompts. Tools
+are invoked via XML tags like `<edit_file>`, `<target_file>`, and
+`<code_edit>`. This is a deliberate choice:
+
+- XML requires less "attention budget" from the model than JSON.
+- JSON forces early commitment to field values, reducing flexibility.
+- XML-based tool calls produce better coding results in Cursor's evals.
+
+This contrasts with the industry trend toward native/JSON function
+calling (which Roo Code adopted, reporting ~10% failure rates with XML).
+
+### 3.4 Sandboxing Model
+
+Cursor provides terminal command sandboxing via `sandbox.json` with
+network and filesystem policies. Commands execute through the agent
+with preserved history and native terminal integration. Cursor 2.0
+supports up to 8 parallel agents, each in an isolated copy of the
+codebase.
+
+### 3.5 MCP Integration
+
+Cursor supports MCP servers for external tool integration. MCP tools
+are accessed via the Chat interface and can interact with databases,
+APIs, and custom services.
+
+### 3.6 Notable Patterns
+
+- **Two-model architecture is unique:** No other agent separates
+  planning and applying into distinct models.
+- **Full-rewrite over diffs:** A data-driven decision that most LLMs
+  cannot reliably generate diffs.
+- **KV cache optimization:** Extensive caching, cache warming, and
+  speculative caching (predicting what users will accept).
+- **MoE for the agent model:** Composer uses Mixture-of-Experts,
+  routing each token to specialized MLPs.
+- **Tab completion model:** A separate, smaller model for real-time
+  code completion (distinct from agent mode).
+- **Agent harness per model:** Cursor tunes instructions and tools
+  for each frontier model it supports.
+
+---
+
+## 4. Kilo Code
+
+Kilo Code is an open-source VS Code extension (also supports JetBrains
+and CLI) descended from the Cline/Roo Code lineage. It uses a mode-based
+architecture with configurable tool access.
+
+### 4.1 Complete Tool List
+
+```
+ #  Tool                   Category         Purpose
+ 1  read_file              file-read        Read file contents (with line ranges, PDF/DOCX support)
+ 2  write_to_file          file-write       Create new files or full overwrite
+ 3  apply_diff             file-write       Apply structured diffs to files
+ 4  replace_in_file        file-write       Search-and-replace in files
+ 5  execute_command         execution        Run terminal commands
+ 6  search_files           search           Regex search in files
+ 7  list_files             search           List directory contents
+ 8  codebase_search        search           Semantic search over codebase
+ 9  browser_action         browser          Browser automation (test web apps)
+10  ask_followup_question  interaction      Ask user for clarification
+11  attempt_completion     control-flow     Signal task completion
+12  new_task               control-flow     Start a new task
+13  switch_mode            control-flow     Switch between modes
+14  run_slash_command       extensibility    Run slash commands
+15  generate_image         generation       Generate images
+16  MCP tools              extensibility    External services via MCP
+```
+
+### 4.2 File Editing Model
+
+Kilo Code provides **three file editing mechanisms:**
+
+1. **write_to_file:** Full file creation or complete overwrite. All
+   changes require user approval via a diff view interface.
+2. **apply_diff:** Structured diffs applied to existing files. Used in
+   the common tool chain: `read_file -> apply_diff -> attempt_completion`.
+3. **replace_in_file:** Search-and-replace for targeted edits (inherited
+   from the Cline lineage).
+
+This is the most flexible editing model of any agent — offering full
+rewrite, structured diff, AND search-replace.
+
+### 4.3 Mode-Based Tool Filtering
+
+Kilo Code's defining feature is **modes that restrict tool access:**
+
+- **Ask Mode:** Read-only tools and information gathering only.
+- **Architect Mode:** Design-focused tools, documentation, limited
+  execution rights.
+- **Code Mode:** Full tool access for implementation.
+- **Debug Mode:** Focused on issue identification and fixing.
+- **Orchestrator Mode:** Decomposes tasks into subtasks, assigns
+  specialized mode agents, coordinates execution.
+- **Custom Modes:** User-defined tool subsets for specialized workflows.
+
+### 4.4 Sandboxing
+
+Kilo Code does not provide OS-level sandboxing. Security is
+permission-based: every tool use requires explicit user approval.
+The UI shows Save/Reject buttons and optional auto-approve toggles.
+This is a **UX-level consent model**, not a security boundary.
+
+### 4.5 MCP Integration
+
+Kilo Code has deep MCP integration including a **MCP Server Marketplace**
+— a built-in way to browse and install MCP servers for extending
+capabilities. MCP tools integrate seamlessly with built-in tools in the
+execution pipeline. The extension segments MCP contexts by operational
+mode to minimize token consumption.
+
+### 4.6 Notable Patterns
+
+- **Cline/Roo lineage:** Inherits the XML tool calling protocol from
+  Cline. (Roo Code has since migrated to native function calling.)
+- **Browser automation as a first-class tool:** `browser_action`
+  enables testing web applications directly.
+- **attempt_completion as explicit control flow:** The agent must
+  explicitly signal when it considers a task done.
+- **Three editing strategies:** Offers the model a choice between
+  full rewrite, diff, and search-replace — more options than any
+  other agent.
+- **Orchestrator for multi-agent:** A meta-mode that plans and
+  delegates rather than executing directly.
+
+---
+
+## 5. VS Code Copilot (GitHub)
+
+GitHub Copilot's agent mode runs inside VS Code, using the editor's
+infrastructure for file access, terminal, and problem detection.
+
+### 5.1 Built-in Tool List
+
+```
+ #  Tool               Category         Purpose
+ 1  editFiles          file-write       Apply code edits
+ 2  codebase           search           Search workspace (semantic + keyword + file name)
+ 3  search             search           Workspace text search
+ 4  problems           context          Read compiler/lint errors from editor
+ 5  changes            context          Read source control changes
+ 6  usages             context          Find symbol usages/references
+ 7  runInTerminal      execution        Run commands in integrated terminal
+ 8  terminalLastCommand context         Get last terminal command output
+ 9  fetch              web              Fetch web content
+10  githubRepo         context          Access GitHub repository information
+11  MCP tools          extensibility    External services via MCP
+```
+
+Tool sets group related tools: a "reader" set includes `changes`,
+`codebase`, `problems`, and `usages`.
+
+### 5.2 File Editing Model
+
+Copilot agent mode generates **proposed edits** that are applied through
+VS Code's native editor APIs. The model generates changes, VS Code
+presents them as diffs, and the user can accept or reject. The system
+detects compile and lint errors after edits and auto-corrects in a loop.
+
+VS Code supports multiple edit formats depending on the model:
+- OpenAI models (GPT-4.1, o4-mini): **apply_patch** format (V4A diffs).
+- Anthropic models (Claude Sonnet): **replace_string** tool.
+
+This multi-format support is a consequence of VS Code being
+model-agnostic — it adapts its edit protocol to match the model's
+trained format.
+
+### 5.3 Sandboxing
+
+VS Code Copilot does not provide OS-level sandboxing. Security is
+through the VS Code permission model:
+- Terminal commands require user approval.
+- File edits are presented in a diff view for review.
+- Rich undo capabilities for reverting changes.
+- `autoFix` setting controls automatic error correction.
+
+The GitHub Copilot Coding Agent (cloud-based) runs in isolated
+containers on GitHub's infrastructure, providing stronger isolation
+for asynchronous tasks.
+
+### 5.4 MCP Integration
+
+VS Code has comprehensive MCP support (GA as of mid-2025):
+- Configuration via `.mcp.json` files in the project tree.
+- Admin governance via enterprise policy and access controls.
+- OAuth 2.0 authentication for remote servers.
+- Fully qualified tool names (`search/codebase`) to avoid conflicts.
+- Max 128 tools enabled per chat request.
+- **Limitation:** Only MCP tools are exposed to agents (not resources
+  or prompts from the MCP spec).
+
+### 5.5 Notable Patterns
+
+- **Editor-native tools:** Unlike terminal agents, Copilot's tools
+  are wired directly into VS Code APIs (problems list, symbol
+  references, source control). This gives it information that
+  terminal agents must reconstruct via shell commands.
+- **Model-adaptive edit format:** Supports both V4A (OpenAI) and
+  replace_string (Anthropic) depending on the model.
+- **Multi-source codebase search:** Combines semantic search, keyword
+  search, filename search, git-modified files, and workspace symbols.
+- **Cross-agent compatibility:** Agent files in `.claude/agents`
+  work in both VS Code and Claude Code, with tool name mapping.
+- **Background agents:** CLI-based agents using git worktrees for
+  isolation from the main workspace.
+- **Custom agents via .agent.md files:** Declarative agent definitions
+  with YAML frontmatter specifying tool access and behavior.
+
+---
+
+## 6. OpenCode
+
+OpenCode is a Go-based terminal agent built by the SST (Serverless
+Stack) team. Uses Bubble Tea for TUI. MIT-licensed, 100K+ GitHub stars.
+Supports 75+ model providers.
+
+### 6.1 Complete Tool List
+
+```
+ #  Tool              Category         Purpose
+ 1  read              file-read        Read file contents (one or more files)
+ 2  write             file-write       Create files or apply patches
+ 3  edit              file-write       Search-and-replace (old_string/new_string)
+ 4  patch             file-write       Apply patch files/diffs
+ 5  multiedit         file-write       Multiple edits in a single call
+ 6  grep              search           Regex content search (ripgrep-based)
+ 7  glob              search           File pattern matching
+ 8  list (ls)         search           List files/directories with metadata
+ 9  bash              execution        Execute shell commands
+10  lsp               code-intel       LSP operations (experimental)
+11  subagent/task     agent            Delegate to specialized subagent
+12  skill             extensibility    Load skill files (SKILL.md)
+13  MCP tools         extensibility    External services via MCP
+```
+
+### 6.2 File Editing Model
+
+OpenCode provides **four editing mechanisms:**
+
+1. **edit:** Exact search-and-replace with `old_string` / `new_string`.
+   Identical to Claude Code's Edit tool. Known issues with formatting
+   conflicts — when OpenCode auto-formats after edit, the model's
+   subsequent edits fail because it expects unformatted content.
+2. **write:** Full file creation or overwrite, can also apply patches.
+3. **patch:** Apply external patch files to the codebase.
+4. **multiedit:** Batch multiple edits in a single tool call.
+
+The search-and-replace model is the primary editing mechanism, but the
+availability of `patch` and `write` gives the model fallback options.
+
+### 6.3 Sandboxing: None (by default)
+
+**OpenCode does NOT sandbox the agent.** Its permission system is purely
+a UX feature — it prompts for confirmation before executing commands
+or writing files, but this is not enforced at the OS level. A
+compromised or malicious prompt can bypass it.
+
+Known security issues:
+- No OS-level filesystem restrictions.
+- No network isolation.
+- A vulnerability was identified where malicious websites could
+  execute commands via XSS in the web UI.
+- The team acknowledged they have "done a poor job handling security
+  reports."
+
+**Third-party mitigations:**
+- `opencode-sandbox` plugin: Uses `@anthropic-ai/sandbox-runtime`
+  (the same library Claude Code uses) to wrap bash commands with
+  Seatbelt/Bubblewrap restrictions.
+- Docker sandboxes: Docker provides guides for running OpenCode in
+  isolated containers.
+
+### 6.4 Search Tools
+
+OpenCode's search tools use **ripgrep under the hood** for grep, glob,
+and list operations. Ripgrep respects `.gitignore` patterns by default.
+A `.ignore` file can explicitly include paths that would normally be
+ignored.
+
+### 6.5 LSP Integration (Experimental)
+
+The LSP tool is unique among terminal agents. When enabled
+(`OPENCODE_EXPERIMENTAL_LSP_TOOL=true`), it provides:
+- goToDefinition, findReferences, hover
+- documentSymbol, workspaceSymbol
+- goToImplementation
+- prepareCallHierarchy, incomingCalls, outgoingCalls
+
+This gives the agent access to **type-aware code intelligence** that
+other terminal agents (Claude Code, Codex CLI) must approximate
+through grep/glob searches or shell commands.
+
+### 6.6 MCP Integration
+
+OpenCode supports MCP with both local (STDIO) and remote (HTTP)
+servers. Configuration in `opencode.json`. Supports OAuth 2.0 for
+remote servers with authorization code flow + PKCE and dynamic client
+registration. MCP tools appear alongside built-ins. Custom tools can
+override built-in tools by using the same name.
+
+### 6.7 Notable Patterns
+
+- **Model freedom as core value:** 75+ model providers, switch
+  mid-session without losing context.
+- **LSP tool is a differentiator:** No other terminal agent provides
+  direct LSP operations as a tool.
+- **SQLite for persistence:** Session data stored locally in SQLite.
+- **Plugin architecture:** "Actions" and "skills" teach the agent
+  domain-specific tasks.
+- **No OS sandboxing is a real gap:** The team is aware but has not
+  shipped a solution; third-party plugins fill the void.
+- **Client-server architecture:** TUI frontend is separated from
+  backend (LLM communication, tool execution, session management).
+
+---
+
+## 7. Cross-Agent Comparison Tables
+
+### 7.1 Tool Category Matrix
+
+```
+Category          Claude  Codex   Cursor  Kilo    Copilot  OpenCode
+                  Code    CLI                     (VSCode)
+─────────────────────────────────────────────────────────────────────
+File Read         Read    read    read    read    codebase read
+                          _file   _file   _file   /search
+File Write        Edit    apply   edit    write   editFiles edit
+  (primary)       +Write  _patch  _file   _to_f            +write
+  (mechanism)     S&R     V4A     2-model S&R/    V4A or   S&R
+                          diff    rewrite diff/   S&R
+                                          S&R
+Shell exec        Bash    shell   term    exec    runIn    bash
+                                  _cmd    _cmd    Terminal
+Glob/pattern      Glob    (shell) (no)    list    (no)     glob
+                                          _files
+Grep/search       Grep    (shell) grep    search  search   grep
+                                  _search _files  /cbase
+Semantic search   (no)    (no)    code    code    codebase (no)
+                                  base_s  base_s
+Web fetch         Web     web     web     (MCP)   fetch    (MCP)
+                  Fetch   _search _search
+Web search        Web     web     web     (MCP)   (no)     (MCP)
+                  Search  _search _search
+Browser           (no)    (no)    (no)    browser (no)     (no)
+                                          _action
+LSP               (no)    (no)    (no)    (no)    usages/  lsp
+                                                  problems (exp.)
+Planning          Todo    update  (no)    new     (no)     (no)
+                  Write   _plan           _task
+Sub-agents        Task    spawn   (8 par  orches  back     subagent
+                          _agent  allel)  trator  ground
+Notebooks         Note    (no)    (no)    (no)    (no)     (no)
+                  bookE
+User interaction  AskUser (no)    (no)    ask     (no)     (no)
+                  Quest           followup
+MCP support       Yes     Yes     Yes     Yes+    Yes      Yes
+                                          Mktplc
+```
+
+### 7.2 File Editing Mechanisms
+
+```
+Agent         Primary Method       Format              Speed
+────────────────────────────────────────────────────────────────
+Claude Code   Search & Replace     old_str/new_str     Model speed
+Codex CLI     V4A Patch            Context-anchored    Model speed
+                                   diff format
+Cursor        Two-model rewrite    Full file rewrite   ~1000 tok/s
+                                   via apply model     (speculative)
+Kilo Code     S&R + Diff + Write   Multiple formats    Model speed
+Copilot       Model-adaptive       V4A (OpenAI) or     Model speed
+                                   S&R (Anthropic)
+OpenCode      Search & Replace     old_str/new_str     Model speed
+              + Patch fallback     + unified diff
+```
+
+### 7.3 Sandboxing Comparison
+
+```
+Agent         OS Sandbox    Filesystem         Network        Default
+────────────────────────────────────────────────────────────────────
+Claude Code   Seatbelt/     Deny-read list,    Proxy-only     ON
+              Bubblewrap    Allow-write list    (no namespace)
+Codex CLI     Landlock/     Read-anywhere,     Blocked by     ON
+              seccomp/      Write-workspace    seccomp unless
+              (opt: bwrap)                     enabled
+Cursor        sandbox.json  Configurable       Configurable   Limited
+Kilo Code     None          Approval UX only   No restriction OFF
+Copilot       None (local)  Editor permissions No restriction OFF
+              Containers    Full isolation     Full isolation ON
+              (cloud)                                         (cloud)
+OpenCode      None          Approval UX only   No restriction OFF
+              (3rd-party    (plugin: seatbelt/ (plugin adds
+              plugin avail) bwrap)             restrictions)
+```
+
+### 7.4 MCP Integration Depth
+
+```
+Agent         Client  Server  Marketplace  Auth     Governance
+────────────────────────────────────────────────────────────────
+Claude Code   Yes     Yes     No           Basic    Project-level
+Codex CLI     Yes     Yes     No           Config   Org-level
+Cursor        Yes     No      No           Config   Per-project
+Kilo Code     Yes     No      YES          Config   Mode-based
+Copilot       Yes     No      No           OAuth    Enterprise
+OpenCode      Yes     No*     No           OAuth    Permission-based
+
+* OpenCode as MCP server is proposed but not yet implemented.
+```
+
+---
+
+## 8. Implications for ilo-lang
+
+### 8.1 The Universal Tool Primitives
+
+Every agent, regardless of architecture, implements these operations:
+
+```
+1. READ     - Read file contents
+2. WRITE    - Create/overwrite file
+3. EDIT     - Modify existing file (search-replace or diff)
+4. SEARCH   - Find files by name/pattern (glob)
+5. GREP     - Find content within files (regex)
+6. EXEC     - Run a shell command
+7. FETCH    - Get content from a URL
+```
+
+These seven operations are the **irreducible core** that every coding
+agent needs. They map directly to what an ilo program needs to be able
+to express when orchestrating tool use.
+
+### 8.2 The Search-Replace Edit Model Dominates
+
+Four of six agents (Claude Code, Kilo Code, OpenCode, and Copilot
+with Anthropic models) use **exact string search-and-replace** as
+their primary editing mechanism. This is the simplest model:
+- No line numbers to track.
+- No diff format to learn.
+- Matches are unambiguous (must be unique in file).
+- The model only generates the changed content.
+
+Codex's V4A patch format is model-specific (GPT-family only).
+Cursor's full-rewrite approach requires a second specialized model.
+
+For ilo's tool declarations, **search-replace is the format to
+optimize for** — it is the most common, simplest, and most portable
+across models.
+
+### 8.3 Shell Execution is Universal but Overloaded
+
+Every agent has a "run shell command" tool, but agents differ in
+whether they rely on it as a general-purpose fallback:
+
+- **Codex CLI:** Shell is a primary tool. The agent uses it for
+  everything the other tools do not cover.
+- **Claude Code:** Shell exists but the system prompt actively
+  discourages it in favor of specialized tools ("use Grep, not grep").
+- **OpenCode:** Similar to Claude Code — specialized tools preferred.
+
+The implication: ilo should model shell execution as a distinct tool
+type, but provide enough built-in operations (file I/O, search, HTTP)
+that agents do not need to fall back to shell for common tasks.
+
+### 8.4 Sandboxing Patterns
+
+Agents that sandbox do it at the OS level with the same two primitives:
+1. **Filesystem allow/deny lists** (path-based)
+2. **Network namespace/proxy isolation** (block all, allow specific)
+
+This suggests ilo's tool execution model should be **sandboxable by
+default** — tools should declare what filesystem and network access
+they require, enabling a runtime to enforce restrictions.
+
+### 8.5 The Semantic Search Gap
+
+Terminal agents (Claude Code, Codex CLI, OpenCode) lack semantic
+search — they rely on grep and glob. IDE agents (Cursor, Kilo Code,
+Copilot) have it because they embed the codebase in a vector index.
+
+OpenCode's experimental LSP tool is an interesting middle ground:
+instead of semantic search, it provides **type-aware navigation**
+(go-to-definition, find-references, call-hierarchy).
+
+For ilo, the graph-native principle already addresses this: if program
+structure is explicit (declared edges, queryable dependencies), agents
+do not need semantic search or LSP — the graph IS the index.
+
+### 8.6 Planning as a Tool
+
+Three agents have explicit planning tools:
+- Claude Code: TodoWrite (structured task lists with states)
+- Codex CLI: update_plan (TODO management)
+- Kilo Code: Orchestrator mode (meta-agent that plans and delegates)
+
+Planning is not a file operation — it is a **coordination primitive**.
+For ilo programs that orchestrate multi-step workflows, this suggests
+a need for structured state tracking as a built-in concept, not just
+a tool.
+
+### 8.7 Sub-Agent Delegation
+
+Four of six agents support sub-agent delegation:
+- Claude Code: Task tool
+- Codex CLI: spawn_agent / send_input / resume_agent / wait / close_agent
+- Kilo Code: Orchestrator mode + new_task
+- OpenCode: subagent/task
+
+Sub-agents get scoped tool access and isolated context windows. This
+is the primary mechanism for handling complex tasks that exceed a
+single context window. The pattern is: decompose into subtasks, run
+each in isolation, aggregate results.
+
+For ilo, this maps to the **graph-native composition** principle:
+programs are subgraphs that can be executed independently. The
+language already supports this structurally — the runtime just needs
+to support parallel/isolated execution of subgraphs.
+
+### 8.8 What ilo Needs as Built-in Operations
+
+Based on universal tool patterns across all six agents:
+
+```
+Category        ilo operation     Maps to agent tool
+──────────────────────────────────────────────────────
+File I/O        read              Read / read_file
+                write             Write / write_to_file
+                edit (S&R)        Edit / replace_in_file
+Search          find (glob)       Glob / list_files
+                grep (regex)      Grep / search_files
+Execution       exec              Bash / shell / execute_command
+HTTP            get               WebFetch / fetch
+                (post, etc.)      (tool declarations)
+Graph query     deps / calls      (ilo-native, no agent equivalent)
+                impacts
+Error handling  R ok err          (already in ilo)
+Planning state  (track/status)    TodoWrite / update_plan
+```
+
+The ilo-native graph operations (deps, calls, impacts) have NO
+equivalent in any agent's built-in tools. These are what makes ilo
+structurally distinct — agents currently reconstruct this information
+through repeated grep/search operations.
+
+### 8.9 Token Costs of Tool Calls
+
+Every tool call costs tokens for:
+1. The tool name and parameters (prompt tokens).
+2. The tool output (response tokens added to context).
+3. The model's reasoning about what tool to use next.
+
+ilo's token-minimal design should extend to tool declarations. The
+`tool` syntax (`tool get-user"desc" uid:t>R profile t`) is already
+more compact than any agent's tool definition format. The key insight
+is that agents spend significant tokens on tool selection and output
+parsing — ilo's constrained vocabulary and typed returns eliminate
+much of this overhead.
+
+---
+
+## Sources
+
+### Claude Code
+- Anthropic Engineering: Claude Code Sandboxing
+- Claude Code System Prompts (Piebald-AI)
+- Claude Code Built-in Tools Reference
+- sandbox-runtime (GitHub)
+
+### Codex CLI
+- Codex CLI Documentation (developers.openai.com)
+- Codex Sandboxing Documentation
+- Apply Patch / V4A format (OpenAI API)
+- Codex Prompting Guide
+- Codex CLI (GitHub)
+
+### Cursor
+- How Cursor Built Fast Apply (Fireworks AI)
+- How Cursor Shipped its Coding Agent (ByteByteGo)
+- Cursor Agent Tools (Community Forum)
+- Cursor Instant Apply (Bind AI)
+
+### Kilo Code
+- Kilo Code (GitHub)
+- Kilo Code Tool Use Overview
+- DeepWiki: Kilo Code Architecture
+
+### VS Code Copilot
+- GitHub Copilot Agent Mode Announcement
+- Agent Mode in VS Code Documentation
+- Tools with Agents (VS Code)
+- Custom Agents via .agent.md files
+
+### OpenCode
+- OpenCode Documentation
+- OpenCode Tools
+- OpenCode MCP Servers
+- DeepWiki: OpenCode File System Tools
+- Docker Sandboxes for OpenCode
+
+---
+
+## See Also
+
+- [agent-framework-tool-mechanics.md](agent-framework-tool-mechanics.md) — deep dive into tool-calling protocols and JSON Schema patterns across agent frameworks
+- [mcp-protocol-research.md](mcp-protocol-research.md) — MCP protocol mechanics that agents use for tool discovery

--- a/research/essential-packages-analysis.md
+++ b/research/essential-packages-analysis.md
@@ -1,0 +1,848 @@
+# Essential Packages: What Language Designers Missed
+
+Cross-language analysis of packages so universally installed they are effectively part of
+the language. This reveals the gap between what designers thought was core vs what developers
+actually need -- and what it means for ilo, where agents cannot install packages.
+
+---
+
+## The Phenomenon
+
+Every major programming language has a set of third-party packages that appear in >50% of
+projects. These are not niche libraries -- they are capabilities that the language's standard
+library lacks but that real-world programs universally require. The existence of these
+"essential packages" is a design signal: it tells us what the language got wrong about scope.
+
+For ilo, this signal is critical. ilo programs are self-contained: an agent cannot
+`pip install requests` or `npm install axios`. Whatever an ilo program needs must be either
+a builtin or a declared tool. The essential packages of other languages are a map of exactly
+what builtins ilo needs.
+
+---
+
+## Language-by-Language Catalog
+
+### Python
+
+Python's standard library is famously "batteries included" -- yet the ecosystem has
+converged on a set of third-party packages that nearly every project installs.
+
+| Package | Installs/month | % of projects | Capability gap |
+|---------|---------------|---------------|----------------|
+| **requests** | 300M+ | ~70% | Usable HTTP client (urllib is painful) |
+| **pydantic** | 200M+ | ~55% | Data validation and settings management |
+| **pytest** | 150M+ | ~65% (of tested projects) | Modern testing framework |
+| **python-dotenv** | 120M+ | ~50% | Load .env files into environment |
+| **click / typer** | 100M+ | ~45% | CLI argument parsing (argparse is verbose) |
+| **black** | 80M+ | ~50% (of formatted projects) | Code formatting |
+| **mypy / pyright** | 70M+ | ~45% | Static type checking |
+| **flask / fastapi** | 60M+ | ~40% (of web projects) | Web framework |
+| **pandas** | 60M+ | ~35% | Tabular data manipulation |
+| **boto3** | 55M+ | ~30% | AWS SDK |
+| **httpx** | 50M+ | ~25% | Async HTTP client |
+
+**What the stdlib got wrong:**
+
+1. **HTTP client.** `urllib` and `urllib2` exist but are so painful to use that `requests`
+   became the de facto standard. The API difference is stark:
+   ```python
+   # urllib (stdlib): 5 lines, manual encoding, manual error handling
+   req = urllib.request.Request(url, headers={'Authorization': f'Bearer {token}'})
+   try:
+       response = urllib.request.urlopen(req, timeout=10)
+       data = json.loads(response.read().decode('utf-8'))
+   except urllib.error.HTTPError as e:
+       handle_error(e)
+
+   # requests (third-party): 1 line, obvious API
+   data = requests.get(url, headers={'Authorization': f'Bearer {token}'}, timeout=10).json()
+   ```
+   The lesson: a bad stdlib API is worse than no stdlib API. Developers will replace it.
+
+2. **Data validation.** Python has no runtime type enforcement. `pydantic` fills this gap
+   by turning type annotations into runtime validators. This is a signal that developers
+   need structured data validation at the boundary between trusted and untrusted data --
+   exactly what ilo's type verifier and tool boundaries provide.
+
+3. **Environment configuration.** `os.getenv()` exists, but `python-dotenv` is installed in
+   half of all projects because developers need to load configuration from `.env` files in
+   development. The pattern: config comes from environment variables, but those variables
+   need to be loaded from somewhere.
+
+4. **Code formatting.** `black` exists because Python has no official formatter. Go's
+   `gofmt` solved this at the language level. ilo's dense format solves it at the
+   specification level -- there is exactly one canonical form.
+
+5. **Type checking.** Python added type hints in 3.5 (2015) but no type checker. `mypy`
+   fills this gap. The lesson: types without enforcement are suggestions. ilo enforces
+   types before execution -- verification is built into the language, not bolted on.
+
+---
+
+### JavaScript / TypeScript
+
+The JS ecosystem is famously fragmented, but a core set of packages has emerged as
+near-universal.
+
+| Package | Weekly downloads | % of projects | Capability gap |
+|---------|----------------|---------------|----------------|
+| **typescript** | 50M+ | ~70% (of all JS) | Type system (JS has none) |
+| **eslint** | 40M+ | ~65% | Linting (no built-in linter) |
+| **prettier** | 35M+ | ~55% | Code formatting (no built-in) |
+| **axios / node-fetch** | 30M+ | ~50% | HTTP client (fetch was not always in Node) |
+| **dotenv** | 30M+ | ~55% | Load .env files into process.env |
+| **jest / vitest** | 25M+ | ~60% (of tested) | Testing framework |
+| **zod** | 20M+ | ~35% | Runtime type validation |
+| **lodash** | 45M+ | ~40% (declining) | Utility functions (array, object, string) |
+| **chalk** | 25M+ | ~35% | Terminal colors |
+| **commander / yargs** | 20M+ | ~30% | CLI argument parsing |
+| **express / fastify** | 15M+ | ~40% (of server projects) | Web framework |
+| **fs-extra** | 15M+ | ~25% | File operations that fs lacks |
+| **debug** | 40M+ | ~40% (as transitive) | Debug logging with namespaces |
+| **inquirer / prompts** | 10M+ | ~20% | Interactive CLI prompts |
+
+**What the ecosystem reveals:**
+
+1. **TypeScript IS JavaScript.** When 70% of JavaScript projects install TypeScript, the
+   language has effectively admitted that dynamic typing is insufficient for production code.
+   TypeScript is the single most popular npm package because the language's core design
+   choice -- no types -- was wrong. ilo's position (types verified before execution) is
+   validated by the entire JS ecosystem voting with their `package.json`.
+
+2. **fetch took 14 years.** Node.js launched in 2009. `node-fetch` polyfilled the browser's
+   `fetch` API. Native `fetch` did not land in Node.js until v18 (2022). For 13 years,
+   every Node.js project that made HTTP requests needed a third-party dependency for the
+   most basic networking operation. The lesson: HTTP clients should ship day one.
+
+3. **dotenv is a confession.** Every language's ecosystem independently invented a `.env`
+   loader. This is not a coincidence -- it is a universal need that zero languages
+   addressed in their stdlib. The need: load configuration from the environment, with a
+   local override file for development.
+
+4. **zod and pydantic are twins.** JavaScript's `zod` and Python's `pydantic` solve the
+   same problem: validate data at the boundary between trusted code and untrusted input
+   (API responses, user data, config files). Both languages lack runtime type validation.
+   ilo's type system + tool boundaries handle this natively.
+
+5. **lodash is dying because the stdlib caught up.** Lodash provided `map`, `filter`,
+   `reduce`, `cloneDeep`, `debounce`, `throttle`, and dozens of other utilities that JS
+   lacked. As ES6+ added `Array.prototype.map/filter/reduce`, `Object.entries/values/keys`,
+   `structuredClone`, and optional chaining, lodash usage declined. The lesson: when the
+   stdlib provides the capability, the third-party package dies. This confirms that
+   building capabilities into the language is the right approach.
+
+---
+
+### Ruby
+
+Ruby's ecosystem is smaller but highly concentrated around a few dominant packages.
+
+| Package | Downloads | % of projects | Capability gap |
+|---------|----------|---------------|----------------|
+| **bundler** | Universal | ~95% | Dependency management (was third-party until Ruby 2.6) |
+| **rails** | Dominant | ~60% (of web) | Full web framework |
+| **rspec** | High | ~65% (of tested) | Testing (Minitest exists but rspec preferred) |
+| **rubocop** | High | ~55% | Linting and formatting |
+| **nokogiri** | High | ~40% | HTML/XML parsing (REXML is too slow) |
+| **pry** | High | ~50% | Better REPL and debugger |
+| **httparty / faraday** | Medium | ~35% | HTTP client (Net::HTTP is verbose) |
+| **dotenv** | Medium | ~40% | Load .env files |
+| **sidekiq** | Medium | ~30% | Background job processing |
+| **devise** | Medium | ~25% (of web) | Authentication |
+
+**What Ruby reveals:**
+
+1. **Net::HTTP is the new urllib.** Ruby has a built-in HTTP client, but it is so verbose
+   that `httparty` and `faraday` exist to wrap it. The same pattern as Python's
+   `urllib` -> `requests`. A bad built-in HTTP client is worse than none.
+
+2. **Bundler was absorbed.** Bundler started as a third-party gem and was eventually merged
+   into Ruby's stdlib (Ruby 2.6). This is the clearest possible signal: when a package is
+   installed in 95% of projects, it belongs in the language. The same happened with `pip`
+   being bundled with Python.
+
+3. **Nokogiri vs REXML.** Ruby has a built-in XML parser (REXML), but it is too slow for
+   real-world use. Nokogiri (a C-binding wrapper) replaced it entirely. The lesson for ilo:
+   if a builtin cannot handle production workloads, it is worse than not having one at all.
+   ilo's approach -- delegating parsing to tools -- avoids this trap entirely.
+
+---
+
+### Go
+
+Go is the most relevant comparison for ilo because of its shared design philosophy:
+simplicity, one way to do things, explicit error handling.
+
+| Package | Stars/Usage | % of projects | Capability gap |
+|---------|------------|---------------|----------------|
+| **gorilla/mux** or **chi** | 20k+ / 17k+ | ~50% (pre-1.22) | HTTP routing (stdlib ServeMux was too basic) |
+| **testify** | 22k+ | ~55% | Testing assertions (stdlib has none) |
+| **cobra** | 36k+ | ~40% | CLI framework |
+| **viper** | 26k+ | ~35% | Configuration management |
+| **zap / zerolog** | 21k+ / 10k+ | ~45% | Structured logging (stdlib log is basic) |
+| **sqlx** | 15k+ | ~30% | Enhanced database driver |
+| **godotenv** | 7k+ | ~25% | Load .env files |
+| **uuid** | 5k+ | ~30% | UUID generation |
+| **go-playground/validator** | 16k+ | ~30% | Struct validation |
+
+**What Go reveals -- and what Go 1.22 fixed:**
+
+1. **ServeMux was the biggest gap.** Go shipped with an HTTP server and router, but
+   `http.ServeMux` was so basic (no path parameters, no method matching) that gorilla/mux
+   and chi became universal. **Go 1.22 (Feb 2024) finally fixed this** by adding method
+   and path parameter support to `ServeMux`. The 12-year gap is the strongest possible
+   evidence that stdlib gaps persist for years even in languages with strong stdlib
+   philosophies.
+
+2. **No testing assertions.** Go's `testing` package provides the test runner but no
+   assertion helpers. `if got != want { t.Errorf(...) }` is the pattern, repeated hundreds
+   of times per project. `testify` provides `assert.Equal(t, got, want)` -- saving 2-3
+   lines per assertion. Go's designers argued that assertions hide information. The
+   community disagreed by a margin of 55%.
+
+3. **Structured logging took 15 years.** Go launched in 2009 with `log.Printf`. The
+   `slog` package (structured logging) was not added to the stdlib until Go 1.21 (Aug
+   2023). For 14 years, every Go project that needed JSON logs -- which is every production
+   Go service -- used zap, zerolog, or logrus. The lesson: logging format matters for
+   machine consumption, and text-only logging is insufficient.
+
+4. **godotenv exists in Go too.** Even in a language with a strong "just use the stdlib"
+   culture, .env loading is a universal need.
+
+---
+
+### Rust
+
+Rust has the most extreme version of this phenomenon: the language is deliberately minimal,
+and the crate ecosystem fills enormous gaps.
+
+| Crate | Downloads | % of projects | Capability gap |
+|-------|----------|---------------|----------------|
+| **serde / serde_json** | 350M+ | ~75% | Serialization (no built-in) |
+| **tokio** | 250M+ | ~60% | Async runtime (language has async/await but no runtime) |
+| **clap** | 150M+ | ~45% | CLI argument parsing |
+| **reqwest** | 130M+ | ~40% | HTTP client (no built-in) |
+| **anyhow / thiserror** | 120M+ | ~50% | Ergonomic error handling |
+| **tracing** | 100M+ | ~40% | Structured logging/tracing |
+| **rand** | 100M+ | ~40% | Random number generation |
+| **regex** | 80M+ | ~35% | Regular expressions |
+| **chrono / time** | 70M+ | ~35% | Date/time handling |
+| **uuid** | 50M+ | ~25% | UUID generation |
+| **dotenv / dotenvy** | 30M+ | ~20% | Load .env files |
+
+**What Rust reveals:**
+
+1. **serde is the language.** When 75% of Rust projects install the same crate, it is no
+   longer optional -- it is the language's serialization model. serde's derive macro
+   (`#[derive(Serialize, Deserialize)]`) is so universal that Rust programs are practically
+   unwriteable without it. The lesson: serialization at data boundaries is not optional.
+   ilo handles this at the tool boundary via `Value <-> JSON` mapping (D1e).
+
+2. **Rust shipped async without a runtime.** Rust added `async`/`await` to the language in
+   1.39 (2019) but deliberately excluded the async runtime. tokio fills this gap for 60%
+   of Rust projects. The decision was intentional (no runtime in the language) but the
+   consequence is that "Rust async" effectively means "Rust + tokio." ilo avoids this by
+   keeping execution fully synchronous at the language level, with parallelism handled by
+   the runtime.
+
+3. **anyhow + thiserror: error ergonomics matter.** Rust's `Result<T, E>` is the model ilo
+   followed, but even Rust developers found raw `Result` too verbose. `anyhow` provides
+   `anyhow::Result` (any error type) and `context("message")` for error wrapping.
+   `thiserror` provides derive macros for custom error types. ilo's `!` auto-unwrap and
+   `^+"context: "e` pattern already provide these ergonomics natively.
+
+4. **No built-in random numbers.** Rust has no `rand` in the stdlib. This is a deliberate
+   choice (cryptographic randomness vs pseudo-randomness is a footgun), but it means every
+   project that needs a random number must pull in a crate. For ilo, random number
+   generation is an agent need (generating IDs, sampling) that should be a builtin.
+
+5. **No built-in regex.** Rust delegates regex to a crate. The `regex` crate is high-quality
+   (no backtracking, guaranteed linear time), but every text-processing project needs to
+   add it. For ilo, regex is a question of builtin vs tool -- the Python and Ruby research
+   suggest builtin behind a feature flag.
+
+---
+
+### PHP
+
+PHP is instructive because it started as a "do everything" language with 8,000+ built-in
+functions, yet still has essential packages.
+
+| Package | Installs | % of projects | Capability gap |
+|---------|---------|---------------|----------------|
+| **laravel / symfony** | Dominant | ~70% (of web) | Web framework (raw PHP is tedious) |
+| **guzzle** | Very high | ~55% | HTTP client (file_get_contents lacks features) |
+| **phpunit** | Very high | ~65% (of tested) | Testing framework |
+| **monolog** | Very high | ~50% | Structured logging (no built-in) |
+| **carbon** | High | ~40% | Date/time manipulation (DateTime is limited) |
+| **vlucas/phpdotenv** | High | ~40% | Load .env files |
+| **composer** | Universal | ~95% | Dependency management (was third-party) |
+
+**What PHP reveals:**
+
+1. **8,000 built-in functions were not enough.** PHP has `file_get_contents()`,
+   `json_decode()`, `preg_match()`, `date()`, and thousands more -- yet guzzle, monolog,
+   carbon, and dotenv are still essential. The lesson: quantity of builtins does not equal
+   coverage. What matters is whether the builtins solve the actual workflow patterns that
+   developers encounter. PHP's `file_get_contents()` can fetch URLs, but it cannot set
+   headers, handle redirects properly, or parse response codes -- so guzzle exists.
+
+2. **Composer, like Bundler, was absorbed.** PHP's dependency manager started as a
+   third-party tool and became the de facto standard. Both Ruby and PHP's ecosystems
+   independently converged on the same pattern: the package manager is too important to be
+   a package.
+
+---
+
+## Universal Patterns Across All Languages
+
+The catalog above reveals patterns that repeat across every language, regardless of design
+philosophy, age, or domain. These are not language-specific gaps -- they are capabilities
+that all programmers need and that no language designer anticipated (or chose to include).
+
+### Pattern 1: HTTP Client
+
+**Every language needs a third-party HTTP client.**
+
+| Language | Stdlib HTTP | Essential package | Gap |
+|----------|-----------|-------------------|-----|
+| Python | urllib (painful) | requests, httpx | Usable API |
+| JavaScript | fetch (added late) | axios, node-fetch | Was missing for 13 years |
+| Ruby | Net::HTTP (verbose) | httparty, faraday | Ergonomic API |
+| Go | net/http (good!) | -- | Go is the exception |
+| Rust | None | reqwest | Entire capability |
+| PHP | file_get_contents (limited) | guzzle | Headers, redirects, errors |
+
+**Why designers missed it:** Languages were designed before the API economy. HTTP was a
+protocol for browsers, not a universal application integration layer. By the time every
+program needed to call APIs, the stdlib was frozen.
+
+**ilo's answer:** `get url` / `$url` is already a builtin (D1b). `post url body` is
+planned. HTTP is not an afterthought in ilo -- it is a first-class primitive. This is the
+correct design for a language born in the API era.
+
+### Pattern 2: Environment Configuration
+
+**Every language needs a dotenv package.**
+
+| Language | Stdlib env access | Essential package |
+|----------|-----------------|-------------------|
+| Python | os.getenv() | python-dotenv |
+| JavaScript | process.env | dotenv |
+| Ruby | ENV[] | dotenv |
+| Go | os.Getenv() | godotenv |
+| Rust | std::env::var() | dotenv/dotenvy |
+| PHP | $_ENV | vlucas/phpdotenv |
+
+**Why designers missed it:** Environment variable access was always in the stdlib. What
+was missing was the *workflow*: developers need local `.env` files for development secrets,
+but environment variables in production. The dotenv pattern bridges this gap. No language
+anticipated this workflow because it emerged from 12-factor app methodology (2011).
+
+**ilo's answer:** `env key` is planned (I3) as a builtin returning `R t t`. For agents,
+the dotenv workflow is less relevant (agents receive configuration from their orchestrator,
+not from `.env` files), but env var access is critical for API keys and runtime
+configuration.
+
+### Pattern 3: Data Validation at Boundaries
+
+**Every language needs a runtime validation library.**
+
+| Language | Stdlib validation | Essential package |
+|----------|-----------------|-------------------|
+| Python | None | pydantic |
+| JavaScript | None | zod, joi, yup |
+| Ruby | None (ActiveModel in Rails) | dry-validation |
+| Go | None | go-playground/validator |
+| Rust | None (serde handles shape) | validator |
+| PHP | None | respect/validation |
+
+**Why designers missed it:** Type systems check types at compile time (or not at all in
+dynamic languages). But the boundary between your code and external data (API responses,
+user input, config files) is where types break down. Data arrives as untyped JSON/text and
+must be validated against expected shapes. No language provides this at the stdlib level.
+
+**ilo's answer:** ilo's tool declarations ARE the validation schema. When a tool declares
+`>R profile t`, the runtime validates the JSON response against the `profile` record
+definition. The type system extends to the boundary. This is what pydantic and zod do, but
+built into the language.
+
+### Pattern 4: Code Formatting
+
+**Every language eventually needs an official formatter.**
+
+| Language | Built-in formatter | Essential package | Year of resolution |
+|----------|-------------------|-------------------|-------------------|
+| Python | None | black, autopep8, yapf | black (2018) -- still third-party |
+| JavaScript | None | prettier | 2017 -- still third-party |
+| Ruby | None | rubocop | Still third-party |
+| Go | **gofmt** (built-in) | -- | 2009 (day one) |
+| Rust | **rustfmt** (official) | -- | 2015 (early ecosystem) |
+| PHP | None (PSR standards) | php-cs-fixer | Still third-party |
+
+**Why designers missed it:** Early language designers viewed formatting as a matter of
+taste. Go proved them wrong: `gofmt` ships with Go, is non-configurable, and eliminates
+all formatting debates. The result: every Go file looks the same. Rust followed with
+`rustfmt`. Python and JavaScript still have competing formatters.
+
+**ilo's answer:** Dense format is canonical. There is exactly one representation.
+`dense(parse(dense(parse(src)))) == dense(parse(src))`. Formatting debates are impossible
+because there are no formatting choices. ilo solved this at the specification level, which
+is even more fundamental than Go's `gofmt`.
+
+### Pattern 5: Testing Framework
+
+**Every language's built-in testing is insufficient.**
+
+| Language | Stdlib testing | Essential package |
+|----------|--------------|-------------------|
+| Python | unittest | pytest |
+| JavaScript | None (node:test added 2022) | jest, vitest, mocha |
+| Ruby | Minitest | rspec |
+| Go | testing (no assertions) | testify |
+| Rust | #[test] (basic) | -- (Rust's is unusually good) |
+| PHP | None | phpunit |
+
+**Why designers missed it:** Language designers build testing as a way to run code and
+check results. Developers want testing as a way to express intent, with rich assertions,
+fixtures, mocking, and parallel execution. The gap is between "mechanism" and "workflow."
+
+**ilo's relevance:** Testing is not applicable to ilo in the traditional sense. ilo programs
+are verified before execution -- the verifier IS the test framework. Type checking,
+exhaustiveness checking, call resolution, and arity checking catch the errors that testing
+frameworks catch in other languages. The remaining testing need (does the program produce
+correct output?) is an orchestration concern, not a language concern.
+
+### Pattern 6: Structured Logging
+
+**Every language needs structured logging.**
+
+| Language | Stdlib logging | Essential package |
+|----------|--------------|-------------------|
+| Python | logging (old-style) | structlog, loguru |
+| JavaScript | console.log (unstructured) | pino, winston |
+| Ruby | Logger (basic) | rails logger, semantic_logger |
+| Go | log (text only, until 1.21) | zap, zerolog, logrus |
+| Rust | log (facade only) | tracing, env_logger |
+| PHP | None | monolog |
+
+**Why designers missed it:** Early languages logged to console/files for humans. Modern
+systems need machine-readable logs (JSON) for aggregation, search, and alerting. The
+"structured logging" pattern (key-value pairs instead of format strings) did not emerge
+until the DevOps era.
+
+**ilo's relevance:** ilo programs are short-lived tool orchestration scripts, not
+long-running services. Traditional logging is not a concern. If logging is needed, it is a
+tool concern (`tool log"Write log entry" msg:t level:t>R _ t`), not a language concern.
+
+### Pattern 7: CLI Argument Parsing
+
+**Every language needs a better CLI parser.**
+
+| Language | Stdlib CLI | Essential package |
+|----------|----------|-------------------|
+| Python | argparse (verbose) | click, typer |
+| JavaScript | process.argv (raw) | commander, yargs |
+| Ruby | OptionParser (adequate) | thor, optimist |
+| Go | flag (basic) | cobra, pflag |
+| Rust | std::env::args (raw) | clap, structopt |
+| PHP | $argv (raw) | symfony/console |
+
+**Why designers missed it:** Early languages treated CLI arguments as a simple array.
+Modern CLI tools need subcommands, flags with types, help text generation, auto-completion,
+and validation. The gap between `argv` and a real CLI experience is enormous.
+
+**ilo's answer:** This pattern is irrelevant for ilo. ilo programs are generated by agents
+for specific tasks. They do not need self-documenting CLI interfaces. Function parameters
+ARE the CLI interface: `ilo 'f x:n y:n>n;+x y' 3 4` maps positional args to typed params.
+No parsing library needed.
+
+---
+
+## The Capability Matrix
+
+Combining all languages, here is the universal set of capabilities that "essential packages"
+provide, organized by how ilo should handle them:
+
+### Already in ilo (builtins)
+
+| Capability | Languages that need a package | ilo builtin |
+|-----------|------------------------------|-------------|
+| HTTP GET | Python, JS, Ruby, Rust, PHP | `get url` / `$url` |
+| String split/join | (Most have stdlib) | `spl` / `cat` |
+| String contains | (Most have stdlib) | `has` |
+| List operations | (Most have stdlib) | `@`, `+=`, `+`, `len`, `hd`, `tl`, `rev`, `srt`, `slc` |
+| Type conversions | (Most have stdlib) | `str`, `num` |
+| Math basics | (Most have stdlib) | `+`, `-`, `*`, `/`, `abs`, `min`, `max`, `flr`, `cel` |
+| Error handling | Python (try/except), JS (try/catch), Rust (anyhow) | `R`, `?`, `!`, `^`, `~` |
+| Code formatting | Python (black), JS (prettier), Ruby (rubocop) | Dense format (canonical) |
+| Data validation | Python (pydantic), JS (zod), Go (validator) | Type verifier + tool boundaries |
+
+### Planned for ilo (roadmap items)
+
+| Capability | Languages that need a package | ilo plan | Phase |
+|-----------|------------------------------|----------|-------|
+| HTTP POST | Python (requests), JS (axios), PHP (guzzle) | `post url body` | G1 |
+| Env vars | ALL languages (dotenv) | `env key` | I3 |
+| JSON parse | Python (json), Rust (serde_json) | `jp`/`jsn` | I1 |
+| Shell execution | Ruby (backticks), PHP (shell_exec) | `sh cmd` or `run cmd` | I2 |
+| String replace | All languages need it | `sub`/`rpl` | I8 |
+| Trim whitespace | All languages need it | `trm` | I8 |
+| Regex | Ruby, Python, PHP (built-in); Rust, Go (crates/packages) | `rgx`/`rga`/`rgs` | I8 |
+| Base64 encode/decode | JS (btoa/atob), Python, Rust | `b64e`/`b64d` | I7 |
+| URL encode/decode | All languages need it | `urle`/`urld` | I7 |
+| SHA-256 hash | Python (hashlib), Rust (no stdlib) | `sha` / `hash` | I9 |
+| HMAC | Python (hmac), Go (crypto/hmac) | `hmac` | I9 |
+| UUID generation | Rust (uuid), Go (uuid), Python (uuid) | `uid()` | I9 |
+| Timestamp | All languages | `now()` | I6 |
+| Sleep/delay | All languages | `slp n` | I6 |
+| ISO date format | All languages (chrono/carbon/moment) | `iso n` | I6 |
+| Maps/dicts | (Most have stdlib but ilo lacks) | `M t v` | E4 |
+| Random numbers | Rust (rand), Python (random) | `rnd()` | I9 |
+| File read/write | All languages | `rd`/`wr` or `fread`/`fwrite` | G8 |
+| Parallel execution | Python (asyncio), JS (Promise.all), Rust (tokio) | `par{...}` | G4 |
+
+### Tool concerns (not builtins)
+
+| Capability | Why it is a tool, not a builtin |
+|-----------|-------------------------------|
+| Web frameworks (express, flask, rails) | Agents consume APIs, they do not serve them |
+| Database drivers (sqlx, prisma) | Domain-specific, requires connection management |
+| HTML/XML parsing (nokogiri, cheerio) | Format-specific parsing is a tool concern |
+| CSV parsing | Format-specific |
+| YAML/TOML parsing | Format-specific |
+| Email sending | External service with complex config |
+| Background jobs (sidekiq, celery) | Long-running service infrastructure |
+| Authentication (devise, passport) | Domain-specific, not composable |
+| Image processing | Domain-specific computation |
+| Machine learning | Heavy computation, tool territory |
+
+---
+
+## The Critical Insight for ilo
+
+### Why this analysis matters more for ilo than for any other language
+
+In Python, a developer who needs HTTP can `pip install requests` in 2 seconds. In
+JavaScript, `npm install axios` takes 1 second. The "essential package" problem is an
+inconvenience in traditional languages -- you install the package and move on.
+
+**In ilo, the essential package problem is a hard wall.**
+
+An ilo program is self-contained. An agent generating an ilo program cannot install
+packages. It cannot reach out to npm or PyPI. Whatever capability the program needs must
+come from one of two sources:
+
+1. **Builtins** -- compiled into the ilo runtime, always available.
+2. **Declared tools** -- external services that the program's environment provides.
+
+There is no third option. No package manager, no import system, no dynamic loading.
+
+This means every gap in the "essential packages" list above that is not covered by a
+builtin or a commonly-available tool is a capability that ilo programs **cannot access at
+all**. Not "inconvenient to access" -- literally impossible.
+
+### The builtin vs tool boundary
+
+The analysis above reveals a natural boundary:
+
+**Builtins** should cover capabilities that are:
+- Universal (needed by >50% of programs regardless of domain)
+- Stateless or nearly stateless (no connection management, no sessions)
+- Fast (completes in milliseconds to seconds)
+- Token-efficient as builtins (1-3 tokens vs 5-10 tokens as tool declarations + calls)
+
+**Tools** should cover capabilities that are:
+- Domain-specific (databases, specific APIs, specific file formats)
+- Stateful (connection pools, sessions, transactions)
+- Slow (minutes-long operations, human-in-the-loop)
+- Configurable (endpoints, credentials, retry policies)
+
+Applying this boundary to the essential packages:
+
+| Essential capability | Builtin or tool? | Rationale |
+|---------------------|-----------------|-----------|
+| HTTP GET/POST | **Builtin** | Universal, stateless, 2-3 tokens |
+| Env vars | **Builtin** | Universal, stateless, 2 tokens |
+| JSON parse/serialize | **Builtin** | Universal at tool boundary, 2 tokens |
+| Shell execution | **Builtin (with feature flag)** | Universal for local agents, stateless |
+| String manipulation (replace, trim, case) | **Builtin** | Stateless, 2-3 tokens |
+| Regex | **Builtin (with feature flag)** | Stateless, 3 tokens |
+| Base64/URL encoding | **Builtin** | Stateless, 2 tokens |
+| Hash/HMAC | **Builtin** | Stateless, 2-3 tokens |
+| UUID/random | **Builtin** | Stateless, 1-2 tokens |
+| Timestamp/sleep | **Builtin** | Stateless, 1-2 tokens |
+| File read/write | **Builtin (with feature flag)** | Nearly universal, but has side effects |
+| Parallel execution | **Builtin (structural)** | `par{...}` block, not a library |
+| Web framework | **Tool** | Agents are clients, not servers |
+| Database | **Tool** | Stateful, domain-specific |
+| Format parsing (XML, CSV, YAML) | **Tool** | Domain-specific |
+
+### The numbers: tokens saved by builtins vs tools
+
+Consider fetching a user from an API and extracting their email:
+
+**As builtins (current + planned):**
+```
+k=env! "API_KEY";u=$!(+"https://api.com/users/123?key=" k);jp! u "email"
+```
+~20 tokens. Everything is built in. The agent generates one line.
+
+**As tools (if builtins did not exist):**
+```
+tool env"Read env var" key:t>R t t
+tool http-get"HTTP GET" url:t>R t t
+tool json-path"Extract JSON field" data:t path:t>R t t
+k=env! "API_KEY";body=http-get! +"https://api.com/users/123?key=" k;jp=json-path! body "email";jp
+```
+~55 tokens. Three tool declarations + three calls. The agent must generate significantly
+more code, and every additional token is a chance for error.
+
+**The token tax of tools:** Every tool declaration costs ~10-15 tokens (name, description,
+params, return type, options). A program that needs 5 common capabilities (HTTP, env, JSON,
+string replace, hash) would spend 50-75 tokens just declaring tools before writing any
+logic. With builtins, those tokens are zero.
+
+This is why the essential packages analysis matters for ilo: **builtins eliminate the token
+tax that tools impose on universal capabilities.**
+
+---
+
+## Gap Analysis: What ilo Needs Today
+
+Based on the universal patterns identified above, here is the prioritized list of
+capabilities that ilo should provide as builtins, ordered by frequency of need across the
+essential package data:
+
+### Tier 1: Critical (blocks real-world programs without them)
+
+| Builtin | Signature | Justification | Status |
+|---------|-----------|---------------|--------|
+| `env key` | `>R t t` | 6/6 languages need dotenv; API keys are universal | Planned (I3) |
+| `post url body` | `>R t t` | 6/6 languages need HTTP POST; every API write | Planned (G1) |
+| `jp text path` | `>R t t` | JSON is the API interchange format; serde=75% of Rust | Planned (I1) |
+| `sh cmd` | `>R t t` | Ruby/PHP prove shell exec is universal for agents | Planned (I2) |
+
+These four builtins, combined with the existing `get`/`$`, would enable an ilo program to:
+- Read configuration from the environment
+- Call any HTTP API (GET and POST)
+- Parse JSON responses
+- Execute shell commands for anything else
+
+This is the minimum viable set for an agent that can do real work.
+
+### Tier 2: High value (saves significant tokens across many programs)
+
+| Builtin | Signature | Justification | Status |
+|---------|-----------|---------------|--------|
+| `rpl t old new` | `>t` | String replace is universal; building URLs, messages | Planned (I8) |
+| `trm t` | `>t` | Trim whitespace; cleaning API responses | Planned (I8) |
+| `now()` | `>n` | Timestamps; every language needs time.time() | Planned (I6) |
+| `slp n` | `>_` | Rate limiting, polling; universal in API work | Planned (I6) |
+| `uid()` | `>t` | UUID generation; 4/6 languages need a package | Planned (I9) |
+| `b64e t` / `b64d t` | `>t` / `>R t t` | Auth headers, data encoding | Planned (I7) |
+| `urle t` / `urld t` | `>t` / `>t` | Building query strings; every API call | Planned (I7) |
+
+### Tier 3: Medium value (needed frequently but workarounds exist)
+
+| Builtin | Signature | Justification | Status |
+|---------|-----------|---------------|--------|
+| `sha t` | `>t` | Hash for cache keys, integrity checks, webhook verification | Planned (I9) |
+| `hmac key msg` | `>t` | Webhook signatures (GitHub, Stripe, AWS) | Planned (I9) |
+| `rnd()` / `rnd a b` | `>n` | Random numbers; Rust's most-installed capability gap | Planned (I9) |
+| `rgx pat text` | `>R t t` | Regex match; text extraction from unstructured data | Planned (I8) |
+| `rgs pat repl text` | `>t` | Regex replace | Planned (I8) |
+| `upr t` / `lwr t` | `>t` | Case conversion; API normalization | Considered |
+| `iso n` | `>t` | Timestamp to ISO 8601; API date format | Planned (I6) |
+| `ts text` | `>R n t` | Parse ISO 8601 to timestamp | Planned (I6) |
+| `rd path` | `>R t t` | Read file; universal for local agents | Planned (G8) |
+| `wr path data` | `>R _ t` | Write file | Planned (G8) |
+
+### Tier 4: Low value for agents (tool concern or rare)
+
+| Capability | Why not a builtin |
+|-----------|-------------------|
+| XML/HTML parsing | Tool concern; domain-specific |
+| CSV parsing | Tool concern; `spl` handles simple cases |
+| YAML/TOML parsing | Tool concern; config is an infra concern |
+| Date arithmetic | Tool concern; complex, locale-dependent |
+| Timezone conversion | Tool concern; agents work in UTC |
+| Encryption (AES, RSA) | Tool concern; dangerous to expose, requires key management |
+| Compression (gzip, zlib) | Tool concern; rare in agent workflows |
+| Database access | Tool concern; stateful, domain-specific |
+| WebSocket | Planned as feature flag (G2); not universal |
+| HTTP server | Agents are clients, not servers |
+| Image processing | Tool concern; heavy computation |
+
+---
+
+## Comparison with Existing ilo Research
+
+This analysis aligns with and reinforces the conclusions from ilo's existing research:
+
+### go-stdlib-research.md alignment
+
+The Go research recommended `fread`/`fwrite` (G8), `env` (I3), `hash`/`hmac` (I9),
+`now()`/`sleep` (I6), and `par{...}` (G4) -- all of which appear in the essential packages
+analysis above. The Go research also recommended against file path manipulation,
+encryption, HTTP server, and XML parsing -- all confirmed as tool concerns by the
+cross-language analysis.
+
+The Go research's strongest insight -- that `if err != nil` boilerplate is eliminated by
+`!` auto-unwrap -- is validated by Rust's anyhow/thiserror being in the essential packages
+list. Two languages independently proved that error handling ergonomics matter enough to
+justify a package/crate. ilo solved this at the language level.
+
+### python-stdlib-analysis.md alignment
+
+The Python research recommended `sh cmd` (I2), `post url body` (G1), `env key` (I3),
+`rpl` (replace), `trm` (trim), and `%` (modulo) as Tier 1 additions. The essential
+packages analysis confirms all of these: requests/httpx (HTTP), python-dotenv (env), and
+pydantic (validation) are the top Python packages, matching the recommended builtins.
+
+The Python research's classification of builtins vs tools (file I/O as tool, HTTP as
+builtin, JSON as builtin, formatting as builtin, encryption as tool) is consistent with the
+cross-language evidence.
+
+### js-ts-ecosystem.md alignment
+
+The JS/TS research recommended `post`, `read`/`write` (file I/O), `sh` (shell), and `env`
+as Tier 1 gaps -- identical to the essential packages analysis. The JS research also
+identified Deno's permission model as relevant to ilo's tool-declaration-as-permission
+approach, and Bun's `$` shell syntax as inspiration for `sh`.
+
+### ruby-php-research.md alignment
+
+The Ruby/PHP research's strongest recommendation was `sh` (shell execution) inspired by
+Ruby's backtick syntax, and `env` (environment access). Both are confirmed as universal
+needs by the cross-language analysis. The Ruby research's insight that blocks/closures are
+not needed (ilo's `@` + guards suffice) is validated by the observation that no essential
+package in any language provides "better lambdas" -- the need is for capabilities, not
+abstractions.
+
+### swift-kotlin-research.md alignment
+
+The Swift/Kotlin research's main recommendation -- runtime-level structured concurrency with
+zero syntax cost -- is supported by the observation that tokio (60% of Rust projects) and
+asyncio-related packages are among the most-installed. The research's recommendation to
+defer generics, protocols, and extension functions is validated by the absence of "better
+type system" packages in any language's essential list. Developers need capabilities (HTTP,
+JSON, env), not abstractions.
+
+---
+
+## What Languages Got Right (and ilo should copy)
+
+### Go: batteries-included stdlib
+
+Go's stdlib includes HTTP server/client, JSON, crypto, testing, and more. The result: Go
+has fewer essential third-party packages than any other language in this analysis. The
+lesson for ilo: more builtins = fewer gaps. Go's stdlib philosophy ("a little copying is
+better than a little dependency") maps directly to ilo's constraint (agents cannot install
+dependencies).
+
+### Rust: serde's "derive the schema" pattern
+
+serde's `#[derive(Serialize, Deserialize)]` turns struct definitions into serialization
+schemas. ilo's `type` declarations serve the same role at tool boundaries. This pattern --
+type definitions as data schemas -- is the right answer to the validation problem that
+pydantic/zod/validator all solve differently.
+
+### Ruby: shell execution as a language primitive
+
+Ruby's backtick syntax (`\`ls -la\``) proves that shell execution can be a language-level
+feature, not just a library function. For agents, this is perhaps the single most powerful
+capability: the ability to run arbitrary system commands. ilo's planned `sh cmd` follows
+this model.
+
+### PHP: URLs are just resources
+
+PHP's `file_get_contents("https://...")` treats URLs the same as file paths. ilo's `get url`
+follows the same philosophy: fetching data from a URL is as natural as any other operation.
+
+### Swift/Kotlin: structured concurrency
+
+Both languages prove that parallelism can be structured (scoped, cancellable, no leaked
+tasks) without exposing threads or channels. ilo's planned `par{...}` block and the runtime
+dependency graph analysis follow this approach.
+
+---
+
+## What Languages Got Wrong (and ilo should avoid)
+
+### Python: too many ways to do the same thing
+
+Python has `urllib`, `urllib2`, `urllib3`, `http.client`, AND `requests`. Three formatting
+syntaxes (`%`, `.format()`, f-strings). Two path libraries (`os.path`, `pathlib`). This
+violates ilo's principle of "one way to do things."
+
+### JavaScript: no batteries at all
+
+Node.js launched with almost nothing. No HTTP client (until 2022), no testing (until 2022),
+no formatting, no type checking. The result: an explosion of packages where projects spend
+more tokens configuring dependencies than writing logic. ilo should be the opposite:
+everything a program commonly needs is built in.
+
+### Rust: too minimal at the stdlib level
+
+Rust's deliberate minimalism (no serialization, no async runtime, no random, no regex)
+means that 75% of projects install serde, 60% install tokio, and 40% install each of reqwest,
+rand, and regex. The "keep the stdlib small" philosophy is principled but imposes real costs.
+For ilo, where installing dependencies is impossible, minimalism at the builtin level would
+be fatal.
+
+### Go: ignoring the community for too long
+
+Go's ServeMux was inadequate for 12 years. Go's `log` package produced only text for 14
+years. Go's testing package still has no assertions. In each case, the community built
+packages that Go eventually had to semi-adopt (ServeMux was fixed in 1.22, slog was added
+in 1.21). The lesson: if the community universally reaches for a package, the language
+should absorb the capability.
+
+### PHP: including everything without quality control
+
+PHP's 8,000+ built-in functions include inconsistent naming (`str_replace` vs `strpos` vs
+`substr`), inconsistent argument order (`array_map(fn, arr)` vs `array_filter(arr, fn)`),
+and inconsistent error handling (some return false, some throw, some set error codes). The
+lesson: more builtins are better, but they must be consistent. ilo's builtin naming
+convention (3-char names, `R` return types, consistent argument order) avoids this trap.
+
+---
+
+## Conclusion: The Essential Builtin Set for ilo
+
+The essential packages phenomenon, analyzed across six major languages, reveals a universal
+set of ~20 capabilities that developers need regardless of language or domain. For ilo, where
+agents cannot install packages, these capabilities must be builtins.
+
+The current ilo builtin set covers math, string basics, list operations, HTTP GET, and
+error handling. The roadmap correctly identifies the remaining essential capabilities (env,
+HTTP POST, JSON, shell execution, regex, encoding, crypto, time, file I/O).
+
+The priority, derived from cross-language frequency data:
+
+```
+Critical (every agent needs):    env, post, jp/jsn, sh
+High value (most agents need):   rpl, trm, now, slp, uid, b64e/b64d, urle/urld
+Medium value (many agents need): sha, hmac, rnd, rgx, rgs, upr/lwr, iso, ts, rd/wr
+```
+
+ilo's advantage over every language analyzed: the verification layer. Where Python needs
+pydantic, JavaScript needs zod, and Go needs go-playground/validator, ilo's type system +
+tool boundaries provide validation without a single extra token. Where Python needs black,
+JavaScript needs prettier, and Ruby needs rubocop, ilo's canonical dense format provides
+formatting without any tooling at all. Where Rust needs anyhow and thiserror, ilo's `!`
+auto-unwrap and `^` error wrapping provide error ergonomics natively.
+
+The essential packages of other languages are not just a list of things to build. They are
+evidence that ilo's core design -- verified types, canonical formatting, typed error
+handling, builtins over packages -- is the right approach for a language where the
+programmer cannot install dependencies.
+
+---
+
+## See Also
+
+- [universal-stdlib-gaps.md](universal-stdlib-gaps.md) — complementary analysis: same phenomenon from the "what stdlibs get wrong" angle
+- [OPEN.md](OPEN.md) — builtin naming decisions and "essential packages" principle
+- Language-specific research files for per-ecosystem detail: [go-stdlib-research.md](go-stdlib-research.md), [python-stdlib-analysis.md](python-stdlib-analysis.md), [js-ts-ecosystem.md](js-ts-ecosystem.md), [ruby-php-research.md](ruby-php-research.md), [rust-capabilities-research.md](rust-capabilities-research.md)

--- a/research/go-stdlib-research.md
+++ b/research/go-stdlib-research.md
@@ -1,0 +1,907 @@
+# Go Standard Library Research for ilo
+
+Go's standard library and design philosophy analyzed through ilo's lens: **total tokens from intent to working code**. Go is relevant because it is the closest mainstream language to ilo's philosophy — simplicity over expressiveness, one way to do things, explicit error handling, fast compilation, small spec.
+
+---
+
+## Why Go matters for ilo
+
+Go and ilo share unusual convictions:
+
+1. **Simplicity is a feature.** Go has ~25 keywords. ilo has ~6 abbreviated keywords (sigils replace most). Both reject the "more features = more power" assumption.
+2. **One way to do things.** Go has one loop (`for`), one string type, one way to handle errors. ilo has one loop sigil (`@`), one conditional form (guard), one error pattern (`R`+`?`+`!`).
+3. **Explicit over implicit.** Go requires explicit error checking (`if err != nil`). ilo requires explicit `?` matching or `!` auto-unwrap. Neither has exceptions.
+4. **Verification before execution.** Go refuses to compile with unused imports or variables. ilo verifies all calls resolve, all types align, all dependencies exist.
+5. **Small spec, big stdlib.** Go ships batteries included — HTTP server, JSON, crypto, testing — all in the standard library. ilo's "tool" model replaces stdlib with tool declarations, but the same principle applies: the runtime should handle common needs without external dependencies.
+
+Where they diverge: Go prioritizes human readability (meaningful names, gofmt, documentation). ilo explicitly sacrifices human readability for token efficiency. Go is general-purpose; ilo is agent-purpose.
+
+---
+
+## 1. File I/O — `os`, `io`, `bufio`, `filepath`
+
+### What Go provides
+
+```go
+// Read file
+data, err := os.ReadFile("config.json")
+
+// Write file
+err := os.WriteFile("output.txt", []byte(content), 0644)
+
+// Buffered I/O
+scanner := bufio.NewScanner(file)
+for scanner.Scan() {
+    line := scanner.Text()
+}
+
+// Path manipulation
+dir := filepath.Dir(path)
+ext := filepath.Ext(path)
+abs, _ := filepath.Abs(rel)
+joined := filepath.Join("dir", "sub", "file.txt")
+```
+
+**Design choices worth noting:**
+- `os.ReadFile` / `os.WriteFile` are one-liners for the 90% case. `bufio` for the 10% that need streaming.
+- `filepath` handles OS-specific separators transparently. The agent never thinks about `/` vs `\`.
+- Every operation returns `(result, error)` — no exceptions, no silent failures.
+
+### Relevance to ilo
+
+ilo's planned file I/O (G8) mirrors Go's layered approach:
+
+| Go | ilo (planned) | Token comparison |
+|----|---------------|------------------|
+| `os.ReadFile("f.txt")` | `fread "f.txt"` | 3 vs 2 tokens |
+| `os.WriteFile("f.txt", data, 0644)` | `fwrite "f.txt" data` | 5 vs 3 tokens |
+| `bufio.Scanner` + loop | `@line stream{...}` (G6) | ~15 vs ~5 tokens |
+| `filepath.Join("a","b","c")` | Not planned | — |
+
+**Recommendation for ilo:**
+- `fread` and `fwrite` as builtins (already planned in G8) — matches Go's one-liner philosophy.
+- **Skip `filepath`-style path manipulation.** Go needs it because Go programs run across OS. ilo programs run through an agent that knows the OS. Path manipulation is a tool concern or handled by the agent.
+- Go's `bufio.Scanner` pattern (line-by-line iteration) maps beautifully to ilo's `@line stream{...}` — if G6 streams land.
+- Go's file permissions model (`0644`) should be hidden in ilo. Agents should not think about unix permissions. Use sensible defaults.
+
+---
+
+## 2. Networking — `net/http`, `net`, WebSocket
+
+### What Go provides
+
+```go
+// HTTP GET — 2 lines for the common case
+resp, err := http.Get("https://api.example.com/data")
+body, err := io.ReadAll(resp.Body)
+
+// HTTP POST with JSON
+resp, err := http.Post(url, "application/json", bytes.NewBuffer(jsonData))
+
+// HTTP server — famous for simplicity
+http.HandleFunc("/", handler)
+http.ListenAndServe(":8080", nil)
+
+// Raw TCP
+conn, err := net.Dial("tcp", "example.com:80")
+conn.Write([]byte("GET / HTTP/1.1\r\n..."))
+
+// WebSocket (gorilla/websocket — not stdlib but de facto standard)
+conn, _, err := websocket.DefaultDialer.Dial(url, nil)
+conn.WriteMessage(websocket.TextMessage, []byte(msg))
+_, message, err := conn.ReadMessage()
+```
+
+**Design choices worth noting:**
+- `http.Get` is a package-level convenience function — one line for the 90% case.
+- The full `http.Client` with timeouts, headers, redirects is available but not required.
+- Go's HTTP server is so simple that it's commonly used as a production server without frameworks.
+- WebSocket is NOT in stdlib — Go's committee was conservative about adding it. This is telling: Go's stdlib boundary is drawn at "stable, universal protocols."
+
+### Relevance to ilo
+
+ilo already has `get`/`$` (D1b). The roadmap covers HTTP methods (G1), WebSocket (G2), and raw TCP (G5).
+
+| Go | ilo (current/planned) | Tokens |
+|----|----------------------|--------|
+| `http.Get(url)` + `io.ReadAll` | `get url` or `$url` | ~8 vs 2 |
+| `http.Post(url, ct, body)` | `post url body` (G1) | ~6 vs 3 |
+| `websocket.Dial(url)` | `ws url` (G2) | ~4 vs 2 |
+| `conn.WriteMessage(msg)` | `ws-send c msg` (G2) | ~4 vs 3 |
+| `conn.ReadMessage()` | `ws-recv c` (G2) | ~3 vs 2 |
+| `http.ListenAndServe` | Not planned | — |
+
+**Lessons from Go for ilo:**
+
+1. **Convenience wrappers win.** Go's `http.Get` is a one-liner that hides `http.Client` complexity. ilo's `$url` is the same philosophy pushed further — one sigil.
+
+2. **No HTTP server needed.** ilo programs are agent tools, not web services. Go's `http.ListenAndServe` is irrelevant. If an agent needs to serve HTTP, that is a tool server concern (like the Playwright server).
+
+3. **WebSocket as a separate concern.** Go correctly keeps WebSocket out of stdlib. ilo should follow suit — `ws` builtins (G2) are important for CDP/real-time, but they are in a feature flag, not core.
+
+4. **The `Content-Type` tax.** Go forces you to specify `"application/json"` on POST. ilo should default to `application/json` — it is what agents send 95% of the time. Token savings: 1 eliminated string per POST.
+
+5. **Response handling.** Go separates the response status, headers, and body. ilo's `R t t` collapses this to ok-body or err-message. For agents, this is the right tradeoff — agents rarely inspect headers or status codes directly. If they need to, a richer response type (record with `status:n`, `body:t`, `headers:M t t`) can be opt-in.
+
+---
+
+## 3. Process Execution — `os/exec`
+
+### What Go provides
+
+```go
+// Simple command — capture output
+out, err := exec.Command("ls", "-la").Output()
+
+// With stdin/stdout/stderr
+cmd := exec.Command("grep", "error")
+cmd.Stdin = strings.NewReader(input)
+var stdout bytes.Buffer
+cmd.Stdout = &stdout
+err := cmd.Run()
+
+// Long-running process
+cmd := exec.Command("node", "server.js")
+cmd.Start()
+// ... later
+cmd.Wait()
+
+// Environment
+cmd.Env = append(os.Environ(), "KEY=VALUE")
+cmd.Dir = "/path/to/working/dir"
+```
+
+**Design choices worth noting:**
+- `exec.Command("name", "arg1", "arg2")` separates command name from args — no shell injection by design.
+- `.Output()` is the convenience one-liner (captures stdout). `.Run()` for more control.
+- `.Start()` + `.Wait()` for async processes — same pattern as ilo's planned `spawn` + `proc-wait`.
+- Environment is explicit, not inherited by default (actually it is inherited — Go inherits parent env, but you can override).
+
+### Relevance to ilo
+
+ilo plans two levels (I2 + G3): `run "cmd"` for one-shot execution, `spawn cmd args` for long-running processes.
+
+| Go | ilo (planned) | Tokens |
+|----|---------------|--------|
+| `exec.Command("ls","-la").Output()` | `run "ls -la"` or `` `ls -la` `` | ~6 vs 2-3 |
+| `cmd.Start()` | `spawn "node" "server.js"` (G3) | ~4 vs 3 |
+| `cmd.Wait()` | `proc-wait h` (G3) | ~3 vs 2 |
+
+**Lessons from Go for ilo:**
+
+1. **Shell injection prevention.** Go's `exec.Command` takes separate args, preventing injection. ilo's `run "ls -la"` passes a single string to `/bin/sh -c` — this is deliberately less safe but more token-efficient. The tradeoff is correct for ilo: agents generate commands, not untrusted user input. If safety is needed, `spawn cmd args` with separate args (G3) is the safe alternative.
+
+2. **Two levels of API.** Go has `.Output()` (simple) and `.Start()`/`.Wait()` (complex). ilo plans the same: `run` (simple one-shot) and `spawn`/`proc-wait`/`proc-kill` (complex lifecycle). This layered design is good — copy it.
+
+3. **Environment as explicit argument.** Go's `cmd.Env` is explicit. ilo's `env key` reads env vars, and `spawn cmd args env` (G3 with maps) passes them. This is right — agents should not silently inherit environment.
+
+---
+
+## 4. Data Formats — `encoding/json`, `encoding/xml`, `encoding/csv`
+
+### What Go provides
+
+```go
+// JSON — struct tags for mapping
+type User struct {
+    Name  string `json:"name"`
+    Email string `json:"email"`
+}
+var user User
+json.Unmarshal(data, &user)  // JSON → struct
+out, _ := json.Marshal(user) // struct → JSON
+
+// Dynamic JSON (when shape is unknown)
+var result map[string]interface{}
+json.Unmarshal(data, &result)
+
+// CSV
+reader := csv.NewReader(file)
+records, _ := reader.ReadAll()
+
+// XML — struct tags
+var feed Feed
+xml.Unmarshal(data, &feed)
+```
+
+**Design choices worth noting:**
+- Go's JSON uses struct tags for field mapping — the struct definition IS the schema. This is exactly what ilo records do: `type profile{id:t;name:t;email:t}` IS the schema.
+- `map[string]interface{}` is Go's escape hatch for unknown JSON — like ilo's `>t` (raw text).
+- Go has built-in JSON, XML, CSV. Most languages require third-party libraries.
+- `encoding/json` handles both serialization and deserialization in one package.
+
+### Relevance to ilo
+
+ilo's position (from OPEN.md): "format parsing is a tool concern." But JSON is the exception (I1).
+
+| Go | ilo (planned) | Tokens |
+|----|---------------|--------|
+| `json.Unmarshal(data, &user)` | `jparse text "profile"` (I1) | ~5 vs 3 |
+| `json.Marshal(user)` | `jdump value` (I1) | ~3 vs 2 |
+| `result["name"]` (dynamic) | `jp body "name"` (I1) | ~3 vs 3 |
+| `csv.NewReader(f).ReadAll()` | Not planned (tool) | — |
+| `xml.Unmarshal(data, &f)` | Not planned (tool) | — |
+
+**Lessons from Go for ilo:**
+
+1. **Struct tags = record declarations.** Go's `json:"name"` annotation maps JSON fields to struct fields. ilo's record declarations already serve this role: `type profile{id:t;name:t}` tells the runtime how to map JSON. D1e (Value <-> JSON) should exploit this — ilo records ARE the schema, just like Go struct tags.
+
+2. **Dynamic JSON needs an escape hatch.** Go's `map[string]interface{}` is ugly but necessary. ilo's `>t` (raw text) plus `jp` (JSON path lookup) is a cleaner equivalent for agents. An agent rarely needs the full parsed tree — it needs specific fields. `jp body "user.name"` is more efficient than parsing the entire response into a dynamic structure.
+
+3. **JSON is special.** Go puts JSON in stdlib. ilo should treat JSON as a builtin concern, not just a tool concern. The `jp` builtin (I1) is the right call — it is the agent equivalent of Go's `json.Unmarshal`.
+
+4. **XML/CSV are NOT special.** Go has them in stdlib because Go is general-purpose. ilo should not. XML/CSV parsing is a tool concern — an agent calling an XML API would use a tool that returns parsed records. Token comparison: teaching ilo to parse XML would add spec complexity (tokens for agents to learn) while saving very few generation tokens.
+
+---
+
+## 5. String Manipulation — `regexp`, `strings`, `fmt`, `encoding`
+
+### What Go provides
+
+```go
+// strings package — comprehensive
+strings.Contains(s, "error")    // substring check
+strings.Split(s, ",")           // split
+strings.Join(parts, ", ")       // join
+strings.Replace(s, "old", "new", -1)
+strings.ToUpper(s) / strings.ToLower(s)
+strings.TrimSpace(s)
+strings.HasPrefix(s, "http")
+strings.HasSuffix(s, ".json")
+
+// regexp
+re := regexp.MustCompile(`\d+`)
+matches := re.FindAllString(text, -1)
+result := re.ReplaceAllString(text, "***")
+
+// fmt — formatted output
+s := fmt.Sprintf("Hello %s, you have %d items", name, count)
+
+// encoding
+base64.StdEncoding.EncodeToString(data)
+hex.EncodeToString(data)
+url.QueryEscape(s)
+```
+
+**Design choices worth noting:**
+- Go's `strings` package has 40+ functions. Most are one-liners. No method chaining — `strings.ToUpper(strings.TrimSpace(s))`.
+- `regexp.MustCompile` panics on bad regex — "fail fast." Regular `Compile` returns an error.
+- `fmt.Sprintf` is the universal string formatting tool — `%s`, `%d`, `%f`, `%v`.
+- Encoding is split into subpackages: `encoding/base64`, `encoding/hex`, `net/url`.
+
+### Relevance to ilo
+
+ilo already has several string builtins. Here is the mapping:
+
+| Go | ilo (current) | Status |
+|----|--------------|--------|
+| `strings.Contains(s, sub)` | `has s sub` | Done |
+| `strings.Split(s, sep)` | `spl s sep` | Done |
+| `strings.Join(parts, sep)` | `cat parts sep` | Done |
+| `len(s)` | `len s` | Done |
+| `s[a:b]` | `slc s a b` | Done |
+| `strings.Replace` | Not planned | — |
+| `strings.ToUpper` / `ToLower` | Not planned | — |
+| `strings.TrimSpace` | Not planned | — |
+| `strings.HasPrefix` / `HasSuffix` | Not planned (`has` does contains) | — |
+| `regexp.FindAllString` | `matchall text pat` (I8) | Planned |
+| `regexp.ReplaceAllString` | `sub text pat repl` (I8) | Planned |
+| `fmt.Sprintf` | `fmt "pattern" args...` (I4) | Planned |
+| `base64.Encode/Decode` | `b64enc`/`b64dec` (I7) | Planned |
+| `url.QueryEscape` | `urlencode` (I7) | Planned |
+
+**Gap analysis — what Go has that ilo might need:**
+
+1. **`replace` / `sub` (non-regex).** Simple string replacement is extremely common. `sub text "old" "new"` could work alongside regex `sub` — or use a single `sub` that treats the pattern as literal when it has no regex metacharacters. Go separates `strings.Replace` (literal) from `regexp.ReplaceAllString` (regex). ilo should unify: one `sub` builtin, regex patterns when needed, literal otherwise.
+
+2. **`upper` / `lower`.** Case conversion comes up in URL normalization, header construction, comparisons. Low token cost to add: `upper t` / `lower t`. But frequency is low for agents — they usually work with APIs that are case-insensitive or case-normalized.
+
+3. **`trim`.** Whitespace trimming is common when processing tool output. `trim t` removes leading/trailing whitespace. High frequency, low cost.
+
+4. **`prefix` / `suffix` checks.** `has` does substring containment. Prefix/suffix checks require `slc` + comparison today (3+ tokens). `pfx s p` / `sfx s p` would save tokens, but the frequency is low.
+
+**Recommendation:** Add `trim`, `sub` (literal), `upper`/`lower` as builtins if token analysis shows agents need them frequently. `replace` is the most likely candidate — building URLs, modifying tool output, and constructing messages all require string replacement.
+
+---
+
+## 6. Concurrency — goroutines, channels, `sync`, `select`
+
+### What Go provides
+
+```go
+// Goroutines — lightweight concurrent execution
+go fetchURL(url)
+
+// Channels — typed communication
+ch := make(chan string)
+go func() { ch <- "result" }()
+msg := <-ch
+
+// Select — multiplex channels
+select {
+case msg := <-ch1:
+    handle(msg)
+case msg := <-ch2:
+    handle(msg)
+case <-time.After(5 * time.Second):
+    timeout()
+}
+
+// WaitGroup — wait for multiple goroutines
+var wg sync.WaitGroup
+for _, url := range urls {
+    wg.Add(1)
+    go func(u string) {
+        defer wg.Done()
+        fetch(u)
+    }(url)
+}
+wg.Wait()
+
+// Mutex — shared state protection
+var mu sync.Mutex
+mu.Lock()
+counter++
+mu.Unlock()
+```
+
+**Design choices worth noting:**
+- Goroutines are the killer feature. `go f()` — 2 tokens to launch concurrent work.
+- Channels are the ONLY way to communicate between goroutines (by convention). No shared memory.
+- `select` is a language primitive for multiplexing — not a library function.
+- Go does NOT have async/await. Goroutines + channels replace it entirely.
+- The concurrency model is built into the language, not bolted on.
+
+### Relevance to ilo — THIS IS THE BIG QUESTION
+
+ilo is currently fully synchronous. The roadmap has G4 (async runtime) as a future phase with a key open question: should ilo expose concurrency to the language, or hide it in the runtime?
+
+**Go's concurrency model is relevant for three ilo use cases:**
+
+1. **Parallel tool calls.** Agent calls 3 APIs. They are independent. Calling them sequentially wastes time. Go: `go fetch(url1); go fetch(url2); go fetch(url3)`. ilo planned: `par{get url1;get url2;get url3}` (G4).
+
+2. **WebSocket + polling.** CDP communication requires sending a message and waiting for an async response while potentially receiving other events. Go: goroutine reads messages, sends to channel, main goroutine selects. ilo: blocking `ws-recv` works for request-response but fails for multiplexed communication.
+
+3. **Streaming responses.** SSE from LLM APIs delivers tokens incrementally. Go: goroutine reads SSE, sends each event to channel. ilo: G1d is planned but the iteration model is unclear.
+
+**Design analysis:**
+
+| Approach | Go equivalent | Token cost | Agent complexity |
+|----------|--------------|------------|-----------------|
+| Sequential (current) | No goroutines | 0 extra | None — agents know sequential |
+| Runtime-hidden parallel | Go's `http.Client` internal goroutines | 1 token (`par{...}`) | Low — agent sees `par` block |
+| Language-level goroutines | `go func()` + channels | 5-10 tokens per concurrent op | High — agents must reason about concurrency |
+| Channel-based | `ch := make(chan); go func()` | 10+ tokens | Very high — deadlock risk, ordering |
+
+**Recommendation for ilo:**
+
+1. **Do NOT expose goroutines or channels.** Go's concurrency model is elegant but requires reasoning about synchronization, deadlocks, and ordering. Agents generating concurrent code will produce deadlocks — a failure mode that is nearly impossible to diagnose from error messages alone. The retry cost of a deadlock is catastrophic: the program hangs, produces no error, and the agent has no signal to fix.
+
+2. **DO use Go's `par` pattern — runtime-managed parallelism.** The planned `par{call1;call2;call3}` (G4) is the right abstraction. The runtime launches all calls concurrently and collects results. The agent writes sequential-looking code. Internally, this is goroutines + WaitGroup, but the agent never sees it.
+
+3. **`select`-like multiplexing as `poll`.** For WebSocket/SSE (G9), a `poll conns timeout` builtin that waits on multiple connections is cleaner than exposing channels. This is Go's `select` with the channel complexity hidden.
+
+4. **Go's mistake to avoid:** Go makes it easy to launch goroutines but hard to know when they finish. `WaitGroup` is ceremony. ilo's `par{...}` avoids this by scoping concurrency — all concurrent work finishes before the block returns.
+
+**Token comparison (parallel API calls):**
+```
+# Go: ~25 tokens
+var wg sync.WaitGroup
+for _, url := range urls {
+    wg.Add(1)
+    go func(u string) {
+        defer wg.Done()
+        fetch(u)
+    }(url)
+}
+wg.Wait()
+
+# ilo (planned): ~5 tokens
+par{get url1;get url2;get url3}
+
+# ilo (current, sequential): ~6 tokens
+r1=get url1;r2=get url2;r3=get url3
+```
+
+---
+
+## 7. Error Handling — `error` interface, `errors`, `fmt.Errorf`
+
+### What Go provides
+
+```go
+// Every function returns error
+result, err := doSomething()
+if err != nil {
+    return fmt.Errorf("failed to do thing: %w", err)
+}
+
+// Error wrapping (Go 1.13+)
+err = fmt.Errorf("context: %w", originalErr)
+errors.Is(err, ErrNotFound)
+errors.As(err, &target)
+
+// Custom errors
+type NotFoundError struct {
+    ID string
+}
+func (e *NotFoundError) Error() string {
+    return "not found: " + e.ID
+}
+
+// Sentinel errors
+var ErrNotFound = errors.New("not found")
+```
+
+**Design choices worth noting:**
+- No exceptions. Period. Every error is a return value.
+- `if err != nil` is the most written line in Go — it is verbose but explicit.
+- Error wrapping (`%w`) adds context without losing the original error.
+- Custom error types allow callers to inspect error details.
+- Go community has debated error handling verbosity for 15 years. The explicit approach won.
+
+### Relevance to ilo — DIRECTLY RELEVANT
+
+ilo's error handling is Go's error handling made terse:
+
+| Go | ilo | Token savings |
+|----|-----|---------------|
+| `result, err := f()` + `if err != nil { return err }` | `f! args` (auto-unwrap) | ~12 tokens vs 1 |
+| `if err != nil { return fmt.Errorf("context: %w", err) }` | `?{^e:^+"context: "e}` | ~15 tokens vs ~8 |
+| `result, err := f()` + `if err != nil { cleanup(); return err }` | `f args;?{^e:cleanup;^e}` | ~15 tokens vs ~8 |
+
+**ilo has already solved Go's biggest criticism.** The `if err != nil` boilerplate — which accounts for roughly 30% of Go code by some estimates — is eliminated by `!` (auto-unwrap). This is ilo's version of Rust's `?` operator, which Go famously rejected.
+
+**Lessons from Go for ilo:**
+
+1. **Error wrapping is valuable.** Go's `fmt.Errorf("context: %w", err)` adds context to propagated errors. ilo's `^+"context: "e` achieves the same thing with string concatenation. This pattern should be documented as a best practice — agents need to know that wrapping errors with context helps debugging.
+
+2. **Sentinel errors are unnecessary for ilo.** Go's `var ErrNotFound = errors.New(...)` pattern exists because Go errors are interfaces that can be inspected. ilo errors are text. Pattern matching on error text (`?{^e:has e "not found"{...}}`) is sufficient for agents. Adding typed error variants would cost more tokens than it saves.
+
+3. **Go's `errors.Is`/`errors.As` for error chain inspection is overkill for ilo.** Agents don't build complex error hierarchies. They call a tool, it succeeds or fails, they retry or report. ilo's flat `R ok err` with text errors is the right level of granularity.
+
+4. **The "no exceptions" principle is critical.** Go proved that explicit error handling works at scale. ilo doubles down on this — `R` return types make errors visible in function signatures, `?` forces handling, `!` is opt-in propagation. An agent can never accidentally ignore an error (the verifier catches unhandled `R` values through match exhaustiveness).
+
+---
+
+## 8. Environment — `os.Getenv`, `os.Args`, `flag`
+
+### What Go provides
+
+```go
+// Environment variables
+key := os.Getenv("API_KEY")
+value, exists := os.LookupEnv("OPTIONAL_VAR")
+
+// Command-line args
+args := os.Args[1:]
+
+// Flag parsing
+port := flag.Int("port", 8080, "server port")
+verbose := flag.Bool("verbose", false, "verbose output")
+flag.Parse()
+```
+
+**Design choices worth noting:**
+- `os.Getenv` returns empty string if not set — no error. `LookupEnv` returns `(string, bool)` for explicit existence check.
+- `os.Args` is raw — no parsing. `flag` package does structured parsing.
+- `flag` uses a registration pattern — define flags, then parse all at once.
+
+### Relevance to ilo
+
+ilo's planned `env key` (I3) maps directly to Go's `os.LookupEnv`:
+
+| Go | ilo (planned) | Tokens |
+|----|---------------|--------|
+| `os.Getenv("API_KEY")` | `env "API_KEY"` | ~4 vs 2 |
+| `os.LookupEnv("KEY")` | `env "KEY"` returns `R t t` | ~5 vs 2 |
+| `os.Args[1:]` | CLI args passed to function params | 0 (implicit) |
+| `flag.Int("port", 8080, "...")` | Not needed | — |
+
+**Lessons from Go for ilo:**
+
+1. **`env` should return `R t t`, not empty string.** Go's `Getenv` returning empty string on missing vars is a mistake — you can't distinguish "not set" from "set to empty." ilo's `R t t` approach (I3) is better: `Err("not set")` vs `Ok("")` vs `Ok("value")`.
+
+2. **CLI args are already handled.** ilo passes CLI args to function parameters positionally. This is more type-safe than Go's `os.Args` (raw strings) and more token-efficient than Go's `flag` (declaration ceremony). No new features needed.
+
+3. **No `flag` package needed.** ilo programs are generated by agents for specific tasks. They don't need self-documenting CLI interfaces with help text and default values. Function parameters ARE the "flags."
+
+---
+
+## 9. Cryptography — `crypto/sha256`, `crypto/hmac`, `crypto/tls`
+
+### What Go provides
+
+```go
+// SHA-256
+hash := sha256.Sum256([]byte("data"))
+hexHash := hex.EncodeToString(hash[:])
+
+// HMAC
+mac := hmac.New(sha256.New, []byte(key))
+mac.Write([]byte(message))
+signature := hex.EncodeToString(mac.Sum(nil))
+
+// TLS — transparent via http.Client
+// Go's http.Client uses TLS by default for HTTPS URLs
+resp, err := http.Get("https://secure.example.com")
+```
+
+**Design choices worth noting:**
+- Go puts crypto in stdlib — no third-party dependency for basic hashing and signing.
+- TLS is transparent — `http.Get("https://...")` just works. No configuration needed for the common case.
+- HMAC is two lines — create, write, sum. Simple API for a common need.
+
+### Relevance to ilo
+
+ilo's planned hashing (I9) is minimal and correct:
+
+| Go | ilo (planned) | Tokens |
+|----|---------------|--------|
+| `sha256.Sum256(data)` + hex encode | `hash text` | ~6 vs 2 |
+| `hmac.New` + `Write` + `Sum` | `hmac key msg` | ~8 vs 3 |
+| TLS via HTTP client | Transparent (http-tls feature) | 0 |
+
+**Lessons from Go for ilo:**
+
+1. **Hash should return hex string directly.** Go requires `hex.EncodeToString` as a separate step. ilo's `hash text` should return a hex string — agents always want the hex form, never raw bytes.
+
+2. **HMAC is essential.** AWS, Stripe, GitHub webhooks — the most common APIs agents interact with require HMAC signatures. Go's `crypto/hmac` is simple. ilo's `hmac key msg` (I9) is simpler. Two tokens for API authentication.
+
+3. **TLS should be transparent.** Go handles TLS automatically for HTTPS URLs. ilo should do the same — the `http-tls` feature flag adds rustls, and `get "https://..."` just works. Agents should never think about TLS configuration.
+
+4. **No encryption builtins needed.** Go has `crypto/aes`, `crypto/rsa`, etc. ilo should NOT. Encryption is a tool concern — it requires key management, IV generation, padding modes, and other details that are dangerous to get wrong. Agents should call encryption tools, not implement crypto.
+
+---
+
+## 10. Time/Date — `time` package
+
+### What Go provides
+
+```go
+// Current time
+now := time.Now()
+unix := now.Unix()
+
+// Duration
+time.Sleep(5 * time.Second)
+elapsed := time.Since(start)
+
+// Formatting — Go's unique approach
+formatted := now.Format("2006-01-02 15:04:05")  // reference time!
+parsed, _ := time.Parse("2006-01-02", "2024-03-15")
+
+// Comparison
+if deadline.Before(time.Now()) { ... }
+```
+
+**Design choices worth noting:**
+- Go's time formatting uses a **reference time** (`Mon Jan 2 15:04:05 MST 2006`) instead of `%Y-%m-%d` format codes. This is famously controversial but arguably more readable.
+- `time.Sleep` takes a `Duration`, not a number — type safety.
+- `time.Since(start)` is a convenience for `time.Now().Sub(start)`.
+- Go refuses to have a `Date` type separate from `Time` — one type for everything temporal.
+
+### Relevance to ilo
+
+ilo's planned time support (I6) is minimal:
+
+| Go | ilo (planned) | Tokens |
+|----|---------------|--------|
+| `time.Now().Unix()` | `now()` | ~4 vs 1 |
+| `time.Sleep(5 * time.Second)` | `sleep 5` | ~5 vs 2 |
+| `time.Format(...)` | `fmt-time n pattern` (deferred) | ~5 vs 3 |
+
+**Lessons from Go for ilo:**
+
+1. **`now()` returns Unix timestamp as float.** Go's `time.Now()` returns a complex `Time` struct. ilo should return a plain number (seconds since epoch, float for sub-second). Agents can do arithmetic on numbers directly: `elapsed = -now() start` (subtract).
+
+2. **`sleep` is essential despite being a side effect.** Go has `time.Sleep` in stdlib. ilo needs `sleep n` for rate limiting and polling. The manifesto concern about "pure execution" should yield to practical necessity — agents call APIs with rate limits.
+
+3. **Skip time formatting.** Go's `time.Format` is complex (the reference time approach). ilo should defer `fmt-time` — if an agent needs formatted timestamps, a tool can handle it. `now()` + `sleep` cover 90% of agent time needs (rate limiting, timeouts, elapsed time measurement).
+
+4. **Duration as number, not type.** Go has a dedicated `Duration` type. ilo should keep time as plain `n` (seconds). `sleep 0.5` sleeps 500ms. No new type needed. This is the token-minimal choice.
+
+---
+
+## 11. Collections — slices, maps, channels
+
+### What Go provides
+
+```go
+// Slices
+s := []int{1, 2, 3}
+s = append(s, 4)
+sub := s[1:3]
+sort.Ints(s)
+slices.Contains(s, 2)  // Go 1.21+
+
+// Maps
+m := map[string]int{"a": 1, "b": 2}
+v, ok := m["key"]  // comma-ok idiom
+delete(m, "key")
+for k, v := range m { ... }
+
+// Channels (as collections)
+ch := make(chan int, 10)  // buffered
+ch <- 42
+v := <-ch
+close(ch)
+for v := range ch { ... }  // iterate until closed
+```
+
+**Design choices worth noting:**
+- Go slices are dynamic arrays with `append` — similar to ilo's lists.
+- Go maps use the "comma-ok" idiom (`v, ok := m["key"]`) — existence check + value retrieval in one operation.
+- `for range` works on slices, maps, strings, AND channels — unified iteration.
+- Go 1.21+ added `slices` and `maps` packages with generic helpers (Contains, Sort, etc.).
+
+### Relevance to ilo
+
+ilo has lists, plans maps (E4), and should NOT have channels.
+
+| Go | ilo (current/planned) | Status |
+|----|----------------------|--------|
+| `[]int{1,2,3}` | `[1,2,3]` | Done |
+| `append(s, v)` | `+=xs v` | Done |
+| `s[1:3]` | `slc xs 1 3` | Done |
+| `sort.Ints(s)` | `srt xs` | Done |
+| `slices.Contains(s, v)` | `has xs v` | Done |
+| `len(s)` | `len xs` | Done |
+| `map[string]int{"a":1}` | `M{...}` (E4) | Planned |
+| `m["key"]` | `at k m` or `get k m` (E4) | Planned |
+| `for range` | `@v xs{...}` | Done |
+| Channels | NOT planned | Deliberate |
+
+**Lessons from Go for ilo:**
+
+1. **Comma-ok pattern maps to `R`/`O`.** Go's `v, ok := m["key"]` is a two-value return that forces existence checking. ilo's map access should return `O v` (optional) — forces the agent to handle the missing-key case via `??` or `?`. This is already planned in E4.
+
+2. **Unified iteration is good.** Go's `for range` works on slices, maps, strings, and channels. ilo's `@` should work on lists (done), maps (E4: `@k m{...}` for keys, `@kv m{...}` for key-value pairs), and potentially streams (G6: `@line stream{...}`). The `@` sigil becomes the universal iterator.
+
+3. **No `make`.** Go requires `make(chan, n)`, `make(map)`, `make([]int, len, cap)` for initialization. ilo uses literals (`[1,2,3]`, `M{...}`) — no factory function needed. Token savings from avoiding `make`.
+
+4. **`delete` as a builtin.** Go has `delete(m, key)` for map entry removal. ilo should have `del k m` if maps (E4) land — agents modifying tool configuration or building requests need to remove fields.
+
+---
+
+## 12. Type System — interfaces, structs, generics
+
+### What Go provides
+
+```go
+// Structs — named product types
+type User struct {
+    Name  string
+    Email string
+}
+u := User{Name: "Alice", Email: "a@b.com"}
+
+// Interfaces — implicit satisfaction
+type Reader interface {
+    Read(p []byte) (n int, err error)
+}
+// Any type with a Read method satisfies Reader — no "implements"
+
+// Generics (Go 1.18+)
+func Map[T, U any](s []T, f func(T) U) []U { ... }
+
+// Type constraints
+type Number interface {
+    ~int | ~float64
+}
+func Sum[T Number](s []T) T { ... }
+```
+
+**Design choices worth noting:**
+- Go interfaces are **implicit** — no `implements` keyword. If a type has the right methods, it satisfies the interface. This is duck typing with compile-time verification.
+- Go survived 10+ years without generics. When generics arrived (1.18), they were minimal — type parameters with constraints, no variance, no higher-kinded types.
+- Go structs have no methods in the definition — methods are declared separately: `func (u User) String() string { ... }`.
+- Go has no enums. Constants + iota is the workaround.
+
+### Relevance to ilo
+
+ilo's type system is intentionally simpler than Go's. The TYPE-SYSTEM.md research already notes: "ilo's position: closer to Elm than Go in error handling, closer to Go in expressiveness."
+
+| Go | ilo (current/planned) | Status |
+|----|----------------------|--------|
+| Structs | Records (`type point{x:n;y:n}`) | Done |
+| Interfaces | Traits (E6) — deferred, lowest priority | Planned (far future) |
+| Generics | E5 — planned but high cost | Planned |
+| Enums | Sum types (E3) — `enum status{...}` | Planned |
+| `any` (empty interface) | `Ty::Unknown` (internal) | Done (internal only) |
+
+**Lessons from Go for ilo:**
+
+1. **Defer generics like Go did.** Go launched in 2009, added generics in 2022. 13 years of production use informed the design. ilo should follow the same path: ship without generics, learn from real agent programs what generic patterns are actually needed, then add the minimum viable generics. The TODO already sequences this correctly (E5 is fifth priority).
+
+2. **Implicit interfaces are wrong for ilo.** Go's implicit interface satisfaction is elegant but requires the compiler to scan all methods of all types. In ilo's constrained world, everything should be explicit — an agent should never wonder whether a type "accidentally" satisfies an interface. If traits (E6) are ever added, they should require explicit implementation declarations.
+
+3. **Go's lack of enums is a mistake ilo should not repeat.** Go uses `const + iota` for enums, which provides no exhaustiveness checking. ilo's planned sum types (E3) with exhaustive `?` matching are strictly better — they catch missing cases at verify time, preventing a class of errors that Go still struggles with.
+
+4. **`any` type is dangerous.** Go's `any` (empty interface) can hold anything, defeating the type system. ilo's `Ty::Unknown` is used internally for error recovery but should never be exposed as a user-facing type. The escape hatch is `t` (raw text) — it is typed (it is text) but unstructured. This is better than `any` because the agent knows it is working with text and must parse it.
+
+5. **Go's struct construction syntax is good for ilo.** Go's `User{Name: "Alice"}` uses named fields. ilo's `point x:10 y:20` is the same pattern with fewer tokens (no braces, no quotes around field names). Both approaches make field mapping explicit — the agent cannot get argument order wrong.
+
+---
+
+## Go Design Principles Applied to ilo
+
+### Principle: "Clear is better than clever"
+
+Go's proverbs include "Clear is better than clever." For ilo, this translates to: **correct is better than terse**. A 3-token solution that an agent generates correctly 10/10 times beats a 2-token solution that fails 2/10 times.
+
+**Applied to ilo decisions:**
+- Prefix notation is "clever" by human standards but "clear" by agent standards — fixed arity makes every expression unambiguous.
+- `!` auto-unwrap is a calculated cleverness — it saves many tokens and has clear semantics (propagate error), so it is worth the learning cost.
+- Short variable names (`s`, `t`, `r`) are clever but not clearer. The TYPE-SYSTEM.md research shows they save characters but not tokens. Go's convention of short-but-meaningful names (`err`, `ctx`, `req`) is better for generation accuracy.
+
+### Principle: "Don't communicate by sharing memory; share memory by communicating"
+
+Go's concurrency mantra. For ilo, the equivalent is: **functions communicate through return values and tool calls, not shared state.**
+
+ilo already enforces this:
+- No global variables
+- No mutable shared state
+- Functions declare explicit dependencies
+- Tool calls return results, not side effects (except for the tool's external effects)
+
+This is stronger than Go — Go allows shared state with mutexes. ilo forbids it entirely.
+
+### Principle: "A little copying is better than a little dependency"
+
+Go's stdlib philosophy: inline small amounts of code rather than importing packages. For ilo, this translates to: **builtins over tool dependencies for common operations.**
+
+JSON parsing (`jp`), HTTP GET (`get`), env vars (`env`), and hashing (`hash`) should be builtins, not tools. The token cost of declaring a tool, calling it, and handling its result is higher than a builtin. Go stdlib's lesson: if every program needs it, put it in the language.
+
+### Principle: "Errors are values"
+
+Go's most important design choice. In ilo, `R ok err` IS "errors are values." But ilo goes further:
+- The `!` operator eliminates Go's `if err != nil` boilerplate
+- The `?` match operator forces explicit handling
+- The verifier checks that `R` return types are matched exhaustively
+
+This is Go's error philosophy perfected for agents.
+
+### Principle: "`gofmt` — one true format"
+
+Go has exactly one code format. `gofmt` is non-configurable. This eliminates all formatting debates and makes all Go code look the same.
+
+ilo takes this further:
+- Dense format is canonical — `dense(parse(dense(parse(src)))) == dense(parse(src))`
+- No formatting choices — no indentation preferences, no brace placement options
+- The agent never wastes tokens on formatting decisions
+
+Go's `gofmt` eliminated human formatting debates. ilo's dense format eliminates formatting entirely.
+
+### Principle: "Unused imports are errors"
+
+Go refuses to compile with unused imports or variables. This is unusually strict for a mainstream language. ilo should adopt the same philosophy:
+- The verifier already checks that all calls resolve and all types exist
+- **Consider adding:** unused variable detection (warn or error when a bound variable is never referenced)
+- **Consider adding:** unused function detection (warn when a function is defined but never called)
+
+For agents, unused code is wasted tokens — both in generation and in context loading. Go's strict approach is correct.
+
+---
+
+## Summary: What ilo Should Take from Go
+
+### Take now (aligns with current roadmap)
+
+| Go feature | ilo equivalent | Priority |
+|-----------|---------------|----------|
+| `os.ReadFile` / `os.WriteFile` one-liners | `fread` / `fwrite` (G8) | High |
+| `json.Unmarshal` struct tag mapping | Record-guided JSON parsing (D1e + I1) | Critical |
+| `http.Get` convenience wrapper | Already done: `get` / `$` | Done |
+| `if err != nil` → return err | Already done: `!` auto-unwrap | Done |
+| `fmt.Sprintf` | `fmt` builtin (I4) | High |
+| `os.Getenv` / `os.LookupEnv` | `env key` (I3) | Critical |
+| `crypto/sha256` + `crypto/hmac` | `hash` / `hmac` (I9) | Medium |
+| `time.Now().Unix()` + `time.Sleep` | `now()` / `sleep n` (I6) | Medium |
+| `gofmt` single format | Already done: dense format | Done |
+| `errors` explicit handling | Already done: `R` + `?` + `!` | Done |
+
+### Take selectively (adapt to ilo's context)
+
+| Go feature | ilo adaptation | Notes |
+|-----------|---------------|-------|
+| Goroutines + WaitGroup | `par{...}` block (G4) | Hide concurrency behind a block |
+| `select` multiplexing | `poll conns timeout` (G9) | Hide channels behind a builtin |
+| `strings` package (40+ funcs) | Add `trim`, `sub`, maybe `upper`/`lower` | Only the highest-frequency operations |
+| Generics (1.18) | Defer to E5, ship without | Follow Go's "wait and see" |
+| Maps | `M t v` type (E4) | With `??` for missing-key handling |
+
+### Do NOT take (wrong for ilo)
+
+| Go feature | Why not |
+|-----------|---------|
+| Goroutines as user-visible | Deadlocks are undiagnosable for agents |
+| Channels | Too complex, wrong concurrency model for tools |
+| Interfaces (implicit) | Too implicit for constrained world |
+| `any` type | Defeats the type system |
+| `flag` package | Functions params are the CLI interface |
+| `http.ListenAndServe` | Agents consume services, not serve them |
+| `filepath` package | Path manipulation is OS concern, tool concern |
+| XML/CSV parsers | Tool concern, not language concern |
+| `crypto/aes` / encryption | Dangerous to expose, tool concern |
+| Time formatting (`time.Format`) | Tool concern, not common enough for a builtin |
+| `make()` constructor | Literals (`[]`, `M{}`) are shorter |
+
+---
+
+## Appendix: Token Comparison — Go vs ilo for Common Agent Tasks
+
+### Task 1: Fetch JSON API and extract field
+
+```go
+// Go: ~18 tokens
+resp, err := http.Get(url)
+if err != nil { return err }
+body, _ := io.ReadAll(resp.Body)
+var data map[string]interface{}
+json.Unmarshal(body, &data)
+name := data["name"].(string)
+```
+
+```
+-- ilo (with planned jp): ~4 tokens
+n=jp! ($!url) "name"
+```
+
+### Task 2: Read env var, call API, handle error
+
+```go
+// Go: ~20 tokens
+key := os.Getenv("API_KEY")
+if key == "" { return errors.New("API_KEY not set") }
+resp, err := http.Get("https://api.example.com?key=" + key)
+if err != nil { return fmt.Errorf("API call failed: %w", err) }
+body, _ := io.ReadAll(resp.Body)
+```
+
+```
+-- ilo (planned): ~8 tokens
+k=env! "API_KEY";r=get! +"https://api.example.com?key=" k;r
+```
+
+### Task 3: Process list of items
+
+```go
+// Go: ~15 tokens
+var results []string
+for _, item := range items {
+    if item.Score >= 100 {
+        results = append(results, item.Name)
+    }
+}
+```
+
+```
+-- ilo: ~8 tokens
+@i its{>=i.score 100{ret i.name}}
+```
+
+### Task 4: Parallel API calls (with planned par)
+
+```go
+// Go: ~30 tokens
+var wg sync.WaitGroup
+results := make([]string, len(urls))
+for i, url := range urls {
+    wg.Add(1)
+    go func(i int, u string) {
+        defer wg.Done()
+        resp, _ := http.Get(u)
+        body, _ := io.ReadAll(resp.Body)
+        results[i] = string(body)
+    }(i, url)
+}
+wg.Wait()
+```
+
+```
+-- ilo (planned): ~5 tokens
+par{get u1;get u2;get u3}
+```
+
+The pattern is consistent: ilo achieves 3-5x token reduction vs Go for common agent tasks, while maintaining equivalent safety guarantees through `R` types, `!` auto-unwrap, and verification before execution. Go's design philosophy validates ilo's choices; ilo pushes Go's principles to their token-minimal conclusion.

--- a/research/js-ts-ecosystem.md
+++ b/research/js-ts-ecosystem.md
@@ -1,0 +1,991 @@
+# JavaScript/TypeScript Ecosystem Research for ilo
+
+Catalog of JS/TS primitives relevant to an AI agent programming language. Evaluated against ilo's design metric: **total tokens from intent to working code**.
+
+---
+
+## 1. File I/O
+
+Three runtimes, three APIs. All async-first.
+
+### Node.js (`node:fs`)
+
+```js
+import { readFile, writeFile, mkdir, readdir, stat, rm } from 'node:fs/promises';
+const text = await readFile('file.txt', 'utf-8');
+await writeFile('out.txt', 'hello');
+await mkdir('dir', { recursive: true });
+const entries = await readdir('dir');
+const info = await stat('file.txt');
+await rm('dir', { recursive: true });
+```
+
+Sync variants exist (`readFileSync`, etc.) — block the event loop. Stream API for large files: `createReadStream`, `createWriteStream`.
+
+### Deno (`Deno.*`)
+
+```js
+const text = await Deno.readTextFile('file.txt');
+await Deno.writeTextFile('out.txt', 'hello');
+await Deno.mkdir('dir', { recursive: true });
+for await (const entry of Deno.readDir('dir')) { ... }
+const info = await Deno.stat('file.txt');
+await Deno.remove('dir', { recursive: true });
+```
+
+Requires `--allow-read` / `--allow-write` permissions. Also supports `node:fs` via compat layer.
+
+### Bun (`Bun.file` / `Bun.write`)
+
+```js
+const text = await Bun.file('file.txt').text();
+const json = await Bun.file('data.json').json();
+const bytes = await Bun.file('img.png').arrayBuffer();
+await Bun.write('out.txt', 'hello');
+await Bun.write('out.bin', new Uint8Array([1, 2, 3]));
+```
+
+`Bun.file()` returns a lazy `BunFile` conforming to the `Blob` interface — `.text()`, `.json()`, `.stream()`, `.arrayBuffer()`, `.bytes()`. For `mkdir`, `readdir`, `stat`, `rm` — use `node:fs` compat (nearly complete).
+
+### What an agent needs
+
+| Operation | Frequency | ilo mapping |
+|-----------|-----------|-------------|
+| Read file as text | Very high | Could be a builtin: `read path` > `R t t` |
+| Write text to file | Very high | Could be a builtin: `write path data` > `R _ t` |
+| List directory | Medium | Tool |
+| File metadata (exists, size) | Medium | Tool |
+| Create/delete dirs | Low | Tool |
+| Stream large files | Low | Tool (agents work on small data) |
+
+**ilo implication:** File I/O maps to 2 builtins (`read`, `write`) returning `R` types. Directory operations stay as tools. Bun's `Bun.file(path).text()` is the cleanest API shape — lazy reference, then read. But for ilo, a flat `read path` is more token-efficient.
+
+---
+
+## 2. Networking
+
+### `fetch` (universal)
+
+Available in all three runtimes. Web standard. The primary HTTP client.
+
+```js
+const res = await fetch(url);
+const body = await res.text();           // or .json(), .arrayBuffer()
+const ok = res.ok;                       // true if 200-299
+const status = res.status;               // numeric status code
+
+// POST with headers
+const res = await fetch(url, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+  body: JSON.stringify(data),
+});
+```
+
+### Node.js `http` / `https` modules
+
+Lower-level. Rarely needed when `fetch` exists. Used for custom servers:
+
+```js
+import http from 'node:http';
+http.createServer((req, res) => { res.end('hello'); }).listen(3000);
+```
+
+### Deno / Bun HTTP servers
+
+```js
+// Deno
+Deno.serve({ port: 3000 }, (req) => new Response('hello'));
+
+// Bun
+Bun.serve({ port: 3000, fetch: (req) => new Response('hello') });
+```
+
+Both use web-standard `Request`/`Response` objects. Bun: ~52k req/sec, Deno: ~29k, Node: ~14k in benchmarks.
+
+### WebSocket
+
+```js
+// Client (all runtimes)
+const ws = new WebSocket('ws://host/path');
+ws.onmessage = (e) => console.log(e.data);
+ws.send('hello');
+
+// Server: runtime-specific or use `ws` npm package
+```
+
+### Server-Sent Events (SSE)
+
+Critical for AI agents — this is how LLM APIs stream responses.
+
+```js
+// Client via fetch + ReadableStream (works everywhere)
+const res = await fetch(url);
+const reader = res.body.getReader();
+const decoder = new TextDecoder();
+while (true) {
+  const { done, value } = await reader.read();
+  if (done) break;
+  const chunk = decoder.decode(value);
+  // parse SSE format: "data: ...\n\n"
+}
+
+// Browser: EventSource API (GET only)
+const es = new EventSource(url);
+es.onmessage = (e) => console.log(e.data);
+```
+
+`EventSource` is browser-only, GET-only. For LLM APIs (POST + auth headers), use `fetch` + streaming. Libraries like `fetch-event-stream` wrap the SSE parsing.
+
+### What an agent needs
+
+| Operation | Frequency | ilo mapping |
+|-----------|-----------|-------------|
+| HTTP GET | Very high | `get url` (already builtin) |
+| HTTP POST with JSON body | Very high | Needs new builtin or tool |
+| Set headers (auth tokens) | High | Part of POST/GET config |
+| Stream SSE responses | High (LLM calls) | Tool or specialized builtin |
+| WebSocket | Medium | Tool |
+| Serve HTTP | Low | Tool |
+
+**ilo implication:** `get` already exists. A `post url body` builtin returning `R t t` covers the most common agent task (calling APIs). Headers could be a config concern. SSE streaming is important for LLM-in-the-loop patterns but may be better as a tool than a language primitive.
+
+---
+
+## 3. Process Execution
+
+### Node.js (`child_process`)
+
+```js
+import { exec, execSync, spawn, spawnSync } from 'node:child_process';
+
+// Simple: get output as string
+const { stdout } = execSync('ls -la', { encoding: 'utf-8' });
+
+// Async with streams
+const child = spawn('git', ['status']);
+child.stdout.on('data', (data) => console.log(data.toString()));
+child.on('close', (code) => console.log(`exit: ${code}`));
+```
+
+`exec` runs in a shell, `spawn` runs directly. `fork` creates Node.js child processes with IPC. Node is notably slow at spawning processes.
+
+### Deno (`Deno.Command`)
+
+```js
+const cmd = new Deno.Command('ls', { args: ['-la'] });
+const { stdout, stderr, code } = await cmd.output();
+const text = new TextDecoder().decode(stdout);
+
+// Sync variant
+const { stdout } = cmd.outputSync();
+```
+
+Requires `--allow-run` permission. Output is `Uint8Array` — must decode manually.
+
+### Bun (`Bun.spawn` / `Bun.$`)
+
+```js
+// Direct spawn
+const proc = Bun.spawn(['ls', '-la']);
+const text = await new Response(proc.stdout).text();
+
+// Bun Shell — the killer feature
+import { $ } from 'bun';
+const output = await $`ls -la`.text();
+await $`echo "hello" > file.txt`;
+await $`cat file.txt | grep hello`;
+```
+
+**Bun Shell `$` syntax** is a tagged template literal that:
+- Escapes interpolations automatically (prevents injection)
+- Supports pipes, redirects, globs natively
+- Cross-platform (Windows/Linux/macOS)
+- Built-in commands (`ls`, `cd`, `rm`) implemented natively
+- 60% faster process spawning than Node.js
+
+```js
+// Variable interpolation (safe — auto-escaped)
+const name = "world";
+await $`echo ${name}`;
+
+// Capture output
+const result = await $`git status`.text();
+
+// Error handling — non-zero exit throws
+try {
+  await $`false`;
+} catch (e) {
+  console.log(e.exitCode); // 1
+}
+
+// Quiet mode
+await $`noisy-command`.quiet();
+```
+
+### What an agent needs
+
+| Operation | Frequency | ilo mapping |
+|-----------|-----------|-------------|
+| Run shell command, get output | Very high | Builtin: `sh "cmd"` > `R t t` |
+| Run with args (safe) | High | `exec cmd args` > `R t t` |
+| Pipe commands | Medium | Tool or shell string |
+| Background processes | Low | Tool |
+
+**ilo implication:** Bun's `$` is brilliant for human developers but too complex for a language primitive. A simple `sh "git status"` > `R t t` builtin covers 90% of agent shell needs. The `exec` variant with separate args prevents injection without template literal machinery.
+
+---
+
+## 4. Data Formats
+
+### JSON (native)
+
+```js
+const obj = JSON.parse('{"a": 1}');
+const str = JSON.stringify(obj);
+const pretty = JSON.stringify(obj, null, 2);
+```
+
+Universal across all runtimes. The only format with native support.
+
+### XML
+
+No built-in parser in Node.js/Bun/Deno. Options:
+- Browser: `DOMParser` (native, DOM tree)
+- Node.js: `fast-xml-parser` (3.6k dependents, pure JS, fast), `xml2js` (legacy)
+- `txml`: 3-5x faster than `fast-xml-parser`, pure JS, works everywhere
+
+### CSV
+
+No built-in. Options:
+- `csv-parse`: streaming, battle-tested
+- `papaparse`: browser + Node, auto-detect delimiters
+- Manual: `text.split('\n').map(line => line.split(','))` — works for simple cases
+
+### What an agent needs
+
+ilo's OPEN.md already states: **"Format parsing is a tool concern, not a language concern."** This is correct.
+
+| Format | Agent frequency | ilo approach |
+|--------|----------------|--------------|
+| JSON parse/stringify | Very high | Builtin at tool boundary (JSON <-> Value mapping) |
+| XML | Low | Tool |
+| CSV | Medium | Tool, or `spl` builtin on text |
+| YAML | Low | Tool |
+| HTML | Medium | Tool (e.g., `fetch url "css-selector"`) |
+
+**ilo implication:** JSON is the one essential format. ilo already handles it at the tool boundary — tool declarations define the schema, the runtime maps JSON to typed records. XML/CSV/HTML parsing stays in tools. This matches the Unix philosophy: `curl | jq` = `get url;?{...}`. The parsing complexity lives in the tool, not the composition language.
+
+---
+
+## 5. String Manipulation
+
+### Regex
+
+```js
+const re = /^(\d{4})-(\d{2})-(\d{2})$/;
+const match = re.exec('2025-01-15');      // ['2025-01-15', '2025', '01', '15']
+const found = 'hello'.match(/l+/g);       // ['ll']
+const replaced = 'foo bar'.replace(/foo/, 'baz');
+const test = /\d+/.test('abc123');        // true
+```
+
+Full PCRE-style regex. Named groups: `/(?<year>\d{4})/`. LLMs are good at generating regex patterns.
+
+### Template literals
+
+```js
+const msg = `Hello ${name}, you have ${count} items`;
+const multiline = `line 1
+line 2`;
+// Tagged templates (Bun Shell uses this)
+const html = html`<div>${content}</div>`;
+```
+
+### Encoding APIs
+
+```js
+// Base64
+const encoded = btoa('hello');           // 'aGVsbG8='
+const decoded = atob('aGVsbG8=');        // 'hello'
+// Note: btoa/atob don't handle Unicode — use TextEncoder for that
+
+// TextEncoder / TextDecoder (UTF-8)
+const encoder = new TextEncoder();
+const bytes = encoder.encode('hello');    // Uint8Array
+const decoder = new TextDecoder();
+const str = decoder.decode(bytes);        // 'hello'
+
+// Node.js Buffer
+const buf = Buffer.from('hello', 'utf-8');
+const b64 = buf.toString('base64');
+const hex = buf.toString('hex');
+
+// New: Uint8Array.prototype.toBase64() (2025+)
+const b64 = new Uint8Array([1,2,3]).toBase64();
+```
+
+### String methods
+
+```js
+str.includes(sub)        str.startsWith(pre)       str.endsWith(suf)
+str.indexOf(sub)         str.slice(start, end)     str.trim()
+str.trimStart()          str.trimEnd()             str.padStart(len, char)
+str.padEnd(len, char)    str.repeat(n)             str.split(sep)
+str.toUpperCase()        str.toLowerCase()         str.replaceAll(old, new)
+str.at(index)            str.normalize()
+```
+
+### What an agent needs
+
+| Operation | Frequency | ilo mapping |
+|-----------|-----------|-------------|
+| Split / join | Very high | `spl` / `cat` (already builtins) |
+| Contains / includes | High | `has` (already builtin) |
+| Slice | High | `slc` (already builtin) |
+| Replace / regex | Medium | Could be builtin: `rep text pattern replacement` |
+| Case conversion | Medium | Could be builtin: `up text` / `low text` |
+| Trim | Medium | Could be builtin: `trm text` |
+| Base64 encode/decode | Low-Medium | Tool or builtin |
+| Template interpolation | N/A | ilo uses `+` concat for text |
+
+**ilo implication:** ilo already has `spl`, `cat`, `has`, `slc`, `hd`, `tl`, `rev`. The main gaps for agents: regex matching (`mtc text pattern`) and text replacement (`rep text pattern replacement`). Template literals are unnecessary — `+` concat is more token-efficient in prefix notation. Base64 could be a tool.
+
+---
+
+## 6. Concurrency
+
+### Promises & async/await
+
+```js
+// Promise creation
+const p = new Promise((resolve, reject) => {
+  setTimeout(() => resolve(42), 1000);
+});
+
+// async/await (sugar over Promises)
+async function fetchData() {
+  const res = await fetch(url);
+  return await res.json();
+}
+
+// Combinators
+const [a, b] = await Promise.all([fetchA(), fetchB()]);     // parallel, all must succeed
+const first = await Promise.race([fetchA(), fetchB()]);      // first to settle
+const results = await Promise.allSettled([a(), b(), c()]);   // all complete, no throw
+const first = await Promise.any([a(), b()]);                 // first success
+```
+
+### Worker Threads (Node.js) / Web Workers
+
+```js
+// Node.js
+import { Worker, isMainThread, parentPort, workerData } from 'node:worker_threads';
+
+if (isMainThread) {
+  const worker = new Worker('./worker.js', { workerData: { input: 42 } });
+  worker.on('message', (result) => console.log(result));
+} else {
+  const result = heavyComputation(workerData.input);
+  parentPort.postMessage(result);
+}
+
+// SharedArrayBuffer for zero-copy sharing
+const shared = new SharedArrayBuffer(1024);
+const arr = new Int32Array(shared);
+Atomics.store(arr, 0, 42);
+Atomics.load(arr, 0);  // 42
+Atomics.wait(arr, 0, 42);   // block until value changes
+Atomics.notify(arr, 0, 1);  // wake one waiter
+```
+
+### What an agent needs
+
+| Pattern | Frequency | ilo mapping |
+|---------|-----------|-------------|
+| Sequential calls (await) | Very high | Default — ilo is sequential |
+| Parallel independent calls | High | `all [call1, call2]` or automatic from DAG |
+| First-success racing | Low | Tool |
+| Background workers | Low | Not needed — agents are task-oriented |
+| Shared memory / Atomics | Very low | Not needed |
+
+**ilo implication:** ilo is synchronous by design — tool calls block. The one valuable concurrency primitive is `Promise.all` — running independent tool calls in parallel. This maps to ilo's graph-native principle: if two calls have no data dependency, execute them in parallel. Could be expressed as `all [call1 arg, call2 arg]` or inferred from the dependency graph.
+
+---
+
+## 7. Error Handling
+
+### try/catch/finally
+
+```js
+try {
+  const data = JSON.parse(input);
+  return process(data);
+} catch (e) {
+  if (e instanceof SyntaxError) { /* JSON parse error */ }
+  if (e instanceof TypeError) { /* type mismatch */ }
+  console.error(e.message, e.stack);
+  throw new Error('processing failed', { cause: e });
+} finally {
+  cleanup();
+}
+```
+
+### Error types
+
+Built-in: `Error`, `TypeError`, `RangeError`, `ReferenceError`, `SyntaxError`, `URIError`, `EvalError`, `AggregateError`.
+
+Custom errors:
+```js
+class ApiError extends Error {
+  constructor(status, message) {
+    super(message);
+    this.status = status;
+  }
+}
+```
+
+### Error chaining (ES2022)
+
+```js
+throw new Error('high-level msg', { cause: originalError });
+```
+
+### What an agent needs
+
+ilo's `R ok err` + `?` match + `!` auto-unwrap already covers this comprehensively:
+
+```
+get-user uid;?{^e:^+"Lookup failed: "e;~d:use d}
+```
+
+This is equivalent to try/catch but:
+- Typed (verifier checks exhaustiveness)
+- Composable (error propagation via `^`)
+- Token-efficient (`!` auto-unwrap = try/catch in 1 token)
+- No exception unwinding (errors are values, not control flow)
+
+**ilo implication:** No changes needed. ilo's error handling is already superior to try/catch for agent use. The `cause` chaining pattern maps to `^+"context: "e` — prepending context to error messages.
+
+---
+
+## 8. Environment
+
+### Node.js
+
+```js
+process.env.API_KEY                 // environment variable
+process.env.HOME                    // home directory
+process.argv                        // command-line args (array of strings)
+process.cwd()                       // current working directory
+process.exit(1)                     // exit with code
+process.platform                    // 'linux', 'darwin', 'win32'
+process.version                     // 'v22.0.0'
+```
+
+### Deno
+
+```js
+Deno.env.get('API_KEY')             // get env var
+Deno.env.set('KEY', 'value')        // set env var
+Deno.args                           // command-line args (after --)
+Deno.cwd()                          // current working directory
+Deno.exit(1)                        // exit with code
+```
+
+Requires `--allow-env` permission for env access.
+
+### Bun
+
+```js
+Bun.env.API_KEY                     // or process.env.API_KEY
+Bun.argv                            // command-line args
+process.cwd()                       // CWD (Node compat)
+```
+
+### What an agent needs
+
+| Operation | Frequency | ilo mapping |
+|-----------|-----------|-------------|
+| Read env var | Very high | Builtin: `env "API_KEY"` > `O t` |
+| CLI arguments | High | Already supported: `process.argv` equivalent via CLI args |
+| Current directory | Medium | Builtin or tool |
+| Exit with code | Low | Implicit from program result |
+
+**ilo implication:** `env "KEY"` returning `O t` (optional text — key might not exist) is the main gap. CLI args are already handled by ilo's CLI. Agent tasks frequently need API keys and config from environment.
+
+---
+
+## 9. Cryptography
+
+### Web Crypto API (universal)
+
+```js
+// Hashing
+const hash = await crypto.subtle.digest('SHA-256', new TextEncoder().encode('hello'));
+const hex = [...new Uint8Array(hash)].map(b => b.toString(16).padStart(2, '0')).join('');
+
+// HMAC
+const key = await crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, true, ['sign']);
+const sig = await crypto.subtle.sign('HMAC', key, data);
+
+// Encrypt/Decrypt (AES-GCM)
+const key = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt']);
+const iv = crypto.getRandomValues(new Uint8Array(12));
+const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, plaintext);
+
+// Random
+crypto.randomUUID();                        // 'f47ac10b-58cc-4372-...'
+crypto.getRandomValues(new Uint8Array(16)); // random bytes
+```
+
+Available in all three runtimes. Node also has its legacy `crypto` module with stream-based APIs.
+
+### What an agent needs
+
+| Operation | Frequency | ilo mapping |
+|-----------|-----------|-------------|
+| Generate UUID | High | Builtin: `uuid()` > `t` |
+| Hash (SHA-256) | Medium | Builtin: `hash text` > `t` |
+| Random number | Medium | Builtin: `rnd min max` > `n` |
+| HMAC signing | Low | Tool |
+| Encrypt/decrypt | Low | Tool |
+
+**ilo implication:** UUID generation and hashing are common enough for builtins. Full cryptographic operations are tool territory — too complex and error-prone for language primitives.
+
+---
+
+## 10. Time / Date
+
+### `Date` (legacy)
+
+```js
+const now = Date.now();                    // milliseconds since epoch
+const d = new Date();
+d.toISOString();                           // '2025-01-15T10:30:00.000Z'
+d.getFullYear(); d.getMonth();             // month is 0-indexed (!)
+```
+
+Notorious problems: mutable, 0-indexed months, no timezone support, bad parsing.
+
+### `Temporal` API (ES2026 — shipping)
+
+Firefox 139 (May 2025) shipped first. Chrome 144 (Jan 2026) followed. Now in production browsers.
+
+```js
+const now = Temporal.Now.instant();                           // exact moment
+const date = Temporal.PlainDate.from('2025-01-15');          // date only
+const time = Temporal.PlainTime.from('10:30:00');            // time only
+const dt = Temporal.PlainDateTime.from('2025-01-15T10:30'); // date + time
+const zdt = Temporal.ZonedDateTime.from('2025-01-15T10:30[America/New_York]');
+const dur = Temporal.Duration.from({ hours: 2, minutes: 30 });
+
+// Arithmetic
+const tomorrow = date.add({ days: 1 });
+const diff = date1.until(date2);          // Duration
+
+// Comparison
+Temporal.PlainDate.compare(a, b);         // -1, 0, 1
+```
+
+Key properties: immutable, explicit types for different use cases, 1-indexed months, IANA timezone support, nanosecond precision.
+
+### What an agent needs
+
+| Operation | Frequency | ilo mapping |
+|-----------|-----------|-------------|
+| Current timestamp (epoch ms) | High | Builtin: `now()` > `n` |
+| ISO format current time | Medium | Builtin: `time()` > `t` |
+| Parse date string | Low-Medium | Tool |
+| Date arithmetic | Low | Tool |
+| Timezone conversion | Low | Tool |
+
+**ilo implication:** `now()` (epoch milliseconds as number) and `time()` (ISO string) cover most agent needs. Complex date manipulation is tool territory.
+
+---
+
+## 11. Collections
+
+### Array
+
+```js
+// Creation
+const arr = [1, 2, 3];
+const range = Array.from({ length: 10 }, (_, i) => i);  // [0..9]
+
+// Functional
+arr.map(x => x * 2)              arr.filter(x => x > 1)
+arr.reduce((acc, x) => acc + x)  arr.find(x => x > 1)
+arr.some(x => x > 5)             arr.every(x => x > 0)
+arr.flatMap(x => [x, x])         arr.flat(depth)
+
+// Mutation
+arr.push(4)    arr.pop()    arr.shift()    arr.unshift(0)
+arr.splice(1, 1)            arr.sort((a, b) => a - b)
+arr.reverse()
+
+// Access
+arr[0]         arr.at(-1)   arr.includes(2)
+arr.indexOf(2) arr.slice(1, 3)
+```
+
+### Map / Set
+
+```js
+const m = new Map();
+m.set('key', 'value');  m.get('key');  m.has('key');  m.delete('key');
+m.size;  m.keys();  m.values();  m.entries();
+
+const s = new Set([1, 2, 3]);
+s.add(4);  s.has(2);  s.delete(1);  s.size;
+// Set operations (ES2025)
+s.union(other);  s.intersection(other);  s.difference(other);
+```
+
+### WeakMap / WeakRef
+
+For garbage-collection-friendly caches. Not relevant for agent programs.
+
+### Typed Arrays
+
+```js
+const buf = new ArrayBuffer(16);
+const i32 = new Int32Array(buf);
+const f64 = new Float64Array(buf);
+const u8 = new Uint8Array(buf);
+```
+
+For binary data manipulation. Used with WebSocket, crypto, file I/O for binary formats.
+
+### What an agent needs
+
+| Collection | Agent frequency | ilo mapping |
+|------------|----------------|-------------|
+| List (Array) | Very high | `L n`, `L t` — already exists |
+| Map (key-value) | High | Phase E: `M t n` — planned |
+| Set | Low | Can be simulated with list + dedup |
+| Typed arrays | Very low | Not needed |
+
+**ilo implication:** Lists exist. Maps are the major gap (planned as E4). The functional operations (`map`, `filter`, `reduce`) gate on generics + lambdas (E5). Until then, `@` iteration + guards cover most cases:
+
+```
+-- "filter to items > 10"
+r=[];@x xs{>x 10{+=r x}};r
+
+-- "sum"
+s=0;@x xs{s=+s x};s
+```
+
+---
+
+## 12. TypeScript Type System
+
+### Core types
+
+```ts
+// Primitives
+let n: number;          let s: string;           let b: boolean;
+let u: undefined;       let v: void;             let a: any;
+let nv: never;          let uk: unknown;
+
+// Literal types
+let dir: 'north' | 'south' | 'east' | 'west';
+let code: 200 | 404 | 500;
+
+// Object types
+interface User { id: string; name: string; email?: string; }
+type Point = { x: number; y: number };
+
+// Function types
+type Handler = (req: Request) => Response;
+type AsyncFn = (id: string) => Promise<User>;
+```
+
+### Generics
+
+```ts
+function first<T>(arr: T[]): T | undefined { return arr[0]; }
+function map<T, U>(arr: T[], fn: (item: T) => U): U[] { ... }
+
+// Constrained generics
+function getProperty<T, K extends keyof T>(obj: T, key: K): T[K] { ... }
+
+// Generic interfaces
+interface Result<T, E = Error> { ok: boolean; value?: T; error?: E; }
+```
+
+### Utility types
+
+```ts
+Partial<T>            // all fields optional
+Required<T>           // all fields required
+Pick<T, K>            // subset of fields
+Omit<T, K>            // exclude fields
+Record<K, V>          // key-value object type
+Readonly<T>           // all fields readonly
+ReturnType<F>         // infer return type of function
+Parameters<F>         // infer parameter types as tuple
+Awaited<T>            // unwrap Promise type
+Extract<T, U>         // types in T assignable to U
+Exclude<T, U>         // types in T not assignable to U
+NonNullable<T>        // remove null/undefined
+```
+
+### Conditional types
+
+```ts
+type IsString<T> = T extends string ? true : false;
+type ElementType<T> = T extends Array<infer E> ? E : never;
+type ApiResponse<T> = T extends 'user' ? User : T extends 'post' ? Post : never;
+```
+
+### Mapped types
+
+```ts
+type Nullable<T> = { [K in keyof T]: T[K] | null };
+type ReadonlyRecord<T> = { readonly [K in keyof T]: T[K] };
+```
+
+### What an agent needs
+
+TypeScript's type system is extremely expressive — far more than ilo needs. The relevant subset:
+
+| TS feature | Agent frequency | ilo equivalent |
+|------------|----------------|----------------|
+| Basic types (number, string, bool) | Very high | `n`, `t`, `b` |
+| Null/undefined handling | Very high | `_` (nil), `O n` (optional, planned) |
+| Union types (Result pattern) | Very high | `R ok err` |
+| Interfaces / object types | High | `type name{fields}` (records) |
+| Arrays with element types | High | `L n`, `L t` |
+| Generics | Medium | Planned (E5) |
+| Utility types | Low | Not needed — agents don't build abstractions |
+| Conditional/mapped types | Very low | Not needed |
+| Literal types / discriminated unions | Medium | Planned as sum types (E3) |
+
+**ilo implication:** ilo's monomorphic type system is appropriate. TypeScript's generics exist because humans write reusable libraries. Agents generate fresh programs per task — they rarely need `Partial<Pick<User, 'name' | 'email'>>`. ilo's approach (concrete types, `R` for errors, records for structure) covers the agent use case without the token cost of TS's type-level computation.
+
+---
+
+## What Bun and Deno Add That Node Doesn't
+
+### Bun additions
+
+| Feature | Impact for agents |
+|---------|-------------------|
+| **`Bun.$` shell syntax** | Tagged template for cross-platform shell commands with safe interpolation. Beautiful API but complex for a language primitive. |
+| **`Bun.file()` / `Bun.write()`** | Lazy file references with Blob interface. Clean shape. |
+| **`Bun.serve()`** | One-line HTTP server with web-standard Request/Response. |
+| **Built-in TypeScript** | No compilation step — `bun run file.ts` just works. |
+| **Built-in bundler** | `bun build` — no webpack/esbuild needed. |
+| **Built-in test runner** | `bun test` with Jest-compatible API. |
+| **Built-in SQLite** | `bun:sqlite` — embedded database with zero deps. |
+| **60% faster process spawning** | Uses `posix_spawn(3)` — matters for shell-heavy agents. |
+| **JavaScriptCore engine** | Faster startup than V8 (~5ms vs ~25ms). |
+| **Acquired by Anthropic (Dec 2025)** | Powers Claude Code and Claude Agent SDK. Direct relevance. |
+
+### Deno additions
+
+| Feature | Impact for agents |
+|---------|-------------------|
+| **Permission model** | `--allow-read`, `--allow-net`, `--allow-env`, `--allow-run`. Sandboxes untrusted code — critical for running agent-generated programs. |
+| **Permission sets in config** (2.5+) | Define permissions in `deno.json` — declarative security. |
+| **Permission broker** | External process can dynamically grant/deny permissions at runtime. |
+| **Permission audit logging** | Track what permissions were requested — observability for agent execution. |
+| **Built-in TypeScript** | Native TS execution, no compilation step. |
+| **URL-based imports** | No `node_modules` — import from URLs directly. |
+| **Built-in formatter + linter** | `deno fmt`, `deno lint` — zero config. |
+| **Web-standard APIs** | `fetch`, `Request`, `Response`, `WebSocket` — same API as browsers. |
+| **Deno Deploy** | Edge deployment platform. |
+
+### Key insight for ilo
+
+**Deno's permission model is the most relevant innovation for agent-generated code.** When an agent writes a program, that program should not have ambient access to the filesystem, network, and environment. Deno's approach — deny by default, grant explicitly — is exactly right for sandboxing agent output.
+
+ilo's tool declarations already embed this thinking: `tool get-user"..." uid:t>R profile t timeout:5,retry:2`. The tool declaration IS a permission grant — "this program can call get-user with these parameters." The closed-world verifier ensures no undeclared tools are called.
+
+**Bun's `$` shell syntax is the most relevant API innovation for developer experience,** but it's a human-facing feature. For agents, a simpler `sh "cmd"` > `R t t` achieves the same result with fewer tokens.
+
+---
+
+## Bun's `$` Shell Syntax — Deep Dive
+
+The Bun Shell is an embedded cross-platform shell interpreter:
+
+```js
+import { $ } from 'bun';
+
+// Basic execution
+await $`echo hello`;
+
+// Safe interpolation (auto-escaped)
+const file = 'my file.txt';
+await $`cat ${file}`;             // properly quoted
+
+// Output capture
+const text = await $`ls -la`.text();
+const lines = await $`ls`.lines();
+const json = await $`cat data.json`.json();
+
+// Environment variables
+await $`echo $HOME`;                         // reads env
+await $`cmd`.env({ API_KEY: 'secret' });     // per-command env
+
+// Pipes and redirects
+await $`cat file.txt | grep pattern | wc -l`;
+await $`echo hello > output.txt`;
+
+// Globs
+await $`ls **/*.ts`;
+
+// Error handling
+const result = await $`may-fail`.nothrow();  // don't throw on non-zero
+console.log(result.exitCode);
+
+// Built-in commands (no external process needed)
+// cd, ls, rm, mv, cp, cat, echo, pwd, which, mkdir, touch
+```
+
+Key properties:
+- Cross-platform (Windows MSYS included)
+- Template literal tag prevents shell injection
+- Built-in commands are Zig-native (faster than spawning processes)
+- Glob support built-in
+- `.text()`, `.lines()`, `.json()` for output parsing
+- `.env()` for per-command environment
+
+---
+
+## Deno's Permission Model — Deep Dive
+
+```bash
+# All permissions
+deno run -A script.ts
+
+# Specific permissions
+deno run --allow-read=/data --allow-net=api.example.com script.ts
+
+# Permission flags
+--allow-read[=path,...]      # filesystem read
+--allow-write[=path,...]     # filesystem write
+--allow-net[=host:port,...]  # network access
+--allow-env[=VAR,...]        # environment variables
+--allow-run[=cmd,...]        # subprocess execution
+--allow-ffi                  # dynamic libraries (dangerous)
+--allow-sys                  # system info (hostname, OS, etc.)
+```
+
+**Config file (Deno 2.5+):**
+```json
+{
+  "permissions": {
+    "allow-read": ["/data", "/config"],
+    "allow-net": ["api.example.com"],
+    "allow-env": ["API_KEY", "DATABASE_URL"]
+  }
+}
+```
+
+**Permission broker (advanced):**
+An external process can intercept permission requests and grant/deny them dynamically. Enables:
+- Audit logging of all permission requests
+- Policy-based access control
+- Interactive approval workflows
+
+**Runtime permission API:**
+```js
+const status = await Deno.permissions.query({ name: 'read', path: '/etc' });
+// status.state: 'granted' | 'denied' | 'prompt'
+
+const result = await Deno.permissions.request({ name: 'net', host: 'api.example.com' });
+```
+
+---
+
+## What Would an Agent Actually Use? — Priority Summary
+
+Ranked by frequency in real-world agent tasks:
+
+### Tier 1: Use constantly (builtin candidates)
+
+| Capability | JS/TS API | ilo status | Agent use case |
+|------------|-----------|------------|----------------|
+| HTTP GET | `fetch` / `get` | Done (`get`/`$`) | API calls, data retrieval |
+| HTTP POST | `fetch` | **Gap** | API calls with payloads, LLM calls |
+| JSON parse/stringify | `JSON.parse/stringify` | Done (tool boundary) | Data interchange |
+| File read | `fs.readFile` / `Bun.file` | **Gap** | Config, data files, code |
+| File write | `fs.writeFile` / `Bun.write` | **Gap** | Output, logs, generated files |
+| Shell command | `child_process.exec` / `Bun.$` | **Gap** | git, build tools, system commands |
+| Env vars | `process.env` | **Gap** | API keys, config |
+| String split/join | `str.split/join` | Done (`spl`/`cat`) | Text processing |
+| Error handling | `try/catch` | Done (`R`/`?`/`!`) | Every fallible operation |
+
+### Tier 2: Use often (builtin or tool)
+
+| Capability | JS/TS API | ilo status | Agent use case |
+|------------|-----------|------------|----------------|
+| Regex match/replace | `RegExp` | **Gap** | Text extraction, validation |
+| UUID generation | `crypto.randomUUID()` | **Gap** | Creating identifiers |
+| Timestamp | `Date.now()` | **Gap** | Logging, timing |
+| Hash (SHA-256) | `crypto.subtle.digest` | **Gap** | Checksums, dedup |
+| Map/dict | `Map` / `Record` | Planned (E4) | Key-value data |
+| Parallel calls | `Promise.all` | **Gap** | Independent API calls |
+| Base64 | `btoa`/`atob` | **Gap** | Auth headers, data encoding |
+
+### Tier 3: Use occasionally (tools only)
+
+| Capability | JS/TS API | ilo status |
+|------------|-----------|------------|
+| WebSocket | `WebSocket` | Tool |
+| SSE streaming | `fetch` + `ReadableStream` | Tool |
+| HTTP server | `http.createServer` / `Bun.serve` | Tool |
+| XML/HTML parsing | `DOMParser` / `fast-xml-parser` | Tool |
+| CSV parsing | `csv-parse` / `papaparse` | Tool |
+| Date arithmetic | `Temporal` / `Date` | Tool |
+| Workers/threads | `Worker` / `worker_threads` | Not needed |
+| Encrypt/decrypt | `crypto.subtle` | Tool |
+| Process management | `spawn` with streams | Tool |
+
+### Tier 4: Not needed for agents
+
+| Capability | Why not |
+|------------|---------|
+| Shared memory / Atomics | Agents are task-oriented, not compute-parallel |
+| WeakMap / WeakRef | GC optimization — not a concern |
+| Typed arrays | Binary protocol handling — agents deal in text/JSON |
+| Conditional types / mapped types | Human abstraction tooling |
+| Module system (import/export) | ilo uses declarations, not modules |
+| Class syntax | OOP machinery — agents compose functions |
+| Proxy / Reflect | Metaprogramming — too complex, too error-prone |
+| Generators / iterators | Async iteration — `@` loop is sufficient |
+
+---
+
+## Implications for ilo's Builtin Set
+
+Based on this analysis, the highest-impact additions to ilo's builtins:
+
+```
+-- Tier 1 gaps (highest priority)
+post url body          > R t t      -- HTTP POST (complement to get)
+read path              > R t t      -- read file as text
+write path data        > R _ t      -- write text to file
+sh cmd                 > R t t      -- execute shell command
+env key                > O t        -- read environment variable
+
+-- Tier 2 gaps (high priority)
+now()                  > n          -- epoch milliseconds
+uuid()                 > t          -- random UUID
+rnd min max            > n          -- random number in range
+
+-- Tier 2 gaps (medium priority)
+mtc text pattern       > L t        -- regex match
+rep text pattern repl  > t          -- regex replace
+hash text              > t          -- SHA-256 hex digest
+b64 text               > t          -- base64 encode
+d64 text               > R t t      -- base64 decode
+trm text               > t          -- trim whitespace
+up text                > t          -- uppercase
+low text               > t          -- lowercase
+```
+
+This set, combined with ilo's existing builtins and the tool system, covers the primitives an agent needs for real-world tasks: calling APIs, processing files, running commands, handling errors, and transforming data.

--- a/research/lua-elixir-research.md
+++ b/research/lua-elixir-research.md
@@ -1,0 +1,1103 @@
+# Lua & Elixir Research for ilo
+
+Comparative analysis of Lua and Elixir language features, evaluated against ilo's manifesto: **total tokens from intent to working code**. Both languages offer deep philosophical parallels to ilo -- Lua through radical minimalism and embeddability, Elixir through pipe-oriented composition and explicit error handling. This document catalogs what they offer, what ilo already handles, and what minimal additions (if any) are justified.
+
+---
+
+## Part 1: Lua
+
+Lua originated in 1993 at PUC-Rio as a language for extending software applications. Its designers (Ierusalimschy, Figueiredo, Celes) made a bet that still holds: a tiny language with powerful mechanisms beats a large language with many features. Thirty years later, Lua powers game engines (Roblox, World of Warcraft), databases (Redis), HTTP servers (Nginx/OpenResty), and embedded firmware -- all because it is small enough to fit anywhere.
+
+### 1.1 Minimalism: 22 Keywords vs 0
+
+Lua 5.4 has exactly 22 reserved words:
+
+```
+and  break  do  else  elseif  end  false  for  function  goto  if
+in  local  nil  not  or  repeat  return  then  true  until  while
+```
+
+That is remarkably few for a language with control flow, iteration, local scoping, boolean logic, and function definitions. Every keyword is a single English word. The reference manual is ~100 pages -- smaller than most language tutorials.
+
+**ilo has ~4 abbreviated English keywords** (`type`, `tool`, `wh`, `ret`, plus `brk`/`cnt` for loop control). The core syntax uses sigils (`?`, `!`, `~`, `^`, `@`, `>`, `>>`, `.?`, `??`) and structural tokens (`=`, `;`, `{`, `}`, `:`) instead of full English words. Builtins (`len`, `str`, `num`, `get`, `spl`, `cat`, etc.) are abbreviated but not reserved words.
+
+**Comparison:**
+
+| Dimension | Lua | ilo |
+|-----------|-----|-----|
+| Reserved words | 22 | ~6 abbreviated (`type`, `tool`, `wh`, `ret`, `brk`, `cnt`) |
+| Control flow | `if/elseif/else/end`, `for/do/end`, `while/do/end`, `repeat/until` | `cond{body}`, `?{arms}`, `@v xs{body}`, `wh cond{body}` |
+| Function def | `function name(params) ... end` | `name params>ret;body` |
+| Error handling | `pcall`/`xpcall` (exception-based) | `R ok err` + `?` + `!` (value-based) |
+| Scope | `local x = expr` | `x=expr` |
+| Boolean operators | `and`, `or`, `not` | `&`, `\|`, `!` |
+
+**Why this matters for AI agents:** Every keyword an LLM must generate is a token. Lua's `function total(p, q, r) local s = p * q; local t = s * r; return s + t end` is 25 tokens. ilo's `tot p:n q:n r:n>n;s=*p q;t=*s r;+s t` is 8 tokens. Lua reduced keywords to 22; ilo reduced them to zero by replacing every keyword with a structural sigil.
+
+**What ilo can learn:** Lua's 22-keyword design has survived 30 years without expansion pressure. The lesson is that a small, stable vocabulary is more valuable than an expressive one. ilo's sigil-based approach is the logical endpoint of this trajectory -- but ilo should monitor whether agents struggle with sigil density. Lua's keywords are self-documenting (`if`, `for`, `return`); ilo's sigils require spec loading. The tradeoff: ilo saves ~17 tokens per function definition but costs ~16 lines of spec context. If the spec is cached in the LLM's prompt, the savings compound across every function. If it is not, each generation starts with a spec-loading tax.
+
+**Assessment:**
+- Relevant to AI agents? **Yes.** Keyword minimalism directly reduces token cost.
+- Does ilo handle this? **Yes, and goes further.** Zero keywords vs 22.
+- Minimal addition needed: **None.** The sigil approach is correct. Monitor agent generation accuracy as sigil count grows.
+
+---
+
+### 1.2 Tables as Universal Data Structure
+
+Lua has exactly one compound data structure: the table. Tables serve as arrays, dictionaries, objects, modules, namespaces, and environments. There is no separate array type, no map type, no struct type, no class type.
+
+```lua
+-- Array
+local items = {1, 2, 3}
+
+-- Dictionary
+local config = {host = "localhost", port = 8080}
+
+-- Object (table + metatable)
+local Dog = {}
+Dog.__index = Dog
+function Dog.new(name) return setmetatable({name = name}, Dog) end
+function Dog:bark() return self.name .. " barks!" end
+
+-- Module
+local M = {}
+function M.greet(name) return "Hello, " .. name end
+return M
+```
+
+One construct, many uses. The mechanism is general; the programmer applies the policy.
+
+**ilo has four compound constructs:** lists (`L n`), records (`type point{x:n;y:n}`), results (`R ok err`), and planned maps (`M t n`). Each is distinct, typed, and verified.
+
+**Comparison:**
+
+| Dimension | Lua tables | ilo types |
+|-----------|-----------|-----------|
+| Array | `{1, 2, 3}` | `[1, 2, 3]` (typed: `L n`) |
+| Dictionary | `{a=1, b=2}` | `M{"a":1;"b":2}` (planned E4) |
+| Record/Struct | `{name="x", age=30}` | `type user{name:t;age:n}` |
+| Object | table + metatable | Not supported (no OOP) |
+| Module | table of functions | Multi-function programs |
+| Namespace | `_ENV` tables | Declaration graph (flat) |
+
+**Why ilo chose typed diversity over universal tables:** Lua tables are flexible but unverified. An agent generating `user.naem` (typo) in Lua discovers the error at runtime -- `nil` silently propagates. In ilo, the verifier catches it at compile time with ILO-T017 ("unknown field 'naem' on type user") and suggests the correct spelling. Each type the verifier knows about is a class of errors it prevents.
+
+The token cost of Lua's flexibility: zero type annotations (saves tokens in generation) but more retries when runtime errors surface. The token cost of ilo's types: ~17% of program tokens are type annotations, but each annotation prevents ~100-200 tokens of retry cost per caught error.
+
+**What ilo can learn:** Lua's single-table approach works because the host application provides the constraints (game engines define what fields an entity must have). ilo's tool declarations serve the same role -- they constrain the agent's world. The parallel: Lua tables + host constraints = ilo values + tool schemas.
+
+Lua's table-as-module pattern is worth noting. In Lua, a module is just a table returned by a file. In ilo, a multi-function program serves the same purpose. Both avoid heavyweight module systems.
+
+**Assessment:**
+- Relevant to AI agents? **Partially.** Universal data structures reduce conceptual overhead but increase runtime errors.
+- Does ilo handle this? **Yes, differently.** Typed constructs trade generation cost for retry prevention.
+- Minimal addition needed: **Maps (E4)** are the one gap. Lua tables handle dynamic key-value data natively; ilo currently requires `t` (raw text) for this case. Once `M t n` lands, ilo covers all common data shapes.
+
+---
+
+### 1.3 Embeddability: Language Inside a Host
+
+Lua was designed from day one as an embedded language -- a library with a C API, not a standalone program. The standalone interpreter is a tiny application built on top of the library. Embeddability shaped every language design decision:
+
+1. **Small size.** The entire Lua implementation is ~30,000 lines of C. The binary is ~200KB. It must fit inside the host without bloating it.
+2. **Clean API boundary.** The C API uses a virtual stack for all data exchange. C pushes values, calls Lua functions, reads results. No global state leaks between host and guest.
+3. **Mechanisms over syntax.** Lua favors mechanisms representable through the C API. Syntax is not accessible through an API; functions are. This is why Lua has metatables (callable through the API) instead of operator overloading syntax (which would require parser extensions).
+4. **Host controls policy.** Lua provides the mechanism (tables, functions, coroutines). The host decides the policy (what functions exist, what the sandbox allows, what libraries are loaded).
+
+**ilo as an embedded agent language:** ilo is designed to be embedded in agent runtimes, not host applications. But the parallel is striking:
+
+| Dimension | Lua embedding | ilo embedding |
+|-----------|--------------|---------------|
+| Host | C/C++ application (game, database, server) | Agent runtime (Claude, GPT, custom) |
+| Guest | Lua scripts | ilo programs |
+| API boundary | C API virtual stack | Tool declarations + Value<->JSON |
+| Extension mechanism | Register C functions in Lua state | `tool` declarations pointing to external services |
+| Sandboxing | Remove `os`/`io` libraries from state | Closed-world verification (only declared tools callable) |
+| Policy source | Host application code | Tool provider configuration |
+
+Lua's embedding insight translates directly: ilo programs should never assume what tools exist. The agent runtime (the "host") provides the tool graph. ilo (the "guest") verifies and composes within that graph.
+
+**What Lua's embeddability teaches ilo:**
+
+1. **Size budget matters.** Lua's 200KB binary fits in firmware. ilo's `help ai` (compact spec for LLM consumption) should fit in ~16 lines. Both are constrained by context -- Lua by memory, ilo by token windows. The spec IS ilo's "binary size."
+
+2. **API over syntax.** Lua avoided syntactic features that could not be represented in the C API. ilo should avoid features that cannot be represented in tool declarations. If a feature requires the agent to understand ilo-specific syntax beyond the spec, it adds to the "spec loading" cost. Mechanisms accessible through the universal tool-call interface (like `get`, `fread`, `hash`) are cheaper to teach than new syntax.
+
+3. **Host removes capabilities, not adds them.** In Lua, a restricted sandbox removes `os.execute` from the state. In ilo, a restricted agent environment removes tool declarations. Both achieve safety by subtraction. This is more robust than allowlisting -- the default is "nothing available," and the host explicitly adds what is needed.
+
+**Assessment:**
+- Relevant to AI agents? **Highly relevant.** The embedding model maps directly to agent runtime integration.
+- Does ilo handle this? **Partially.** Tool declarations and closed-world verification implement the "host provides capabilities" model. The `ToolProvider` trait (D1d) makes this explicit.
+- Minimal addition needed: **Tool discovery from host** (D2: MCP integration). Today, tool signatures are agent-authored. They should come from the host runtime (MCP server discovery), just as Lua's available functions come from the host application. This closes the "constrained principle gap" noted in D-AGENT-INTEGRATION.md.
+
+---
+
+### 1.4 Metatables and Metamethods
+
+Metatables are Lua's mechanism for extending behavior without new syntax. Every table can have a metatable that defines how the table responds to operations:
+
+```lua
+local Vector = {}
+Vector.__index = Vector
+
+function Vector.new(x, y)
+  return setmetatable({x = x, y = y}, Vector)
+end
+
+-- Operator overloading via metamethod
+function Vector.__add(a, b)
+  return Vector.new(a.x + b.x, a.y + b.y)
+end
+
+-- Indexing via metamethod
+function Vector.__tostring(v)
+  return "(" .. v.x .. ", " .. v.y .. ")"
+end
+
+local v1 = Vector.new(1, 2)
+local v2 = Vector.new(3, 4)
+local v3 = v1 + v2  -- calls Vector.__add
+```
+
+Key metamethods: `__add`, `__sub`, `__mul`, `__div` (arithmetic), `__index`, `__newindex` (table access), `__call` (function call), `__tostring` (string conversion), `__len` (length), `__eq`, `__lt`, `__le` (comparison).
+
+This is Lua's "mechanisms over policies" at its purest. The language does not have classes, operator overloading, or property access syntax. It has metatables, and you build all of those on top.
+
+**ilo's approach: no user-extensible behavior.** ilo operators (`+`, `-`, `*`, `/`, `=`, etc.) have fixed semantics defined by type. `+` on numbers is addition, on text is concatenation, on lists is concatenation. There is no mechanism for users to change what `+` means for a custom type.
+
+**Why this is correct for ilo:**
+
+1. **Constrained generation.** When an agent generates `+a b`, the verifier knows exactly what this means based on the types of `a` and `b`. If `+` were user-overloadable, the verifier would need to resolve the metamethod, adding complexity and potential for error.
+
+2. **No abstraction tax.** Metatables enable abstraction (OOP, DSLs, custom types). Agents generate concrete code for specific tasks -- they do not build abstractions. The manifesto: "Agents generate concrete code, not abstract interfaces."
+
+3. **Token cost of metamethods.** Defining a metatable in Lua costs ~20-30 tokens. Using it saves tokens at call sites. But agents generate single-use programs, so the definition cost is rarely amortized across enough uses to pay off.
+
+**What ilo could learn (future):** If ilo ever adds traits/interfaces (Phase E6), Lua's metamethod model offers a lesson: define behavior via a lookup table (metatable/trait implementation), not via syntax. This keeps the language grammar fixed while allowing extensibility. But E6 is the lowest priority feature and may never be needed.
+
+**Assessment:**
+- Relevant to AI agents? **No.** Agents do not need extensible operator semantics.
+- Does ilo handle this? **Yes, by deliberate omission.** Fixed operator semantics with type-based dispatch is the right choice.
+- Minimal addition needed: **None.**
+
+---
+
+### 1.5 Coroutines: Cooperative Multitasking
+
+Lua provides full asymmetric coroutines -- cooperative threads that yield explicitly. Only one coroutine runs at a time. There is no preemption.
+
+```lua
+function producer()
+  while true do
+    local value = generate_value()
+    coroutine.yield(value)
+  end
+end
+
+function consumer(co)
+  while true do
+    local ok, value = coroutine.resume(co)
+    if not ok then break end
+    process(value)
+  end
+end
+
+local co = coroutine.create(producer)
+consumer(co)
+```
+
+Applications: cooperative multitasking in games (each NPC is a coroutine), lazy generators (produce values on demand), event-loop integration (coroutine yields on I/O, resumes when data arrives), state machines (each state is a yield point).
+
+**Relevance to agent task switching:**
+
+Agent workflows naturally have yield points -- waiting for tool responses, waiting for user input, waiting for external events. Lua's coroutine model maps to this:
+
+| Lua coroutine | Agent workflow |
+|---------------|----------------|
+| `coroutine.create(fn)` | Start a tool-calling workflow |
+| `coroutine.yield(value)` | Wait for tool response |
+| `coroutine.resume(co, result)` | Supply tool result, continue workflow |
+| Status: suspended/running/dead | Workflow: waiting/executing/complete |
+
+**ilo's current model:** Fully synchronous. Tool calls block. No explicit concurrency mechanism. The runtime handles blocking; the language stays sequential.
+
+**Why ilo should NOT add coroutines:**
+
+1. **Agents do not manage concurrency.** The runtime does. Coroutines require the programmer (the agent) to decide when to yield and resume. This is concurrency reasoning, which agents do poorly -- the retry cost of a missed yield is undiagnosable.
+
+2. **Runtime-level parallelism is cheaper.** ilo's planned `par{...}` block (G4) and dependency-graph-based auto-parallelism achieve the same result with zero agent complexity. The runtime detects independent tool calls and parallelizes them. No yield, no resume, no coroutine management.
+
+3. **Token cost.** Lua coroutine code: `coroutine.create`, `coroutine.yield`, `coroutine.resume` = 3 tokens per operation. ilo's sequential `r=tool! args` = 1 token. Even if coroutines were added, the sequential model is more token-efficient for the common case.
+
+**Where coroutines WOULD help:** Streaming responses (SSE from LLM APIs, WebSocket event loops). A coroutine could process events as they arrive without buffering the entire response. But this is a runtime concern (G6: streams), not a language concern.
+
+**Assessment:**
+- Relevant to AI agents? **The concept is relevant (task suspension/resumption), but the mechanism is wrong.** Agents should not manage concurrency explicitly.
+- Does ilo handle this? **The runtime should, not the language.** Planned `par{...}` and dependency-graph parallelism address the underlying need.
+- Minimal addition needed: **None at the language level.** Runtime-level streaming (G6) would use coroutine-like mechanics internally, invisible to the agent.
+
+---
+
+### 1.6 "Mechanisms Over Policies"
+
+This is Lua's deepest design principle. Rather than providing specific solutions (policies), Lua provides general mechanisms that can be combined to implement those solutions.
+
+**Examples of mechanisms over policies in Lua:**
+
+| Need | Policy (what other languages do) | Mechanism (what Lua does) |
+|------|------|------|
+| Object-oriented programming | `class` keyword, `extends`, `implements` | Tables + metatables + `__index` chain |
+| Modules/packages | `import`/`module` keywords | Tables returned from `require()` |
+| Iterators | `iterator` protocol, `yield` | Functions that return functions (closures) |
+| Namespaces | `namespace` keyword | Nested tables + environments |
+| Exceptions | `try`/`catch`/`throw` | `pcall(fn)` returning `(ok, result_or_error)` |
+| Sandboxing | Permission system | Remove functions from `_ENV` |
+
+**How this maps to ilo:**
+
+ilo follows a similar philosophy, but goes further by removing the need for policies entirely in most cases:
+
+| Need | Lua mechanism + user policy | ilo approach |
+|------|------|------|
+| Error handling | `pcall` → user decides pattern | `R` type + `?` + `!` -- one way, enforced by verifier |
+| Data structures | Tables → user decides array vs map | `L`, `R`, records, `M` -- each typed, each verified |
+| Iteration | Closure-based iterators | `@v xs{body}` -- one syntax, verified |
+| Modules | Tables returned from files | Multi-function programs in one file |
+| Tool integration | Host registers C functions | `tool` declarations -- verified before execution |
+
+ilo's twist: **ilo provides mechanisms, but the verifier enforces policies.** Lua provides mechanisms and trusts the programmer. ilo provides mechanisms and trusts the verifier. This is the correct adaptation for agents -- agents generate code quickly but make mistakes that a verifier catches cheaply.
+
+**The deepest parallel:** Lua's `pcall(fn)` returning `(ok, result_or_error)` is structurally identical to ilo's `R ok err`. Both represent fallible operations as values, not control flow. Lua leaves the handling to the programmer; ilo's verifier ensures exhaustive handling via match exhaustiveness (ILO-T024).
+
+**Assessment:**
+- Relevant to AI agents? **Yes.** Mechanisms over policies reduces vocabulary size, which reduces token cost.
+- Does ilo handle this? **Yes, and improves on it.** Mechanisms + verifier-enforced policies = fewer retries than mechanisms + programmer trust.
+- Minimal addition needed: **None.** The philosophy is already embedded in ilo's design.
+
+---
+
+### 1.7 LuaJIT: Performance Through Minimal Design
+
+LuaJIT is widely considered the fastest dynamic language implementation. Key facts:
+
+- **2ns per call** for simple numeric functions on Apple M4 (from ilo's own benchmarks in jit-backends.md).
+- The JIT compiler adds only ~32KB of code to the Lua core.
+- Trace-based compilation: monitors hot execution paths, compiles them to native code.
+- LuaJIT 2.0's hand-written assembler interpreter is faster than most languages' compiled output.
+
+**Why LuaJIT is so fast:** Lua's minimal design directly enables JIT optimization. Fewer language constructs means fewer cases for the trace compiler to handle. Tables have a dual array/hash representation that LuaJIT exploits for fast access. Coroutines enable trace stitching across yield/resume boundaries.
+
+Cloudflare's WAF exemplifies this: Lua code representing firewall rules is JIT-compiled as attacks trigger specific paths. The JIT adapts dynamically to attack patterns -- something a static compiler cannot do.
+
+**ilo's JIT position (from jit-backends.md):**
+
+| Backend | Performance |
+|---------|------------|
+| ilo Cranelift JIT | 2ns/call |
+| LuaJIT | 1ns/call |
+| ilo Custom ARM64 JIT | 2ns/call |
+| V8 (Node.js) | 18ns/call |
+| CPython | 80ns/call |
+
+ilo's JIT is within 2x of LuaJIT for numeric functions (2ns vs 1ns). Both achieve fast codegen through the same mechanism: minimal language design enables efficient code generation.
+
+**What LuaJIT teaches ilo:**
+
+1. **Trace compilation rewards simplicity.** LuaJIT's trace compiler works because Lua has few constructs to trace through. ilo's prefix notation is even simpler -- fixed-arity operators mean the trace compiler never needs to handle operator precedence ambiguity.
+
+2. **Interpreter speed matters.** LuaJIT's hand-written assembler interpreter is faster than most compiled languages. ilo's register VM (66ns) is respectable but 60x slower than the JIT. For short-lived agent programs, the interpreter matters more than the JIT because compilation cost dominates for single-run programs.
+
+3. **JIT eligibility should expand.** ilo's JIT currently handles only pure-numeric functions. LuaJIT traces through tables, strings, and control flow. Expanding ilo's JIT to handle strings, records, and conditionals would bring the interpreter's overhead classes of programs into JIT territory.
+
+**Assessment:**
+- Relevant to AI agents? **Moderately.** Agent programs are I/O-bound (waiting for tools), so JIT speed matters less than for compute-bound workloads. But fast execution reduces the "execution" term in the total cost equation.
+- Does ilo handle this? **Yes, for numeric code.** Cranelift JIT matches LuaJIT.
+- Minimal addition needed: **Expand JIT eligibility** to strings and control flow. This is already tracked in jit-backends.md.
+
+---
+
+### 1.8 Standard Library: What Lua Includes vs Excludes
+
+Lua's standard library is deliberately minimal, organized into eight modules:
+
+| Module | Contents | Size rationale |
+|--------|----------|----------------|
+| `basic` | `print`, `type`, `tonumber`, `tostring`, `pcall`, `error`, `assert` | Essential primitives |
+| `string` | Pattern matching, `format`, `sub`, `rep`, `find`, `gsub` | No full regex (saves ~4000 lines of code) |
+| `table` | `insert`, `remove`, `sort`, `concat`, `move` | Minimal table manipulation |
+| `math` | `abs`, `ceil`, `floor`, `max`, `min`, `random`, `sin`, `cos`, etc. | ISO C math |
+| `io` | `open`, `read`, `write`, `close`, `lines` | ISO C I/O |
+| `os` | `clock`, `date`, `time`, `execute`, `getenv`, `remove`, `rename` | ISO C OS interface |
+| `coroutine` | `create`, `resume`, `yield`, `status`, `wrap` | Core concurrency |
+| `debug` | `getinfo`, `sethook`, `traceback` | Introspection (optional) |
+
+**What is NOT included:** networking, GUI, full regex, JSON, XML, database access, HTTP, cryptography, image processing. All of these come from external libraries (LuaRocks).
+
+**Design principle:** Portability restricts the stdlib to what is available in ISO C. Everything platform-specific is excluded. Lua's string patterns (simpler than PCRE regex) were chosen because full POSIX regex would add 4000+ lines -- bigger than all Lua standard libraries combined.
+
+**Comparison with ilo's builtins:**
+
+| Lua stdlib | ilo builtin | Status |
+|-----------|------------|--------|
+| `string.len` | `len` | Done |
+| `string.sub` | `slc` | Done |
+| `string.find` | `has` (contains) | Done |
+| `string.format` | `fmt` (I4) | Planned |
+| `table.insert` | `+=` (append) | Done |
+| `table.sort` | `srt` | Done |
+| `table.concat` | `cat` | Done |
+| `math.abs` | `abs` | Done |
+| `math.ceil` | `cel` | Done |
+| `math.floor` | `flr` | Done |
+| `math.max` / `math.min` | `max` / `min` | Done |
+| `tonumber` / `tostring` | `num` / `str` | Done |
+| `pcall` (error handling) | `!` auto-unwrap | Done |
+| `io.open` / `io.read` | `fread` / `fwrite` (G8) | Planned |
+| `os.time` | `now()` (I6) | Planned |
+| `os.getenv` | `env` (I3) | Planned |
+| `os.execute` | `run` (I2) | Planned |
+| Sockets | `get` / `$` (HTTP) | Done (HTTP only) |
+| JSON | `jp` / `jdump` (I1) | Planned |
+
+**What ilo takes from Lua's stdlib philosophy:**
+
+1. **Size budget.** Lua rejects full regex because it is too big relative to the language. ilo should apply the same test: every builtin added is a line in the spec (context cost) and a concept agents must learn. The spec IS ilo's "binary size."
+
+2. **ISO C as boundary.** Lua's boundary is "what ISO C provides." ilo's boundary should be "what an agent needs for tool orchestration." This is more specific: HTTP, JSON, env vars, hashing, time -- the primitives of API-calling workflows.
+
+3. **Pattern matching over regex.** Lua's simplified patterns cover 80% of use cases at 12% of the code size. ilo should consider whether regex (I8) is worth the spec complexity. A simpler pattern syntax (like Lua's `%d`, `%a`, `%w` classes) might be more agent-friendly.
+
+4. **No networking in core.** Lua puts sockets in external libraries. ilo already breaks from this (HTTP `get` is a builtin) because HTTP is fundamental to agent workloads. This is the right deviation -- ilo is not general-purpose.
+
+**Assessment:**
+- Relevant to AI agents? **Yes.** The stdlib boundary question directly affects spec size and agent learning cost.
+- Does ilo handle this? **Yes, with deliberate choices.** Builtins are selected for agent workloads, not general computing.
+- Minimal addition needed: **Stick to the planned roadmap.** The builtins in I1-I9 cover agent needs. Avoid the temptation to add general-purpose stdlib features that agents rarely use.
+
+---
+
+## Part 2: Elixir
+
+Elixir (2012, Jose Valim) runs on the BEAM VM (Erlang's virtual machine), inheriting Erlang's battle-tested concurrency, distribution, and fault tolerance. Elixir adds modern syntax, a powerful macro system, and tooling (Mix, Hex, ExUnit) that make the BEAM accessible to a wider audience. Where Lua teaches ilo about minimalism and embedding, Elixir teaches ilo about composition, error handling, and concurrent orchestration.
+
+### 2.1 `{:ok, val}/{:error, reason}` Pattern
+
+Elixir's dominant error handling pattern uses tagged tuples:
+
+```elixir
+case File.read("data.json") do
+  {:ok, content} -> process(content)
+  {:error, reason} -> handle_error(reason)
+end
+```
+
+Every fallible function returns `{:ok, value}` or `{:error, reason}`. This is a convention, not a type -- Elixir is dynamically typed. The convention is so strong that it shapes the entire ecosystem:
+
+```elixir
+# Pattern matching in function heads
+def handle_result({:ok, user}), do: send_welcome(user)
+def handle_result({:error, :not_found}), do: {:error, "User not found"}
+def handle_result({:error, reason}), do: {:error, "Failed: #{reason}"}
+```
+
+**ilo's `R ok err`:**
+
+| Dimension | Elixir `{:ok, val}/{:error, reason}` | ilo `R ok err` |
+|-----------|------|------|
+| Nature | Convention (tuple + atoms) | Type (verified by compiler) |
+| Enforcement | None (runtime crash if pattern mismatch) | Verifier checks exhaustive matching (ILO-T024) |
+| Propagation | Manual: `with` or explicit matching | `!` auto-unwrap: 1 token |
+| Nesting | `{:ok, {:ok, inner}}` possible (messy) | `R R n t t` possible but discouraged |
+| Construction | `{:ok, value}` | `~value` (Ok), `^reason` (Err) |
+| Matching | `{:ok, v} ->` | `~v:` |
+
+**ilo validates Elixir's core insight and hardens it:**
+
+Elixir proved that tagged-tuple error handling is more composable than exceptions. ilo took this insight and made it typed: `R n t` in a function signature tells the verifier (and the agent) that this function can fail. The verifier enforces handling. Elixir's convention is "you should handle errors"; ilo's type is "you must handle errors."
+
+The token comparison is stark:
+
+```elixir
+# Elixir: 15+ tokens for error propagation
+case get_user(id) do
+  {:ok, user} -> {:ok, user.name}
+  {:error, reason} -> {:error, reason}
+end
+```
+
+```
+-- ilo: 3 tokens for the same thing
+u=get-user! id;~u.name
+```
+
+**Assessment:**
+- Relevant to AI agents? **Foundational.** Every tool call is fallible. Error handling is the most common pattern in agent code.
+- Does ilo handle this? **Yes, better than Elixir.** `R` type + `!` auto-unwrap + verifier enforcement = typed, terse, verified.
+- Minimal addition needed: **Error-to-Optional bridge** (from swift-kotlin-research.md). `f? args` converting `Err` to `nil`, combined with `??`, would give a 4-token "call with fallback" pattern. Gates on the `O` type (Phase E2).
+
+---
+
+### 2.2 Pipe Operator `|>`
+
+Elixir's pipe operator passes the result of the left expression as the first argument of the right expression:
+
+```elixir
+"hello world"
+|> String.split(" ")
+|> Enum.map(&String.upcase/1)
+|> Enum.join(", ")
+# => "HELLO, WORLD"
+```
+
+Without pipes, this would be nested calls:
+
+```elixir
+Enum.join(Enum.map(String.split("hello world", " "), &String.upcase/1), ", ")
+```
+
+The pipe makes data flow visible and left-to-right. It is arguably Elixir's most iconic feature.
+
+**ilo's `>>` pipe:**
+
+```
+-- ilo pipe (implemented)
+spl "hello world" " ">>map upper>>cat ", "
+
+-- Without pipe
+a=spl "hello world" " ";b=map upper a;cat b ", "
+```
+
+| Dimension | Elixir `\|>` | ilo `>>` |
+|-----------|------|------|
+| Syntax | `expr \|> func(args)` | `expr>>func args` |
+| Argument position | First argument | Last argument |
+| Token cost | 1 token per pipe | 1 token per pipe |
+| Desugar | Parse-time rewrite | Parse-time rewrite (no new AST node) |
+| Works with `!` | No native integration | `f x>>g!>>h` (auto-unwrap in pipe) |
+
+**Key difference: first vs last argument.** Elixir pipes into the first argument; ilo pipes into the last. This is because ilo's builtins take the "subject" as the last argument for some operations, matching the Unix convention where the data flows last. The choice of argument position determines how naturally functions compose.
+
+**Tension with prefix notation:** Pipes are inherently infix/postfix -- they reverse the prefix reading order. Elixir code reads left-to-right because it is infix. ilo code normally reads inside-out because it is prefix. Pipes give ilo a left-to-right alternative for linear chains.
+
+This is a design tension ilo should embrace, not resolve. Prefix is better for nested expressions (`+*a b c`). Pipes are better for linear chains (`f x>>g>>h`). Both exist. The agent should use whichever produces fewer tokens for the specific case.
+
+**What Elixir's pipe culture teaches ilo:**
+
+1. **Pipes encourage small, composable functions.** Elixir functions tend to take one "subject" argument and return a transformed version. This style maps perfectly to ilo's builtins (`len`, `str`, `spl`, `cat`, `rev`, `srt`).
+
+2. **Pipe chains replace intermediate variables.** Elixir developers avoid naming intermediate results. ilo's pipe does the same: `f x>>g>>h` eliminates `a=f x;b=g a;h b` (saves 2 bindings = ~4 tokens per chain).
+
+3. **Error handling in pipes is hard.** Elixir's pipes break when a step returns `{:error, reason}` instead of the expected value. The `with` construct exists partly to handle this. ilo's `!` in pipes (`f x>>g!>>h`) solves this more elegantly -- auto-unwrap at any pipe stage.
+
+**Assessment:**
+- Relevant to AI agents? **Yes.** Linear tool-call chains are the most common agent pattern. Pipes save ~2 tokens per step.
+- Does ilo handle this? **Yes.** `>>` is implemented and works with `!` for error propagation.
+- Minimal addition needed: **None.** The current design is sound. Encourage pipe usage in spec examples.
+
+---
+
+### 2.3 Pattern Matching Everywhere
+
+Elixir integrates pattern matching into every control structure:
+
+```elixir
+# In function heads
+def process(%User{role: :admin, name: name}), do: "Admin: #{name}"
+def process(%User{role: :user, name: name}), do: "User: #{name}"
+
+# In case
+case fetch_user(id) do
+  {:ok, %{name: name, verified: true}} -> welcome(name)
+  {:ok, %{verified: false}} -> {:error, "Not verified"}
+  {:error, reason} -> {:error, reason}
+end
+
+# In with
+with {:ok, user} <- get_user(id),
+     {:ok, profile} <- get_profile(user),
+     {:ok, _} <- validate(profile) do
+  {:ok, profile}
+end
+
+# In function guards
+def classify(score) when score >= 90, do: "A"
+def classify(score) when score >= 80, do: "B"
+def classify(_score), do: "C"
+```
+
+**ilo's pattern matching:**
+
+```
+-- Match arms (like Elixir case)
+?r{~v:use v;^e:handle e}
+
+-- Guards (like Elixir function guards)
+>=sp 1000 "gold";>=sp 500 "silver";"bronze"
+
+-- Auto-unwrap (like Elixir with)
+u=get-user! id;p=get-profile! u;validate! p;~p
+```
+
+**Comparison:**
+
+| Pattern type | Elixir | ilo | Token comparison |
+|-------------|--------|-----|-----------------|
+| Result matching | `case r do {:ok, v} -> ... {:error, e} -> ... end` | `?r{~v:...;^e:...}` | ~15 vs ~7 |
+| Guard chain | Three `def classify` clauses | `>=sp 1000 "gold";>=sp 500 "silver";"bronze"` | ~20 vs ~8 |
+| Happy-path chain | `with {:ok, a} <- f(), {:ok, b} <- g(a) do` | `a=f!;b=g! a;~b` | ~25 vs ~5 |
+| Literal match | `case tier do "gold" -> 100; "silver" -> 50; _ -> 10 end` | `?tier{"gold":100;"silver":50;_:10}` | ~15 vs ~8 |
+
+ilo's pattern matching is consistently 2-3x more token-efficient than Elixir's. The savings come from:
+- No `case`/`do`/`end` delimiters (replaced by `?` and `{}`/`;`)
+- No `<-` pattern operator (replaced by `:` in match arms)
+- No `{:ok, v}` tuple syntax (replaced by `~v`)
+- No `when` keyword (guards are bare expressions)
+
+**What Elixir's pattern matching teaches ilo:**
+
+1. **Multi-clause functions are powerful.** Elixir's ability to define multiple function clauses with different patterns is expressive. ilo does not support this -- one function, one body. Instead, ilo uses guards at the top of the body, which is more token-efficient for the common case (2-4 branches) but less elegant for many branches.
+
+2. **Deep structural matching.** Elixir can match nested structures: `%{user: %{address: %{city: city}}}`. ilo can only match on Result (`~v`/`^e`) and literal values. Matching on record fields would require destructuring (F7 in CONTROL-FLOW.md).
+
+3. **Guards on parameters.** Elixir's `when score >= 90` on function parameters catches invalid input at the function boundary. ilo's guards do the same but inside the body, which is fine for agent code (single-entry functions).
+
+**Assessment:**
+- Relevant to AI agents? **Yes.** Pattern matching is the core of agent error handling and branching.
+- Does ilo handle this? **Yes, more concisely.** Guards + `?` match + `!` auto-unwrap cover the common patterns.
+- Minimal addition needed: **Destructuring bind (F7)** for extracting multiple record fields in one statement. This is already planned.
+
+---
+
+### 2.4 `with` Statement: Multi-Step Error Handling
+
+Elixir's `with` chains pattern-matched steps, short-circuiting on the first failure:
+
+```elixir
+with {:ok, user} <- get_user(id),
+     {:ok, profile} <- get_profile(user.id),
+     {:ok, _} <- authorize(profile),
+     {:ok, _} <- send_notification(profile) do
+  {:ok, "Done"}
+else
+  {:error, :not_found} -> {:error, "User not found"}
+  {:error, :unauthorized} -> {:error, "Access denied"}
+  {:error, reason} -> {:error, "Failed: #{reason}"}
+end
+```
+
+This is ~40 tokens for a 4-step workflow with 3 error handlers.
+
+**ilo equivalent with `!`:**
+
+```
+u=get-user! id;p=get-profile! u.id;authorize! p;send-notification! p;~"Done"
+```
+
+This is ~10 tokens. The `!` on each call does what `with`'s `<-` does: unwrap Ok, propagate Err.
+
+The entire `else` block in Elixir's `with` is implicit in ilo -- `!` propagates the exact error from whichever step fails. If the agent needs custom error messages:
+
+```
+u=get-user id;?u{^_:^"User not found";~u:p=get-profile u.id;?p{^_:^"Access denied";~p:send-notification! p;~"Done"}}
+```
+
+This is more verbose (~20 tokens) but still half the tokens of Elixir's `with` and includes custom error messages.
+
+**The key insight:** ilo's `!` is more concise than Elixir's `with` for the happy path (the 90% case). Elixir's `with` + `else` is more expressive for custom error handling (the 10% case). For agents, optimizing the 90% case saves more total tokens.
+
+**Assessment:**
+- Relevant to AI agents? **The underlying pattern (multi-step error propagation) is the core agent pattern.**
+- Does ilo handle this? **Yes, better than Elixir for the common case.** `!` is 1 token vs `with`'s ~5-token overhead per step.
+- Minimal addition needed: **None.** The current `!` + `?` combination covers both simple propagation and custom error handling.
+
+---
+
+### 2.5 OTP/GenServer: Actor Model and Supervision Trees
+
+OTP (Open Telecom Platform) is Elixir's framework for building concurrent, fault-tolerant systems. The core abstractions:
+
+1. **GenServer:** A generic server process. Holds state, handles synchronous calls (`handle_call`) and asynchronous messages (`handle_cast`). Standardized callbacks for init, terminate, and code change.
+
+2. **Supervisor:** Watches child processes. When a child crashes, the supervisor restarts it according to a strategy (`:one_for_one`, `:one_for_all`, `:rest_for_one`).
+
+3. **Supervision trees:** Supervisors supervise other supervisors, forming a tree. Failure containment: a crash in a leaf node only affects its subtree, not the whole system.
+
+4. **"Let it crash" philosophy:** Instead of defensive programming (catch every possible error), design processes to crash cleanly and let the supervisor restart them. This simplifies individual process logic dramatically.
+
+**Relevance to agent orchestration:**
+
+| OTP concept | Agent equivalent | ilo mapping |
+|-------------|-----------------|-------------|
+| GenServer (stateful process) | Tool with session state (WebSocket, database connection) | `tool` declaration with timeout/retry |
+| Supervisor (restart on failure) | Agent retry logic | `retry:n` in tool declaration |
+| Supervision tree | Multi-agent workflow hierarchy | Program dependency graph |
+| "Let it crash" | "Let it fail, propagate error" | `!` auto-unwrap (propagate `^e`) |
+| Message passing | Tool call/response | `R ok err` return values |
+
+**"Let it crash" maps to ilo's error propagation.** In both Elixir and ilo, individual operations are allowed to fail. The system-level response to failure is what matters:
+
+```elixir
+# Elixir: GenServer crashes, supervisor restarts it
+# The GenServer code is simple -- no try/catch needed
+def handle_call(:fetch, _from, state) do
+  data = dangerous_operation!()  # may crash -- that's OK
+  {:reply, data, state}
+end
+```
+
+```
+-- ilo: tool call fails, error propagates, agent handles at top level
+-- The function code is simple -- no defensive checks needed
+f uid:t>R t t;u=get-user! uid;p=get-profile! u.id;~p.name
+```
+
+Both achieve simplicity through the same insight: separate the "what to do" (function/GenServer logic) from the "what to do when it fails" (supervisor/caller error handling).
+
+**What ilo should NOT take from OTP:**
+
+1. **Explicit process management.** `GenServer.start_link`, `Supervisor.init`, `DynamicSupervisor.start_child` -- this is infrastructure ceremony that agents should never write.
+
+2. **Message passing syntax.** `send`, `receive`, mailboxes -- agents should not reason about message ordering and selective receive.
+
+3. **Hot code reloading.** OTP supports replacing code in running processes. Agent programs are short-lived; regeneration replaces reloading.
+
+**What ilo SHOULD take from OTP:**
+
+1. **Declarative retry/restart.** ilo's `tool` declaration already has `retry:n`. This is the right level of abstraction -- the agent declares intent ("retry twice"), the runtime implements policy.
+
+2. **Supervision as runtime concern.** If ilo programs run in an agent loop, the loop IS the supervisor. A failed program generates an error; the agent loop restarts with error context. This maps to OTP's supervisor without language-level constructs.
+
+3. **Failure isolation.** OTP's per-process isolation (one crash does not affect others) maps to ilo's per-function isolation. A tool call failure in one function does not corrupt another function's state (there is no shared mutable state).
+
+**Assessment:**
+- Relevant to AI agents? **The philosophy ("let it crash", declarative retry, failure isolation) is highly relevant. The mechanisms (GenServer, Supervisor, process management) are not.**
+- Does ilo handle this? **Partially.** `tool retry:n` handles declarative retry. `!` handles error propagation. The agent loop acts as a supervisor.
+- Minimal addition needed: **Runtime-level supervision** for the agent loop (D4). The language itself does not need OTP constructs.
+
+---
+
+### 2.6 Streams: Lazy Enumeration
+
+Elixir distinguishes eager `Enum` from lazy `Stream`:
+
+```elixir
+# Eager: processes entire list at each step
+1..1000
+|> Enum.filter(&(&1 > 500))
+|> Enum.map(&(&1 * 2))
+|> Enum.take(5)
+# Creates intermediate lists at each step
+
+# Lazy: processes one element at a time
+1..1000
+|> Stream.filter(&(&1 > 500))
+|> Stream.map(&(&1 * 2))
+|> Enum.take(5)
+# No intermediate lists -- elements flow through the pipeline
+```
+
+Streams are valuable when:
+- The data is large (millions of elements)
+- The data is infinite (sensor readings, log streams)
+- You only need a subset (early termination saves work)
+- Memory is constrained (one element at a time vs entire list)
+
+**Relevance to AI agent workloads:**
+
+| Use case | Eager (ilo `@`) | Lazy (stream) |
+|----------|------|------|
+| Process 10 tool results | Fine | Unnecessary overhead |
+| Filter 100 records | Fine | Unnecessary |
+| Process 1M log lines | Memory explosion | Process-one-at-a-time |
+| Real-time event stream | Cannot hold all events | Process as they arrive |
+| LLM token stream | Must buffer entire response | Process token-by-token |
+
+Most agent workloads deal with small collections (10-100 items). Streams add complexity without benefit for these cases. But two agent scenarios need streams:
+
+1. **Log processing.** Agent analyzing application logs cannot load millions of lines.
+2. **LLM streaming.** SSE responses from LLM APIs arrive token-by-token.
+
+**ilo's planned streaming (G6):** `@line stream{...}` for line-by-line processing. This is the right abstraction -- lazy iteration with familiar syntax. The `@` sigil unifies eager list iteration and lazy stream iteration.
+
+**Assessment:**
+- Relevant to AI agents? **For most workloads, no.** For log processing and LLM streaming, yes.
+- Does ilo handle this? **Not yet.** `@` is eager. G6 (streams) is planned.
+- Minimal addition needed: **G6 stream iteration.** The `@line stream{body}` pattern handles the agent use cases without exposing lazy stream combinators. Keep it simple -- agents do not need `Stream.unfold` or `Stream.resource`.
+
+---
+
+### 2.7 Phoenix LiveView: Real-Time Web Patterns
+
+Phoenix LiveView enables real-time web UIs with server-rendered HTML over WebSockets. Key patterns:
+
+1. **Declarative state management.** The server holds state; the client renders diffs. No client-side state management.
+2. **Efficient diffs.** LiveView tracks which assigns changed and sends only the diff. 5-10x faster than full HTML replacement.
+3. **PubSub for broadcast.** Changes propagate to all connected clients via PubSub.
+4. **Async data loading.** `assign_async` loads data in the background, updates the UI when ready.
+
+**Relevance to ilo:** Mostly not relevant. ilo programs are tool orchestration scripts, not web applications. However, two patterns are worth noting:
+
+1. **Server-driven UI.** LiveView's model (server holds truth, client renders) maps to "agent holds program, runtime executes." The agent does not need to understand the execution environment; it generates the program and the runtime handles execution.
+
+2. **Diff-based updates.** If ilo programs are edited incrementally (agent modifies one function), the runtime could re-verify only the changed function and its dependents, not the entire program. This is "diff-based verification" -- analogous to LiveView's diff-based rendering.
+
+**Assessment:**
+- Relevant to AI agents? **No, for the web patterns. The diff/incremental update concept is tangentially useful.**
+- Does ilo handle this? **N/A.**
+- Minimal addition needed: **None.** If incremental verification becomes important, it is a runtime optimization, not a language feature.
+
+---
+
+### 2.8 Mix: Build Tool and Dependency Management
+
+Mix is Elixir's build tool, providing:
+
+```elixir
+# Create project
+mix new my_app
+
+# Dependencies (in mix.exs)
+defp deps do
+  [{:jason, "~> 1.4"}, {:plug, "~> 1.14"}]
+end
+
+# Fetch dependencies
+mix deps.get
+
+# Run tests
+mix test
+
+# Compile
+mix compile
+
+# Custom tasks
+mix my_custom_task
+```
+
+**Relevance to ilo:** ilo programs are single files (or inline code). There is no build step, no dependency resolution, no project structure. This is deliberate -- agent programs are generated fresh for each task.
+
+However, Mix's `mix.exs` as a declarative manifest has a parallel: ilo's `tool` declarations at the top of a program ARE the dependency manifest. They declare what external capabilities the program needs:
+
+```
+tool get-user"Retrieve user by ID" uid:t>R profile t timeout:5,retry:2
+tool send-email"Send an email" to:t subject:t body:t>R _ t timeout:10,retry:1
+```
+
+This IS `mix.exs` for a single-use program. No separate manifest file needed. The program declares its own dependencies inline.
+
+**Assessment:**
+- Relevant to AI agents? **The concept (declarative dependency manifest) is relevant. The build tool machinery is not.**
+- Does ilo handle this? **Yes.** Tool declarations serve as inline dependency manifests.
+- Minimal addition needed: **None.**
+
+---
+
+## Part 3: Cross-Cutting Themes
+
+### 3.1 Pipe-Oriented Thinking (Elixir `|>` vs ilo prefix + `>>`)
+
+Elixir's pipe operator fundamentally shaped how Elixir developers think about programs: data flows left-to-right through a series of transformations. This "pipeline thinking" maps to how agents naturally compose tool calls -- get data, transform it, pass it to the next step.
+
+**Three composition models compared:**
+
+```elixir
+# Elixir: pipe-oriented (left to right)
+id
+|> get_user()
+|> get_profile()
+|> extract_email()
+|> send_notification()
+```
+
+```lua
+-- Lua: nested calls (inside out)
+send_notification(extract_email(get_profile(get_user(id))))
+```
+
+```
+-- ilo: bind-first (top to bottom, sequential)
+u=get-user! id;p=get-profile! u;e=extract-email p;send-notification! e
+
+-- ilo: pipe (left to right)
+get-user! id>>get-profile!>>extract-email>>send-notification!
+```
+
+**Why both prefix and pipe coexist in ilo:**
+
+Prefix notation excels at nested expressions where operators combine values:
+```
+-- Prefix: natural for math/logic (3 tokens for nested ops)
++*a b c        -- (a * b) + c
+
+-- Pipe: awkward for math (*a b>>+ c feels wrong)
+```
+
+Pipes excel at linear chains where each step feeds the next:
+```
+-- Pipe: natural for sequential processing
+spl t " ">>rev>>cat ", "
+
+-- Prefix: requires intermediate binds
+a=spl t " ";b=rev a;cat b ", "
+```
+
+The guideline for agents: **use prefix for expressions, pipes for chains.** This is two ways to do one thing, which normally violates the manifesto. But the two forms are complementary, not redundant -- they optimize different patterns. Prefix saves tokens in nested expressions (22% savings vs infix). Pipes save tokens in linear chains (~4 tokens per 3-step chain).
+
+---
+
+### 3.2 Embeddability (Lua as Language-in-Runtime vs ilo as Agent-Language)
+
+Both Lua and ilo are designed to be embedded, but in different hosts:
+
+| Dimension | Lua | ilo |
+|-----------|-----|-----|
+| Host | C/C++ application | AI agent runtime |
+| Host provides | C functions registered in Lua state | Tool declarations from MCP/config |
+| Guest provides | Scripts extending host behavior | Programs orchestrating tools |
+| Communication | C API virtual stack | Value <-> JSON at tool boundary |
+| Size constraint | Memory (200KB binary) | Tokens (~16-line spec) |
+| Sandbox | Remove libraries from state | Closed-world verification |
+| Lifecycle | Long-running (game loop, server) | Short-lived (generate, verify, execute, discard) |
+
+**The key insight from Lua's embedding model:**
+
+Lua's embeddability shapes its language design -- features that cannot be exposed through the C API are avoided. Similarly, ilo's "embeddability" in agent runtimes should shape its design: features that cannot be expressed in the ~16-line compact spec (`ilo help ai`) are too complex. If an agent cannot learn a feature from the spec, the feature increases total token cost through generation errors and retries.
+
+**Lua's API-first design principle applied to ilo:** Every ilo feature should be "spec-first" -- describable in a few lines of the compact spec. The `!` operator passes this test ("call + auto-unwrap Result -- propagates error"). A hypothetical coroutine system would fail it (requires explaining yield, resume, scheduling, and error handling across yield boundaries).
+
+---
+
+### 3.3 Minimalism Spectrum (Lua's 22 vs ilo's 0)
+
+The minimalism spectrum for relevant languages:
+
+```
+More keywords                                     Fewer keywords
+Java (~50)  Python (~35)  Go (~25)  Lua (~22)  Forth (~0)  ilo (~6)
+```
+
+Lua sits near the minimal end of mainstream languages. ilo sits at the extreme -- ~6 abbreviated keywords (`type`, `tool`, `wh`, `ret`, `brk`, `cnt`) plus single-character sigils for all control flow.
+
+**What each level of minimalism costs and gains:**
+
+| Level | Keywords | Generation cost | Learning cost | Error clarity |
+|-------|----------|----------------|---------------|---------------|
+| Java ~50 | 50 reserved words | High (many valid next-tokens) | High (large spec) | High (verbose errors) |
+| Python ~35 | 35 reserved words | Medium | Medium | Medium |
+| Go ~25 | 25 reserved words | Low-medium | Low | High |
+| Lua ~22 | 22 reserved words | Low | Low | Medium (runtime) |
+| ilo ~6 | ~6 abbreviated keywords, ~15 sigils | Very low | Very low (with spec) | High (verified + suggestions) |
+
+**Lua and ilo both prove that fewer keywords work.** Lua has run production systems for 30 years with 22 keywords. ilo achieves 10/10 LLM generation accuracy with ~6 abbreviated keywords and sigil-based syntax (tested across 4 task types with claude-haiku-4-5). The evidence suggests that the lower bound for keywords is zero, as long as:
+
+1. The spec is available in context
+2. Sigils are unambiguous (no overloading)
+3. Examples demonstrate every construct
+4. Error messages reference the spec
+
+**The risk ilo should monitor:** As ilo adds features, the sigil count grows. Currently: `?`, `!`, `~`, `^`, `@`, `>`, `>>`, `.?`, `??`, `=`, `;`, `{`, `}`, `:`, `--`. That is 15 structural tokens. If this grows to 25+, the cognitive load approaches Lua's 22 keywords, but with less self-documentation. Each new sigil should pass the test: "Does this save more tokens than the spec line needed to explain it?"
+
+---
+
+## Part 4: Feature-by-Feature Assessment Matrix
+
+### Lua Features
+
+| Feature | Agent relevance | ilo coverage | Addition needed |
+|---------|----------------|-------------|-----------------|
+| 22 keywords (minimalism) | High | Already surpassed (~6 abbreviated keywords) | None |
+| Tables (universal data) | Medium | Typed alternatives (`L`, `R`, records) | Maps (E4) |
+| Embeddability / C API | High | Tool declarations + ToolProvider | MCP integration (D2) |
+| Metatables / metamethods | None | Deliberately omitted | None |
+| Coroutines | Low (concept useful, mechanism wrong) | Runtime parallelism (G4) | None at language level |
+| "Mechanisms over policies" | High (philosophical) | Mechanisms + verifier-enforced policies | None |
+| LuaJIT performance | Medium | Cranelift JIT matches LuaJIT for numerics | Expand JIT eligibility |
+| Minimal stdlib | High (spec size budget) | Agent-focused builtins | Stick to roadmap (I1-I9) |
+| String patterns (not regex) | Medium | `has`, `spl`, `cat` + planned I8 | Consider simpler patterns |
+| `pcall` as error handling | High | `R` + `?` + `!` (superior) | None |
+| Closures / first-class functions | Medium | Not yet (E5: generics + lambdas) | Phase E5 |
+| `nil` as value | Low | `_` (nil type) + planned `O` (optional) | Phase E2 |
+
+### Elixir Features
+
+| Feature | Agent relevance | ilo coverage | Addition needed |
+|---------|----------------|-------------|-----------------|
+| `{:ok, val}/{:error, reason}` | Foundational | `R ok err` + `~`/`^` (typed, verified) | Error-to-Optional bridge |
+| Pipe `\|>` | High | `>>` (implemented, works with `!`) | None |
+| Pattern matching everywhere | High | `?` match + guards (more concise) | Destructuring (F7) |
+| `with` statement | High | `!` auto-unwrap (more concise) | None |
+| OTP / GenServer | Philosophy relevant, mechanisms not | `tool retry:n` + `!` propagation | Runtime supervision (D4) |
+| Streams (lazy) | Low (most agent data is small) | `@` is eager | G6 for streams |
+| Phoenix LiveView | Not relevant | N/A | None |
+| Mix build tool | Concept relevant | Tool declarations as inline manifest | None |
+| Macro system | Not relevant | No metaprogramming | None |
+| `Enum.map/filter/reduce` | High | `@` loop + bind-first pattern | `map`/`flt`/`fld` builtins (needs E5) |
+| Protocols (ad-hoc polymorphism) | Not relevant | Deliberately omitted | None |
+| Behaviours (callback contracts) | Low | N/A | None |
+| Sigils (`~r`, `~w`, etc.) | Low | Sigils used differently (structural) | None |
+| `Task.async` + `Task.await` | Medium | Planned `par{...}` (G4) | Runtime parallelism |
+
+---
+
+## Part 5: Synthesis and Recommendations
+
+### Already validated by Lua and Elixir (no action needed)
+
+1. **Zero-keyword minimalism.** Lua's 22-keyword success validates reducing keywords. ilo's 0-keyword sigil approach is the logical extreme and works (10/10 generation accuracy).
+
+2. **Value-based error handling.** Both Lua's `pcall` returning `(ok, result)` and Elixir's `{:ok, val}/{:error, reason}` validate ilo's `R ok err`. ilo adds type verification and `!` auto-unwrap, making it strictly superior for agent workloads.
+
+3. **Pipe operator.** Elixir proved pipes transform how developers think about composition. ilo's `>>` captures this benefit at 1 token per pipe stage.
+
+4. **Mechanisms over policies.** Lua's philosophy of providing general mechanisms instead of specific features is validated by 30 years of use. ilo follows this with its small set of constructs (`?`, `@`, `!`, `~`, `^`) that combine to handle any control flow pattern.
+
+5. **Embeddability as design constraint.** Lua's embeddability shaped its minimalism (nothing that cannot be expressed through the C API). ilo's embeddability in agent runtimes should follow the same principle (nothing that cannot be explained in the compact spec).
+
+### Validated as planned (proceed with roadmap)
+
+1. **Maps (E4)** -- Lua tables handle dynamic key-value natively. ilo needs `M t n` for tool responses with variable keys.
+
+2. **Optional type (E2)** -- Both Lua's nil propagation issues and Elixir's `nil` handling validate the need for typed optionals. The `O` type + verifier enforcement would catch nil crashes pre-execution.
+
+3. **Error-to-Optional bridge** -- Elixir's pattern of converting errors to nil (via `case`/default) and Lua's `pcall` returning false on error both point to needing `f? args` + `??` for the "call with fallback" pattern.
+
+4. **Runtime parallelism (G4)** -- Elixir's `Task.async`/`Task.await` and Lua's coroutines both address concurrent execution. ilo's `par{...}` block is the right abstraction: the runtime parallelizes, the language stays sequential.
+
+5. **Streams (G6)** -- Elixir's `Stream` module proves lazy enumeration is needed for large data. ilo's `@line stream{body}` is the right minimal approach.
+
+6. **Destructuring bind (F7)** -- Elixir's pattern matching in bindings (`%{name: n} = user`) saves tokens for record field extraction. ilo's planned `{n;e}=expr` matches this.
+
+### New insights from this research
+
+1. **Spec size as binary size.** Lua's 200KB binary constraint shaped its design. ilo's ~16-line compact spec constraint should shape its design with equal discipline. Every feature added is a spec line; every spec line is a context token. Apply Lua's ruthless size budgeting to ilo's spec.
+
+2. **String patterns, not full regex.** Lua rejected POSIX regex because the implementation (4000+ lines) was bigger than all Lua standard libraries combined. ilo should consider whether the planned regex support (I8) could use a simplified pattern syntax (like Lua's `%d`, `%a`, `%w`) instead of full PCRE. Agent workloads rarely need lookahead, backreferences, or non-greedy matching. Simpler patterns = smaller spec section = fewer agent learning tokens.
+
+3. **Lua's stdlib boundary = ilo's builtin boundary.** Lua includes only what ISO C provides. ilo should include only what tool orchestration requires: HTTP, JSON, env, hashing, time, file I/O, string basics. Resist the temptation to add general-purpose builtins (matrix math, compression, image processing) that agents rarely need.
+
+4. **OTP's "let it crash" = ilo's `!` propagation.** The philosophical alignment is exact. Both say: "individual operations should be simple; error handling belongs at a higher level." In OTP, the supervisor handles crashes. In ilo, the caller (or the agent loop) handles `^e`. This should be emphasized in ilo's documentation as a design principle, not just a feature.
+
+5. **Coroutines are runtime, not language.** Both Lua's coroutines and Elixir's processes are concurrency mechanisms exposed to the programmer. For agents, concurrency should be invisible -- the runtime detects parallelism from the dependency graph. This is ilo's "graph-native" principle applied to execution, validated by comparing Lua/Elixir's explicit models with the complexity they impose on code generators.
+
+### Features to NOT add (validated by Lua/Elixir analysis)
+
+| Feature | Why not |
+|---------|---------|
+| Metatables / operator overloading | Agents generate concrete code, not abstractions |
+| Coroutines / explicit concurrency | Agents should not manage yield/resume; runtime handles parallelism |
+| OTP-style process management | Too much ceremony; agent programs are short-lived |
+| Macro system (Elixir) | Metaprogramming adds spec complexity without reducing agent token cost |
+| Protocol / behavior system | Agents do not write reusable libraries |
+| Full regex engine | Consider Lua's simplified patterns instead |
+| Module / namespace system | Programs are small single files; tool declarations are the namespace |
+| Hot code reloading | Programs are regenerated, not patched |
+
+---
+
+## Appendix A: Token Comparison — Lua vs Elixir vs ilo
+
+### Task: Fetch API, extract field, handle error
+
+```lua
+-- Lua (with http library): ~30 tokens
+local http = require("socket.http")
+local json = require("cjson")
+local body, code = http.request(url)
+if code ~= 200 then
+  return nil, "HTTP error: " .. code
+end
+local data = json.decode(body)
+return data.name
+```
+
+```elixir
+# Elixir (with HTTPoison): ~25 tokens
+case HTTPoison.get(url) do
+  {:ok, %{status_code: 200, body: body}} ->
+    {:ok, Jason.decode!(body)["name"]}
+  {:ok, %{status_code: code}} ->
+    {:error, "HTTP error: #{code}"}
+  {:error, reason} ->
+    {:error, "Request failed: #{reason.reason}"}
+end
+```
+
+```
+-- ilo: ~5 tokens
+n=jp! ($!url) "name";~n
+```
+
+### Task: Process list, filter, transform
+
+```lua
+-- Lua: ~20 tokens
+local result = {}
+for _, item in ipairs(items) do
+  if item.score >= 100 then
+    table.insert(result, item.name)
+  end
+end
+return result
+```
+
+```elixir
+# Elixir: ~12 tokens
+items
+|> Enum.filter(&(&1.score >= 100))
+|> Enum.map(& &1.name)
+```
+
+```
+-- ilo: ~8 tokens
+@i its{>=i.score 100{i.name}}
+```
+
+### Task: Multi-step workflow with error handling
+
+```lua
+-- Lua: ~40 tokens
+local ok, user = pcall(get_user, id)
+if not ok then return nil, "User lookup failed: " .. user end
+local ok2, profile = pcall(get_profile, user.id)
+if not ok2 then return nil, "Profile lookup failed: " .. profile end
+local ok3, _ = pcall(send_email, profile.email, "Hello", msg)
+if not ok3 then return nil, "Email failed" end
+return true
+```
+
+```elixir
+# Elixir: ~30 tokens
+with {:ok, user} <- get_user(id),
+     {:ok, profile} <- get_profile(user.id),
+     {:ok, _} <- send_email(profile.email, "Hello", msg) do
+  {:ok, true}
+else
+  {:error, reason} -> {:error, reason}
+end
+```
+
+```
+-- ilo: ~8 tokens
+u=get-user! id;p=get-profile! u.id;send-email! p.email "Hello" msg;~true
+```
+
+**Pattern:** ilo achieves 3-5x token reduction vs Lua and 2-4x vs Elixir for typical agent tasks, while maintaining equivalent or stronger safety guarantees through static verification.
+
+---
+
+## Appendix B: Language Philosophy Comparison
+
+| Principle | Lua | Elixir | ilo |
+|-----------|-----|--------|-----|
+| Core insight | One mechanism per concern | Data flows through pipes | Minimize total tokens |
+| Data structure | One (table) | Many (tuple, list, map, struct) | Typed set (L, R, record, M) |
+| Error model | pcall/xpcall (exception-like) | {:ok}/{:error} convention | R type + verifier enforcement |
+| Concurrency | Coroutines (cooperative) | Processes (preemptive, BEAM) | Runtime-managed (planned) |
+| Extension | Metatables (user extensible) | Protocols + macros | Tools (host extensible) |
+| Typing | Dynamic, untyped | Dynamic, convention-typed | Static, verified |
+| Composition | Nested calls | Pipes (`\|>`) | Prefix nesting + pipes (`>>`) |
+| Community motto | "Mechanisms over policies" | "Let it crash" | "Total tokens from intent to code" |
+| Stdlib philosophy | ISO C boundary | Batteries included (OTP) | Agent workload boundary |
+| Target user | C/C++ host application | Web/distributed systems developer | AI agent runtime |
+| Spec size | ~100 pages | ~2000+ pages (with OTP) | ~16 lines (compact) / ~5 pages (full) |

--- a/research/mcp-protocol-research.md
+++ b/research/mcp-protocol-research.md
@@ -1,0 +1,1214 @@
+# Model Context Protocol (MCP) -- Technical Research
+
+## Purpose
+
+This document provides a mechanical reference for the Model Context Protocol (MCP), Anthropic's open standard for connecting AI agents to external tools, data sources, and services. The focus is on protocol internals: wire format, message flows, transport layers, primitives, and lifecycle. This research informs what ilo-lang needs to support natively for agent-tool interaction.
+
+The authoritative specification lives at https://modelcontextprotocol.io/specification/. The current stable versions are 2025-06-18 and 2025-11-25 (which adds async tasks and extensions). This document covers the protocol as of 2025-11-25.
+
+---
+
+## 1. Architecture: Host, Client, Server
+
+MCP uses a three-tier architecture:
+
+```
+  Host (AI application / IDE / agent runtime)
+    |
+    +-- Client (protocol handler, 1:1 with a server)
+    |     |
+    |     +-- Server (exposes tools, resources, prompts)
+    |
+    +-- Client
+          |
+          +-- Server
+```
+
+- **Host**: The AI-enabled application (chatbot, IDE, agent runtime). A host may create multiple clients.
+- **Client**: Manages one MCP connection. Handles JSON-RPC framing, capability negotiation, and method routing. Lives inside the host process.
+- **Server**: An independent process or service that exposes capabilities. Communicates with exactly one client per session.
+
+A single host can connect to many servers simultaneously (one client per server). The host decides which server to route a tool call to based on the tool name returned during discovery.
+
+**Implication for ilo**: An ilo runtime acting as an agent would be the Host. It would need a client component per MCP server it connects to. Tool calls in ilo programs would route through these clients.
+
+---
+
+## 2. Wire Format: JSON-RPC 2.0
+
+All MCP communication uses JSON-RPC 2.0 over whatever transport is active. Three message types exist:
+
+### 2.1 Requests
+
+A request expects a response. It carries an `id` that the responder echoes back.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/list",
+  "params": {}
+}
+```
+
+Fields:
+- `jsonrpc`: Always `"2.0"`.
+- `id`: Unique per-session. String or integer. Used to match responses.
+- `method`: The operation name (e.g., `"initialize"`, `"tools/call"`, `"sampling/createMessage"`).
+- `params`: Optional object or array. Method-specific parameters.
+
+### 2.2 Responses
+
+A response matches a prior request by `id`. Contains exactly one of `result` or `error`.
+
+Success:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "tools": [ ... ]
+  }
+}
+```
+
+Error:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32601,
+    "message": "Method not found"
+  }
+}
+```
+
+Standard JSON-RPC error codes:
+- `-32700` -- Parse error (invalid JSON)
+- `-32600` -- Invalid request
+- `-32601` -- Method not found
+- `-32602` -- Invalid params
+- `-32603` -- Internal error
+- `-32042` -- URL elicitation required (MCP-specific)
+
+### 2.3 Notifications
+
+Fire-and-forget messages. No `id`, no response expected.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/initialized"
+}
+```
+
+Used for: lifecycle events (`notifications/initialized`), progress updates (`notifications/progress`), cancellations (`notifications/cancelled`), list-change signals (`notifications/tools/list_changed`), and logging.
+
+### 2.4 Key Design Property
+
+JSON-RPC 2.0 was chosen deliberately. It is the same foundation used by the Language Server Protocol (LSP). It is simple, human-readable, universally parseable, and avoids reinventing RPC primitives. The protocol is stateful -- each session maintains connection state from initialization through shutdown.
+
+---
+
+## 3. Transport Layers
+
+MCP defines three transports. All carry JSON-RPC 2.0 messages; they differ only in how bytes move between client and server.
+
+### 3.1 stdio (Standard Input/Output)
+
+The client spawns the server as a subprocess. Communication happens over stdin/stdout.
+
+```
+Client ---stdin--->  Server process
+Client <--stdout---  Server process
+             stderr -> logging (optional, not protocol messages)
+```
+
+Rules:
+- Messages are newline-delimited. MUST NOT contain embedded newlines.
+- Server MUST NOT write non-MCP data to stdout.
+- Client MUST NOT write non-MCP data to the server's stdin.
+- Server MAY write UTF-8 logging to stderr. Client MAY capture or ignore it.
+
+This is the standard transport for local tools: filesystem access, database queries, CLI wrappers. It is the simplest to implement -- no HTTP, no TLS, no session tokens.
+
+**Implication for ilo**: An ilo runtime could spawn MCP servers as child processes and read/write JSON-RPC over pipes. This maps cleanly to a `spawn + read-line + write-line` pattern.
+
+### 3.2 Streamable HTTP (Current Standard for Remote)
+
+Replaces the old SSE transport as of protocol version 2025-03-26.
+
+The server exposes a single HTTP endpoint (e.g., `https://example.com/mcp`). Communication:
+
+- **Client to Server**: HTTP POST with JSON-RPC body.
+- **Server to Client**: The response can be either:
+  - A single JSON-RPC response (simple case), or
+  - An SSE stream (for streaming results, progress, server-initiated requests).
+- **Server to Client (unsolicited)**: Client opens an HTTP GET to the same endpoint. Server sends SSE events.
+
+Session management:
+- The server MAY assign a session ID via the `Mcp-Session-Id` header during initialization.
+- The client MUST include this header on subsequent requests.
+- Supports connection resumability: client sends `Last-Event-ID` header on reconnect; server MAY replay missed events.
+
+This is the transport for remote/cloud MCP servers. A single endpoint handles everything -- no dual-endpoint complexity.
+
+### 3.3 SSE (Server-Sent Events) -- Deprecated
+
+The original remote transport (protocol version 2024-11-05). Required two endpoints:
+- `/sse` -- Client opens GET, receives SSE stream from server.
+- `/messages` -- Client POSTs JSON-RPC requests.
+
+Deprecated because: dual endpoints are complex, connection drops lose in-flight responses, and there is no resumability. Streamable HTTP fixes all of these.
+
+Still available for backward compatibility. Clients can auto-detect: POST an `initialize` request; if 4xx, fall back to GET for SSE.
+
+### 3.4 Transport Selection Summary
+
+| Transport       | Use Case          | Endpoints    | Status     |
+|----------------|-------------------|-------------|------------|
+| stdio          | Local processes    | stdin/stdout | Active     |
+| Streamable HTTP| Remote/cloud       | Single URL   | Active     |
+| SSE            | Legacy remote      | Dual URLs    | Deprecated |
+
+---
+
+## 4. Lifecycle: Initialization, Operation, Shutdown
+
+MCP is stateful. Every session goes through three phases.
+
+### 4.1 Phase 1: Initialization
+
+The client sends an `initialize` request. This MUST be the first message and MUST NOT be batched with other requests.
+
+**Client -> Server: initialize request**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2025-06-18",
+    "capabilities": {
+      "roots": { "listChanged": true },
+      "sampling": {},
+      "elicitation": {}
+    },
+    "clientInfo": {
+      "name": "ilo-runtime",
+      "version": "0.1.0"
+    }
+  }
+}
+```
+
+**Server -> Client: initialize response**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "protocolVersion": "2025-06-18",
+    "capabilities": {
+      "tools": { "listChanged": true },
+      "resources": { "subscribe": true, "listChanged": true },
+      "prompts": { "listChanged": true },
+      "logging": {}
+    },
+    "serverInfo": {
+      "name": "weather-server",
+      "version": "2.0.0"
+    },
+    "instructions": "This server provides weather data for any city worldwide."
+  }
+}
+```
+
+**Client -> Server: initialized notification**
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/initialized"
+}
+```
+
+Protocol version negotiation:
+- Client sends the latest version it supports.
+- If the server supports that version, it echoes it back.
+- If not, the server responds with a version it does support.
+- If the client cannot work with the server's version, it disconnects.
+
+Capability negotiation:
+- Client declares what it can handle (sampling, roots, elicitation).
+- Server declares what it offers (tools, resources, prompts, logging).
+- Neither party may use features the other did not advertise.
+- This creates a binding contract for the session.
+
+**Client capabilities** (what the client can provide to the server):
+- `roots` -- Client can expose filesystem roots. `listChanged`: will notify on changes.
+- `sampling` -- Client can fulfill `sampling/createMessage` requests.
+- `elicitation` -- Client can show forms/dialogs to the user on the server's behalf.
+
+**Server capabilities** (what the server offers to the client):
+- `tools` -- Server exposes callable tools. `listChanged`: will notify when tool list changes.
+- `resources` -- Server exposes readable resources. `subscribe`: supports subscriptions. `listChanged`: will notify on changes.
+- `prompts` -- Server exposes prompt templates. `listChanged`: will notify on changes.
+- `logging` -- Server can send log messages.
+- `completions` -- Server supports argument auto-completion.
+
+Rules before initialization completes:
+- Client SHOULD NOT send requests other than pings.
+- Server SHOULD NOT send requests other than pings and logging.
+
+### 4.2 Phase 2: Operation
+
+Normal bidirectional communication. Both sides send requests, responses, and notifications according to the negotiated capabilities.
+
+Key constraint: neither party may invoke features not agreed upon in initialization.
+
+### 4.3 Phase 3: Shutdown
+
+No explicit shutdown message. Shutdown is transport-level:
+- **stdio**: Client closes stdin to the server. Waits for exit. Escalates to SIGTERM/SIGKILL if needed.
+- **HTTP**: Client stops sending requests. Server may time out the session.
+
+### 4.4 Utility Messages (Available in All Phases)
+
+**Ping** (either direction):
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 99,
+  "method": "ping"
+}
+```
+Response: `{ "jsonrpc": "2.0", "id": 99, "result": {} }`
+
+**Progress notification** (either direction):
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/progress",
+  "params": {
+    "progressToken": "abc-123",
+    "progress": 50,
+    "total": 100,
+    "message": "Processing records..."
+  }
+}
+```
+
+**Cancellation notification** (either direction):
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/cancelled",
+  "params": {
+    "requestId": 5,
+    "reason": "User cancelled"
+  }
+}
+```
+
+Implementations SHOULD establish timeouts on all sent requests. When a timeout fires, send a cancellation notification and stop waiting.
+
+---
+
+## 5. The Six Primitives
+
+MCP defines six primitives divided into two categories:
+
+**Server-side** (server exposes, client consumes):
+1. Tools -- callable actions with side effects
+2. Resources -- read-only data
+3. Prompts -- reusable message templates
+
+**Client-side** (client exposes, server consumes):
+4. Sampling -- server asks client's LLM for completions
+5. Roots -- client tells server its filesystem boundaries
+6. Elicitation -- server asks client to collect user input
+
+### 5.1 Tools
+
+Tools are the core agent interaction primitive. A tool represents an operation the server is willing to perform: query a database, call an API, write a file, run a calculation. Tools MAY have side effects (unlike resources).
+
+Tools are **model-controlled**: the LLM discovers available tools and decides which to invoke based on user intent. However, a human-in-the-loop SHOULD be able to approve or deny any invocation.
+
+#### Discovery: tools/list
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/list",
+  "params": {}
+}
+```
+
+Supports pagination via optional `cursor` param.
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "tools": [
+      {
+        "name": "get_weather",
+        "title": "Get Weather",
+        "description": "Get current weather for a city. Returns temperature in Celsius and conditions.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "city": {
+              "type": "string",
+              "description": "City name, e.g. 'Paris' or 'Tokyo'"
+            },
+            "units": {
+              "type": "string",
+              "enum": ["celsius", "fahrenheit"],
+              "description": "Temperature unit. Defaults to celsius."
+            }
+          },
+          "required": ["city"]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "temperature": { "type": "number" },
+            "conditions": { "type": "string" },
+            "humidity": { "type": "number" }
+          },
+          "required": ["temperature", "conditions"]
+        },
+        "annotations": {
+          "readOnlyHint": true,
+          "openWorldHint": true
+        }
+      },
+      {
+        "name": "delete_file",
+        "title": "Delete File",
+        "description": "Permanently delete a file at the given path.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string",
+              "description": "Absolute file path to delete"
+            }
+          },
+          "required": ["path"]
+        },
+        "annotations": {
+          "readOnlyHint": false,
+          "destructiveHint": true,
+          "idempotentHint": true,
+          "openWorldHint": false
+        }
+      }
+    ]
+  }
+}
+```
+
+Tool definition fields:
+- `name`: Unique identifier. 1-128 chars. Allowed chars: `A-Z`, `a-z`, `0-9`, `_`, `-`, `.`. Case-sensitive.
+- `title`: Optional human-readable display name.
+- `description`: Natural language description. This is what the LLM reads to decide whether to use the tool.
+- `inputSchema`: JSON Schema (draft 2020-12) defining expected arguments. Top-level type is always `object`.
+- `outputSchema`: Optional JSON Schema for structured output validation.
+- `annotations`: Behavioral hints (see below).
+
+Tool annotations (all boolean, all advisory):
+- `readOnlyHint` (default: false) -- Tool does not modify its environment.
+- `destructiveHint` (default: true) -- Tool may destroy data. Only meaningful when readOnlyHint is false.
+- `idempotentHint` (default: false) -- Repeated calls with same args have no additional effect. Only meaningful when readOnlyHint is false.
+- `openWorldHint` (default: true) -- Tool interacts with external/unbounded entities (e.g., the web).
+
+Annotations are hints only. They are not enforced. Clients MAY use them for UI treatment (e.g., requiring confirmation for destructive tools).
+
+#### Invocation: tools/call
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "tools/call",
+  "params": {
+    "name": "get_weather",
+    "arguments": {
+      "city": "Paris",
+      "units": "celsius"
+    }
+  }
+}
+```
+
+**Successful response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Current weather in Paris: 18C, partly cloudy, 65% humidity"
+      }
+    ],
+    "structuredContent": {
+      "temperature": 18,
+      "conditions": "partly cloudy",
+      "humidity": 65
+    },
+    "isError": false
+  }
+}
+```
+
+**Error response (tool execution failure):**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Error: City 'Atlantis' not found in weather database"
+      }
+    ],
+    "isError": true
+  }
+}
+```
+
+Critical distinction: **protocol errors** vs **tool execution errors**:
+- Protocol errors (invalid method, bad params) use the JSON-RPC `error` field. The LLM never sees these.
+- Tool execution errors (API timeout, invalid input, business logic failure) use `isError: true` inside `result`. The LLM DOES see these and can reason about them, retry, or change strategy.
+
+Content types in the `content` array:
+- `TextContent`: `{ "type": "text", "text": "..." }`
+- `ImageContent`: `{ "type": "image", "data": "<base64>", "mimeType": "image/png" }`
+- `AudioContent`: `{ "type": "audio", "data": "<base64>", "mimeType": "audio/wav" }`
+- `EmbeddedResource`: `{ "type": "resource", "resource": { "uri": "...", "text": "...", "mimeType": "..." } }`
+
+The `structuredContent` field (introduced 2025-06-18) contains a JSON object matching the tool's `outputSchema`. When both `content` and `structuredContent` are present, they MUST be semantically equivalent. For backward compatibility, servers SHOULD include a `TextContent` block with serialized JSON alongside `structuredContent`.
+
+#### Change notification
+
+When available tools change at runtime:
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/tools/list_changed"
+}
+```
+
+Client should re-fetch with `tools/list`.
+
+**Implication for ilo**: Tool definitions map directly to function signatures. `inputSchema` is a JSON Schema object -- ilo records (`type name{field:type;...}`) map 1:1 to this. `outputSchema` maps to the return type. The `name` field becomes the callable identifier. Tool annotations could inform ilo's verifier (e.g., flagging destructive calls for confirmation).
+
+### 5.2 Resources
+
+Resources represent read-only data that provides context to the LLM. Files, database schemas, API documentation, configuration. Unlike tools, resources have NO side effects.
+
+Resources are **application-controlled** (the host/client decides which resources to fetch), not model-controlled like tools.
+
+#### Discovery: resources/list
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "method": "resources/list",
+  "params": {}
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "result": {
+    "resources": [
+      {
+        "uri": "file:///project/src/main.rs",
+        "name": "Main source file",
+        "description": "The application entry point",
+        "mimeType": "text/x-rust"
+      },
+      {
+        "uri": "db://production/schema",
+        "name": "Database schema",
+        "mimeType": "application/json"
+      }
+    ]
+  }
+}
+```
+
+Each resource has:
+- `uri`: Unique identifier. Any valid URI (file://, http://, custom://).
+- `name`: Human-readable label.
+- `description`: Optional.
+- `mimeType`: Optional content type hint.
+
+#### URI Templates: resources/templates/list
+
+For parameterized resources (RFC 6570 URI templates):
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 6,
+  "result": {
+    "resourceTemplates": [
+      {
+        "uriTemplate": "logs://app/{date}/errors",
+        "name": "Error logs by date",
+        "description": "Application error logs for a specific date",
+        "mimeType": "text/plain"
+      }
+    ]
+  }
+}
+```
+
+#### Reading: resources/read
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "method": "resources/read",
+  "params": {
+    "uri": "file:///project/src/main.rs"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "result": {
+    "contents": [
+      {
+        "uri": "file:///project/src/main.rs",
+        "mimeType": "text/x-rust",
+        "text": "fn main() {\n    println!(\"Hello\");\n}"
+      }
+    ]
+  }
+}
+```
+
+Content is either `text` (UTF-8) or `blob` (base64 binary). A single read MAY return multiple items (e.g., reading a directory returns its files).
+
+Resources support subscriptions: client subscribes to a URI, server sends `notifications/resources/updated` when it changes.
+
+### 5.3 Prompts
+
+Prompts are reusable message templates exposed by the server. They are **user-controlled**: the user explicitly selects which prompt to use (e.g., from a menu or slash command). They are NOT invoked by the model autonomously.
+
+#### Discovery: prompts/list
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 8,
+  "result": {
+    "prompts": [
+      {
+        "name": "code_review",
+        "title": "Code Review",
+        "description": "Review code for bugs, style issues, and improvements",
+        "arguments": [
+          {
+            "name": "language",
+            "description": "Programming language of the code",
+            "required": true
+          },
+          {
+            "name": "focus",
+            "description": "What to focus on: bugs, style, performance, or all",
+            "required": false
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+#### Retrieval: prompts/get
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 9,
+  "method": "prompts/get",
+  "params": {
+    "name": "code_review",
+    "arguments": {
+      "language": "rust",
+      "focus": "bugs"
+    }
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 9,
+  "result": {
+    "description": "Code review for Rust, focusing on bugs",
+    "messages": [
+      {
+        "role": "user",
+        "content": {
+          "type": "text",
+          "text": "Review the following Rust code for bugs. Focus on memory safety, error handling, and logic errors."
+        }
+      }
+    ]
+  }
+}
+```
+
+The server fills in the `{{language}}` and `{{focus}}` placeholders and returns fully-formed messages ready to feed to the LLM. Messages can include embedded resources, images, or any content type.
+
+### 5.4 Sampling (Client-side)
+
+Sampling inverts the typical flow: the **server** asks the **client** to run an LLM completion. The client has access to a model; the server does not. This enables agentic patterns where a tool needs AI reasoning as part of its execution.
+
+The client MUST have declared `sampling` capability during initialization.
+
+#### Request: sampling/createMessage
+
+**Server -> Client:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 10,
+  "method": "sampling/createMessage",
+  "params": {
+    "messages": [
+      {
+        "role": "user",
+        "content": {
+          "type": "text",
+          "text": "Summarize these error logs and identify the root cause:\n\nERROR 2025-01-15 DB connection timeout\nERROR 2025-01-15 DB connection timeout\nWARN 2025-01-15 Pool exhausted, 0 available connections"
+        }
+      }
+    ],
+    "systemPrompt": "You are a production incident analyst. Be concise.",
+    "maxTokens": 200,
+    "includeContext": "thisServer",
+    "modelPreferences": {
+      "hints": [
+        { "name": "claude-sonnet-4-20250514" }
+      ],
+      "costPriority": 0.8,
+      "speedPriority": 0.5,
+      "intelligencePriority": 0.3
+    }
+  }
+}
+```
+
+Fields:
+- `messages`: Conversation history to send to the LLM.
+- `systemPrompt`: Optional. The client MAY modify or ignore it.
+- `maxTokens`: Required. Maximum tokens for the completion.
+- `includeContext`: `"none"`, `"thisServer"`, or `"allServers"`. Hints to the client about what additional context to include.
+- `modelPreferences`: Optional hints. `hints` suggests model names; `costPriority`, `speedPriority`, `intelligencePriority` are 0-1 floats for tradeoff guidance.
+
+**Client -> Server:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 10,
+  "result": {
+    "role": "assistant",
+    "content": {
+      "type": "text",
+      "text": "Root cause: database connection pool exhaustion. All connections timed out, likely due to a slow query or connection leak."
+    },
+    "model": "claude-sonnet-4-20250514",
+    "stopReason": "endTurn"
+  }
+}
+```
+
+Human-in-the-loop: The client SHOULD show the user what the server wants to ask, let the user edit/approve/reject the prompt, then show the completion for approval before returning it to the server.
+
+The client decides which model to use. The server's `modelPreferences` are advisory. API costs are borne by the client, not the server.
+
+### 5.5 Roots (Client-side)
+
+Roots define the boundaries of what the server should operate on. They are URIs (typically `file://` paths) representing the client's workspace scope.
+
+The client MUST have declared `roots` capability during initialization.
+
+#### Server requests roots: roots/list
+
+**Server -> Client:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 11,
+  "method": "roots/list"
+}
+```
+
+**Client -> Server:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 11,
+  "result": {
+    "roots": [
+      {
+        "uri": "file:///home/user/projects/my-app",
+        "name": "My Application"
+      },
+      {
+        "uri": "file:///home/user/projects/shared-lib",
+        "name": "Shared Library"
+      }
+    ]
+  }
+}
+```
+
+When roots change (user switches projects), the client sends:
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/roots/list_changed"
+}
+```
+
+The server then re-fetches roots with `roots/list`.
+
+**Critical caveat**: Roots are informational/advisory. The MCP specification does NOT enforce that servers respect root boundaries. A server is not technically prevented from accessing files outside declared roots. It is a trust mechanism, not a security mechanism.
+
+### 5.6 Elicitation (Client-side)
+
+Elicitation allows the server to pause execution and ask the user a question via a structured form. Introduced in 2025-06-18.
+
+The client MUST have declared `elicitation` capability during initialization.
+
+#### Request: elicitation/create
+
+**Server -> Client:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 12,
+  "method": "elicitation/create",
+  "params": {
+    "message": "Which database should we deploy the migration to?",
+    "requestedSchema": {
+      "type": "object",
+      "properties": {
+        "database": {
+          "type": "string",
+          "enum": ["staging", "production"],
+          "description": "Target database environment"
+        },
+        "confirm_destructive": {
+          "type": "boolean",
+          "description": "Confirm that this migration includes destructive changes"
+        }
+      },
+      "required": ["database", "confirm_destructive"]
+    }
+  }
+}
+```
+
+The `requestedSchema` uses a restricted subset of JSON Schema -- flat objects only (no nesting). Supported property types:
+- `string` -- with optional `minLength`, `maxLength`, `format` (`"email"`, `"uri"`, `"date"`, `"date-time"`), and `enum`.
+- `number` / `integer` -- with optional `minimum`, `maximum`.
+- `boolean`.
+
+Enum variants can have titles via JSON Schema `oneOf` with `const`/`title` pairs.
+
+**Client -> Server (user accepted):**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 12,
+  "result": {
+    "action": "accept",
+    "content": {
+      "database": "staging",
+      "confirm_destructive": true
+    }
+  }
+}
+```
+
+Three possible actions:
+- `"accept"` -- User submitted the form. `content` contains the values.
+- `"decline"` -- User explicitly rejected the request.
+- `"cancel"` -- User dismissed without choosing (closed dialog, pressed Escape).
+
+The 2025-11-25 spec adds **URL-mode elicitation**: instead of an in-client form, the server can send a URL (e.g., an OAuth page) for the user to complete in a browser. Error code `-32042` signals that URL elicitations must be completed before the original request can be retried.
+
+---
+
+## 6. Tool Discovery: The inputSchema in Detail
+
+The `inputSchema` on every tool is the critical interface between the LLM and the external world. It tells the model exactly what arguments to provide.
+
+### 6.1 Schema Format
+
+Always JSON Schema (draft 2020-12 as of 2025-11-25). Top-level type is always `"object"`. Properties define individual parameters.
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "query": {
+      "type": "string",
+      "description": "SQL query to execute. Must be a SELECT statement.",
+      "maxLength": 10000
+    },
+    "database": {
+      "type": "string",
+      "enum": ["users", "orders", "analytics"],
+      "description": "Which database to query"
+    },
+    "limit": {
+      "type": "integer",
+      "description": "Maximum rows to return",
+      "minimum": 1,
+      "maximum": 1000
+    },
+    "include_headers": {
+      "type": "boolean",
+      "description": "Include column names in results"
+    }
+  },
+  "required": ["query", "database"]
+}
+```
+
+### 6.2 Description as Micro-Prompt Engineering
+
+Each property description tells the LLM what to extract from conversation context to fill that parameter. These descriptions are effectively micro-prompts:
+
+- Good: `"description": "City name, e.g. 'Paris' or 'New York'"`
+- Bad: `"description": "city"`
+
+The LLM reads the tool description + property descriptions to decide whether the tool matches the user's intent and how to populate the arguments.
+
+### 6.3 Schema Best Practices from the Spec
+
+- Keep schemas flat. Avoid deep nesting, `oneOf`, `allOf` -- they increase token count and parsing difficulty for the model.
+- If a tool needs complex input, split it into multiple simpler tools.
+- Property descriptions are critical for LLM accuracy.
+- Name tools clearly. The `name` + `description` combo is what the LLM uses for tool selection.
+- Naming constraints: 1-128 chars, `[A-Za-z0-9_\-.]` only, case-sensitive, unique per server.
+
+### 6.4 Output Schema
+
+Optional. When present, `structuredContent` in the response MUST conform to it. Clients SHOULD validate against it.
+
+```json
+"outputSchema": {
+  "type": "object",
+  "properties": {
+    "rows": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": { "type": "string" }
+      }
+    },
+    "row_count": { "type": "integer" }
+  },
+  "required": ["rows", "row_count"]
+}
+```
+
+**Implication for ilo**: ilo's type system (`n`, `t`, `b`, records, lists) maps onto JSON Schema types: `number` -> `n`, `string` -> `t`, `boolean` -> `b`, `object` -> ilo record, `array` -> `L`. The MCP `inputSchema` can be mechanically translated to ilo tool declarations. A tool discovered via MCP becomes a callable function signature in ilo's closed world.
+
+---
+
+## 7. End-to-End Message Flow: Agent Invokes a Tool
+
+Here is the complete sequence from agent intent to tool result, showing every MCP message exchanged.
+
+### Phase 0: Connection Setup
+
+```
+Agent runtime spawns MCP server (stdio) or connects (HTTP)
+  |
+  +-> Client sends: initialize request
+  +<- Server sends: initialize response (capabilities: tools, resources)
+  +-> Client sends: notifications/initialized
+```
+
+### Phase 1: Tool Discovery
+
+```
+Agent needs to know what tools are available.
+  |
+  +-> Client sends:
+      { "jsonrpc":"2.0", "id":2, "method":"tools/list", "params":{} }
+  |
+  +<- Server responds:
+      { "jsonrpc":"2.0", "id":2, "result": { "tools": [
+        { "name":"get_weather", "description":"...", "inputSchema":{...} },
+        { "name":"send_email",  "description":"...", "inputSchema":{...} }
+      ]}}
+```
+
+The host registers these tool signatures. In ilo terms, this populates the function table with external tool declarations.
+
+### Phase 2: LLM Decides to Use a Tool
+
+The host presents the user's message + available tool schemas to the LLM. The LLM's response includes a tool-use decision:
+
+```
+LLM output (internal to host, NOT an MCP message):
+  "I need to call get_weather with city='Tokyo'"
+```
+
+This is model-specific. The LLM's tool-use output format varies by provider (Anthropic tool_use blocks, OpenAI function_call, etc.). MCP does NOT define how the LLM decides -- only how the call is executed.
+
+### Phase 3: Tool Execution
+
+```
+  +-> Client sends:
+      { "jsonrpc":"2.0", "id":3, "method":"tools/call",
+        "params": { "name":"get_weather", "arguments":{"city":"Tokyo"} } }
+  |
+  +<- Server sends (optional, during execution):
+      { "jsonrpc":"2.0", "method":"notifications/progress",
+        "params": { "progressToken":"req-3", "progress":50, "total":100 } }
+  |
+  +<- Server responds:
+      { "jsonrpc":"2.0", "id":3, "result": {
+        "content": [{ "type":"text", "text":"Tokyo: 22C, clear sky" }],
+        "structuredContent": { "temperature":22, "conditions":"clear sky" },
+        "isError": false
+      }}
+```
+
+### Phase 4: Result Fed Back to LLM
+
+The host takes the tool result and feeds it back into the LLM's conversation:
+
+```
+LLM receives (internal, not MCP):
+  [tool result: "Tokyo: 22C, clear sky"]
+
+LLM generates final response:
+  "The current weather in Tokyo is 22 degrees Celsius with clear skies."
+```
+
+### Phase 5 (Optional): Tool List Changes at Runtime
+
+```
+  +<- Server sends:
+      { "jsonrpc":"2.0", "method":"notifications/tools/list_changed" }
+  |
+  +-> Client sends:
+      { "jsonrpc":"2.0", "id":4, "method":"tools/list", "params":{} }
+  |
+  +<- Server responds with updated tool list
+```
+
+The agent's available function table updates dynamically.
+
+### Summary Flow Diagram
+
+```
+User: "What's the weather in Tokyo?"
+  |
+  v
+Host: present message + tool schemas to LLM
+  |
+  v
+LLM: "I'll use get_weather(city='Tokyo')"
+  |
+  v
+Client ----tools/call----> Server
+  |                           |
+  |                      (executes tool)
+  |                           |
+Client <---result---------- Server
+  |
+  v
+Host: feed result back to LLM
+  |
+  v
+LLM: "The weather in Tokyo is 22C and clear."
+  |
+  v
+User sees response
+```
+
+---
+
+## 8. Async Tasks (2025-11-25, Experimental)
+
+The 2025-11-25 spec introduces Tasks, allowing any request to become asynchronous.
+
+When a server cannot complete a request immediately, it returns a task handle instead of a result. The client can then poll for status or receive updates via notifications.
+
+This enables:
+- Long-running operations (deployment, data processing).
+- Parallel task execution by the agent.
+- Disconnect/reconnect without losing work.
+- Status polling and progress tracking.
+
+Tasks are still experimental and their design may change. But the pattern is significant: an agent kicks off work, continues reasoning, and collects results later. This maps to a `future` or `promise` pattern at the language level.
+
+**Implication for ilo**: If ilo supports async tool calls, it would need a way to represent a "pending result" -- perhaps a value that the runtime can block on or poll. The `R ok err` result type could wrap a task handle, with a special `await` or `!` operator that blocks until the task completes.
+
+---
+
+## 9. Security and Trust Model
+
+MCP's security model is worth understanding because it constrains what an agent language can safely do.
+
+### 9.1 Human-in-the-Loop
+
+The spec repeatedly emphasizes: there SHOULD always be a human in the loop with the ability to deny tool invocations. This applies to:
+- `tools/call` -- Human can approve/deny each invocation.
+- `sampling/createMessage` -- Human can edit/approve/deny the prompt and the completion.
+- `elicitation/create` -- Human interacts directly.
+
+### 9.2 Tool Descriptions Are Untrusted
+
+Tool names, descriptions, and annotations come from the server. They SHOULD be treated as untrusted unless the server is known-trusted. A malicious server could describe a destructive tool as "read-only" via annotations.
+
+### 9.3 Roots Are Advisory
+
+Servers are not prevented from accessing files outside declared roots. The boundary is communicated, not enforced.
+
+### 9.4 Input Validation
+
+Tool execution errors (bad arguments, business logic failures) are returned inside `result` with `isError: true`. This lets the LLM see the error and self-correct. Protocol errors (malformed JSON, unknown method) are returned in the JSON-RPC `error` field and do NOT reach the LLM.
+
+The 2025-11-25 spec clarifies: input validation failures should be tool execution errors (not protocol errors), specifically to enable model self-correction.
+
+---
+
+## 10. Implications for ilo-lang
+
+### 10.1 Tool Declarations as First-Class Syntax
+
+MCP tools are discovered via `tools/list` and have:
+- A name (the callable identifier)
+- An inputSchema (parameter types)
+- An optional outputSchema (return type)
+- Annotations (behavioral hints)
+
+In ilo, this maps to:
+
+```
+-- MCP tool: get_weather(city:string, units?:string) -> {temperature:number, conditions:string}
+-- ilo equivalent (conceptual):
+tool get_weather "Get current weather" city:t units:t > weather
+```
+
+ilo's existing `tool name"desc" params>return` syntax (from D-AGENT-INTEGRATION.md) aligns directly.
+
+### 10.2 Schema <-> Type Mapping
+
+| JSON Schema   | ilo Type |
+|--------------|----------|
+| `number`     | `n`      |
+| `string`     | `t`      |
+| `boolean`    | `b`      |
+| `null`       | `_`      |
+| `object`     | record   |
+| `array`      | `L x`    |
+
+MCP's `inputSchema` properties map to ilo record fields. Required/optional maps to ilo's eventual optional type support.
+
+### 10.3 Closed-World Verification from Discovery
+
+ilo's "constrained" principle says every callable function is known ahead of time. MCP `tools/list` provides exactly this: a complete enumeration of available tools with their signatures. The ilo verifier can:
+1. Fetch tool schemas from MCP servers at program load time.
+2. Register them as external function declarations.
+3. Verify all tool calls in the program against real schemas.
+4. Reject programs that call non-existent tools or pass wrong argument types.
+
+This makes `ToolProvider` a **signature source**, as noted in ilo's D-AGENT-INTEGRATION.md.
+
+### 10.4 Error Handling
+
+MCP returns tool errors in `result` with `isError: true`. This maps to ilo's `R ok err` type. A tool call that fails returns `R _ t` (nil ok, text error), which the agent handles with `?` conditional or `!` auto-unwrap.
+
+### 10.5 Structured Content
+
+MCP's `structuredContent` field returns typed JSON matching the `outputSchema`. When ilo defines the return type of a tool as a record, the runtime can deserialize `structuredContent` directly into an ilo value. The `content` text field serves as the human-readable fallback.
+
+### 10.6 What ilo Does NOT Need to Handle
+
+- **Transport details**: The ilo runtime handles stdio/HTTP framing. The language does not need transport syntax.
+- **Initialization handshake**: Runtime concern. The language just calls tools; the runtime negotiates capabilities.
+- **Sampling/Elicitation/Roots**: These are client-side primitives. If ilo is the agent (host/client), these are runtime features. If ilo is the tool (server), it might need to emit `sampling/createMessage` requests, which could be a builtin.
+- **JSON serialization**: Tool boundary concern handled by the runtime. ilo values map to JSON; JSON maps back to ilo values.
+- **Progress/cancellation**: Runtime handles these transparently.
+
+### 10.7 What ilo DOES Need
+
+1. **Tool declaration syntax** that maps to MCP's `inputSchema`/`outputSchema`.
+2. **Result type** (`R ok err`) for all tool calls.
+3. **Schema-to-type compiler** in the runtime that converts MCP `tools/list` responses into ilo function signatures.
+4. **Dynamic tool table** that can update when `notifications/tools/list_changed` fires.
+5. **Async support** (eventually) for MCP Tasks -- a way to represent pending results.
+
+---
+
+## Sources
+
+- [MCP Specification (2025-11-25)](https://modelcontextprotocol.io/specification/2025-11-25)
+- [MCP Specification (2025-06-18)](https://modelcontextprotocol.io/specification/2025-06-18)
+- [MCP Architecture Overview](https://modelcontextprotocol.io/docs/learn/architecture)
+- [MCP Tools Specification (Draft)](https://modelcontextprotocol.io/specification/draft/server/tools)
+- [MCP Resources Specification](https://modelcontextprotocol.io/specification/2025-06-18/server/resources)
+- [MCP Prompts Specification](https://modelcontextprotocol.io/specification/2025-06-18/server/prompts)
+- [MCP Sampling Specification](https://modelcontextprotocol.io/specification/2025-06-18/client/sampling)
+- [MCP Roots Specification](https://modelcontextprotocol.io/specification/2025-06-18/client/roots)
+- [MCP Elicitation Specification](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation)
+- [MCP Transports Specification](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports)
+- [MCP Lifecycle Specification](https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle)
+- [MCP 2025-11-25 Changelog](https://modelcontextprotocol.io/specification/2025-11-25/changelog)
+- [MCP Message Types: JSON-RPC Reference Guide (Portkey)](https://portkey.ai/blog/mcp-message-types-complete-json-rpc-reference-guide/)
+- [Understanding MCP Features: Tools, Resources, Prompts, Sampling, Roots, Elicitation (WorkOS)](https://workos.com/blog/mcp-features-guide)
+- [MCP Primitives: The Mental Model Behind the Protocol (Portkey)](https://portkey.ai/blog/mcp-primitives-the-mental-model-behind-the-protocol/)
+- [MCP 2025-11-25: Async Tasks, OAuth, Extensions (WorkOS)](https://workos.com/blog/mcp-2025-11-25-spec-update)
+- [Why MCP Deprecated SSE (fka.dev)](https://blog.fka.dev/blog/2025-06-06-why-mcp-deprecated-sse-and-go-with-streamable-http/)
+- [MCP Transport Comparison (MCPcat)](https://mcpcat.io/guides/comparing-stdio-sse-streamablehttp/)
+- [MCP Tool Schema (Merge)](https://www.merge.dev/blog/mcp-tool-schema)
+- [MCP Tool Annotations (Marc Nuri)](https://blog.marcnuri.com/mcp-tool-annotations-introduction)
+- [MCP Protocol Mechanics and Architecture (Pradeep Loganathan)](https://pradeepl.com/blog/model-context-protocol/mcp-protocol-mechanics-and-architecture/)
+- [Capabilities Negotiation in MCP (APXML)](https://apxml.com/courses/getting-started-model-context-protocol/chapter-1-architecture-and-fundamentals/capabilities-negotiation)
+- [Defining Tool Schemas in MCP (APXML)](https://apxml.com/courses/getting-started-model-context-protocol/chapter-3-implementing-tools-and-logic/tool-definition-schema)
+- [MCP Specification (Stainless Portal)](https://www.stainless.com/mcp/mcp-specification)
+- [MCP GitHub Repository](https://github.com/modelcontextprotocol/modelcontextprotocol)

--- a/research/playwright-for-ilo.md
+++ b/research/playwright-for-ilo.md
@@ -1,0 +1,322 @@
+# Playwright for ilo — Design Exploration
+
+How should ilo programs automate browsers? Two approaches explored: wrapping Playwright as a tool server (practical) vs native CDP client (ambitious).
+
+## The problem
+
+An AI agent writing ilo code needs to automate browsers — navigate, click, fill forms, assert content, take screenshots. Playwright (Node.js) solves this for JavaScript. What's the ilo equivalent?
+
+## Approach 1: Playwright tool server (recommended)
+
+Wrap Playwright as an external process that ilo talks to via the tool provider interface (D1d). ilo programs declare browser actions as tools and call them like any other tool.
+
+### Architecture
+
+```
+ilo program  →  ToolProvider (HTTP/stdio)  →  Playwright server (Node.js)  →  Browser (CDP)
+```
+
+The Playwright server is a thin Node.js process that:
+1. Launches a browser on startup
+2. Accepts commands as JSON-RPC over stdio or HTTP
+3. Translates commands to Playwright API calls
+4. Returns results as JSON
+
+### Tool declarations
+
+```
+tool nav"Navigate to URL" url:t>R _ t timeout:30
+tool click"Click element" sel:t>R _ t timeout:10
+tool dclick"Double-click element" sel:t>R _ t timeout:10
+tool fill"Fill input field" sel:t val:t>R _ t timeout:10
+tool clear"Clear input field" sel:t>R _ t timeout:10
+tool check"Check checkbox" sel:t>R _ t timeout:10
+tool sel"Select option" sel:t val:t>R _ t timeout:10
+tool txt"Get text content" sel:t>R t t timeout:5
+tool attr"Get attribute" sel:t name:t>R t t timeout:5
+tool html"Get inner HTML" sel:t>R t t timeout:5
+tool vis"Check element visible" sel:t>R b t timeout:5
+tool wait"Wait for selector" sel:t>R _ t timeout:30
+tool shot"Screenshot to file" path:t>R t t timeout:10
+tool eshot"Screenshot element" sel:t path:t>R t t timeout:10
+tool eval"Evaluate JavaScript" code:t>R t t timeout:10
+tool title"Get page title" >R t t timeout:5
+tool url"Get current URL" >R t t timeout:5
+```
+
+### Example: login test in ilo
+
+```
+tool nav"Navigate" url:t>R _ t timeout:30
+tool fill"Fill input" sel:t val:t>R _ t timeout:10
+tool click"Click" sel:t>R _ t timeout:10
+tool txt"Get text" sel:t>R t t timeout:5
+tool url"Get URL" >R t t timeout:5
+
+login u:t p:t>R t t;nav! "https://app.example.com/login";fill! "[name=email]" u;fill! "[name=password]" p;click! "[type=submit]";wait! ".dashboard";url!()
+```
+
+That's a complete login + assertion in one line, ~30 tokens. Equivalent Playwright JS:
+
+```javascript
+await page.goto('https://app.example.com/login');
+await page.fill('[name=email]', user);
+await page.fill('[name=password]', pass);
+await page.click('[type=submit]');
+await page.waitForSelector('.dashboard');
+return page.url();
+```
+
+~45 tokens. ilo is 0.67x the tokens with the same semantics, plus verified error handling at every step via `!`.
+
+### Example: scrape and validate
+
+```
+tool nav"Navigate" url:t>R _ t timeout:30
+tool txt"Get text" sel:t>R t t timeout:5
+tool vis"Visible?" sel:t>R b t timeout:5
+
+chk url:t>R _ t;nav! url;t=txt! "h1";!has t "Welcome"{^+"Expected welcome, got: "t};v=vis! ".error-banner";v{^"Error banner visible"};~_
+```
+
+### Server implementation sketch (Node.js)
+
+```javascript
+// playwright-server.js — tool server for ilo
+const { chromium } = require('playwright');
+
+let browser, page;
+
+async function init() {
+  browser = await chromium.launch();
+  const context = await browser.newContext();
+  page = await context.newPage();
+}
+
+const handlers = {
+  nav:    async ({ url }) => { await page.goto(url); },
+  click:  async ({ sel }) => { await page.click(sel); },
+  fill:   async ({ sel, val }) => { await page.fill(sel, val); },
+  txt:    async ({ sel }) => await page.textContent(sel),
+  vis:    async ({ sel }) => await page.isVisible(sel),
+  wait:   async ({ sel }) => { await page.waitForSelector(sel); },
+  shot:   async ({ path }) => { await page.screenshot({ path }); return path; },
+  eval:   async ({ code }) => await page.evaluate(code),
+  title:  async () => await page.title(),
+  url:    async () => page.url(),
+};
+
+// stdio JSON-RPC loop
+process.stdin.setEncoding('utf8');
+let buffer = '';
+process.stdin.on('data', async (chunk) => {
+  buffer += chunk;
+  // newline-delimited JSON
+  let nl;
+  while ((nl = buffer.indexOf('\n')) !== -1) {
+    const line = buffer.slice(0, nl);
+    buffer = buffer.slice(nl + 1);
+    try {
+      const { id, method, params } = JSON.parse(line);
+      const handler = handlers[method];
+      if (!handler) {
+        process.stdout.write(JSON.stringify({ id, error: `unknown method: ${method}` }) + '\n');
+        continue;
+      }
+      const result = await handler(params || {});
+      process.stdout.write(JSON.stringify({ id, result: result ?? null }) + '\n');
+    } catch (e) {
+      process.stdout.write(JSON.stringify({ id: null, error: e.message }) + '\n');
+    }
+  }
+});
+
+init();
+```
+
+### What this needs from ilo
+
+- **D1d: ToolProvider infrastructure** — the `StdioProvider` variant that spawns a child process and communicates via newline-delimited JSON over stdin/stdout
+- **D1e: Value <-> JSON** — serialise tool args to JSON, deserialise results back to ilo values
+- **No new language features** — everything works with existing `tool` declarations, `!` auto-unwrap, `?` matching, and `R` result types
+
+### Advantages
+
+- Works today (once D1d is done) — no new language primitives needed
+- Full Playwright power — all browsers, all features, maintained by Microsoft
+- Small tool surface — ~15 tool declarations cover 90% of browser automation
+- Agent writes terse ilo, heavy lifting is in the Node.js server
+- Server can be swapped (Puppeteer, Selenium, etc.) without changing ilo code
+
+### Disadvantages
+
+- Requires Node.js + Playwright installed alongside ilo
+- Latency: ilo → stdio → Node.js → CDP → browser (extra hop vs direct CDP)
+- State management: server must track page/context state across calls
+- Can't express complex Playwright patterns (custom selectors, route handlers, multi-page coordination) without more tools
+
+---
+
+## Approach 2: Native CDP client
+
+ilo speaks Chrome DevTools Protocol directly. No Node.js dependency.
+
+### Architecture
+
+```
+ilo program  →  WebSocket (G2)  →  Chromium (CDP)
+         └──→  spawn (G3)  →  chromium --remote-debugging-port=9222
+```
+
+### What CDP looks like
+
+CDP is JSON-RPC over WebSocket. Example: navigate to a URL.
+
+Request:
+```json
+{"id": 1, "method": "Page.navigate", "params": {"url": "https://example.com"}}
+```
+
+Response:
+```json
+{"id": 1, "result": {"frameId": "ABC123", "loaderId": "DEF456"}}
+```
+
+Event (async, pushed by browser):
+```json
+{"method": "Page.loadEventFired", "params": {"timestamp": 1234567890.123}}
+```
+
+### What ilo would need
+
+```
+-- launch browser
+type cdp{ws:ws;id:n}
+
+launch>R cdp t
+  ;h=spawn! "chromium" "--headless --remote-debugging-port=9222"
+  ;c=ws! "ws://127.0.0.1:9222/devtools/page/..."
+  ;~cdp ws:c id:0
+
+-- send CDP command and wait for response
+cdp-call c:cdp method:t params:t>R t t
+  ;nid=+c.id 1
+  ;msg=++++"{\"id\":" (str nid) ",\"method\":\"" method "\",\"params\":" params "}"
+  ;ws-send! c.ws msg
+  ;r=ws-recv! c.ws
+  ;~r
+
+-- navigate
+nav c:cdp url:t>R t t
+  ;p=++"{\"url\":\"" url "\"}"
+  ;cdp-call c "Page.navigate" p
+```
+
+### Problems with this approach
+
+**1. String building is brutal in ilo.** Constructing JSON by hand with `+` concatenation is error-prone and token-expensive. ilo has no string interpolation, no template literals. Every CDP message becomes a wall of `+` operators.
+
+**2. CDP is event-driven.** After `Page.navigate`, you need to listen for `Page.loadEventFired`. That's an async event pushed by the browser at an unpredictable time. ilo has no event model — `ws-recv` blocks, so you'd need a polling loop:
+
+```
+wait-load c:cdp>R _ t;r=ws-recv c.ws;?r{^e:^e;~msg:has msg "loadEventFired"{~_}};wait-load c
+```
+
+This is recursive polling — fragile, doesn't handle interleaved messages, and will stack overflow on slow pages.
+
+**3. CDP is enormous.** The protocol has ~80 domains with ~500 methods and ~300 event types. Even a minimal browser automation needs:
+- `Page.navigate`, `Page.reload`
+- `Runtime.evaluate` (run JS in page)
+- `DOM.querySelector`, `DOM.getDocument`
+- `Input.dispatchMouseEvent`, `Input.dispatchKeyEvent`
+- `Page.captureScreenshot` (returns base64 PNG)
+- `Network.enable`, `Network.requestWillBeSent` (request interception)
+
+That's ~20 methods minimum, each needing JSON construction, response parsing, and event handling.
+
+**4. No JSON parsing.** CDP responses are JSON. ilo can't parse JSON — there's no `json-get key obj` builtin, no map type (yet). You'd get raw text back and have no way to extract fields.
+
+**5. Binary data.** Screenshots come back as base64-encoded PNGs in JSON. ilo has no base64 decode, no binary write.
+
+### When this approach makes sense
+
+Only after:
+- G2 (WebSocket) — bidirectional communication
+- G3 (process spawning) — launch browser
+- G4 (async) — handle CDP events without blocking
+- E4 (maps) — parse JSON responses
+- A JSON builtin or tool — `json-get key text > R t t`
+- A base64/binary story — at minimum `b64decode text > bytes`, `write-file path bytes`
+
+That's a lot of prerequisites. Could be 6+ months of work.
+
+### Advantages (if built)
+
+- Zero external dependencies — just ilo + chromium binary
+- Fastest possible path (no Node.js overhead)
+- Full control over CDP — can do things Playwright abstracts away
+- Aligns with ilo's self-contained philosophy
+
+### Disadvantages
+
+- Massive implementation effort
+- Reinvents what Playwright already solves
+- Chromium-only (Firefox and WebKit use different protocols)
+- CDP is a moving target — Chrome updates break things
+
+---
+
+## Recommendation
+
+**Start with Approach 1 (tool server).** It's practical, works with existing ilo features (once D1d lands), and gives agents full browser automation immediately. The tool surface is small (~15 declarations) and the server is <100 lines of Node.js.
+
+**Approach 2 is a long-term possibility** gated on G2-G4 + E4. If ilo's networking primitives mature enough, a native CDP client becomes feasible — but it's months of work and the ROI vs the tool server is marginal for most use cases.
+
+The hybrid path: start with Approach 1, gradually move individual operations native as G2/G3/G4 land, and eventually the tool server becomes optional.
+
+## Token efficiency comparison
+
+| Framework | Login test | Tokens | vs Playwright |
+|-----------|-----------|--------|---------------|
+| Playwright (JS) | 6 lines, await chains | ~45 | 1.00x |
+| Cypress (JS) | 6 lines, cy chains | ~50 | 1.11x |
+| ilo + tool server | 1 line, `!` chains | ~30 | 0.67x |
+| ilo + native CDP | 1 line but JSON construction | ~60 | 1.33x |
+
+The tool server wrapper is actually more token-efficient than native CDP because the tool server handles JSON construction and CDP complexity internally.
+
+## Multi-page and multi-context patterns
+
+For tests needing multiple pages or browser contexts, the tool server can expose context management:
+
+```
+tool new-ctx"New browser context" >R t t timeout:10
+tool new-page"New page in context" ctx:t>R t t timeout:10
+tool use-page"Switch active page" pid:t>R _ t timeout:5
+tool close-page"Close page" pid:t>R _ t timeout:5
+
+-- multi-tab test
+multi>R _ t;c=new-ctx!();p1=new-page! c;p2=new-page! c;use-page! p1;nav! "https://a.com";use-page! p2;nav! "https://b.com";close-page! p2;~_
+```
+
+Page/context IDs are opaque text handles — the server tracks the mapping internally.
+
+## Network interception
+
+```
+tool route"Intercept network requests" pattern:t handler:t>R _ t timeout:5
+tool unroute"Remove interception" pattern:t>R _ t timeout:5
+
+-- mock API responses
+mock>R _ t;route! "**/api/user" "{\"name\":\"test\"}";nav! "https://app.com";unroute! "**api/user";~_
+```
+
+The `handler` param is a JSON string describing the mock response. Complex routing logic stays in the server.
+
+## Next steps
+
+1. **Build D1d (ToolProvider)** — the stdio provider is the foundation
+2. **Build the Playwright server** — ~100 lines of Node.js, 15 tool endpoints
+3. **Write example ilo programs** — login test, scrape + validate, multi-page flow
+4. **Benchmark token efficiency** — compare ilo + tools vs raw Playwright JS
+5. **Iterate tool surface** — add/remove tools based on what agents actually need

--- a/research/python-stdlib-analysis.md
+++ b/research/python-stdlib-analysis.md
@@ -1,0 +1,1118 @@
+# Python Standard Library Analysis for ilo
+
+What an AI agent actually needs from Python's capabilities, evaluated against ilo's manifesto: **total tokens from intent to working code**. For each capability domain, we catalog what Python offers, what agents actually use, what's human ceremony, and what ilo should provide.
+
+The organizing principle: ilo is a **typed shell for composing tool calls**, not a general-purpose language. Format parsing is a tool concern. Heavy computation is a tool concern. ilo provides the verified composition layer. This analysis identifies which Python primitives are truly compositional glue (belong in ilo) vs which are domain-specific work (belong in tools).
+
+---
+
+## 1. File I/O
+
+### What Python offers
+
+```python
+# Reading/writing
+with open("file.txt", "r") as f: content = f.read()
+with open("file.txt", "w") as f: f.write(data)
+Path("file.txt").read_text()
+Path("file.txt").write_text(data)
+
+# Paths
+from pathlib import Path
+p = Path("/home") / "user" / "file.txt"
+p.parent, p.stem, p.suffix, p.exists()
+os.path.join, os.path.split, os.path.exists
+
+# Directories
+os.listdir, os.walk, os.makedirs
+Path.iterdir(), Path.glob("*.py"), Path.mkdir(parents=True)
+shutil.copy, shutil.rmtree, shutil.move
+
+# Temp files
+tempfile.NamedTemporaryFile, tempfile.mkdtemp
+```
+
+### What agents actually use
+
+Agents interact with files constantly. The core operations:
+
+1. **Read file** -- the single most common file operation. Read a config, read source code, read data.
+2. **Write file** -- second most common. Write generated code, write configs, write data.
+3. **List directory** -- discover what files exist before reading them.
+4. **Check existence** -- guard before read/write.
+5. **Path joining** -- construct paths from components.
+6. **File metadata** -- size, modification time (rare but needed for caching decisions).
+7. **Glob/find** -- find files matching a pattern.
+
+### What's human ceremony
+
+- `with` context managers -- agents don't leak file handles because programs are short-lived
+- `pathlib` vs `os.path` dual API -- one way to do things
+- `shutil` as a separate module -- copy/move are basic operations, not a separate namespace
+- Encoding parameter on every `open()` call -- default to UTF-8, period
+- File modes (`r`, `w`, `a`, `rb`, `wb`) -- agents need read-text, write-text, read-bytes, write-bytes. Four operations, not a mode string.
+
+### What ilo needs
+
+File I/O is a **tool concern** in ilo's model. The language doesn't need file builtins -- it needs tools:
+
+```
+tool read"Read file contents" path:t>R t t
+tool write"Write text to file" path:t data:t>R _ t
+tool ls"List directory" path:t>R L t t
+tool exists"Check if path exists" path:t>b
+```
+
+**Rationale:** File operations are side effects with real failure modes (permissions, disk full, missing paths). They belong in the tool layer with timeout/retry semantics, not as builtins. The `get` builtin is network I/O exposed as a builtin because HTTP GET is *the* primitive agent operation; file I/O is less universal (many agents operate in sandboxed/API-only environments).
+
+**If ilo ever adds file builtins**, the minimal set:
+
+| Builtin | Python equivalent | Tokens |
+|---------|-------------------|--------|
+| `rd path` | `Path(path).read_text()` | 2 |
+| `wr path data` | `Path(path).write_text(data)` | 3 |
+| `ls path` | `os.listdir(path)` | 2 |
+| `ex path` | `Path(path).exists()` | 2 |
+
+All return `R` types. No modes, no encoding params, no context managers.
+
+---
+
+## 2. Networking
+
+### What Python offers
+
+```python
+# HTTP — stdlib
+urllib.request.urlopen(url).read()
+urllib.request.Request(url, headers={...}, method="POST", data=b"...")
+
+# HTTP — popular third-party
+requests.get(url, headers={}, params={}, timeout=5)
+requests.post(url, json={}, headers={})
+httpx.AsyncClient().get(url)
+
+# Sockets
+socket.socket(AF_INET, SOCK_STREAM)
+sock.connect((host, port))
+sock.send(data); sock.recv(1024)
+
+# WebSocket (third-party)
+websockets.connect(uri)
+ws.send(message); ws.recv()
+
+# Low-level
+http.client.HTTPConnection
+http.server.HTTPServer
+```
+
+### What agents actually use
+
+1. **HTTP GET** -- fetch data from APIs, download content. Already in ilo as `get`/`$`.
+2. **HTTP POST** -- submit data to APIs. The second most important network operation.
+3. **HTTP with headers** -- auth tokens (`Authorization: Bearer ...`), content types, API keys.
+4. **HTTP with JSON body** -- POST/PUT/PATCH with structured payloads.
+5. **Response status code** -- 200 vs 404 vs 500 matters for control flow.
+6. **Response headers** -- rate limiting (`Retry-After`), pagination (`Link`), content type.
+
+### What agents rarely need directly
+
+- **Raw sockets** -- agents call APIs, not socket protocols
+- **WebSocket** -- streaming is an infrastructure concern, not a composition concern
+- **UDP** -- almost never
+- **HTTP server** -- agents are clients, not servers
+- **Connection pooling** -- runtime concern, not language concern
+- **SSL/TLS configuration** -- should just work
+
+### What's human ceremony
+
+- `urllib` vs `requests` vs `httpx` -- three ways to do the same thing
+- `requests.Session()` for connection reuse -- runtime optimization, not semantics
+- Manual `response.json()` parsing -- should be automatic when return type is a record
+- Exception handling for every HTTP call -- ilo's `R` type handles this structurally
+- `response.raise_for_status()` -- Python's "opt-in error checking" pattern; ilo checks by default
+
+### What ilo needs
+
+ilo already has `get url` returning `R t t`. The next primitives:
+
+| Builtin/Tool | Purpose | Signature |
+|-------------|---------|-----------|
+| `get url` | HTTP GET (exists) | `>R t t` |
+| `post url body` | HTTP POST with text/JSON body | `>R t t` |
+| `req method url headers body` | Full HTTP request | `>R t t` |
+
+**Design question:** Should `post` be a builtin (like `get`) or a tool?
+
+Arguments for builtin:
+- POST is the second most common agent HTTP operation
+- `post url body` is 3 tokens -- extremely terse
+- Agents calling APIs need POST for every write operation
+
+Arguments for tool:
+- Headers, auth, content-type add complexity
+- POST semantics vary (JSON body vs form body vs raw)
+- The `tool` system already handles parameterized external calls
+
+**Recommendation:** Add `post url body` as a builtin (returns `R t t`, body auto-serialized as JSON if it's a record, text otherwise). For full HTTP control, provide a `req` builtin or tool with method/headers/body. This covers 95% of agent HTTP needs in 2-3 tokens.
+
+Headers could use a record:
+
+```
+h=headers auth:"Bearer tok123" ct:"application/json"
+r=req "POST" url h body
+```
+
+Or a simpler approach -- headers as a list of key:value text pairs:
+
+```
+r=req "POST" url ["Authorization:Bearer tok123"] body
+```
+
+---
+
+## 3. Process Execution
+
+### What Python offers
+
+```python
+# subprocess (modern)
+subprocess.run(["ls", "-la"], capture_output=True, text=True)
+subprocess.run("ls -la", shell=True, capture_output=True)
+subprocess.Popen(cmd, stdout=PIPE, stderr=PIPE)
+result.stdout, result.stderr, result.returncode
+
+# os (legacy)
+os.system("ls -la")
+os.popen("ls -la").read()
+
+# shlex for safe argument splitting
+shlex.split("ls -la 'file name'")
+```
+
+### What agents actually use
+
+This is a **critical** capability. AI agents frequently need to:
+
+1. **Run shell commands** -- `git status`, `npm install`, `cargo build`, `ls`, `cat`
+2. **Capture stdout** -- get command output for processing
+3. **Check exit code** -- did the command succeed?
+4. **Capture stderr** -- error messages for debugging
+5. **Pipe commands** -- `cat file | grep pattern | wc -l`
+6. **Run with timeout** -- prevent hanging on interactive commands
+
+### What's human ceremony
+
+- `subprocess.run` vs `os.system` vs `Popen` -- three interfaces for the same thing
+- `capture_output=True, text=True` boilerplate on every call
+- `shell=True` security warnings -- agents in sandboxed environments don't care
+- `shlex.split` for argument safety -- the shell itself handles this
+- `Popen` for streaming -- rare in agent contexts; agents want the full output
+
+### What ilo needs
+
+Shell execution is **essential** for agents. This is arguably more important than HTTP for local-agent workflows (Claude Code, Cursor, Devin all execute shell commands as their primary tool).
+
+| Builtin | Purpose | Signature |
+|---------|---------|-----------|
+| `sh cmd` | Run shell command, return stdout | `>R t t` |
+| `sh! cmd` | Run + auto-unwrap (propagate non-zero exit) | stdout text |
+
+The `R` result maps perfectly: `~stdout` on exit 0, `^stderr` on non-zero exit.
+
+```
+-- List files, check for errors
+r=sh "ls -la";?r{~out:process out;^err:^+"ls failed: "err}
+
+-- Or with auto-unwrap
+files=sh! "ls -la"
+```
+
+**Token comparison:**
+```python
+# Python: 8 tokens minimum
+result = subprocess.run(["ls", "-la"], capture_output=True, text=True)
+if result.returncode != 0: raise Exception(result.stderr)
+output = result.stdout
+
+# ilo: 2-3 tokens
+out=sh! "ls -la"
+```
+
+**Design decision:** Should `sh` be a builtin or tool?
+
+Builtin:
+- Shell execution is as fundamental as HTTP for agents
+- Every agent framework provides it
+- `sh cmd` at 2 tokens is maximally terse
+- Timeout can be a runtime default (e.g. 30s) with override
+
+Tool:
+- Shell execution is platform-dependent
+- Security implications in multi-tenant environments
+- Some agent environments intentionally sandbox shell access
+
+**Recommendation:** Builtin behind a feature flag (like `get` is behind `http`). `sh` feature on by default, disabled with `--no-default-features` for sandboxed environments.
+
+---
+
+## 4. Data Formats
+
+### What Python offers
+
+```python
+# JSON
+json.loads(text)         # parse
+json.dumps(obj)          # serialize
+json.dumps(obj, indent=2)  # pretty-print
+
+# YAML (third-party)
+yaml.safe_load(text)
+yaml.dump(obj)
+
+# XML
+xml.etree.ElementTree.parse(file)
+ET.fromstring(text)
+
+# CSV
+csv.reader(file)
+csv.DictReader(file)
+csv.writer(file)
+
+# TOML (3.11+)
+tomllib.loads(text)
+
+# INI
+configparser.ConfigParser()
+```
+
+### What agents actually use
+
+1. **JSON parse** -- API responses, config files, tool outputs. **By far** the most common.
+2. **JSON serialize** -- constructing API request bodies, writing configs.
+3. **CSV read** -- data processing, spreadsheet data.
+4. **YAML read** -- config files (Docker, K8s, CI/CD).
+5. **TOML read** -- Rust/Python project configs.
+6. **XML** -- increasingly rare; legacy APIs, HTML parsing.
+
+### What's human ceremony
+
+- `json.loads` / `json.dumps` naming -- not discoverable
+- `indent=2` for pretty-printing -- formatting is a display concern
+- `yaml.safe_load` vs `yaml.load` security distinction -- just be safe by default
+- `csv.DictReader` vs `csv.reader` -- agents always want the dict form (keyed access)
+- XML's verbose DOM API -- agents want to extract values, not traverse nodes
+
+### What ilo needs
+
+From OPEN.md: **"Format parsing is a tool concern, not a language concern."** This is the right principle. However, JSON is special because it's the tool boundary format -- JSON<->Value mapping is built into ilo's tool infrastructure (D1e in TODO).
+
+| Capability | Mechanism | Notes |
+|-----------|-----------|-------|
+| JSON parse | Tool boundary (automatic) | Tool returns typed record/list, JSON mapping implicit |
+| JSON parse (raw) | `jsn text` builtin | When tool returns `t` and agent needs to extract fields |
+| JSON serialize | Tool boundary (automatic) | Record/list auto-serialized when passed to tool |
+| CSV/YAML/TOML/XML | Tools | `tool csv-read"Parse CSV" data:t>L L t`, etc. |
+
+**The key insight:** Most data format handling in Python is boilerplate that bridges untyped text to typed data. ilo's tool declarations *are* the schema. When a tool declares `>R profile t`, the runtime maps JSON to a typed record automatically. The agent never calls `json.loads`.
+
+**Only JSON needs language-level support** because it's the universal API interchange format. Everything else is domain-specific and belongs in tools.
+
+Possible JSON builtins:
+
+```
+jsn text     -- parse JSON text to ilo value (R val t)
+ser value    -- serialize ilo value to JSON text
+```
+
+But even these might be unnecessary if the tool boundary handles all JSON automatically. An agent composing tool calls never touches raw JSON -- it flows through typed interfaces.
+
+---
+
+## 5. String Manipulation
+
+### What Python offers
+
+```python
+# Basic operations
+s.upper(), s.lower(), s.strip(), s.replace(old, new)
+s.startswith(prefix), s.endswith(suffix)
+s.split(sep), sep.join(list), s.find(sub)
+s[start:end], len(s)
+
+# Regex
+import re
+re.search(pattern, text)
+re.findall(pattern, text)
+re.sub(pattern, replacement, text)
+re.match(pattern, text)
+re.compile(pattern)
+
+# Formatting
+f"Hello {name}, you have {count} items"
+"Hello {}".format(name)
+"%s has %d items" % (name, count)
+Template("$name has $count items").substitute(...)
+
+# Encoding
+base64.b64encode(data), base64.b64decode(data)
+urllib.parse.quote(text), urllib.parse.unquote(text)
+text.encode('utf-8'), bytes.decode('utf-8')
+binascii.hexlify(data)
+```
+
+### What agents actually use
+
+1. **String concatenation** -- building prompts, messages, URLs. Already in ilo as `+a b`.
+2. **Split/join** -- parsing delimited data. Already in ilo as `spl`/`cat`.
+3. **Substring search** -- checking if text contains something. Already in ilo as `has`.
+4. **String interpolation/formatting** -- constructing URLs, messages, payloads.
+5. **Replace** -- text transformation.
+6. **Trim/strip** -- cleaning whitespace from API responses.
+7. **Regex match/extract** -- parsing semi-structured text.
+8. **Case conversion** -- API key normalization, comparison.
+9. **Base64 encode/decode** -- auth tokens, binary data in JSON.
+10. **URL encoding** -- constructing query strings.
+
+### What's human ceremony
+
+- Three string formatting syntaxes (f-strings, `.format()`, `%`) -- one way to do things
+- `re.compile` for performance -- premature optimization; agents run once
+- Separate `re` module import -- should be inline
+- `str.encode('utf-8')` for byte conversion -- UTF-8 should be implicit
+- `urllib.parse.quote` in a separate module -- URL encoding is a builtin-level operation for API work
+
+### What ilo needs
+
+ilo already has: `+` (concat), `spl` (split), `cat` (join), `has` (contains), `len`, `hd`, `tl`, `slc` (slice), `rev` (reverse).
+
+Missing primitives that agents need:
+
+| Builtin | Purpose | Python equivalent | Frequency |
+|---------|---------|-------------------|-----------|
+| `rpl t old new` | Replace substring | `s.replace(old, new)` | Very high |
+| `trm t` | Trim whitespace | `s.strip()` | High |
+| `upr t` | Uppercase | `s.upper()` | Medium |
+| `lwr t` | Lowercase | `s.lower()` | Medium |
+| `idx t sub` | Find index of substring (-1 if missing) | `s.find(sub)` | Medium |
+| `pfx t pre` | Starts with prefix | `s.startswith(pre)` | Medium |
+| `sfx t suf` | Ends with suffix | `s.endswith(suf)` | Medium |
+| `b64e t` | Base64 encode | `base64.b64encode()` | Medium (auth) |
+| `b64d t` | Base64 decode | `base64.b64decode()` | Medium (auth) |
+| `urle t` | URL encode | `urllib.parse.quote()` | Medium (API) |
+| `urld t` | URL decode | `urllib.parse.unquote()` | Low |
+
+**Regex:** Should regex be a builtin or tool?
+
+Arguments for builtin:
+- Agents use regex constantly for text extraction
+- `rgx pattern text` at 3 tokens is very terse
+- LLMs are excellent at generating regex patterns
+
+Arguments for tool:
+- Regex engines are complex (backtracking, unicode)
+- Adding a regex engine inflates the binary
+- Most regex use cases are extracting structured data -- which tools handle better
+
+**Recommendation:** Add regex as a builtin behind a feature flag. Core operations:
+
+```
+rgx pattern text       -- find first match, return R t t (Ok=match, Err="no match")
+rga pattern text       -- find all matches, return L t
+rgs pattern repl text  -- replace all matches, return t
+```
+
+3 builtins, 3 tokens each. Covers 95% of agent regex use.
+
+**String interpolation:** ilo currently builds strings with `+` concatenation:
+
+```
+m=+"Hello "+name+", you have "+(str count)+" items"
+```
+
+This is verbose. A template builtin would help:
+
+```
+fmt "Hello {}, you have {} items" name (str count)
+```
+
+But this conflicts with the manifesto's "one way to do things" -- `+` already concatenates. And `fmt` needs variadic args (not in ilo). **Defer until real pain is measured.**
+
+---
+
+## 6. Concurrency
+
+### What Python offers
+
+```python
+# async/await
+async def fetch(url):
+    async with aiohttp.ClientSession() as session:
+        response = await session.get(url)
+        return await response.text()
+asyncio.run(fetch(url))
+
+# Threading
+thread = threading.Thread(target=func, args=(...))
+thread.start(); thread.join()
+from concurrent.futures import ThreadPoolExecutor
+with ThreadPoolExecutor(max_workers=5) as executor:
+    results = executor.map(func, urls)
+
+# Multiprocessing
+from multiprocessing import Pool
+with Pool(4) as p: results = p.map(func, data)
+```
+
+### What agents actually use
+
+1. **Parallel HTTP requests** -- fetch multiple APIs concurrently.
+2. **Parallel tool calls** -- call independent tools in parallel.
+3. **Timeout on operations** -- don't block forever.
+4. **Sequential pipelines** -- most agent work is sequential (call A, use result in B).
+
+### What agents don't need
+
+- Thread synchronization (locks, semaphores, conditions)
+- Shared mutable state
+- Process pools for CPU parallelism
+- Event loops they manage themselves
+- Cancellation tokens / cooperative cancellation
+- async/await syntax
+
+### What's human ceremony
+
+- `async`/`await` keyword ceremony -- agents want parallel execution, not coroutine management
+- `asyncio.run()` boilerplate -- agents shouldn't manage event loops
+- Thread management (start/join) -- agents want "run these in parallel, give me all results"
+- `concurrent.futures` abstraction layers -- too much ceremony for "do N things at once"
+
+### What ilo needs
+
+Agent concurrency is embarrassingly parallel: "call these 3 tools, wait for all, continue." No shared state, no synchronization, no futures.
+
+The right primitive is **parallel map** or **parallel call**:
+
+```
+-- Sequential (current):
+a=get! url1;b=get! url2;c=get! url3
+
+-- Parallel (proposed):
+[a, b, c]=par{get url1;get url2;get url3}
+
+-- Or parallel map over a list:
+rs=@! x urls{get x}    -- @! = parallel foreach
+```
+
+**Design options:**
+
+1. **`par{...}` block** -- execute all statements in parallel, return list of results. Simple, explicit.
+2. **`@!` parallel foreach** -- like `@` but iterations run concurrently. Natural extension.
+3. **Runtime decides** -- the runtime analyzes the dependency graph and parallelizes independent calls automatically. No syntax needed. Most aligned with ilo's philosophy -- the agent shouldn't need to think about parallelism.
+
+**Recommendation:** Option 3 (runtime auto-parallelization) is most aligned with the manifesto, but hard to implement. Start with option 1 (`par{...}`) as an explicit construct, which makes the intent clear and is simple to verify.
+
+Timeout is already in tool declarations (`timeout:5`). No additional language support needed.
+
+---
+
+## 7. Error Handling
+
+### What Python offers
+
+```python
+try:
+    result = risky_operation()
+except ValueError as e:
+    handle_value_error(e)
+except (IOError, OSError) as e:
+    handle_io_error(e)
+except Exception as e:
+    handle_any(e)
+finally:
+    cleanup()
+raise ValueError("bad input")
+# Custom exceptions
+class AppError(Exception): pass
+```
+
+### What agents actually use
+
+1. **Try/catch around tool calls** -- API might fail, file might not exist.
+2. **Error propagation** -- if step 2 fails, the whole workflow fails.
+3. **Error messages** -- need to know *what* failed to fix it.
+4. **Retry on transient errors** -- API timeout -> try again.
+5. **Compensation on failure** -- if charge fails, release the reservation.
+
+### What agents don't need
+
+- Exception class hierarchies -- agents care about "did it work?" not "was it a ValueError or TypeError?"
+- `finally` blocks -- short-lived programs don't need cleanup
+- Re-raising with modified messages -- `raise ... from ...`
+- Custom exception types -- `R ok err` with text errors is sufficient
+- Stack traces -- agents need the error message, not the call stack
+
+### What's human ceremony
+
+- `try`/`except`/`finally`/`else` -- four keywords for "might fail"
+- Exception class hierarchy (`ValueError` vs `TypeError` vs `RuntimeError`) -- agents just need the message
+- `raise` + exception construction -- verbose
+- Multiple `except` clauses -- agents rarely branch on error type
+- `traceback` module for formatting -- display concern
+
+### What ilo already has (and it's good)
+
+ilo's error handling is already well-designed for agents:
+
+```
+-- R ok err type: structural, verified, zero ceremony
+get-user uid;?{^e:^+"Lookup failed: "e;~d:use d}
+
+-- ! auto-unwrap: propagate errors in 1 token
+d=get-user! uid
+
+-- Compensation:
+rid=reserve items;charge pid amt;?{^e:release rid;^+"Payment failed: "e;~cid:continue}
+```
+
+**ilo's R type + ! operator is strictly better than Python's try/except for agents.** It's structural (verifier checks exhaustiveness), terse (1 token for propagation), and compositional (results flow through pipes).
+
+**What's missing:**
+
+| Feature | Purpose | Proposal |
+|---------|---------|----------|
+| Retry | Re-attempt on transient failure | Already in tool declarations: `retry:3` |
+| Error type matching | Branch on error kind | `?r{^"timeout":retry;^e:^e;~v:v}` (text prefix matching) |
+| Multiple error types | Different error variants | Defer to sum types (E3) |
+
+**Verdict:** ilo's error handling is already excellent. No additions needed for Phase D. Sum types (Phase E3) will add typed error variants when needed.
+
+---
+
+## 8. Environment
+
+### What Python offers
+
+```python
+# Environment variables
+os.environ["API_KEY"]
+os.environ.get("API_KEY", "default")
+os.getenv("API_KEY", "default")
+
+# Command-line arguments
+sys.argv[1:]
+import argparse
+parser = argparse.ArgumentParser()
+parser.add_argument("--output", default="result.txt")
+
+# stdin/stdout
+input()                     # read line from stdin
+sys.stdin.read()            # read all stdin
+print(result)               # write to stdout
+sys.stderr.write("error")  # write to stderr
+```
+
+### What agents actually use
+
+1. **Env vars** -- API keys, config values, secrets. **Critical** for agents -- secrets should never be in code.
+2. **Command-line args** -- ilo already handles this (positional args to functions).
+3. **Stdout** -- returning results. ilo already does this (last expression printed).
+4. **Stdin** -- piping data in. Useful for `cat data.json | ilo 'process-program'`.
+
+### What's human ceremony
+
+- `argparse` -- agents don't need help text, subcommands, or argument parsing libraries
+- `sys.argv` raw array access -- ilo's typed function params are already better
+- `print()` with formatting options -- output is the return value
+
+### What ilo needs
+
+| Builtin | Purpose | Signature |
+|---------|---------|-----------|
+| `env key` | Read environment variable | `>R t t` (Err if not set) |
+| `env key default` | Read env var with default | `>t` |
+
+That's it. Two forms of one operation. ilo's function parameters already handle CLI args. stdout is already the return value.
+
+**stdin:** Could be a builtin `inp()` that reads all of stdin as text. Enables piping:
+
+```bash
+cat data.json | ilo 'f d:t>t;process d'  # d = stdin content
+```
+
+But ilo already accepts args from the command line. Stdin support is a **runtime concern** (the CLI reads stdin and passes it as an argument), not a language concern.
+
+**Recommendation:** Add `env` as a builtin. Stdin support in the CLI runner (not the language).
+
+---
+
+## 9. Cryptography
+
+### What Python offers
+
+```python
+# Hashing
+import hashlib
+hashlib.sha256(data.encode()).hexdigest()
+hashlib.md5(data.encode()).hexdigest()
+
+# HMAC
+import hmac
+hmac.new(key, message, hashlib.sha256).hexdigest()
+
+# Secrets
+import secrets
+secrets.token_hex(32)
+secrets.token_urlsafe(32)
+
+# Encryption (third-party)
+from cryptography.fernet import Fernet
+key = Fernet.generate_key()
+cipher = Fernet(key)
+encrypted = cipher.encrypt(data)
+```
+
+### What agents actually use
+
+1. **SHA256 hash** -- verifying data integrity, generating cache keys, API signature verification.
+2. **HMAC** -- webhook signature verification (GitHub, Stripe, Slack all use HMAC-SHA256).
+3. **Random tokens** -- generating unique IDs, nonces, session tokens.
+4. **UUID generation** -- unique identifiers for records, requests.
+
+### What agents rarely need
+
+- Symmetric/asymmetric encryption -- agents don't encrypt data; they call APIs that handle encryption
+- Certificate management -- transport-layer concern
+- Key derivation (PBKDF2, scrypt) -- auth systems handle this
+- MD5 -- deprecated, but still used for legacy cache keys
+
+### What's human ceremony
+
+- `hashlib.sha256(data.encode()).hexdigest()` -- 6 method calls for one hash
+- Separate `hmac` module -- HMAC is just hash + key
+- `secrets` vs `random` distinction -- agents should always get cryptographic randomness
+
+### What ilo needs
+
+| Builtin | Purpose | Signature |
+|---------|---------|-----------|
+| `sha text` | SHA-256 hash (hex string) | `>t` |
+| `hmac key text` | HMAC-SHA256 (hex string) | `>t` |
+| `uid()` | Generate UUID v4 | `>t` |
+| `rnd()` | Random float 0.0-1.0 | `>n` |
+| `rnd a b` | Random integer in range | `>n` |
+
+5 builtins. Covers webhook verification, cache keys, unique IDs, and random values. No encryption (tool concern), no key management (infra concern), no certificate handling (transport concern).
+
+**Feature flag:** `crypto` -- adds sha/hmac. `uid` and `rnd` could be default (no deps).
+
+---
+
+## 10. Time/Date
+
+### What Python offers
+
+```python
+# Current time
+import time
+time.time()                    # Unix timestamp float
+time.monotonic()               # Monotonic clock
+
+# datetime
+from datetime import datetime, timedelta
+now = datetime.now()
+now = datetime.utcnow()
+formatted = now.strftime("%Y-%m-%d %H:%M:%S")
+parsed = datetime.strptime(text, "%Y-%m-%d")
+delta = timedelta(hours=2, minutes=30)
+future = now + delta
+
+# ISO format
+now.isoformat()
+datetime.fromisoformat(text)
+
+# timezone
+from datetime import timezone
+datetime.now(timezone.utc)
+```
+
+### What agents actually use
+
+1. **Current timestamp** -- logging, cache expiry, scheduling.
+2. **ISO 8601 format** -- API dates are almost always ISO 8601.
+3. **Timestamp arithmetic** -- "2 hours from now", "is this expired?"
+4. **Parse date string** -- reading API response dates.
+5. **Sleep/delay** -- rate limiting, polling intervals.
+
+### What agents don't need
+
+- Timezone conversion libraries -- agents work in UTC
+- `strftime` format strings -- ISO 8601 covers 95% of cases
+- Calendar arithmetic (business days, holidays) -- domain-specific tool
+- Locale-aware date formatting -- display concern
+
+### What's human ceremony
+
+- `datetime.now()` vs `time.time()` vs `datetime.utcnow()` -- three ways to get current time
+- `strftime` format codes (`%Y-%m-%d`) -- just use ISO 8601
+- `timedelta` construction verbosity -- `timedelta(hours=2, minutes=30)` is 6+ tokens
+- Timezone-naive vs timezone-aware datetime objects -- just always use UTC
+
+### What ilo needs
+
+| Builtin | Purpose | Signature |
+|---------|---------|-----------|
+| `now()` | Unix timestamp (seconds, f64) | `>n` |
+| `iso n` | Timestamp to ISO 8601 string (UTC) | `>t` |
+| `ts t` | Parse ISO 8601 string to timestamp | `>R n t` |
+| `slp n` | Sleep for n seconds | `>_` |
+
+4 builtins. Timestamps are numbers (f64) -- arithmetic works with standard `+`/`-`/`*`. "Two hours from now" is `+now() 7200`. Duration is just a number of seconds.
+
+No timezone type, no date type, no timedelta type. Just numbers (unix timestamps) and text (ISO 8601 strings). This is sufficient for every agent use case and costs zero type system complexity.
+
+---
+
+## 11. Math
+
+### What Python offers
+
+```python
+import math
+math.floor(x), math.ceil(x), math.sqrt(x)
+math.pow(x, y), math.log(x), math.log10(x)
+math.sin(x), math.cos(x), math.tan(x)
+math.pi, math.e, math.inf
+abs(x), min(a, b), max(a, b), round(x, n)
+sum(iterable), sorted(iterable)
+int(x), float(x)
+
+# Random
+import random
+random.random(), random.randint(a, b)
+random.choice(list), random.shuffle(list)
+random.sample(list, k)
+```
+
+### What agents actually use
+
+1. **Arithmetic** -- already in ilo (`+`, `-`, `*`, `/`)
+2. **Floor/ceil** -- already in ilo (`flr`, `cel`)
+3. **Abs/min/max** -- already in ilo (`abs`, `min`, `max`)
+4. **Rounding** -- for currency, display values
+5. **Power** -- occasionally, for exponential backoff, geometric calculations
+6. **Modulo** -- checking divisibility, cycling through lists
+7. **Square root** -- rare in agent code
+8. **Random** -- ID generation, sampling (covered in crypto section)
+
+### What agents almost never need
+
+- Trigonometric functions -- agents don't do graphics or physics
+- Logarithms -- unless doing ML, which is a tool concern
+- Mathematical constants (pi, e) -- rare
+- Complex numbers -- never
+
+### What's human ceremony
+
+- Separate `math` module import -- basic math should be inline
+- `math.pow(x, y)` instead of `x ** y` -- operator is better
+- `sum()` as a function vs `+` reduce -- agents need fold/reduce, not a special `sum`
+
+### What ilo already has and what's missing
+
+Already has: `+`, `-`, `*`, `/`, `abs`, `min`, `max`, `flr`, `cel`, `str` (n->t), `num` (t->n).
+
+| Builtin | Purpose | Priority |
+|---------|---------|----------|
+| `%a b` or `mod a b` | Modulo | High -- needed for cycling, divisibility checks |
+| `pow a b` | Power | Medium -- exponential backoff, simple math |
+| `rnd a b` | Round to b decimal places | Medium -- currency, display |
+| `sqr n` | Square root | Low |
+
+**Recommendation:** Add `%` (modulo) as a prefix operator. It's used frequently enough to warrant single-character syntax. `pow` as a builtin. `rnd` for rounding (note: conflicts with random -- use `rnd` for random, `rnd` overloaded by arity? Or `rndf` for round-float? Better: `rnd n d` = round n to d decimals, `rnd()` = random. Arity disambiguates.)
+
+---
+
+## 12. Collections
+
+### What Python offers
+
+```python
+# Lists
+xs = [1, 2, 3]
+xs.append(x), xs.extend(ys), xs.pop(), xs.insert(i, x)
+xs[i], xs[start:end], xs.index(v), xs.count(v)
+sorted(xs), reversed(xs), len(xs)
+list(map(f, xs)), list(filter(f, xs))
+[f(x) for x in xs if cond(x)]  # list comprehension
+
+# Dicts
+d = {"key": "value"}
+d[key], d.get(key, default), d.keys(), d.values(), d.items()
+d.update(other), {**d1, **d2}  # merge
+{k: v for k, v in items if cond}  # dict comprehension
+
+# Sets
+s = {1, 2, 3}
+s.add(x), s.remove(x), s.union(other), s.intersection(other)
+x in s  # O(1) membership
+
+# Tuples
+t = (1, "hello", True)  # immutable, heterogeneous
+
+# Named tuples / dataclasses
+from dataclasses import dataclass
+@dataclass
+class Point:
+    x: float
+    y: float
+```
+
+### What agents actually use
+
+1. **Lists** -- already in ilo. The primary collection.
+2. **Dicts/Maps** -- key-value lookup, API response data, config. **NOT yet in ilo** (Phase E4).
+3. **List iteration** -- already in ilo (`@`).
+4. **List filtering** -- selecting items that match a condition.
+5. **List transformation** -- applying a function to each element.
+6. **Key access** -- getting a value by key from a dict/record. Records already do this.
+7. **Membership test** -- already in ilo (`has`).
+8. **Sorting** -- already in ilo (`srt`).
+
+### What agents rarely need
+
+- Sets -- agents don't do set theory; use lists with `has` for membership
+- Tuples -- ilo records serve the same purpose with named fields
+- List comprehensions (as syntax) -- agents need map/filter, not a special syntax
+- Dict comprehensions -- rare
+- `collections.Counter`, `defaultdict`, `OrderedDict` -- specialized tools
+
+### What's human ceremony
+
+- List comprehensions vs `map()`/`filter()` -- two ways to do the same thing
+- `dict.get(key, default)` vs `dict[key]` with `KeyError` -- ilo's `??` (nil-coalesce) is better
+- Mutable vs immutable collections -- agents don't care about mutability semantics
+- `dataclass` decorator ceremony -- ilo's `type point{x:n;y:n}` is already minimal
+
+### What ilo already has and what's missing
+
+Already has: `[1, 2, 3]` (list literals), `@` (iterate), `+=` (append), `+` (concat), `spl`/`cat` (split/join), `has` (contains), `hd`/`tl` (head/tail), `rev` (reverse), `srt` (sort), `slc` (slice), `len`, index access (`xs.0`).
+
+Missing high-value operations:
+
+| Capability | Purpose | Proposal | Priority |
+|-----------|---------|----------|----------|
+| Map (transform) | Apply function to each element | `map f xs` or `@x xs{expr}` already works | Exists (via `@`) |
+| Filter | Select matching elements | `flt cond xs` or guard in `@` loop | High |
+| Reduce/fold | Accumulate list to single value | `fld op init xs` | High (needs E5) |
+| Map type | Dynamic key-value store | `M t n` (Phase E4) | High |
+| Map literal | Construct map inline | `M{"k1":v1;"k2":v2}` | High (with E4) |
+| Unique/dedup | Remove duplicates | `unq xs` | Low |
+| Flatten | Flatten nested lists | `flt xs` (name conflict with filter!) | Low |
+| Zip | Pair elements from two lists | `zip xs ys` | Low |
+| Enumerate | Index + value pairs | `@i x xs{...}` (two-var `@`) | Medium |
+
+**The `@` loop already covers map and filter patterns**, just with more tokens:
+
+```
+-- Map: double each element
+@x xs{*x 2}
+
+-- Filter: keep elements > 5 (currently returns list with nil gaps -- needs filter semantics)
+@x xs{>x 5{x}}
+```
+
+The gap is that `@` with a guard returns a list with nil entries for non-matching elements. A true `flt` builtin would return only matching elements.
+
+**Map type (E4) is the biggest gap.** API responses are full of key-value structures that don't fit static records. Without maps, agents must use `t` (raw text) and lose type checking.
+
+---
+
+## 13. Type System
+
+### What Python offers
+
+```python
+# Type hints (PEP 484+)
+def greet(name: str) -> str: ...
+x: int = 5
+xs: list[int] = [1, 2, 3]
+d: dict[str, int] = {"a": 1}
+
+# Optional / Union
+from typing import Optional, Union
+def find(id: str) -> Optional[User]: ...
+def parse(x: Union[str, int]) -> float: ...
+# 3.10+ syntax
+def parse(x: str | int) -> float: ...
+
+# Generics
+from typing import TypeVar, Generic
+T = TypeVar('T')
+def first(xs: list[T]) -> T: ...
+
+# Protocols (structural typing)
+from typing import Protocol
+class Readable(Protocol):
+    def read(self) -> str: ...
+
+# TypedDict
+from typing import TypedDict
+class Movie(TypedDict):
+    name: str
+    year: int
+
+# Literal types
+from typing import Literal
+def set_mode(mode: Literal["read", "write"]): ...
+
+# Runtime checking: none (unless using pydantic, beartype, etc.)
+```
+
+### What agents actually use
+
+1. **Basic types** -- know that a function takes a string and returns a number. Already in ilo.
+2. **Optional/nullable** -- API fields that might be null. Planned for ilo (E2).
+3. **Result types** -- success/failure. Already in ilo as `R ok err`.
+4. **Record types** -- structured data from APIs. Already in ilo.
+5. **List types** -- collections. Already in ilo as `L elem`.
+6. **Generic types** -- `map` that works on any list. Planned for ilo (E5).
+
+### What agents don't need
+
+- Union types beyond Optional/Result -- `str | int` is a human convenience
+- Protocol/structural typing -- agents write concrete code for specific tasks
+- `TypeVar` ceremony -- too verbose, too abstract
+- `TypedDict` vs `dataclass` vs `NamedTuple` -- one record type is enough
+- Literal types -- string matching works fine
+- Type narrowing / type guards -- verifier handles this
+- Runtime type checking libraries (pydantic) -- ilo verifies before execution
+
+### What's human ceremony
+
+- `from typing import ...` on every file -- ilo types are built in
+- `Optional[X]` instead of `X?` or `X | None` -- evolved through 3 syntax versions
+- `TypeVar` declaration before use -- too much boilerplate for agents
+- Generic class definitions -- agents don't write generic libraries
+- `Protocol` ceremony -- structural typing is good but the syntax is heavy
+
+### What ilo already has and roadmap
+
+ilo's type system is already well-suited for agents:
+
+| Feature | Python | ilo | Status |
+|---------|--------|-----|--------|
+| Primitives | `int`, `float`, `str`, `bool` | `n`, `t`, `b` | Done |
+| Nil/None | `None` | `_` | Done |
+| Lists | `list[int]` | `L n` | Done |
+| Result | No stdlib equivalent | `R ok err` | Done |
+| Records | `@dataclass` | `type name{fields}` | Done |
+| Optional | `Optional[X]` | `O n` | Planned (E2) |
+| Maps | `dict[str, int]` | `M t n` | Planned (E4) |
+| Enums | `enum.Enum` | `enum name{variants}` | Planned (E3) |
+| Generics | `TypeVar` + `Generic` | `a`, `b` type vars | Planned (E5) |
+| Type aliases | `type Alias = ...` | `alias name type` | Planned (E1) |
+
+**The type system roadmap (E1-E6) is well-aligned with agent needs.** The key insight from Python: agents need *cheap, precise* types that prevent errors, not *expressive* types that enable abstraction. ilo's 1-char type syntax (`n`, `t`, `b`, `L`, `R`) is already optimal for token cost.
+
+---
+
+## Synthesis: Priority Capabilities for ilo
+
+### Tier 1 -- Essential agent primitives (highest impact)
+
+These are capabilities that every agent needs and currently cannot do in ilo:
+
+| Capability | Python equivalent | Proposed ilo | Tokens | Status |
+|-----------|-------------------|-------------|--------|--------|
+| Shell execution | `subprocess.run()` | `sh cmd` / `sh! cmd` | 2 | New |
+| HTTP POST | `requests.post()` | `post url body` | 3 | New |
+| Env vars | `os.getenv()` | `env key` / `env key default` | 2-3 | New |
+| Replace string | `s.replace()` | `rpl t old new` | 4 | New |
+| Trim whitespace | `s.strip()` | `trm t` | 2 | New |
+| Modulo | `a % b` | `%a b` | 3 | New |
+| Current time | `time.time()` | `now()` | 1 | New |
+
+### Tier 2 -- High-value for API-heavy agents
+
+| Capability | Python equivalent | Proposed ilo | Tokens | Status |
+|-----------|-------------------|-------------|--------|--------|
+| Full HTTP request | `requests.request()` | `req method url headers body` | 5 | New |
+| JSON parse (raw) | `json.loads()` | `jsn text` | 2 | New |
+| JSON serialize | `json.dumps()` | `ser value` | 2 | New |
+| Base64 encode | `base64.b64encode()` | `b64e t` | 2 | New |
+| Base64 decode | `base64.b64decode()` | `b64d t` | 2 | New |
+| URL encode | `urllib.parse.quote()` | `urle t` | 2 | New |
+| SHA-256 hash | `hashlib.sha256()` | `sha t` | 2 | New |
+| HMAC | `hmac.new()` | `hmac key t` | 3 | New |
+| UUID | `uuid.uuid4()` | `uid()` | 1 | New |
+| Timestamp to ISO | `datetime.isoformat()` | `iso n` | 2 | New |
+| ISO to timestamp | `datetime.fromisoformat()` | `ts t` | 2 | New |
+| Sleep | `time.sleep()` | `slp n` | 2 | New |
+
+### Tier 3 -- Nice to have, deferrable
+
+| Capability | Python equivalent | Proposed ilo | Notes |
+|-----------|-------------------|-------------|-------|
+| Regex match | `re.search()` | `rgx pat text` | Feature flag |
+| Regex replace | `re.sub()` | `rgs pat repl text` | Feature flag |
+| Uppercase | `s.upper()` | `upr t` | Low frequency |
+| Lowercase | `s.lower()` | `lwr t` | Low frequency |
+| Starts/ends with | `s.startswith()` | `pfx t pre` / `sfx t suf` | `has` partially covers |
+| Find index | `s.find()` | `idx t sub` | Low frequency |
+| Power | `math.pow()` | `pow a b` | Low frequency |
+| Random | `random.random()` | `rnd()` / `rnd a b` | With crypto flag |
+| File read | `open().read()` | `rd path` | Tool or feature flag |
+| File write | `open().write()` | `wr path data` | Tool or feature flag |
+| Parallel exec | `ThreadPoolExecutor` | `par{...}` | Needs design |
+| Map/filter builtins | `map()`, `filter()` | `map f xs`, `flt f xs` | Needs E5 (generics) |
+
+### What ilo should NOT add from Python
+
+| Python feature | Why not in ilo |
+|---------------|----------------|
+| Classes / OOP | Agents don't write class hierarchies |
+| Decorators | Framework pattern, not agent pattern |
+| Generators / yield | Complex state machines; agents compose tools |
+| Context managers | Short-lived programs don't need resource cleanup |
+| Import system | Programs are self-contained by manifesto |
+| Global variables | Manifesto: "no globals, no ambient state" |
+| Multiple inheritance | Never |
+| Metaclasses | Never |
+| Property descriptors | Never |
+| Operator overloading | One meaning per operator |
+| Comprehensions (as special syntax) | `@` loop covers this |
+| String formatting mini-language | `+` concatenation is sufficient |
+| Docstrings | Comments (`--`) are enough |
+| `assert` statements | Verifier catches errors before runtime |
+| Dynamic attribute access (`getattr`) | Records have fixed fields |
+
+---
+
+## Key Principle: Builtins vs Tools
+
+The hardest design decision is the **builtin vs tool boundary**. The manifesto says "format parsing is a tool concern." Extending this principle:
+
+**Builtins** (compile to opcodes, always available):
+- Operations that are *composition glue*: string manipulation, math, data access
+- Operations every agent needs regardless of domain: HTTP GET, env vars
+- Operations that are too small to be tools: `len`, `+`, `has`
+
+**Tools** (declared, external, fallible):
+- Operations with *side effects on external systems*: file I/O, database, API calls
+- Operations that are *domain-specific*: CSV parsing, image processing, ML inference
+- Operations that need *timeout/retry semantics*: slow API calls, network requests
+
+**The gray area:** `sh` (shell execution), `post` (HTTP POST), file I/O. These have side effects but are so fundamental to agents that the token cost of declaring them as tools on every program is prohibitive.
+
+**Recommendation:** Make them builtins behind feature flags. The runtime provides them; the agent doesn't need to declare them. The feature flag system lets sandboxed environments disable them.
+
+```
+default features: [cranelift, http, shell]
+http features: get, post, req
+shell features: sh
+crypto features: sha, hmac
+time features: now, iso, ts, slp
+```
+
+This gives agents full capability by default while allowing locked-down environments to strip features.

--- a/research/ruby-php-research.md
+++ b/research/ruby-php-research.md
@@ -1,0 +1,730 @@
+# Ruby & PHP Capabilities Research for ilo
+
+Research into Ruby and PHP features relevant to ilo's design as a token-minimal AI agent programming language. Focus: what patterns from these languages are worth adopting, what should be avoided, and what ilo already handles better.
+
+---
+
+## 1. Ruby Capabilities Catalog
+
+### 1.1 File I/O — File, IO, Dir, Pathname
+
+**What Ruby provides:**
+
+| Class | Role | Key Methods |
+|-------|------|-------------|
+| `File` | Read/write/stat/rename/delete files | `read`, `write`, `open`, `exist?`, `delete`, `rename`, `size` |
+| `IO` | Low-level byte/line I/O, pipe creation | `read`, `write`, `gets`, `puts`, `pipe` |
+| `Dir` | Directory listing, creation, deletion | `entries`, `glob`, `mkdir`, `chdir`, `exist?` |
+| `Pathname` | Unified facade over File+Dir+FileTest | `join`, `basename`, `dirname`, `exist?`, `read`, `glob` |
+
+**How Ruby does it (minimal examples):**
+
+```ruby
+# Read entire file
+content = File.read("data.json")
+
+# Write file
+File.write("out.txt", "hello")
+
+# Block-based (auto-closes)
+File.open("log.txt", "a") { |f| f.puts "entry" }
+
+# Pathname unification
+require 'pathname'
+p = Pathname.new("/tmp") / "data" / "file.json"
+p.read          # reads file
+p.exist?        # checks existence
+p.dirname       # parent directory
+```
+
+**Key design insight:** `Pathname` is an immutable value object. `/` operator joins paths. Every method returns a new `Pathname`. Thread-safe by design. The block pattern (`File.open { |f| ... }`) guarantees resource cleanup without explicit close calls.
+
+**ilo relevance:**
+- File I/O is a **tool concern**, not a language concern (per OPEN.md: "format parsing is a tool concern"). An agent needing file access would call a `read-file` or `write-file` tool.
+- However, the Pathname-as-value pattern is worth noting: paths as immutable typed values that compose with `/` maps to ilo's record + operator model.
+- Ruby's block-based auto-cleanup maps to ilo's Result type — `R t t` handles the success/failure case; cleanup is the tool's job.
+
+---
+
+### 1.2 Networking — Net::HTTP, open-uri, Sockets
+
+**What Ruby provides:**
+
+| Library | Ceremony Level | Best For |
+|---------|---------------|----------|
+| `open-uri` | Minimal — `URI.open(url).read` | Simple GETs |
+| `Net::HTTP` | Medium — connection management, headers, HTTPS | Full HTTP |
+| `TCPSocket` | Low-level — raw TCP/UDP | Custom protocols |
+
+**How Ruby does it:**
+
+```ruby
+# open-uri: 1 line for GET
+require 'open-uri'
+body = URI.open("https://api.example.com/data").read
+
+# Net::HTTP: more control
+require 'net/http'
+uri = URI("https://api.example.com/data")
+res = Net::HTTP.get_response(uri)
+body = res.body if res.is_a?(Net::HTTPSuccess)
+
+# Persistent connections
+Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+  res1 = http.get("/users")
+  res2 = http.get("/orders")
+end
+```
+
+**Key design insight:** Ruby's `open-uri` wraps HTTP with a file-like interface — `open(url)` returns an IO-like object. This "URLs are just files" abstraction is powerful but leaky (no POST, no headers control). Net::HTTP's block form (`start { |http| ... }`) manages connection lifecycle.
+
+**ilo relevance:**
+- ilo already has `get url` / `$url` returning `R t t`. This is MORE concise than even `open-uri` (3 chars vs ~30).
+- POST/PUT/DELETE: currently deferred. When added, should follow the same `verb url body` pattern — keep it terse. `post url data` / `put url data` / `del url`.
+- Connection pooling is a runtime concern, not a language concern. The tool provider infrastructure (D1d) handles this.
+
+---
+
+### 1.3 Process Execution — Backticks, system, exec, Open3
+
+**Ruby provides 5 distinct methods for running external commands:**
+
+| Method | Returns | Captures stdout | Captures stderr | Replaces process |
+|--------|---------|----------------|----------------|-----------------|
+| `` `cmd` `` / `%x(cmd)` | stdout as String | Yes | No | No |
+| `system(cmd)` | `true`/`false`/`nil` | No (prints to console) | No | No |
+| `exec(cmd)` | Never returns | No | No | Yes |
+| `Open3.capture3` | stdout, stderr, status | Yes | Yes | No |
+| `Open3.popen3` | stdin, stdout, stderr, thread | Yes | Yes | No |
+
+**How backticks work in detail:**
+
+```ruby
+# Basic: returns stdout as string
+output = `ls -la`
+
+# With interpolation
+dir = "/tmp"
+output = `ls #{dir}`
+
+# With %x alternative syntax (any delimiter)
+output = %x(date)
+output = %x{whoami}
+output = %x-uname -a-
+
+# Exit status via $? global
+output = `cat /etc/hosts`
+if $?.success?
+  puts output
+else
+  puts "Failed with exit code #{$?.exitstatus}"
+end
+
+# Newline handling — .chomp is standard
+hostname = `hostname`.chomp
+```
+
+**Under the hood:** Both backticks and `system` use `fork()` + `exec()`. Backticks capture the forked process's stdout into a string. `$?` is set to a `Process::Status` object after execution.
+
+**Security concern:** Backticks with interpolation are vulnerable to command injection. `user_input = "hello; rm -rf *"` + `` `echo #{user_input}` `` executes both commands. Ruby's `system` with array form is safe: `system("echo", user_input)`.
+
+**ilo relevance:**
+- **Backtick-as-shell-exec is relevant for agents.** An agent that can run shell commands has immense capability with minimal vocabulary. Ruby's backtick is 2 tokens (the backtick pair) for arbitrary shell access.
+- ilo currently has no shell execution. The `tool` mechanism is the intended external interface. But a shell execution builtin (like `sh "cmd"` returning `R t t`) would be enormously powerful — stdout as Ok, stderr/failure as Err. This is essentially what ilo's `get` does for HTTP.
+- The `$?` global for exit status is clunky. ilo's `R` type is better — the Result carries success/failure inline.
+- Security: for agent use, injection is less of a concern (the agent IS the programmer), but sandboxing matters. This is a runtime/policy concern, not a language concern.
+
+---
+
+### 1.4 Data Formats — JSON, YAML, XML, CSV
+
+**All four are built into Ruby's standard library:**
+
+| Format | Library | Parse | Generate |
+|--------|---------|-------|----------|
+| JSON | `json` | `JSON.parse(str)` → Hash/Array | `hash.to_json` |
+| YAML | `yaml` | `YAML.load(str)` → Ruby objects | `obj.to_yaml` |
+| CSV | `csv` | `CSV.parse(str)` → Array of Arrays | `CSV.generate { \|csv\| ... }` |
+| XML | `rexml` | `REXML::Document.new(str)` | Built-in, verbose |
+
+```ruby
+require 'json'
+data = JSON.parse('{"name":"alice","age":30}')
+data["name"]  # => "alice"
+
+require 'yaml'
+config = YAML.load(File.read("config.yml"))
+
+require 'csv'
+CSV.foreach("data.csv", headers: true) { |row| puts row["name"] }
+```
+
+**Key design insight:** JSON in Ruby maps directly to native types (Hash, Array, String, Integer, Float, true/false, nil). No wrapper objects. `JSON.parse` returns a plain Hash.
+
+**ilo relevance:**
+- Per OPEN.md: "format parsing is a tool concern, not a language concern." ilo composes typed tool results. Tools return `R record t` or `R t t`.
+- JSON-to-Value mapping is already planned (D1e: `Value::from_json(type_hint)`). This is the RIGHT boundary — the tool parses, ilo consumes typed values.
+- YAML/CSV/XML parsing would be tools, not builtins. An agent calls `parse-csv data` and gets back a list of records.
+- **One exception worth considering:** JSON is so fundamental to API communication that a `json` builtin (parse text to Value) might earn its place alongside `get`. `j=json txt` → typed Value. This saves a tool roundtrip for the most common data format.
+
+---
+
+### 1.5 String Manipulation — Regex, Interpolation, Encoding
+
+**What Ruby provides:**
+
+| Feature | Syntax | Example |
+|---------|--------|---------|
+| Regex literal | `/pattern/flags` | `/\d+/` |
+| Match test | `=~` | `"abc" =~ /\d/` → nil |
+| Match data | `.match` | `"age:30".match(/(\d+)/)[1]` → "30" |
+| Interpolation | `"#{expr}"` | `"Hello #{name}"` |
+| Substitution | `.gsub` | `"hello".gsub(/l/, "r")` → "herro" |
+| Split | `.split` | `"a,b,c".split(",")` → ["a","b","c"] |
+| Encoding | `.encode` | `str.encode("UTF-8")` |
+
+```ruby
+# Regex is first-class
+email = "user@example.com"
+if email =~ /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z]+)*\.\w+\z/i
+  puts "Valid"
+end
+
+# Capture groups
+"2025-01-15".match(/(\d{4})-(\d{2})-(\d{2})/) do |m|
+  year, month, day = m[1], m[2], m[3]
+end
+
+# Interpolation inside regex
+domain = "example\\.com"
+/#{domain}$/
+
+# gsub with block
+"Hello World".gsub(/\w+/) { |word| word.upcase }
+# => "HELLO WORLD"
+```
+
+**Key design insight:** Ruby's regex is first-class (literal syntax, `=~` operator, `$~` match data). Regex interpolation means patterns are composable. String interpolation with `#{}` is universal — works in strings, regex, heredocs.
+
+**ilo relevance:**
+- ilo has `spl` (split), `has` (substring test), `+` (concat). No regex.
+- **Regex is a significant capability gap for text extraction.** Agents frequently need to extract patterns from text (parse URLs, extract numbers, match formats). Without regex, this requires chaining `spl`/`has`/`slc` — verbose and error-prone.
+- A regex match builtin could be: `rx text pattern` → `R L t t` (Ok = list of captures, Err = no match or bad pattern). Or `rx text pattern` → `R t t` (Ok = first match, Err = no match).
+- String interpolation: ilo uses `+` for concat (`+"Hello " name`). This is more token-efficient than `"Hello #{name}"` (which costs the `#{}` delimiters). ilo's approach is already optimal for agents.
+- Encoding: not relevant for agent use. UTF-8 everywhere.
+
+---
+
+### 1.6 Concurrency — Threads, Fibers, Ractor
+
+**Ruby's three concurrency primitives:**
+
+| Primitive | Type | Parallelism | Best For |
+|-----------|------|-------------|----------|
+| Threads | Preemptive, GVL-limited | No (I/O only) | Waiting on network/disk |
+| Fibers | Cooperative, manual yield | No | Non-blocking I/O, generators |
+| Ractors | Isolated interpreters | Yes (each has own GVL) | CPU-bound, experimental |
+
+```ruby
+# Threads — concurrent I/O
+threads = urls.map { |url| Thread.new { Net::HTTP.get(URI(url)) } }
+results = threads.map(&:value)
+
+# Fibers — cooperative
+fib = Fiber.new do
+  Fiber.yield 1
+  Fiber.yield 2
+  3
+end
+fib.resume  # => 1
+fib.resume  # => 2
+fib.resume  # => 3
+
+# Ractors — true parallelism (Ruby 3.0+)
+ractors = 4.times.map do
+  Ractor.new { heavy_computation }
+end
+results = ractors.map(&:take)
+```
+
+**Key design insight:** Ruby's GVL means threads are only useful for I/O concurrency. Fibers are lightweight but require explicit `yield`. Ractors achieve true parallelism by forbidding shared mutable state — each Ractor is an isolated world that communicates via message passing.
+
+**ilo relevance:**
+- ilo programs are currently sequential. Concurrency is a future concern.
+- **Ractor's isolation model aligns with ilo's "self-contained" principle.** Each function declares its deps, no global state. If ilo adds concurrency, isolated execution units with message passing (like Ractors) would be natural.
+- For agent use, the most relevant concurrency pattern is **parallel tool calls** — fire off multiple `get` calls simultaneously. This is a runtime optimization, not a language feature. The tool provider (D1d) could parallelize independent tool calls in a DAG automatically.
+- Fibers could inform a future "generator" pattern for streaming data, but this is speculative.
+
+---
+
+### 1.7 Error Handling — begin/rescue/ensure
+
+**Ruby's exception model:**
+
+```ruby
+begin
+  risky_operation
+rescue ArgumentError, TypeError => e
+  # Handle specific errors
+rescue StandardError => e
+  # Handle general errors
+  retry if retryable?     # restart begin block
+else
+  # Runs only if no exception
+ensure
+  # ALWAYS runs (cleanup)
+end
+
+# Method-level rescue (no begin needed)
+def fetch(url)
+  Net::HTTP.get(URI(url))
+rescue SocketError => e
+  "Connection failed: #{e.message}"
+end
+
+# Custom exceptions
+class PaymentError < StandardError; end
+class InsufficientFunds < PaymentError; end
+
+raise InsufficientFunds, "Balance too low"
+```
+
+**Key design insight:** Ruby's `ensure` guarantees cleanup. `retry` re-executes the begin block (useful for transient failures). Method-level rescue eliminates `begin/end` boilerplate. Custom exception hierarchies enable `rescue ParentError` to catch all subtypes.
+
+**ilo relevance:**
+- ilo uses `R ok err` (Result type) instead of exceptions. This is **strictly better for agents**:
+  - Exceptions are invisible in the type signature — an agent can't know what might throw without reading the body.
+  - Results are explicit in the signature: `>R profile t` — the agent sees the error possibility at the call site.
+  - `!` auto-unwrap is ilo's equivalent of letting errors propagate: `get! url` propagates the Err to the caller.
+- `ensure` (guaranteed cleanup) maps to ilo's inline compensation pattern: `charge pid amt;?{^e:release rid;^+"Payment failed: "e;~cid:continue}`. The rollback is explicit in the control flow.
+- `retry` is interesting but dangerous (infinite loops). ilo's `tool` declarations have `retry:n` which is bounded and handled by the runtime.
+- **No adoption needed.** ilo's Result type is superior for agent use. Exception hierarchies are unnecessary when errors are typed values.
+
+---
+
+### 1.8 Environment — ENV, ARGV
+
+**Ruby's environment access:**
+
+```ruby
+# ENV — hash-like object wrapping process environment
+ENV["HOME"]            # => "/home/user"
+ENV["API_KEY"]         # => "sk-..."
+ENV.fetch("PORT", "3000")  # with default
+
+# ARGV — array of command-line arguments
+# ruby script.rb --verbose data.json
+ARGV[0]  # => "--verbose"
+ARGV[1]  # => "data.json"
+# Note: ARGV[0] is first arg, NOT program name ($0 is program name)
+
+# Destructuring
+first, *rest = ARGV
+```
+
+**ilo relevance:**
+- ilo already handles CLI arguments via function parameters: `ilo 'f x:n y:n>n;+x y' 3 4` maps positional args to params.
+- `ENV` access is not currently in ilo. For agent use, environment variables are important for:
+  - API keys (`ENV["OPENAI_KEY"]`)
+  - Configuration (`ENV["DATABASE_URL"]`)
+  - Feature flags (`ENV["DEBUG"]`)
+- A builtin `env "KEY"` returning `R t t` (Ok=value, Err=not set) would be minimal. Or `env "KEY"` returning the value or nil, combined with `??`: `k=env "API_KEY"??"default"`.
+- This is a 3-char builtin (matches `get`, `len`, `str`, `num`, `abs`, `min`, `max`, `flr`, `cel`, `spl`, `cat`, `has`, `srt`, `slc`, `rev`).
+
+---
+
+### 1.9 Backtick Execution — Deep Dive
+
+**Exact mechanics:**
+
+1. Ruby encounters `` `cmd` `` or `%x(cmd)`
+2. Calls `Kernel#`` ` `` method (yes, backtick is a method name)
+3. Forks the current process via `fork()`
+4. In the child process, calls `exec(cmd)` via `/bin/sh -c cmd`
+5. Parent process waits (blocking) for child to complete
+6. Captures child's stdout into a String
+7. Sets `$?` to `Process::Status` object
+8. Returns the captured stdout String
+
+**What gets captured:** Only stdout. Stderr goes to the parent's stderr (visible in terminal but not captured). To capture stderr: `` `cmd 2>&1` `` (redirect in shell) or use `Open3.capture3`.
+
+**Return value:** Always a String (stdout content). Empty string on failure (non-zero exit). The *exit status* is in `$?`, not the return value. This is a design flaw — success/failure is a side channel.
+
+**String interpolation:** Backticks support `#{}` interpolation:
+```ruby
+file = "data.json"
+content = `cat #{file}`
+```
+
+**The `%x` alternative:** Identical to backticks but with configurable delimiters. Useful when the command itself contains backticks.
+
+**Overridability:** Since `` ` `` is a Kernel method, it can be overridden:
+```ruby
+def `(cmd)
+  puts "Would run: #{cmd}"
+  "mocked output"
+end
+`dangerous-command`  # => prints warning, returns mock
+```
+
+**ilo relevance — the case for a shell builtin:**
+
+Ruby's backtick is essentially: `run_shell(cmd: string) -> stdout: string` with exit status on the side. ilo could do this better:
+
+```
+-- Hypothetical shell execution builtin
+sh "ls -la"              -- R t t: Ok=stdout, Err=stderr+exitcode
+sh! "cat data.json"      -- auto-unwrap: stdout or propagate error
+d=sh! "curl -s api.com"  -- capture API response
+```
+
+This maps perfectly to ilo's existing patterns:
+- Returns `R t t` like `get`
+- Works with `!` auto-unwrap
+- Works with `?` match for error handling
+- 2 chars / 1 token for the builtin name
+
+**Why this matters for agents:** Shell execution is the universal escape hatch. An agent with `sh` can do anything the host system can do — install packages, run scripts, process files, call APIs, interact with git. It's the most powerful single capability an agent can have, and Ruby proved it works with a 1-character syntax.
+
+---
+
+### 1.10 Blocks and Iterators — Composition Model
+
+**How Ruby composes operations:**
+
+```ruby
+# Block: anonymous code passed to a method
+[1,2,3].map { |x| x * 2 }         # => [2,4,6]
+[1,2,3].select { |x| x > 1 }      # => [2,3]
+[1,2,3].reduce(0) { |sum, x| sum + x }  # => 6
+
+# Chaining blocks (method chaining)
+users
+  .select { |u| u.active? }
+  .map { |u| u.name }
+  .sort
+  .first(10)
+
+# yield — inject caller's code into a method
+def with_retry(n)
+  n.times do |attempt|
+    result = yield(attempt)
+    return result if result
+  rescue => e
+    raise if attempt == n - 1
+  end
+end
+
+with_retry(3) { |i| http_get(url) }
+
+# Proc/Lambda — blocks as objects
+doubler = ->(x) { x * 2 }
+[1,2,3].map(&doubler)  # => [2,4,6]
+
+# to_proc shorthand
+["hello", "world"].map(&:upcase)  # => ["HELLO", "WORLD"]
+```
+
+**The composition model:**
+
+Ruby blocks are the key to its expressiveness. They enable:
+1. **Internal iteration** — the collection controls traversal, the block provides the logic
+2. **Resource management** — `File.open { |f| ... }` guarantees close
+3. **Custom control flow** — `with_retry(3) { action }` is a user-defined control structure
+4. **Lazy evaluation** — `(1..Float::INFINITY).lazy.select(&:odd?).first(10)`
+
+**Method chaining + blocks** creates a pipeline:
+```ruby
+data
+  .map { |row| parse(row) }        # transform
+  .select { |r| r.valid? }         # filter
+  .group_by { |r| r.category }     # aggregate
+  .transform_values { |v| v.count } # summarize
+```
+
+**ilo relevance — what maps to ilo:**
+
+| Ruby Pattern | ilo Equivalent | Token Cost |
+|-------------|---------------|------------|
+| `arr.map { \|x\| x * 2 }` | `@x xs{*x 2}` | ilo: 6 tokens, Ruby: ~10 |
+| `arr.select { \|x\| x > 1 }` | No direct equivalent (need filter builtin or tool) | -- |
+| `arr.reduce(0) { \|s,x\| s+x }` | `s=0;@x xs{s=+s x};s` (with while) | ilo: ~12, Ruby: ~12 |
+| Method chaining | `>>` pipe operator | Similar |
+| `File.open { }` (cleanup) | Tool handles cleanup | N/A |
+
+**Gaps revealed:**
+- **`filter`/`select`**: ilo's `@` always produces a list by collecting results. There's no built-in filter. A `flt xs fn` builtin (filter list by predicate) would fill this gap. Or: `@` with a guard that skips elements.
+- **`reduce`/`fold`**: No builtin. Expressible with `wh` + accumulator but verbose. A `fld xs init fn` builtin would save significant tokens for aggregation.
+- **Block-as-argument**: Ruby passes blocks to methods. ilo has no closures/lambdas/first-class functions. This is intentional (constrained vocabulary), but means patterns like `with_retry(3) { action }` must be expressed differently — via `tool` declarations with `retry:n`.
+
+---
+
+## 2. PHP Capabilities Catalog
+
+### 2.1 What Made PHP Successful for Web
+
+**The low-ceremony design:**
+
+| Feature | PHP | Traditional Languages |
+|---------|-----|----------------------|
+| Handle HTTP GET | `$_GET["name"]` | Parse request object, extract params |
+| Handle HTTP POST | `$_POST["email"]` | Parse request body, decode form data |
+| Read environment | `$_ENV["DB_HOST"]` | Import os module, call getenv |
+| Read file | `file_get_contents("f.txt")` | Open, read, close (or context manager) |
+| HTTP GET request | `file_get_contents("https://...")` | Import HTTP library, create client, call |
+| Parse JSON | `json_decode($str)` | Import JSON module, call parse |
+| Execute shell | `shell_exec("cmd")` | Import subprocess, configure, call |
+
+**PHP's 4 key success patterns:**
+
+1. **Superglobals are ambient.** `$_GET`, `$_POST`, `$_ENV`, `$_SERVER` are always available. No imports, no initialization, no dependency injection. The HTTP request is *just there*.
+
+2. **URLs are files.** `file_get_contents("https://api.com/data")` uses the same function for local files and HTTP URLs. PHP's stream wrappers make the protocol transparent.
+
+3. **Everything returns immediately usable types.** `json_decode()` returns arrays/objects. `file_get_contents()` returns a string. No wrapper classes, no result objects (until recently).
+
+4. **The program IS the request handler.** In PHP's original model, each `.php` file handles one URL. No routing framework, no application object, no main function. The file executes and the output is the response.
+
+### 2.2 PHP Process Execution
+
+| Function | Returns | stdout | stderr | Exit status |
+|----------|---------|--------|--------|-------------|
+| `shell_exec($cmd)` | stdout as string (or null) | Captured | No | No |
+| `exec($cmd, &$out, &$ret)` | Last line of stdout | Via reference array | No | Via reference |
+| `system($cmd, &$ret)` | Last line (also prints) | Prints to output | No | Via reference |
+| `passthru($cmd, &$ret)` | void (raw to browser) | Direct passthrough | Direct | Via reference |
+| `proc_open(...)` | Resource handle | Via pipes | Via pipes | Via `proc_close()` |
+
+**Notable:** `shell_exec()` is literally aliased to the backtick operator in PHP: `` $output = `ls -la`; `` is identical to `$output = shell_exec("ls -la");`. PHP borrowed Ruby's backtick syntax.
+
+### 2.3 PHP Superglobals — Agent Relevance
+
+| Superglobal | Purpose | Agent Equivalent |
+|-------------|---------|-----------------|
+| `$_GET` | URL query parameters | Tool call arguments (already in ilo) |
+| `$_POST` | Form/request body data | Tool call arguments |
+| `$_ENV` | Environment variables | `env` builtin (proposed) |
+| `$_SERVER` | Server/request metadata | Runtime context (not needed in ilo) |
+| `$_COOKIE` | HTTP cookies | Not relevant for agents |
+| `$_SESSION` | Session state | State between tool calls (deferred) |
+| `$_FILES` | Uploaded files | Tool concern |
+| `$GLOBALS` | All global variables | Anti-pattern for ilo (no globals) |
+
+**Analysis:** The superglobal that matters most for agents is `$_ENV`. Agents need configuration (API keys, endpoints, feature flags) and environment variables are the standard way to provide it. `$_GET`/`$_POST` map to ilo's existing tool parameter mechanism — when a tool is called, arguments are the "request."
+
+### 2.4 PHP Data Formats
+
+| Format | Built-in? | Parse | Generate |
+|--------|-----------|-------|----------|
+| JSON | Yes | `json_decode($s)` → array/object | `json_encode($v)` |
+| XML | Yes (SimpleXML, DOM) | `simplexml_load_string($s)` | Built-in |
+| CSV | Yes | `str_getcsv($s)` / `fgetcsv($f)` | `fputcsv($f, $row)` |
+| YAML | No (ext: yaml) | `yaml_parse($s)` | `yaml_emit($v)` |
+| INI | Yes | `parse_ini_file($f)` | No built-in |
+
+### 2.5 PHP String Manipulation & Regex
+
+PHP uses PCRE (Perl-Compatible Regular Expressions) via `preg_*` functions:
+
+```php
+// Match
+preg_match('/(\d+)/', 'age: 30', $matches);
+$matches[1]  // => "30"
+
+// Replace
+preg_replace('/\d+/', 'X', 'age: 30');  // => "age: X"
+
+// Split
+preg_split('/\s*,\s*/', 'a, b, c');  // => ["a", "b", "c"]
+```
+
+**Notable:** PHP's regex returns `1`/`0`/`false` — three distinct values that are easy to confuse due to loose typing. This is a classic PHP footgun.
+
+### 2.6 PHP Error Handling
+
+PHP evolved from error codes to exceptions:
+
+```php
+// Modern try/catch (PHP 5+)
+try {
+    $data = json_decode(file_get_contents($url), true, 512, JSON_THROW_ON_ERROR);
+} catch (JsonException $e) {
+    echo "Parse failed: " . $e->getMessage();
+}
+
+// Traditional: functions return false on failure
+$content = file_get_contents("missing.txt");  // returns false
+if ($content === false) {
+    // handle error
+}
+```
+
+**Agent relevance:** PHP's mixed error model (some functions return false, some throw, some set error codes) is exactly what ilo avoids. ilo's uniform `R ok err` + `!` auto-unwrap is cleaner.
+
+### 2.7 PHP Concurrency
+
+PHP is traditionally single-threaded per request. Modern options:
+- **Fibers** (PHP 8.1+) — cooperative multitasking
+- **parallel** extension — true multi-threading
+- **pcntl_fork()** — process forking
+- **ReactPHP / Amp** — async event loops
+
+Not particularly relevant for ilo's current design.
+
+---
+
+## 3. Patterns Worth Adopting for ilo
+
+### 3.1 Shell Execution Builtin (from Ruby backticks) -- HIGH VALUE
+
+**The pattern:** Ruby's backtick syntax gives agents shell access in 2 tokens. PHP's `shell_exec()` / backtick alias does the same.
+
+**Proposed ilo equivalent:**
+
+```
+-- sh: execute shell command, returns R t t (Ok=stdout, Err=stderr+code)
+sh "ls -la"                    -- R t t
+d=sh! "cat data.json"         -- auto-unwrap stdout
+sh! "git add -A"              -- fire-and-forget (discard stdout)
+sh "curl -s https://api.com"  -- but prefer get for HTTP
+```
+
+**Why:**
+- `sh` is 2 chars / 1 token, matches the builtin naming convention
+- Returns `R t t` — consistent with `get`
+- Works with `!` auto-unwrap and `?` match
+- Gives agents universal system access — file ops, git, package management, anything
+- The tool mechanism is for structured API calls; `sh` is for unstructured system commands
+- Combined with `get` for HTTP and `sh` for shell, an agent can interact with almost anything
+
+**Token comparison:**
+```
+-- Read a file:
+d=sh! "cat data.json"      -- 6 tokens in ilo
+`cat data.json`             -- 3 tokens in Ruby (but no error handling)
+
+-- With error handling:
+sh "cat data.json";?{~d:use d;^e:^e}   -- 12 tokens in ilo (typed, explicit)
+```
+
+**Tradeoff:** `sh` is inherently untyped — it returns text. The agent must parse the output. This is the bash problem ilo was designed to avoid. Mitigation: `sh` is the escape hatch, not the primary interface. Typed tools are preferred; `sh` is for when no tool exists.
+
+### 3.2 Environment Variable Access (from Ruby ENV / PHP $_ENV) -- HIGH VALUE
+
+**The pattern:** Both Ruby (`ENV["KEY"]`) and PHP (`$_ENV["KEY"]`) provide direct access to environment variables.
+
+**Proposed ilo equivalent:**
+
+```
+-- env: read environment variable
+k=env "API_KEY"              -- returns value or nil
+k=env "API_KEY"??"default"   -- with nil-coalesce for defaults
+k=env "PORT";p=num k??3000   -- parse to number with default
+```
+
+**Why:**
+- Agents need configuration: API keys, endpoints, database URLs
+- `env` is 3 chars / 1 token, matches existing builtins
+- Returns `t` or nil (not `R t t` — missing env vars aren't "errors", they're absent values)
+- Composes with `??` for defaults
+- No import or setup required (like PHP superglobals — just there)
+
+### 3.3 Regex Match Builtin (from Ruby regex / PHP preg_match) -- MEDIUM VALUE
+
+**The pattern:** Both Ruby (`=~`, `.match`, `.gsub`) and PHP (`preg_match`, `preg_replace`) provide built-in regex.
+
+**Proposed ilo equivalent:**
+
+```
+-- rx: regex match, returns R L t t (Ok=list of captures, Err=no match)
+rx "age: 30" "(\d+)"        -- R L t t: Ok=["30"]
+m=rx! text pattern           -- auto-unwrap captures
+
+-- rxr: regex replace
+rxr "age: 30" "\d+" "X"     -- "age: X"
+```
+
+**Why:**
+- Agents frequently extract structured data from text (parse URLs, dates, numbers, log lines)
+- Without regex, text extraction requires chaining `spl`/`has`/`slc` — error-prone and verbose
+- `rx` is 2 chars / 1 token
+- Returns `R L t t` — captures as list of text, consistent with ilo types
+
+**Tradeoff:** Regex patterns are notoriously token-expensive. `/(\d{4})-(\d{2})-(\d{2})/` is many tokens. But the alternative (manual parsing) is even more tokens. Regex is net-positive for token cost.
+
+### 3.4 Filter/Reduce Builtins (from Ruby blocks + Enumerable) -- MEDIUM VALUE
+
+**The pattern:** Ruby's `select`/`reject`/`reduce` with blocks compose operations on collections.
+
+**The gap:** ilo's `@` iterates and collects. There's no filter or fold.
+
+**Proposed:**
+
+```
+-- Today: filter requires manual accumulation
+r=[];@x xs{>x 5{+=r x}};r
+
+-- Proposed: flt builtin with inline predicate
+-- Option A: builtin with expression (needs lambda/expression-as-value)
+-- Option B: keep using @ with conditional append (already works)
+```
+
+**Assessment:** This is harder to adopt without first-class functions. Ruby's blocks work because you can pass code to a method. ilo intentionally lacks closures. The current `@` + guard + `+=` pattern is verbose but works. A `flt` builtin would need a way to express the predicate — this likely requires a design decision about anonymous expressions or lambda syntax.
+
+**Defer until ilo considers closures or expression parameters.**
+
+### 3.5 PHP's "URLs Are Files" Pattern -- ALREADY ADOPTED
+
+**The pattern:** PHP's `file_get_contents($url)` treats URLs like files.
+
+**ilo status:** Already adopted. `get url` is the equivalent — one terse builtin for HTTP. ilo goes further by making it even more concise (`$url` alias) and adding typed error handling (`R t t`). This is one area where ilo is already ahead of both Ruby and PHP.
+
+### 3.6 Ruby's Pipe/Chain Composition -- ALREADY ADOPTED
+
+**The pattern:** Ruby's method chaining (`arr.map{}.select{}.first`) composes operations linearly.
+
+**ilo status:** Already adopted via `>>` pipe operator: `f x>>g>>h` desugars to `h(g(f(x)))`. This is the right model for agents — linear composition without naming intermediates.
+
+---
+
+## 4. Patterns NOT Worth Adopting
+
+### 4.1 Exception Handling (Ruby begin/rescue/ensure)
+
+**Why not:** ilo's Result type (`R ok err`) is strictly superior for agents. Exceptions are invisible in signatures. Results are explicit. Auto-unwrap (`!`) gives the ergonomic benefits of exceptions without the hidden control flow.
+
+### 4.2 Concurrency Primitives (Ruby threads/fibers/Ractors)
+
+**Why not (yet):** Agent programs are typically short-lived scripts, not long-running services. Concurrency matters at the runtime level (parallel tool calls) not the language level. Defer until agent patterns demand it.
+
+### 4.3 PHP Superglobals (beyond ENV)
+
+**Why not:** `$_GET`, `$_POST`, `$_SERVER` model a web request-response cycle. ilo agents don't serve HTTP — they consume APIs. Tool parameters replace GET/POST. The only superglobal worth adopting is `$_ENV` (as the `env` builtin above).
+
+### 4.4 Ruby's Custom Exception Hierarchies
+
+**Why not:** Error hierarchies require a class system. ilo's errors are text values in the Err branch of Result. Pattern matching on error text (`?r{^e:has e "timeout"{retry};^e:^e}`) is sufficient. Custom error types add vocabulary without proportional value.
+
+### 4.5 Block/Lambda/Closure (Ruby blocks, Proc, Lambda)
+
+**Why not (yet):** First-class functions increase the vocabulary and the valid-next-token space. ilo's "constrained" principle says fewer choices at each step. The `@` iterator + `>>` pipe + `?` match cover the most common composition patterns without closures. Revisit only if filter/fold patterns become frequent enough that the `@` + guard workaround costs more total tokens than adding lambdas.
+
+---
+
+## 5. Summary: Recommended Additions
+
+| Addition | Source | Chars | Tokens | Returns | Priority |
+|----------|--------|-------|--------|---------|----------|
+| `sh cmd` | Ruby backticks | 2 | 1 | `R t t` | High |
+| `env key` | Ruby ENV / PHP $_ENV | 3 | 1 | `t` or nil | High |
+| `rx text pat` | Ruby regex / PHP preg_match | 2 | 1 | `R L t t` | Medium |
+| `rxr text pat rep` | Ruby gsub / PHP preg_replace | 3 | 1 | `t` | Medium |
+| `post url body` | Ruby Net::HTTP / PHP streams | 4 | 1 | `R t t` | Medium |
+
+**What ilo already does better than both Ruby and PHP:**
+- HTTP GET: `get url` / `$url` — more concise than any Ruby or PHP equivalent
+- Error handling: `R ok err` + `!` + `?` — typed, explicit, composable, 0 hidden control flow
+- Tool composition: typed parameters, verified before execution, closed world
+- Process execution model (when `sh` is added): `sh cmd` → `R t t` is cleaner than Ruby's backtick+`$?` split or PHP's `shell_exec()` returning null on error
+
+**The big insight from this research:** Ruby and PHP both validate ilo's core design — concise builtins, minimal ceremony, treating external resources (HTTP, files, shell) as simple function calls returning usable values. Where they differ is in error handling and typing, and ilo's approach (typed Results) is superior for agent use. The main capability gaps are shell execution (`sh`) and environment access (`env`), both of which are trivial to add and would dramatically expand what an agent can do.

--- a/research/rust-capabilities-research.md
+++ b/research/rust-capabilities-research.md
@@ -1,0 +1,1134 @@
+# Rust Standard Library & Language Features: Research for ilo
+
+Rust's ownership model, type system, and standard library analyzed through ilo's lens: **total tokens from intent to working code**. Rust is the most technically relevant comparison language because ilo is implemented in Rust, shares Rust's explicit error handling philosophy (Result/Option, no exceptions), and targets a similar safety-before-execution ethos. This document catalogs Rust's capabilities, identifies gaps in ilo, and proposes minimal additions where the gap matters for AI agent workloads.
+
+---
+
+## Why Rust matters for ilo
+
+Rust and ilo share deep structural commitments:
+
+1. **Explicit error handling.** Rust has `Result<T, E>` and `Option<T>`. ilo has `R ok err` and the planned `O n`. Neither uses exceptions. Both force the programmer to handle failure structurally.
+2. **The `?` operator.** Rust's `?` auto-propagates errors up the call stack. ilo's `!` does the same thing in one character less (`get! url` vs `get(url)?`). Same semantics, terser syntax.
+3. **Exhaustive pattern matching.** Rust's `match` requires covering all variants. ilo's `?` matching checks exhaustiveness via verifier (ILO-T024). Both catch missed cases before runtime.
+4. **Verification before execution.** Rust refuses to compile unsound code. ilo verifies all calls resolve, all types align, all dependencies exist before executing anything.
+5. **No null.** Rust encodes absence as `Option<T>`. ilo has `_` (nil) at runtime but is adding `O n` (E2) to enforce nil-checking at the type level.
+
+Where they diverge: Rust prioritizes memory safety (ownership, lifetimes, borrowing). ilo has garbage collection (Rc/clone in the interpreter, value types in the VM) and does not need ownership semantics. Rust is general-purpose; ilo is agent-purpose. Rust optimizes for zero-cost abstractions; ilo optimizes for zero-cost token generation.
+
+---
+
+## 1. Error Handling
+
+### What Rust provides
+
+```rust
+// Result<T, E> — success or failure with typed error
+fn get_user(id: u64) -> Result<User, DbError> { ... }
+
+// Option<T> — present or absent
+fn find_item(name: &str) -> Option<Item> { ... }
+
+// ? operator — propagate error to caller
+fn process(id: u64) -> Result<String, AppError> {
+    let user = get_user(id)?;           // propagate DbError
+    let profile = get_profile(&user)?;  // propagate ProfileError
+    Ok(format!("{}: {}", user.name, profile.bio))
+}
+
+// From/Into conversions — automatic error type widening
+impl From<DbError> for AppError {
+    fn from(e: DbError) -> Self { AppError::Db(e) }
+}
+
+// map, and_then, unwrap_or, unwrap_or_else on Result/Option
+let name = get_user(id)
+    .map(|u| u.name)
+    .unwrap_or("unknown".to_string());
+
+// ok_or / ok_or_else — Option to Result conversion
+let item = find_item("key").ok_or(AppError::NotFound)?;
+```
+
+### What ilo has
+
+| Rust | ilo | Status |
+|------|-----|--------|
+| `Result<T, E>` | `R ok err` | Implemented |
+| `Option<T>` | `O n` | Planned (E2) |
+| `?` operator | `!` auto-unwrap | Implemented |
+| `From<E>` conversions | None | Gap |
+| `.map()` on Result | None | Gap |
+| `.unwrap_or()` | `??` (nil-coalesce) | Implemented (for nil) |
+| `.and_then()` | `!` chaining | Partial |
+| `ok_or()` (Option->Result) | None | Gap |
+
+### Gap analysis
+
+**1a. Error type conversion (From/Into)**
+
+Rust's `?` operator calls `.into()` on the error type, allowing automatic widening: a function returning `Result<T, AppError>` can use `?` on a `Result<T, DbError>` if `From<DbError> for AppError` exists. This means different error types compose seamlessly.
+
+ilo's `!` only works when the caller and callee have the same error type. If `get-user` returns `R profile t` and `charge` returns `R receipt t`, chaining works because both error types are `t`. But if error types differ, `!` cannot auto-convert.
+
+**Does this matter for agents?** Moderately. In practice, most ilo tools return `R ok t` where the error type is always text. Rust's rich error type hierarchies exist because Rust programs are long-lived and need to distinguish error kinds for recovery. Agent programs are short-lived and typically either retry or propagate. Text errors are sufficient for 90% of agent use cases.
+
+**Minimal fix if needed:** No language change required. Convention is sufficient: all tool errors are `t` (text). If typed errors become necessary, sum types (E3) provide the mechanism, and a future `From`-like trait (E6) could enable auto-conversion. But this is very low priority.
+
+**1b. Combinators on Result (map, and_then, unwrap_or)**
+
+Rust's Result combinators enable functional-style error handling without `match`:
+
+```rust
+let name = get_user(id)
+    .map(|u| u.name)                    // transform Ok value
+    .unwrap_or("unknown".to_string());  // default on Err
+```
+
+ilo's equivalent today:
+
+```
+r=get-user id;?r{~u:u.name;^_:"unknown"}
+```
+
+This is 11 tokens vs Rust's ~12 tokens (after tokenization). The gap is small. With pipes (already implemented), the pattern becomes slightly more composable, but Result combinators require lambda syntax (E5) to be truly useful.
+
+**Does this matter for agents?** Low. The match-based pattern in ilo is already terse. Combinators save tokens only for simple transforms, and ilo's `!` handles the most common case (propagation) in 1 token.
+
+**1c. Option-to-Result conversion (ok_or)**
+
+Rust's `option.ok_or(error)` converts `None` to `Err(error)`. This bridges optional values into the error-handling pipeline.
+
+ilo's equivalent would be:
+
+```
+?val{_:^"not found";~v:~v}
+```
+
+7 tokens. A dedicated conversion is slightly more terse but infrequent enough to defer.
+
+**Does this matter for agents?** Low. The pattern appears occasionally (checking if a key exists before using it), but it is well-served by the existing match syntax. If Optional (E2) lands, `val??^"not found"` could work as an idiomatic pattern with nil-coalesce producing an Err, but this needs design thought.
+
+### Verdict
+
+ilo's error handling is strong. The `R`/`!`/`?` trio covers the same ground as Rust's `Result`/`?`/`match`. The main gap is Optional (`O`), which is tracked as E2 and is the next type system priority. Error type conversion and Result combinators are low priority -- the text-error convention and match syntax are sufficient for agents.
+
+---
+
+## 2. Traits and Generics
+
+### What Rust provides
+
+```rust
+// Generics — write once, use with any type
+fn first<T>(items: &[T]) -> Option<&T> {
+    items.first()
+}
+
+// Trait — shared behavior across types
+trait Summary {
+    fn summarize(&self) -> String;
+}
+
+impl Summary for Article {
+    fn summarize(&self) -> String {
+        format!("{}: {}", self.title, self.author)
+    }
+}
+
+// Trait bounds — constrain generic types
+fn notify<T: Summary>(item: &T) {
+    println!("Breaking: {}", item.summarize());
+}
+
+// Iterator trait — the foundation of collection processing
+trait Iterator {
+    type Item;
+    fn next(&mut self) -> Option<Self::Item>;
+}
+```
+
+### What ilo has
+
+ilo is fully monomorphic. No type variables, no polymorphism, no generics. Every function has a fixed, concrete type signature.
+
+### Gap analysis
+
+**2a. Generics for builtins (map, filter, fold)**
+
+The biggest pain point: ilo cannot type-check generic list operations. `map f xs` needs the signature `fn(fn(a>b), L a) > L b`, which requires type variables. Without generics, map/filter/fold are either:
+
+- Untyped builtins (verifier skips them) -- loses the "verification before execution" guarantee
+- Per-type variants (`map-n`, `map-t`) -- combinatorial explosion
+- Inline loops (`@x xs{...}`) -- verbose but fully typed
+
+The inline loop is ilo's current answer:
+
+```
+-- Rust: items.iter().map(|x| x * 2).collect::<Vec<_>>()
+-- ilo:  @x items{*x 2}
+```
+
+The ilo version is 5 tokens. Rust's is ~13 tokens. ilo wins on token count already. The issue is not terseness -- it is composability. You cannot chain `@` loops without intermediate variables:
+
+```
+-- Rust: items.iter().filter(|x| x > 5).map(|x| x * 2).sum()
+-- ilo:  a=@x items{>x 5{x}};b=@x a{*x 2};s=0;@x b{s=+s x};s
+```
+
+15 tokens vs Rust's ~15 tokens. But with generic builtins + pipe:
+
+```
+-- ilo (future): flt {>_ 5} items>>map {*_ 2}>>fld + 0
+```
+
+~12 tokens. Marginal savings, but much more readable for complex chains.
+
+**Does this matter for agents?** Medium. Agents generate list processing frequently (filtering API results, transforming data, aggregating). The inline `@` loop works but requires more structural tokens. Generic builtins would reduce generation complexity.
+
+**2b. Traits / interfaces**
+
+Rust traits enable:
+- Polymorphic dispatch (call `.summarize()` on any type that implements Summary)
+- Operator overloading (via `Add`, `Display`, etc.)
+- Collection abstractions (Iterator, IntoIterator)
+
+**Does this matter for agents?** No. As noted in ilo's TYPE-SYSTEM.md: "Agents generate concrete code for specific tasks. They don't write frameworks or abstract interfaces." Traits solve the human problem of code reuse across a codebase maintained over time. Agent programs are disposable -- generated fresh per task. There is no codebase to maintain, no library to abstract.
+
+**2c. Associated types and type-level computation**
+
+Rust's associated types (`type Item` in Iterator), const generics (`[T; N]`), and GATs (generic associated types) are powerful but complex. They solve problems that arise in large-scale library design.
+
+**Does this matter for agents?** No. These features add complexity to type annotations without reducing agent error rates. The type annotation tax (already 17-22% of ilo program tokens) would increase significantly.
+
+### Verdict
+
+Generics (E5) are the one feature from this category worth pursuing, specifically to enable typed `map`/`flt`/`fld` builtins. Traits (E6) and associated types are out of scope. The implementation order is correct: E5 is fifth priority, gated on lambda syntax, and E6 is deferred indefinitely.
+
+---
+
+## 3. Iterators and Collection Processing
+
+### What Rust provides
+
+Rust's iterator system is its crown jewel for data processing:
+
+```rust
+// Lazy iterator chain — nothing allocates until .collect()
+let result: Vec<i32> = items.iter()
+    .filter(|x| **x > 5)
+    .map(|x| x * 2)
+    .take(10)
+    .collect();
+
+// fold/reduce
+let sum: i32 = items.iter().fold(0, |acc, x| acc + x);
+let sum: i32 = items.iter().sum(); // sugar for fold with Add
+
+// zip — pair two iterators
+let pairs: Vec<_> = names.iter().zip(scores.iter()).collect();
+
+// enumerate — index + value
+for (i, item) in items.iter().enumerate() { ... }
+
+// chain — concatenate iterators
+let all: Vec<_> = first.iter().chain(second.iter()).collect();
+
+// find, any, all, position, count
+let found = items.iter().find(|x| **x > 100);
+let has_big = items.iter().any(|x| *x > 100);
+
+// flat_map — map + flatten
+let words: Vec<&str> = lines.iter().flat_map(|l| l.split(' ')).collect();
+
+// partition — split by predicate
+let (big, small): (Vec<_>, Vec<_>) = items.iter().partition(|x| **x > 50);
+
+// windows, chunks — sliding/fixed-size views
+for window in items.windows(3) { ... }
+for chunk in items.chunks(5) { ... }
+```
+
+### What ilo has
+
+| Rust iterator | ilo equivalent | Tokens | Gap? |
+|--------------|----------------|--------|------|
+| `.map(\|x\| x*2)` | `@x xs{*x 2}` | 5 | None -- ilo is terser |
+| `.filter(\|x\| x>5)` | `@x xs{>x 5{x}}` | 7 | Slight gap -- guard-as-filter is verbose |
+| `.fold(0, \|a,x\| a+x)` | `s=0;@x xs{s=+s x};s` | 8 | Gap -- `fld + 0 xs` would be 4 |
+| `.sum()` | `s=0;@x xs{s=+s x};s` | 8 | Same gap as fold |
+| `.collect()` | Implicit (@ always returns list) | 0 | ilo wins -- no allocation ceremony |
+| `.zip(other)` | No equivalent | -- | Gap |
+| `.enumerate()` | No equivalent | -- | Gap |
+| `.chain(other)` | `+xs ys` (list concat) | 3 | None -- already concise |
+| `.find(\|x\| x>100)` | `@x xs{>x 100{ret x}}` | 8 | Gap -- ret-from-loop workaround |
+| `.any(\|x\| x>100)` | `@x xs{>x 100{ret true}};false` | 10 | Gap |
+| `.flat_map(f)` | No equivalent | -- | Gap |
+| `.partition(pred)` | No equivalent | -- | Gap |
+| `.take(n)` | `slc xs 0 n` | 4 | None -- slice covers this |
+| `.skip(n)` | `slc xs n (len xs)` | 5 | Slight gap -- needs len call |
+| `.rev()` | `rev xs` | 2 | None |
+| `.sort()` | `srt xs` | 2 | None |
+| `.count()` | `len xs` | 2 | None |
+
+### Gap analysis
+
+**3a. Fold/reduce -- the biggest iterator gap**
+
+Sum, product, max, min of a list -- these are among the most common list operations in agent code (aggregating API results, computing totals, finding extremes). ilo requires 8 tokens for a sum:
+
+```
+s=0;@x xs{s=+s x};s
+```
+
+Rust requires ~8 tokens too (`.iter().fold(0, |a,x| a+x)`), but has sugar: `.sum()` is 2 tokens.
+
+ilo's planned `fld` builtin would match:
+```
+fld + 0 xs     -- 4 tokens
+```
+
+Gates on E5 (generics). However, a monomorphic special-case approach could work sooner: hardcode `fld` for `+`, `*`, `max`, `min` on `L n` without full generics. This is the approach recommended in TODO.md.
+
+**Does this matter for agents?** Yes. Aggregation appears in nearly every data-processing task. Saving 4 tokens per aggregation adds up.
+
+**Minimal fix:** Implement `fld` as a monomorphic builtin for numeric lists first. Signature: `fld op:t init:n xs:L n > n` where `op` is one of `"+"`, `"*"`, `"max"`, `"min"`. No generics needed. 4 tokens for any numeric aggregation.
+
+**3b. Enumerate -- index + value iteration**
+
+Rust's `.enumerate()` pairs each element with its index. Common when agents need position-aware processing (e.g., "process the third item differently").
+
+ilo's workaround:
+```
+i=0;@x xs{process i x;i=+i 1}    -- 10 tokens
+```
+
+With range iteration (F7, planned):
+```
+@i 0..len xs{x=xs.i;process i x}  -- 8 tokens
+```
+
+**Does this matter for agents?** Medium. Index-aware iteration appears in ~20% of list processing tasks. Range iteration (F7) partially addresses this.
+
+**Minimal fix:** Range iteration (F7) is the pragmatic answer. A dedicated `enum` builtin (`@ix xs{...}` where `i` and `x` are bound) would save 2-3 tokens but adds parsing complexity.
+
+**3c. Zip -- parallel iteration**
+
+Rust's `.zip()` pairs elements from two iterators. Used for correlating two lists (names + scores, keys + values).
+
+ilo has no equivalent. Workaround:
+```
+@i 0..len xs{a=xs.i;b=ys.i;process a b}  -- 10 tokens
+```
+
+**Does this matter for agents?** Low-medium. Zip appears in data correlation tasks but is less common than map/filter/fold.
+
+**Minimal fix:** A `zip` builtin returning `L L` (list of pairs) would be natural: `zs=zip xs ys;@p zs{p.0 p.1}`. But this requires tuples or nested lists as pairs, which adds complexity. Defer until range iteration (F7) provides the workaround.
+
+**3d. Find -- first match**
+
+Finding the first element matching a predicate. Common in agent lookups.
+
+ilo's workaround with `ret`:
+```
+@x xs{>x 100{ret x}};_    -- 8 tokens
+```
+
+This works with early return (F5, implemented). The 8-token cost is acceptable.
+
+**Does this matter for agents?** Low. The ret-from-loop pattern is clear and functional.
+
+**3e. Flat_map -- map + flatten**
+
+Transforms each element into a list and concatenates. Used for "split all lines into words" or "get all items from all orders."
+
+ilo has no equivalent. Workaround:
+```
+r=[];@x xs{ys=get-items x;r=+r ys};r    -- 11 tokens
+```
+
+**Does this matter for agents?** Low. Nested list flattening appears occasionally. A `flat` builtin (flatten one level) plus `@` loop covers it.
+
+### Verdict
+
+ilo's `@` loop is surprisingly competitive with Rust's iterators for simple cases. The main gaps:
+
+1. **Fold/reduce** -- high priority. Implement `fld` as monomorphic builtin (no generics needed).
+2. **Enumerate/index loops** -- medium priority. Range iteration (F7) is the answer.
+3. **Zip, flat_map, partition** -- low priority. Workarounds exist via range iteration + concat.
+
+The lazy evaluation aspect of Rust iterators (no intermediate allocations) is irrelevant for ilo -- agent programs process small datasets. Allocation efficiency is a non-concern.
+
+---
+
+## 4. Concurrency
+
+### What Rust provides
+
+```rust
+// async/await (with tokio)
+async fn fetch_all(urls: Vec<String>) -> Vec<Result<String, Error>> {
+    let futures: Vec<_> = urls.into_iter()
+        .map(|url| reqwest::get(url))
+        .collect();
+    futures::future::join_all(futures).await
+}
+
+// Channels (mpsc)
+let (tx, rx) = tokio::sync::mpsc::channel(100);
+tokio::spawn(async move {
+    tx.send("hello").await.unwrap();
+});
+let msg = rx.recv().await.unwrap();
+
+// Mutex, RwLock, Arc for shared state
+let counter = Arc::new(Mutex::new(0));
+
+// tokio::spawn — lightweight tasks
+tokio::spawn(async { long_running_task().await });
+
+// select! — wait for first of multiple futures
+tokio::select! {
+    msg = rx.recv() => handle_message(msg),
+    _ = tokio::time::sleep(Duration::from_secs(5)) => handle_timeout(),
+}
+
+// Streams — async iterators
+let mut stream = tokio_stream::wrappers::ReceiverStream::new(rx);
+while let Some(item) = stream.next().await {
+    process(item);
+}
+```
+
+### What ilo has
+
+ilo is fully synchronous. `get url` blocks until the response arrives. There is no async, no spawn, no channels, no parallel execution.
+
+### Gap analysis
+
+**4a. Parallel tool calls**
+
+The single most important concurrency pattern for agents: call multiple independent tools simultaneously.
+
+```rust
+// Rust: parallel HTTP requests
+let (user, orders, profile) = tokio::join!(
+    get_user(id),
+    get_orders(id),
+    get_profile(id),
+);
+```
+
+ilo today (sequential):
+```
+u=get-user! id;o=get-orders! id;p=get-profile! id
+```
+
+Three sequential HTTP calls. If each takes 200ms, total is 600ms. Parallel would be ~200ms.
+
+**Does this matter for agents?** Yes. Agent workloads are I/O-bound. An agent orchestrating API calls spends most time waiting for responses. Parallel calls directly reduce wall-clock time.
+
+**Minimal fix:** The planned `par{...}` syntax (G4) is correct:
+```
+par{u=get-user id;o=get-orders id;p=get-profile id}
+```
+
+Internally async (tokio), externally sequential from the ilo program's perspective. The agent does not need to think about concurrency -- the runtime parallelizes independent calls. This is the right design: no new concepts (promises, futures, await), just a block that says "run these in parallel."
+
+Token cost: 1 token (`par`) + braces. Net saving: none in tokens, significant in wall-clock time.
+
+**4b. Async/await as a language feature**
+
+Should ilo expose async/await to the programmer?
+
+Rust requires explicit async/await because it has no runtime -- the programmer must choose an executor (tokio, async-std) and manage future lifetimes. This explicitness is the Rust way.
+
+For ilo, the answer is clearly **no**. Reasons:
+
+1. **Manifesto: "one way to do things."** Adding async/await creates two worlds: sync functions and async functions. This doubles the vocabulary.
+2. **Agents do not manage concurrency.** An agent generates a sequence of tool calls. The runtime manages parallelism. This is the same philosophy as SQL: you describe what you want, the engine decides how to execute it.
+3. **Token cost.** `async`, `await`, promise types, error handling across async boundaries -- all add tokens with no reduction in agent error rate.
+
+The correct approach is runtime-managed parallelism behind `par{}`, with the ilo program remaining sequential.
+
+**4c. Channels and message passing**
+
+Rust's channels (mpsc, broadcast, watch) enable inter-task communication. Relevant for:
+- WebSocket event handling (G2)
+- Process output streaming (G3)
+- Long-running background tasks
+
+ilo's planned design uses blocking calls (`ws-recv conn`) rather than channels. This is simpler and sufficient for CDP-style request-response patterns.
+
+**Does this matter for agents?** Low for now. If ilo needs event-driven patterns (multiple WebSocket connections, SSE streams), channels or a `poll`/`select` mechanism becomes necessary. But this is deferred to G9 (event/callback model).
+
+**4d. Shared state (Mutex, Arc)**
+
+Rust's ownership model makes shared mutable state explicit via `Arc<Mutex<T>>`. This prevents data races at compile time.
+
+**Does this matter for agents?** No. ilo programs are single-threaded from the language's perspective. If `par{}` runs calls in parallel, each call is independent -- no shared mutable state. The runtime manages internal synchronization. The agent never needs Mutex/Arc.
+
+### Verdict
+
+Concurrency is a runtime concern, not a language concern for ilo. The right additions:
+
+1. **`par{...}`** -- parallel tool calls (G4). High priority for agent performance.
+2. **Runtime-internal async** -- tokio behind the scenes for non-blocking I/O. Already planned (D1d, G4).
+3. **No language-level async/await.** No channels, no mutexes, no futures in the language.
+
+This matches Go's original philosophy of hiding concurrency behind goroutines + channels at the runtime level, except ilo goes further by hiding channels too. The agent writes sequential code; the runtime optimizes.
+
+---
+
+## 5. File I/O
+
+### What Rust provides
+
+```rust
+// Read file — one-liner
+let content = std::fs::read_to_string("config.json")?;
+
+// Write file — one-liner
+std::fs::write("output.txt", content)?;
+
+// Path manipulation
+let path = Path::new("/home").join("user").join("file.txt");
+let ext = path.extension();
+let parent = path.parent();
+let exists = path.exists();
+
+// Directory listing
+for entry in std::fs::read_dir("./")? {
+    let entry = entry?;
+    println!("{}", entry.path().display());
+}
+
+// Metadata
+let meta = std::fs::metadata("file.txt")?;
+println!("size: {}, modified: {:?}", meta.len(), meta.modified());
+
+// Buffered reading (large files)
+let file = File::open("big.txt")?;
+let reader = BufReader::new(file);
+for line in reader.lines() {
+    let line = line?;
+    process(line);
+}
+
+// Create directories recursively
+std::fs::create_dir_all("path/to/nested/dir")?;
+
+// Temp files
+let tmp = tempfile::NamedTempFile::new()?;
+```
+
+### What ilo has
+
+Nothing. No file system access. Already planned as G8.
+
+### Gap analysis
+
+**5a. Read/write files**
+
+The most fundamental agent operation after HTTP. Agents read configs, source files, data files. They write generated code, logs, results.
+
+Rust's `fs::read_to_string` / `fs::write` are one-liners. ilo's planned equivalents:
+
+| Rust | ilo (planned G8) | Tokens |
+|------|-------------------|--------|
+| `fs::read_to_string("f")?` | `fread! "f"` | 2 |
+| `fs::write("f", data)?` | `fwrite! "f" data` | 3 |
+| `path.exists()` | `fexists "f"` | 2 |
+
+ilo is terser. The design is correct: simple builtins, `R` return type, `!` auto-unwrap.
+
+**Does this matter for agents?** Yes. File I/O is essential. This is a blocking gap.
+
+**Minimal fix:** Implement G8 (`fread`, `fwrite`, `fexists`, `fappend`) as builtins behind the `fs` feature flag. No path manipulation needed -- agents know the full path.
+
+**5b. Directory listing**
+
+Agents need to discover what files exist (find source files, list configs, scan directories).
+
+Rust: `fs::read_dir` returns an iterator of `DirEntry`. ilo planned: `fls path > R L t t` (returns list of file names or error).
+
+**Does this matter for agents?** Medium. Listing directories is needed for discovery tasks but less frequent than read/write.
+
+**5c. Path manipulation**
+
+Rust's `Path`/`PathBuf` handle OS-specific separators, extension extraction, parent directories, etc.
+
+**Does this matter for agents?** No. As noted in the Go research: "ilo programs run through an agent that knows the OS. Path manipulation is a tool concern." Agents construct full paths as text strings. They do not need `Path::join` or `extension()`.
+
+**5d. Buffered reading / streaming**
+
+For large files, Rust provides `BufReader` for line-by-line iteration. ilo's planned stream model (G6) addresses this: `@line stream{...}`.
+
+**Does this matter for agents?** Low. Agent programs process small-to-medium files. Reading entire files into memory (`fread`) covers 95% of cases. Streaming is needed only for log tailing or very large datasets.
+
+### Verdict
+
+File I/O is a real gap. G8 (`fread`/`fwrite`/`fexists`/`fappend`) should be prioritized. Path manipulation and streaming are unnecessary for the common case. The design is already correct in the roadmap.
+
+---
+
+## 6. String Processing
+
+### What Rust provides
+
+```rust
+// Basic operations
+let upper = s.to_uppercase();
+let lower = s.to_lowercase();
+let trimmed = s.trim();
+let replaced = s.replace("old", "new");
+let contains = s.contains("needle");
+let starts = s.starts_with("prefix");
+let ends = s.ends_with("suffix");
+
+// Split and join
+let parts: Vec<&str> = s.split(',').collect();
+let joined = parts.join(", ");
+
+// Formatting
+let msg = format!("Hello, {}! You have {} items.", name, count);
+
+// Regex (regex crate — not stdlib but de facto standard)
+let re = Regex::new(r"\d+")?;
+let matches: Vec<&str> = re.find_iter(text).map(|m| m.as_str()).collect();
+let replaced = re.replace_all(text, "***");
+
+// Parsing
+let n: i32 = "42".parse()?;
+let f: f64 = "3.14".parse()?;
+```
+
+### What ilo has
+
+| Rust | ilo | Status |
+|------|-----|--------|
+| `split` | `spl t sep` | Implemented |
+| `join` | `cat xs sep` | Implemented |
+| `contains` | `has t sub` | Implemented |
+| `len` | `len t` | Implemented |
+| `starts_with` / `ends_with` | None | Gap |
+| `trim` | None | Gap |
+| `replace` | None | Gap |
+| `to_uppercase` / `to_lowercase` | None | Gap |
+| `format!` (interpolation) | None | Gap |
+| `parse` (to number) | `num t` | Implemented |
+| `to_string` (from number) | `str n` | Implemented |
+| Regex | None | Gap |
+| `slice` | `slc t a b` | Implemented |
+| `reverse` | `rev t` | Implemented |
+| `sort` (chars) | `srt t` | Implemented |
+
+### Gap analysis
+
+**6a. String formatting / interpolation**
+
+The biggest string processing gap. Every language has some form of string interpolation:
+
+```rust
+format!("Hello, {}! Total: ${:.2}", name, total)
+```
+
+ilo has only string concatenation:
+```
+m=+"Hello, " name;m=+m "! Total: $";m=+m (str total)
+```
+
+12 tokens for what format does in ~8. The gap widens with more interpolation points.
+
+**Does this matter for agents?** Yes. Agents construct messages, prompts, URLs, and payloads constantly. String interpolation is high-frequency.
+
+**Minimal fix:** A `fmt` builtin or template syntax. Options:
+
+Option A -- positional `fmt`:
+```
+fmt "Hello, {}! Total: ${}" name (str total)    -- 7 tokens
+```
+
+Option B -- embedded references (like shell):
+```
+"Hello, {name}! Total: ${total}"    -- 3 tokens but changes string semantics
+```
+
+Option B is far more token-efficient but requires parser changes to string literals. Option A is safer -- a new builtin with `{}` placeholders, no language changes.
+
+Recommendation: `fmt` builtin. `fmt template args...` where `{}` is replaced by successive arguments. Returns `t`. Token cost: 1 extra token for `fmt`. Token savings: 3-8 per interpolation.
+
+**6b. Trim, replace, starts_with, ends_with**
+
+Common string operations missing from ilo's builtins:
+
+| Operation | Proposed | Tokens |
+|-----------|----------|--------|
+| `s.trim()` | `trm t` | 2 |
+| `s.replace(a, b)` | `rep t old new` | 4 |
+| `s.starts_with(p)` | `pfx t p` | 3 |
+| `s.ends_with(s)` | `sfx t s` | 3 |
+| `s.to_uppercase()` | `upc t` | 2 |
+| `s.to_lowercase()` | `lwc t` | 2 |
+
+**Does this matter for agents?** Medium. `replace` and `trim` appear frequently in data cleaning. `starts_with`/`ends_with` appear in routing and classification. These are workaround-able with `spl`/`slc`/`has` but cost more tokens.
+
+**Minimal fix:** Add `trm` and `rep` as builtins (highest frequency). `pfx`/`sfx` can wait. Case conversion is low priority -- agents rarely need it.
+
+**6c. Regex**
+
+Rust's `regex` crate is external but ubiquitous. Regex is the universal tool for pattern matching in text.
+
+**Does this matter for agents?** Low-medium. Regex is powerful but error-prone for LLM generation. LLMs frequently generate incorrect regex patterns, leading to retry loops. This directly conflicts with ilo's manifesto: regex increases retry cost.
+
+**Minimal fix:** If needed, a `re` builtin: `re pattern text > R L t t` (returns matches or error). But defer until a compelling agent use case emerges. Most text extraction is better handled by tools (JSON parsing via `jp`, HTML parsing via tools) than by regex in the language.
+
+### Verdict
+
+String formatting (`fmt`) is the highest-priority gap. `trm` and `rep` builtins are medium priority. Regex is low priority and potentially counterproductive for LLM generation accuracy.
+
+---
+
+## 7. Serialization (Serde / JSON)
+
+### What Rust provides
+
+```rust
+// Derive-based serialization
+#[derive(Serialize, Deserialize)]
+struct User {
+    name: String,
+    age: u32,
+    email: Option<String>,
+}
+
+// Serialize to JSON
+let json = serde_json::to_string(&user)?;
+
+// Deserialize from JSON
+let user: User = serde_json::from_str(&json)?;
+
+// Dynamic JSON (serde_json::Value)
+let v: serde_json::Value = serde_json::from_str(&json)?;
+let name = v["name"].as_str();
+let items = v["items"].as_array();
+
+// JSON path access
+let deep = v["users"][0]["address"]["city"].as_str();
+
+// Flexible formats — same derive works for TOML, YAML, MessagePack, etc.
+let toml: Config = toml::from_str(&toml_string)?;
+```
+
+### What ilo has
+
+ilo internally uses serde_json for AST serialization and JSON error output. At the language level:
+
+| Capability | ilo status |
+|-----------|-----------|
+| JSON parse (text -> value) | Planned (I1: `jp`) |
+| JSON path access | Planned (I1: `jp text path`) |
+| JSON serialize (value -> text) | Not planned |
+| Record <-> JSON mapping | Planned (D1e) |
+| Dynamic JSON (untyped) | `t` escape hatch |
+
+### Gap analysis
+
+**7a. JSON parsing and path access**
+
+The most common agent operation after HTTP: parse a JSON response and extract a field.
+
+Rust:
+```rust
+let v: Value = serde_json::from_str(&body)?;
+let name = v["data"]["user"]["name"].as_str().unwrap_or("unknown");
+```
+
+ilo planned (I1):
+```
+n=jp! body "data.user.name"
+```
+
+3 tokens. Dramatically terser. The `jp` (JSON path) builtin is the right design -- it combines parsing and path extraction in one call.
+
+**Does this matter for agents?** Yes. JSON parsing is the #1 data extraction operation for API-consuming agents.
+
+**Minimal fix:** Implement I1 (`jp` builtin). High priority.
+
+**7b. JSON serialization (value -> text)**
+
+Converting ilo values to JSON text for API request bodies.
+
+ilo planned: D1e (Value <-> JSON mapping) handles this at the tool boundary. Records auto-serialize to JSON when passed to tools. But there is no explicit "serialize this to JSON text" builtin.
+
+**Does this matter for agents?** Medium. Agents constructing API payloads need to produce JSON. Currently they would concatenate strings manually:
+
+```
+b=+"{\"name\":\"" name;b=+b "\",\"age\":";b=+b (str age);b=+b "}"
+```
+
+Terrible. 15+ tokens for a simple object.
+
+**Minimal fix:** A `js` (JSON stringify) builtin: `js value > t`. Converts any ilo value (record, list, number, text) to JSON text. Combined with record construction:
+
+```
+p=user name:"alice" age:30;b=js p    -- 8 tokens, clean
+```
+
+**7c. Multiple serialization formats (TOML, YAML, MessagePack)**
+
+Rust's serde ecosystem supports dozens of formats through the same derive macros.
+
+**Does this matter for agents?** No. JSON is the universal agent interchange format. TOML/YAML are config file formats -- if an agent needs to read a YAML config, that is a tool concern (`tool read-yaml"Parse YAML" path:t>R t t`). ilo should not build a multi-format serialization framework.
+
+### Verdict
+
+`jp` (JSON path parse) and `js` (JSON stringify) are the two essential builtins. `jp` is already planned (I1) and high priority. `js` should be added to the roadmap. Everything else is a tool concern.
+
+---
+
+## 8. Pattern Matching
+
+### What Rust provides
+
+```rust
+// Match with destructuring
+match user {
+    User { name, age, .. } if age >= 18 => format!("{} is adult", name),
+    User { name, .. } => format!("{} is minor", name),
+}
+
+// Match on enums with data
+match shape {
+    Shape::Circle(r) => std::f64::consts::PI * r * r,
+    Shape::Rect(w, h) => w * h,
+    Shape::Triangle { base, height } => 0.5 * base * height,
+}
+
+// Nested pattern matching
+match response {
+    Ok(Response { status: 200, body }) => process(body),
+    Ok(Response { status, .. }) => handle_error(status),
+    Err(e) => retry(e),
+}
+
+// Or patterns
+match status {
+    200 | 201 | 204 => "success",
+    400..=499 => "client error",
+    500..=599 => "server error",
+    _ => "unknown",
+}
+
+// if let / while let
+if let Some(user) = find_user(id) {
+    send_email(user);
+}
+while let Some(msg) = receiver.recv().await {
+    process(msg);
+}
+
+// let-else (Rust 1.65+)
+let Some(user) = find_user(id) else {
+    return Err("not found");
+};
+
+// @ bindings
+match age {
+    n @ 0..=12 => println!("child: {}", n),
+    n @ 13..=19 => println!("teen: {}", n),
+    n => println!("adult: {}", n),
+}
+```
+
+### What ilo has
+
+| Rust pattern | ilo equivalent | Status |
+|-------------|---------------|--------|
+| Literal match | `"gold":body` / `42:body` | Implemented |
+| Ok/Some match | `~v:body` | Implemented |
+| Err/None match | `^e:body` / `_:body` | Implemented |
+| Wildcard | `_:body` | Implemented |
+| Exhaustiveness | ILO-T024 | Implemented |
+| Guard clauses | `cond{body}` / `cond body` | Implemented |
+| Enum destructuring | None | Gap (needs E3) |
+| Record destructuring in match | None | Gap |
+| Nested patterns | None | Gap |
+| Or patterns | None | Gap |
+| Range patterns | None | Gap |
+| `if let` | `?v{~x:use x}` | Covered (match with one arm) |
+| `let-else` | `?v{_:^"err"};use v` | Covered (guard) |
+| Match guards | None | Gap |
+
+### Gap analysis
+
+**8a. Record destructuring in match arms**
+
+Rust:
+```rust
+match user {
+    User { name, verified: true, .. } => send(name),
+    User { name, .. } => reject(name),
+}
+```
+
+ilo has no destructuring in match arms. You match Ok/Err/literal, then access fields manually:
+```
+?r{~u:u.verified{send u.name};reject u.name;^e:^e}
+```
+
+**Does this matter for agents?** Low-medium. Record destructuring in match saves a few field accesses but adds pattern complexity. ilo's approach (match on Result/Option, then access fields) is more predictable for LLM generation.
+
+**Minimal fix:** Defer until sum types (E3) land. Sum types make match-with-destructuring natural (`?shape{circle r:do-circle r;rect w h:do-rect w h}`). Without sum types, destructuring in match arms has limited value.
+
+**8b. Or patterns**
+
+Rust: `200 | 201 | 204 => "success"`. Matching multiple values in one arm.
+
+ilo has no or-patterns. Workaround:
+```
+?s{200:~"ok";201:~"ok";204:~"ok";_:^"fail"}
+```
+
+Repetitive. An or-pattern would be:
+```
+?s{200|201|204:~"ok";_:^"fail"}
+```
+
+**Does this matter for agents?** Low. Or-patterns save tokens when matching multiple literals, but this pattern is uncommon in agent code. Agents typically branch on status categories (success/failure), not exhaustive status lists.
+
+**8c. Match guards**
+
+Rust: `x if x > 100 => ...`. Additional predicate on a match arm.
+
+ilo has no match guards. Workaround is guard inside the arm body:
+```
+?r{~v:>v 100{process v};reject v;^e:^e}
+```
+
+**Does this matter for agents?** Low. Guards inside arm bodies are equivalent and ilo already supports them.
+
+**8d. Nested patterns**
+
+Rust:
+```rust
+match result {
+    Ok(Some(value)) => use_value(value),
+    Ok(None) => default(),
+    Err(e) => handle(e),
+}
+```
+
+ilo:
+```
+?r{~v:?v{~x:use x;_:default()};^e:handle e}
+```
+
+Nested matches work but are verbose. Nested patterns would flatten:
+```
+?r{~~x:use x;~_:default();^e:handle e}
+```
+
+**Does this matter for agents?** Low. Nested Result/Option is uncommon in agent code. Tools return flat `R ok err`, not nested Results.
+
+### Verdict
+
+ilo's pattern matching covers the essential cases well. The `~`/`^`/`_`/literal pattern set handles Result, Option, and value matching. Gaps exist in destructuring (needs E3), or-patterns, and match guards, but these are low priority for agents. The biggest improvement would come from sum types (E3), which unlock enum pattern matching -- the pattern that Rust uses most heavily.
+
+---
+
+## 9. Ownership, Lifetimes, and Borrowing
+
+### What Rust provides
+
+Rust's defining feature: compile-time memory safety without garbage collection.
+
+```rust
+// Ownership — each value has exactly one owner
+let s1 = String::from("hello");
+let s2 = s1;  // s1 is moved, no longer valid
+
+// Borrowing — references without ownership transfer
+fn len(s: &str) -> usize { s.len() }
+
+// Lifetimes — compiler tracks reference validity
+fn longest<'a>(x: &'a str, y: &'a str) -> &'a str {
+    if x.len() > y.len() { x } else { y }
+}
+
+// Clone — explicit copy when needed
+let s2 = s1.clone();
+```
+
+### Relevance to ilo
+
+**None.** Ownership, borrowing, and lifetimes solve the problem of memory management without garbage collection. ilo's runtime uses `Value` enum types that are `Clone`-derived, reference-counted where needed, and garbage-collected by Rust's normal drop semantics. Agent programs are short-lived -- there is no memory leak concern over minutes or hours. Ownership complexity would massively increase the token cost of type annotations with zero benefit for agents.
+
+ilo correctly ignores this entire category. No action needed.
+
+---
+
+## 10. Modules and Visibility
+
+### What Rust provides
+
+```rust
+mod network {
+    pub fn get(url: &str) -> Result<String, Error> { ... }
+    fn internal_helper() { ... }  // private
+}
+
+use network::get;
+use std::collections::HashMap;
+```
+
+### Relevance to ilo
+
+ilo programs are flat -- all declarations exist at the top level. There are no modules, no imports, no visibility modifiers. This is deliberate:
+
+1. **Self-contained units.** Each function declares its dependencies (what it calls, what types it uses). No import ceremony.
+2. **Closed world.** All functions are known at verification time. No external modules to resolve.
+3. **Small programs.** Agent programs are typically 5-20 functions. Namespace collisions are not a real problem at this scale.
+
+**Does this matter for agents?** No. Modules solve the problem of organizing large codebases maintained by teams over years. Agent programs are disposable single-purpose scripts. If programs grow large enough to need namespacing, tool declarations provide the boundary (each tool is an external namespace).
+
+No action needed.
+
+---
+
+## 11. Smart Pointers and Interior Mutability
+
+### What Rust provides
+
+`Box<T>`, `Rc<T>`, `Arc<T>`, `Cell<T>`, `RefCell<T>`, `Cow<T>`.
+
+### Relevance to ilo
+
+None. These are implementation-level concerns for the Rust runtime, not language-level concepts. ilo's VM already uses the equivalent internally (boxed values, reference counting for records). The agent never sees or needs these concepts.
+
+No action needed.
+
+---
+
+## 12. Summary of Gaps and Recommendations
+
+### Tier 1: High priority, matters now
+
+| Gap | Rust feature | ilo fix | Priority |
+|-----|-------------|---------|----------|
+| Optional type | `Option<T>` | E2: `O n` | Next type system item |
+| JSON parsing | `serde_json` | I1: `jp` builtin | High |
+| File I/O | `std::fs` | G8: `fread`/`fwrite` | High |
+| Fold/reduce | `.fold()` / `.sum()` | Monomorphic `fld` builtin | High |
+| String formatting | `format!` | `fmt` builtin | High |
+| Parallel calls | `tokio::join!` | G4: `par{...}` | High |
+
+### Tier 2: Medium priority, has workarounds
+
+| Gap | Rust feature | ilo fix | Priority |
+|-----|-------------|---------|----------|
+| Range iteration | `0..n` | F7: `@i 0..n{...}` | Medium |
+| JSON stringify | `serde_json::to_string` | `js` builtin | Medium |
+| String trim | `.trim()` | `trm` builtin | Medium |
+| String replace | `.replace()` | `rep` builtin | Medium |
+| Sum types | `enum` | E3 | Medium |
+| Enumerate | `.enumerate()` | Range iteration covers this | Medium |
+
+### Tier 3: Low priority, defer
+
+| Gap | Rust feature | Status | Reason |
+|-----|-------------|--------|--------|
+| Generics | `<T>` | E5 (planned) | High cost, lambda syntax prerequisite |
+| Traits | `trait` | E6 (deferred) | Agents do not write abstractions |
+| Error type conversion | `From`/`Into` | Not needed | Text errors convention sufficient |
+| Regex | `regex` crate | Defer | High retry risk for LLM generation |
+| Async/await | `async`/`await` | Never | Hidden behind `par{}` |
+| Ownership/borrowing | Borrow checker | Never | ilo is GC-managed |
+| Modules | `mod`/`use` | Never | Programs are flat by design |
+| Nested patterns | Match destructuring | Defer until E3 | Uncommon in agent code |
+| Or-patterns | `\|` in match | Defer | Low frequency |
+
+### Tier 4: Explicitly excluded
+
+| Rust feature | Reason for exclusion |
+|-------------|---------------------|
+| Lifetimes | Memory management abstraction -- ilo uses GC |
+| Smart pointers | Implementation detail, not language concept |
+| Unsafe blocks | ilo has no unsafe escape hatch by design |
+| Macros (proc/declarative) | Metaprogramming adds vocabulary, increases retry rate |
+| dyn Trait / vtable dispatch | Agents generate concrete types |
+| Pin/Unpin | Async implementation detail |
+| const generics | Type-level computation is token-expensive |
+| Closures with move semantics | No ownership to move |
+
+---
+
+## 13. What ilo Gets Right That Rust Does Not
+
+Areas where ilo's design is superior to Rust for the agent use case:
+
+**13a. Auto-unwrap is terser than `?`**
+
+Rust: `let user = get_user(id)?;` -- 8 tokens (including the semicolon, let, type)
+ilo: `u=get-user! id` -- 4 tokens
+
+ilo's `!` saves 50% of tokens on every fallible call. Across a 10-call program, that is 40 saved tokens.
+
+**13b. No type annotation ceremony**
+
+Rust: `fn total(price: f64, quantity: i32, rate: f64) -> f64` -- 14 tokens
+ilo: `tot p:n q:n r:n>n` -- 8 tokens (including the signature separator `>`)
+
+ilo's single-character types save ~6 tokens per function signature.
+
+**13c. No import/use ceremony**
+
+Rust programs begin with `use std::...` declarations. A typical program has 5-15 import lines. ilo has zero imports -- everything is in scope.
+
+**13d. Pattern matching is built into control flow**
+
+Rust requires explicit `match` blocks. ilo's `?{...}` integrates matching into the statement flow, and `!` eliminates matching entirely for the propagation case.
+
+**13e. Implicit last-result matching**
+
+ilo's `?{...}` (no subject) matches the result of the previous expression. Rust always requires naming the match subject. This saves 1-2 tokens per match and eliminates throwaway variable names.
+
+**13f. No semicolon-vs-expression ambiguity**
+
+In Rust, forgetting a semicolon changes whether something is a statement or expression, causing confusing type errors. ilo's last-expression-is-return-value rule has no ambiguity.
+
+---
+
+## 14. Implementation Notes (ilo Is Written in Rust)
+
+Since ilo's runtime is implemented in Rust, several Rust features directly inform implementation decisions:
+
+**14a. serde for JSON interchange**
+
+ilo already uses `serde` + `serde_json` for AST serialization and structured error output. The `jp` builtin should use `serde_json::Value` internally -- it is already a dependency.
+
+**14b. Cranelift for JIT**
+
+The Cranelift JIT backend (already implemented) is a Rust-native code generator. Future additions (range iteration, fold, parallel calls) need Cranelift codegen paths.
+
+**14c. tokio for async runtime**
+
+The planned async runtime (G4) should use tokio. It is already the de facto standard, integrates with the existing Rust ecosystem, and handles the platform abstractions. The `http` feature could migrate from `minreq` (sync) to `reqwest` (async, tokio-based) when async lands.
+
+**14d. Error propagation in the runtime**
+
+ilo's runtime error handling (`RuntimeError`, `VmError`, `VmRuntimeError`) already follows Rust patterns: `thiserror` for derive, `?` for propagation, span attachment for source mapping. The error infrastructure is solid.
+
+---
+
+## Conclusion
+
+Rust and ilo share a philosophical commitment to explicit error handling, verification before execution, and exhaustive pattern matching. Where they diverge is in the audience: Rust serves human systems programmers building long-lived, memory-safe infrastructure; ilo serves AI agents generating short-lived, token-minimal tool orchestration.
+
+The most valuable Rust ideas for ilo are already adopted: Result types, the `?`/`!` operator, exhaustive match, static verification. The remaining gaps cluster in three areas:
+
+1. **Data processing** -- fold/reduce, string formatting, JSON parsing. These are high-frequency agent operations that need builtins.
+2. **I/O expansion** -- file I/O and parallel tool calls. Essential for real-world agent tasks.
+3. **Type system growth** -- Optional type and sum types. Incremental additions that prevent specific classes of runtime failures.
+
+Everything else from Rust -- ownership, lifetimes, traits, modules, async/await, smart pointers, macros -- is either irrelevant to agents, handled by the runtime, or actively harmful to token efficiency. ilo's strength is knowing what to exclude.

--- a/research/shell-languages-research.md
+++ b/research/shell-languages-research.md
@@ -1,0 +1,973 @@
+# Shell Languages & Execution Research for ilo-lang
+
+Research into shell languages, execution models, and patterns relevant to ilo — a
+token-minimal programming language for AI agents. Evaluated against the manifesto:
+**total tokens from intent to working code**.
+
+Key thesis: Shell execution (`sh cmd` or `run cmd`) was identified as more important
+than HTTP for local agents. Claude Code, Cursor, Codex, and other agentic CLIs all
+use bash/shell as their primary tool. ilo currently has `get url` for HTTP but no
+shell execution primitive. This document analyzes what ilo needs.
+
+---
+
+## 1. Bash/Zsh — The Baseline
+
+### Core primitives
+
+Bash is the lingua franca of shell scripting. Every AI coding agent uses it as
+its primary execution tool. The primitives:
+
+| Primitive | Syntax | What it does |
+|-----------|--------|-------------|
+| Command execution | `cmd arg1 arg2` | Fork + exec, wait for exit |
+| Pipe | `cmd1 \| cmd2` | stdout of cmd1 → stdin of cmd2 |
+| Redirect stdout | `cmd > file` | Write stdout to file |
+| Redirect stderr | `cmd 2> file` | Write stderr to file |
+| Redirect both | `cmd &> file` or `cmd 2>&1` | Merge stderr into stdout |
+| Subshell | `$(cmd)` or `` `cmd` `` | Capture stdout as string |
+| Process substitution | `<(cmd)` / `>(cmd)` | File descriptor as argument |
+| Background | `cmd &` | Non-blocking execution |
+| Chaining | `cmd1 && cmd2` | Run cmd2 only if cmd1 succeeds |
+| Chaining | `cmd1 \|\| cmd2` | Run cmd2 only if cmd1 fails |
+| Exit code | `$?` | Integer 0-255, 0 = success |
+| Env vars | `VAR=val cmd` | Set for one command |
+| Here-string | `cmd <<< "text"` | Feed string as stdin |
+
+### How shell execution works internally
+
+1. The shell **forks** a child process via `fork()` (or `posix_spawn`)
+2. The child calls `exec()` to replace itself with the target binary
+3. The parent **waits** (for foreground) or **continues** (for background)
+4. File descriptors for stdin/stdout/stderr are set up before exec
+5. Exit code is captured from `waitpid()` — 0 = success, non-zero = failure
+6. Pipes connect fd1 of process N to fd0 of process N+1 via `pipe()`
+
+### Environment variable handling
+
+- Inherited from parent process at fork time
+- `export VAR=val` makes it available to all children
+- `VAR=val cmd` sets only for that one command (no export)
+- `$VAR` expands at shell parse time, before command execution
+- `env` command lists all current environment variables
+- `.env` files are a convention, not a shell feature (need `source` or `dotenv`)
+
+### What agents actually use from bash
+
+Analysis of Claude Code, Codex CLI, and Cursor tool patterns reveals a clear
+hierarchy of shell usage:
+
+**High frequency (every session):**
+- `cat`, `head`, `tail` — read file contents
+- `grep`, `rg` — search file contents
+- `find`, `ls` — discover files
+- `git` subcommands — status, diff, log, add, commit, push
+- `cd` — change working directory
+- `echo` — write output / test commands
+
+**Medium frequency (most sessions):**
+- `npm`/`pip`/`cargo` — package management
+- `python`/`node`/`bun` — run scripts
+- `curl`/`wget` — HTTP requests
+- `mkdir`, `rm`, `mv`, `cp` — filesystem operations
+- `sed`, `awk` — text transformation
+- `wc` — counting (lines, words)
+
+**Low frequency (complex tasks):**
+- `docker` — container operations
+- `ssh` — remote execution
+- `tar`, `zip` — archive operations
+- `chmod`, `chown` — permissions
+- `kill`, `ps` — process management
+
+**Patterns observed:**
+1. Commands are overwhelmingly **single-shot**: run, capture output, analyze
+2. Pipes are common but typically 2-3 stages max: `cmd | grep | wc`
+3. Exit codes are checked but not deeply — agents care about success/failure
+4. Stderr is often more useful than stdout for error diagnosis
+5. Agents rarely use background processes or job control
+6. Environment variables are read (not set) in most tool invocations
+
+### What bash gets wrong for agents
+
+From ilo's OPEN.md, which already identified these:
+
+- **No types** — everything is text. `jq` output looks like an error message
+- **Silent failures** — `curl` can fail and the pipeline continues with empty input
+- **Text parsing tax** — agents generate `grep`, `awk`, `sed` to extract structured data
+- **Quoting hell** — escaping rules cause retry loops (token cost)
+- **No verification** — `rm -rf /` is syntactically valid, semantically catastrophic
+
+Resource profile from AgentCgroup research: test execution commands spike to
+~518MB memory, file exploration uses only ~4.5MB, git operations ~13.5MB. The
+burst-silence pattern means 98.5% of memory bursts occur during tool calls.
+
+---
+
+## 2. Nushell — The Closest Analog to ilo's Future
+
+Nushell is the most relevant comparison for ilo's shell ambitions. It replaces
+bash's text pipelines with structured data pipelines — exactly the model
+ilo's OPEN.md describes as "typed shell for agents."
+
+### Structured data pipelines
+
+| Bash | Nushell |
+|------|---------|
+| Text streams | Records, tables, lists |
+| `grep` to filter | `where` clause |
+| `awk` to extract | `.column` access |
+| `sort` (text) | `sort-by column` (typed) |
+| `jq` for JSON | Native JSON/YAML/TOML/CSV parsing |
+| Pipe: bytes | Pipe: structured values |
+
+Example — find large files:
+```
+# Bash: text parsing required
+ls -la | awk '$5 > 1000000 {print $9, $5}'
+
+# Nushell: structured query
+ls | where size > 1mb | select name size
+```
+
+The pipeline operator `|` in Nushell passes structured values between commands.
+Each command declares its input/output types. The runtime checks type
+compatibility. Errors carry source spans.
+
+### Type system
+
+Nushell has a dual type system:
+- **Compile-time types:** checked during parsing, catch mismatches early
+- **Runtime types:** the `Value` enum carries actual data with type tags
+
+Recent additions (2025) include runtime type checking for pipeline input
+types. Structural typing allows flexible matching — `[{a: 123} {a: 456, b: 789}]`
+is a subtype of `table<a: int>`.
+
+Types include: `int`, `float`, `string`, `bool`, `list`, `record`, `table`,
+`duration`, `filesize`, `date`, `binary`, `nothing`, `error`.
+
+**ilo parallel:** ilo's type system already has `n`, `t`, `b`, `_`, `L`, `R`,
+records. Nushell validates that structured pipelines with types work. The key
+difference: Nushell discovers types at runtime, ilo verifies at compile time.
+
+### par-each — parallel iteration
+
+Nushell's `par-each` replaces `each` for parallel execution:
+
+```
+# Sequential
+ls | where type == dir | each { |row| { name: $row.name, len: (ls $row.name | length) } }
+
+# Parallel — same syntax, different command
+ls | where type == dir | par-each { |row| { name: $row.name, len: (ls $row.name | length) } }
+```
+
+Benchmarks show 3-4x speedup for I/O-bound operations (21ms to 6ms in one test).
+The API is identical to `each` — drop-in replacement.
+
+**ilo gap:** ilo has `@` for iteration but no parallel variant. The proposed
+`@!` or `par{...}` from research/python-stdlib-analysis.md maps directly to
+Nushell's `par-each`. This validates the design direction.
+
+### Environment variables
+
+Nushell's env model is structured:
+- `$env.VAR` to read (record access, not string expansion)
+- `$env.VAR = "value"` to set (scoped to current block)
+- `$env.VAR?` for safe access (returns `nothing` if unset, not error)
+- `$env.VAR? | default "fallback"` for defaults
+- `with-env { FOO: "bar" } { command }` for temporary env
+- `ENV_CONVERSIONS` for automatic type coercion (PATH string → list)
+
+The `$env` is a structured record, not a flat string map. This means you can
+pipe it, filter it, query it: `$env | select PATH HOME`.
+
+**ilo implication:** Environment access should return structured values, not
+raw strings. `env "PATH"` returning `L t` (list of text, split on `:`) would
+be more useful than returning the raw colon-separated string.
+
+### External command execution
+
+Nushell bridges structured pipelines with external processes:
+- `run-external` or `^command` for explicit external invocation
+- Automatic detection: if not a builtin/custom command, try external
+- I/O is handled via thread-based readers to prevent deadlocks
+- Exit codes captured as structured values
+- Background jobs via `job spawn`, killed via `job kill`
+
+Limitation: background jobs are threads, not processes — they die when the
+shell exits. No `disown` equivalent (as of 2025). External process spawning
+into the background is still an open issue.
+
+### Error handling
+
+- `try { cmd } catch { |e| handle $e }` — structured error handling
+- Errors carry source spans for precise location reporting
+- `ShellError` instances include expected type, actual type, span
+- Streams can yield `Value::Error` for per-element errors
+
+### NUON — Nushell Object Notation
+
+Nushell has its own serialization format that preserves all Nushell types
+(durations, filesizes, dates). Unlike JSON, it round-trips without data loss.
+
+**ilo lesson:** A native serialization format for ilo values would enable
+efficient persistence and IPC between ilo processes.
+
+---
+
+## 3. Fish — User-Friendly Shell Design
+
+Fish (Friendly Interactive Shell) is relevant for its design philosophy
+around discoverability and error prevention, though less relevant for ilo's
+execution model.
+
+### Key design choices
+
+- **Autosuggestions out of the box** — no plugins needed. Grayed-out suggestions
+  from command history appear as you type. Right arrow to accept.
+- **Syntax highlighting** — green for valid commands, red for errors, real-time
+  as you type. Catches typos before execution.
+- **No POSIX compliance** — deliberately breaks from POSIX in favor of cleaner
+  syntax. `set VAR value` instead of `VAR=value`. No `$()`, uses `()` directly.
+- **Man page parsing** — auto-generates completions from installed man pages.
+  Zero-config tab completion for any installed tool.
+- **Web-based configuration** — `fish_config` opens a browser UI for themes,
+  prompts, and settings.
+
+### Syntax differences from bash
+
+| Bash | Fish |
+|------|------|
+| `export VAR=val` | `set -gx VAR val` |
+| `VAR=val` (local) | `set VAR val` |
+| `$(cmd)` | `(cmd)` |
+| `[ condition ]` | `test condition` |
+| `if [ ]; then; fi` | `if condition; end` |
+| `for x in list; do; done` | `for x in list; end` |
+| `function f() { }` | `function f; end` |
+| `alias x='cmd'` | `function x; cmd $argv; end` |
+
+### What's relevant for ilo
+
+**Positive lessons:**
+1. **Zero-config discoverability** — Fish proves that intelligent defaults
+   beat configuration. ilo's "constrained" principle aligns: fewer choices,
+   better defaults.
+2. **Real-time validation** — syntax highlighting catches errors before
+   execution. ilo's verifier does this at the language level.
+3. **Helpful error messages** — Fish's errors explain what went wrong and
+   suggest fixes. ilo already has this with "did you mean?" suggestions.
+
+**Anti-patterns for ilo:**
+1. **POSIX incompatibility** — Fish's choice to break POSIX means scripts are
+   not portable. ilo doesn't have this concern (it's a new language), but it
+   validates the approach: if you're going to break convention, break it
+   completely and provide better alternatives.
+2. **Interactive-first** — Fish is optimized for human interaction (web config,
+   autosuggestions). ilo is agent-first. Different audience, different priorities.
+
+Fish was rewritten from C++ to Rust in version 4.0 (February 2025), reaching
+4.5.0 by February 2026. This validates Rust as a shell implementation language.
+
+---
+
+## 4. PowerShell — Object Pipeline Model
+
+PowerShell pioneered the object pipeline — passing structured objects between
+commands instead of text. This is directly relevant to ilo's vision.
+
+### Object pipeline vs text pipeline
+
+| Aspect | Bash | PowerShell |
+|--------|------|------------|
+| Pipeline content | Text bytes | .NET objects |
+| Filtering | `grep pattern` | `Where-Object { $_.Prop -gt 5 }` |
+| Extraction | `awk '{print $3}'` | `Select-Object Name, Size` |
+| Sorting | `sort` (text) | `Sort-Object -Property Name` |
+| Error handling | Exit codes + stderr text | Exception objects + error stream |
+| Type safety | None | Rich type system (.NET) |
+| Discovery | `man cmd` | `Get-Member`, `Get-Help` |
+
+### How cmdlets work
+
+Every cmdlet declares:
+- **Input types** — what objects it accepts via pipeline
+- **Output types** — what objects it produces
+- **Parameters** — named, typed, with validation attributes
+- **Parameter binding** — ByValue (match type) and ByPropertyName (match name)
+
+This is remarkably similar to ilo's tool declarations:
+```
+# PowerShell: declared types, named params, pipeline input
+function Get-UserProfile {
+    [CmdletBinding()]
+    param([Parameter(ValueFromPipeline)]$UserId)
+    ...
+}
+
+# ilo: declared types, positional params, result type
+tool get-profile"Get user profile" uid:t>R profile t
+```
+
+### Multiple output streams
+
+PowerShell has 6+ streams: Output, Error, Warning, Verbose, Debug, Information.
+Each carries structured objects. Compare to bash's 2 (stdout, stderr) carrying
+text.
+
+**ilo implication:** ilo's `R ok err` captures the most important distinction
+(success/failure). Additional streams (debug, verbose) could be tool-provider
+concerns, not language concerns.
+
+### What PowerShell gets right for agents
+
+1. **Object pipeline eliminates parsing** — no `grep`/`awk`/`sed` tax
+2. **Type-safe parameter binding** — wrong types caught before execution
+3. **Rich error objects** — errors carry context, not just text
+4. **Discoverability** — `Get-Member` shows what an object can do
+
+### What PowerShell gets wrong for agents
+
+1. **Verbosity** — `Get-ChildItem | Where-Object { $_.Length -gt 1MB }` is 11
+   tokens. Nushell's equivalent is 7, ilo's would be fewer.
+2. **.NET dependency** — massive runtime, not embeddable
+3. **Windows-first** — cross-platform support improved but not native
+4. **Cmdlet naming convention** — `Verb-Noun` is discoverable but verbose
+
+---
+
+## 5. Bun Shell — JS-Native Shell Execution
+
+Bun Shell is directly relevant because Anthropic acquired Bun in December 2025
+to power Claude Code infrastructure. Bun Shell represents the direction
+Anthropic is investing in for agent-native shell execution.
+
+### The $ template literal
+
+```js
+import { $ } from "bun";
+
+// Basic execution
+await $`echo "Hello World"`;
+
+// Capture output
+const text = await $`ls *.js`.text();
+const json = await $`cat data.json`.json();
+const lines = await $`ls`.lines();
+
+// Pipes
+const result = await $`echo "Hello World!" | wc -w`.text();
+
+// Destructure stdout, stderr, exit code
+const { stdout, stderr, exitCode } = await $`cmd`.nothrow().quiet();
+```
+
+### Key design decisions
+
+1. **Not a system shell** — Bun Shell does not invoke `/bin/sh`. It re-implements
+   bash parsing in-process. This is faster and more secure.
+2. **Automatic escaping** — all interpolated values are treated as single literal
+   strings. `${userInput}` cannot inject commands.
+3. **Promise-based** — every command returns a Promise. Natural for async JS.
+4. **Multiple output formats** — `.text()`, `.json()`, `.lines()`, `.blob()`,
+   `.arrayBuffer()`. The caller chooses the parse format.
+5. **Exit code handling** — throws on non-zero by default. `.nothrow()` to
+   capture instead. `.throws(true/false)` for global config.
+6. **Built-in commands** — `ls`, `cd`, `rm`, `echo` etc. reimplemented natively.
+   20x faster than zx for built-in operations.
+7. **Cross-platform** — same API on Windows, Linux, macOS.
+
+### Environment variables
+
+```js
+await $`echo $FOO`.env({ FOO: "bar" });  // scoped env
+await $`echo $HOME`.cwd("/tmp");          // scoped cwd
+```
+
+### Redirect operators
+
+```js
+await $`cmd 1>&2`;        // stdout to stderr
+await $`cmd 2>&1`;        // stderr to stdout
+await $`cmd > file.txt`;  // stdout to file
+await $`cmd 2> err.txt`;  // stderr to file
+```
+
+### What Bun Shell means for ilo
+
+Bun Shell validates several ilo design directions:
+
+1. **Shell-in-process is viable** — you don't need to fork `/bin/sh`. A shell
+   re-implementation within the runtime is faster and more controllable.
+2. **Structured output from shell** — `.json()`, `.lines()`, `.text()` prove
+   that shell output can be structured at the boundary. ilo's `R t t` is the
+   starting point; returning structured types (records, lists) would be the
+   Bun Shell equivalent.
+3. **Automatic escaping is essential** — for agent-generated commands, injection
+   prevention must be built in. ilo's tool system already handles this (tools
+   are typed functions, not string-interpolated commands), but a `sh` builtin
+   would need the same protection.
+4. **Exit code → Result mapping** — Bun Shell's "throw on non-zero" maps
+   directly to ilo's `R ok err`. Exit code 0 → `~stdout`, non-zero → `^stderr`.
+
+### Bun.spawn for lower-level control
+
+```js
+const proc = Bun.spawn(["cmd", "arg1", "arg2"], {
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { FOO: "bar" },
+    cwd: "/tmp"
+});
+const output = await new Response(proc.stdout).text();
+const exitCode = await proc.exited;
+```
+
+This lower-level API exposes the full process lifecycle: spawn, pipe I/O,
+wait for exit. ilo's equivalent would be the `sh`/`run` builtin internally.
+
+---
+
+## 6. Deno — Permission Model (Validates ilo's Verifier)
+
+Deno's permission model is the strongest validation of ilo's "closed world"
+verifier approach. Deno proves that a runtime can be secure by default.
+
+### Secure by default
+
+A Deno program has **zero** OS access unless explicitly granted:
+- No file reads (`--allow-read`)
+- No file writes (`--allow-write`)
+- No network (`--allow-net`)
+- No environment variables (`--allow-env`)
+- No subprocess spawning (`--allow-run`)
+- No high-resolution time (`--allow-hrtime`)
+- No FFI (`--allow-ffi`)
+
+### Granular permissions
+
+Permissions can be scoped to specific paths or hosts:
+```
+deno --allow-read=/path/to/dir --allow-net=api.example.com script.ts
+```
+
+### Permission auditing (Deno 2.5+)
+
+```
+DENO_AUDIT_PERMISSIONS=/var/log/deno-audit.jsonl deno run script.ts
+DENO_TRACE_PERMISSIONS=1 deno run script.ts  # includes stack traces
+```
+
+Every permission check is logged with the permission type and value. Stack
+traces show exactly where in code the access was attempted.
+
+### Permission broker
+
+For enterprise use, Deno can delegate all permission checks to an external
+broker process:
+```
+DENO_PERMISSION_BROKER_PATH=/path/to/broker deno run script.ts
+```
+
+When using a broker, all `--allow-*` and `--deny-*` flags are ignored.
+Every permission check goes to the broker, which decides per-request.
+
+### Security advisories and escalation risks
+
+Deno's experience reveals important edge cases:
+- `--allow-read` on `/proc/self/environ` provides equivalent of `--allow-env`
+- `--allow-write` on `/proc/self/mem` provides equivalent of `--allow-all`
+- `--allow-run` essentially invalidates the sandbox (spawned processes aren't sandboxed)
+
+Deno 1.43+ blocks access to `/etc`, `/dev`, `/proc`, `/sys` on Linux and
+`\\` paths on Windows without explicit `--allow-all`.
+
+### How this validates ilo's approach
+
+ilo's "closed world" verifier catches issues at **verification time**:
+- All function calls must resolve to known functions
+- All types must align
+- All dependencies must be declared
+
+Deno does this at **runtime** with permission checks. ilo goes further — the
+program cannot even *reference* an unknown capability. This is strictly better
+for agents:
+
+| Aspect | Deno | ilo |
+|--------|------|-----|
+| When checked | Runtime | Verification time (before execution) |
+| Unknown function | Runtime error | Compile error (ILO-T005) |
+| Type mismatch | Runtime or never caught | Compile error (ILO-T009) |
+| Undeclared dependency | Permission denied at runtime | Cannot exist in program |
+| Cost of violation | Wasted execution + retry | Zero execution cost |
+
+**Key insight:** Deno's `--allow-run` effectively breaks the sandbox. For ilo,
+a `sh` builtin would be similar — it grants arbitrary OS access. The solution
+is NOT to prevent shell execution (agents need it), but to:
+1. Make shell commands explicit in the program (not hidden in tool implementations)
+2. Verify shell command arguments are well-formed where possible
+3. Run with appropriate OS-level sandboxing (containers, seccomp, etc.)
+4. Audit all shell invocations (Deno's audit log pattern)
+
+---
+
+## 7. What AI Coding Agents Actually Do
+
+### The tool hierarchy
+
+Based on analysis of Claude Code, Codex CLI, Cursor, and other agentic tools:
+
+**Tools by frequency of use:**
+
+| Rank | Tool | What it does |
+|------|------|-------------|
+| 1 | File read | Read file contents (cat, Read) |
+| 2 | File search | Find files by name/content (grep, rg, find) |
+| 3 | File write/edit | Modify file contents |
+| 4 | Shell execution | Run arbitrary commands (build, test, lint) |
+| 5 | Git operations | Status, diff, commit, push |
+| 6 | Package management | npm install, pip install, cargo build |
+| 7 | HTTP requests | Fetch URLs, API calls |
+| 8 | Web search | Research / documentation lookup |
+
+Shell execution is the **4th most common** operation but the **most powerful** —
+it subsumes file operations, git, package management, and HTTP. An agent with
+only a shell tool can do everything; an agent with only file tools cannot run
+tests.
+
+### The execution pattern
+
+The core loop for every AI coding agent:
+
+```
+1. Reason about the task
+2. Choose a tool (usually file read or shell)
+3. Execute the tool
+4. Observe the output
+5. Reason about the result
+6. Repeat until done
+```
+
+This is the ReAct (Reason + Act) pattern. The key observation: **tool calls are
+single-shot with captured output.** Agents don't maintain persistent shell
+sessions or background processes. Each command is:
+- Spawn process
+- Wait for completion
+- Capture stdout + stderr
+- Check exit code
+- Return result to agent
+
+### Claude Code's shell integration
+
+Claude Code's Bash tool:
+- Spawns `/bin/bash -lc "command"` (login shell, single command)
+- Captures stdout and stderr separately
+- Returns exit code
+- Has approval modes: suggest (ask first), auto (read/write in workspace),
+  full-auto (all operations allowed)
+- Inherits the user's bash environment (PATH, aliases, etc.)
+
+Codex CLI's shell tool:
+- Similar pattern: `["/bin/bash", "-lc", "command"]` on Unix
+- `["powershell.exe", "-Command", "command"]` on Windows
+- Sandbox policies: workspace-read, workspace-write, danger-full-access
+- Prefers dedicated tools over shell where available (e.g., `read_file` over `cat`)
+
+### What agents need from shell
+
+Distilled from observed patterns:
+
+1. **Run command, get output** — the fundamental operation
+2. **Check success/failure** — exit code → boolean
+3. **Capture stdout** — the command's output (usually text)
+4. **Capture stderr** — error messages for diagnosis
+5. **Set working directory** — run command in a specific path
+6. **Set environment variables** — configure tool behavior
+7. **Timeout** — don't block forever on hung processes
+8. **Pipe output** — chain 2-3 commands (rare but needed)
+
+What agents do NOT need:
+- Background processes / job control
+- Interactive input (stdin)
+- Signal handling
+- Terminal emulation
+- Shell scripting features (loops, conditionals in bash)
+- Process groups or sessions
+
+---
+
+## 8. Synthesis: What ilo Needs
+
+### The sh builtin
+
+The highest-priority addition. Proposed:
+
+```
+sh "command"       -- R t t: Ok=stdout, Err=stderr (on non-zero exit)
+sh! "command"      -- auto-unwrap: stdout on success, propagate err
+```
+
+Design decisions:
+
+**Return type: `R t t`**
+- Ok: stdout as text (trimmed trailing newline, like Ruby's `.chomp`)
+- Err: stderr as text + exit code in message
+- Matches `get url` pattern — same return type, same error handling
+- Auto-unwrap `!` works identically: `out=sh! "ls -la"`
+
+**Command as text, not as tokens**
+- `sh "git status"` not `sh git status` — the command is opaque to ilo
+- This avoids ilo needing to understand shell syntax
+- Interpolation via string concatenation: `sh +"git log -n " (str n)`
+- Or via a template if ilo adds `fmt`: `sh (fmt "git log -n {}" n)`
+
+**Working directory**
+- Option A: `sh "cd /tmp && ls"` — bash handles it (simplest)
+- Option B: `sh "ls" cwd:"/tmp"` — named option on the builtin
+- Option A is sufficient for agents and costs zero design tokens
+
+**Environment variables**
+- Option A: `sh "FOO=bar cmd"` — bash handles it (simplest)
+- Option B: `sh "cmd" env:{"FOO":"bar"}` — structured option
+- Option A is sufficient initially
+
+**Timeout**
+- Default timeout (e.g., 30s) to prevent hung processes
+- Override: `sh "cmd" timeout:60` — or just use tool declaration pattern
+- Essential for agent reliability — a hung process blocks the entire loop
+
+**Token cost analysis:**
+```
+# Current workaround: no shell execution, use tool
+tool run-cmd"Run shell command" cmd:t>R t t
+
+# With sh builtin:
+sh "git status"        -- 3 tokens
+sh! "cargo test"       -- 3 tokens (auto-unwrap)
+r=sh "ls";?r{~o:o;^e:^e}  -- explicit error handling
+```
+
+### The env builtin
+
+Read environment variables:
+
+```
+env "HOME"         -- R t t: Ok=value, Err="not set"
+env! "HOME"        -- auto-unwrap: value or propagate err
+env "FOO"??"bar"   -- with default (if env returns nil for unset)
+```
+
+Alternative design (nil for unset, no Result):
+```
+env "HOME"         -- t or nil
+env "HOME"??"bar"  -- with nil-coalesce default
+```
+
+The nil-returning version is simpler and more composable with `??`.
+Nushell's `$env.VAR?` pattern validates this approach.
+
+**Token cost:** `env "PATH"` is 2 tokens. Cheaper than `sh "echo $PATH"` (4 tokens)
+and semantically cleaner.
+
+### Structured output from shell
+
+Most shell output is text, but agents often need structured data:
+
+```
+# Raw text (default)
+out=sh! "ls -la"              -- text
+
+# JSON parsing (common pattern)
+d=sh! "cat package.json"      -- text
+-- need json parsing tool to make it structured
+
+# Line splitting (very common)
+ls=spl (sh! "ls") "\n"        -- L t: list of filenames
+```
+
+ilo should NOT add JSON parsing as a language feature (manifesto: "format
+parsing is a tool concern"). But `spl` (split) on newlines for line-based
+output is already available and covers the most common case.
+
+For structured shell output, the Nushell/PowerShell model suggests a future
+direction: commands that return typed values instead of text. But this requires
+a fundamentally different execution model — ilo functions as shell commands,
+not external processes. This is a longer-term vision, not an immediate need.
+
+### par-each / parallel iteration
+
+Nushell's `par-each` validates the need. ilo's proposed designs:
+
+**Option 1: `@!` parallel foreach (Nushell-aligned)**
+```
+rs=@! x urls{get x}    -- parallel map over list
+```
+
+**Option 2: `par{...}` block (Go/Swift-aligned)**
+```
+[a, b, c]=par{get url1;get url2;get url3}
+```
+
+**Option 3: Runtime auto-parallelization (graph-native)**
+No syntax — the runtime detects independent calls and parallelizes them.
+
+Previous research (python-stdlib-analysis.md, swift-kotlin-research.md,
+go-stdlib-research.md) converged on: start with Option 2 (`par{...}`) for
+explicit parallelism. Option 3 is the long-term goal but requires dependency
+graph analysis.
+
+**For shell execution specifically:**
+```
+-- Sequential: 3 API calls, blocking
+a=sh! "curl -s api1";b=sh! "curl -s api2";c=sh! "curl -s api3"
+
+-- Parallel: 3 API calls, concurrent
+[a,b,c]=par{sh "curl -s api1";sh "curl -s api2";sh "curl -s api3"}
+
+-- Parallel foreach: same command, different args
+rs=@! u urls{sh +"curl -s " u}
+```
+
+### Process control
+
+Agents need minimal process control:
+
+| Operation | Syntax | Notes |
+|-----------|--------|-------|
+| Run + wait | `sh "cmd"` | Default, synchronous |
+| Run + timeout | `sh "cmd" timeout:30` | Kill after N seconds |
+| Run in background | Future: `bg "cmd"` | Returns handle |
+| Kill process | Future: `kill handle` | By handle from bg |
+| Check if running | Future: `alive handle` | Returns bool |
+
+Background processes are low priority. The overwhelming pattern is
+synchronous execution. If needed, `par{...}` covers the common case
+(multiple concurrent operations with a join point).
+
+### Permission model
+
+ilo's verifier is the permission model. Deno's experience informs the design:
+
+1. **sh is declared in the program** — the verifier knows shell is used
+2. **sh cannot be hidden** — no way to sneak shell execution into a tool
+3. **Runtime sandboxing is orthogonal** — OS-level containers, seccomp, etc.
+4. **Audit logging** — every `sh` call logged with command + result
+5. **Allowlist mode** — future: `sh "cmd" allow:["git","cargo"]` restricts
+   which executables can be invoked
+
+The Deno lesson: `--allow-run` breaks the sandbox. For ilo, `sh` is always
+a powerful escape hatch. The mitigation is not to restrict it (agents need it)
+but to make it visible and auditable.
+
+---
+
+## 9. Comparison Matrix
+
+| Feature | Bash | Nushell | Fish | PowerShell | Bun Shell | Deno | ilo (proposed) |
+|---------|------|---------|------|------------|-----------|------|----------------|
+| Pipeline type | Text | Structured | Text | Objects | Text + parse | N/A | Typed values |
+| Error model | Exit code + text | ShellError + span | Exit code | Exception objects | ShellError + exitCode | Error objects | `R ok err` |
+| Type safety | None | Structural | None | .NET types | None (JS) | TypeScript | Verified at compile |
+| Env vars | `$VAR` | `$env.VAR` | `$VAR` | `$env:VAR` | `.env({})` | `Deno.env` | `env "VAR"` |
+| Parallel | `cmd &` + wait | `par-each` | `cmd &` | Jobs / Runspaces | Promise.all | Async | `par{...}` / `@!` |
+| Permission model | None | None | None | Execution Policy | Safe escaping | `--allow-*` | Verifier + sandbox |
+| Agent-friendly | Baseline | Better | Worse (interactive) | Verbose | Good (JS interop) | Good | Best (designed for) |
+| Shell-in-process | No (fork) | Yes | No (fork) | Yes (.NET) | Yes (native) | No (Deno.run) | Yes (proposed) |
+
+---
+
+## 10. Implementation Priority for ilo
+
+Ranked by impact on agent workflows:
+
+### Tier 1: Essential (unblocks agent usage)
+
+**1. `sh` builtin — shell command execution**
+- `sh "cmd"` → `R t t` (stdout/stderr)
+- `sh! "cmd"` → auto-unwrap
+- Default timeout (30s)
+- Feature-flagged like `get` (behind `shell` feature)
+- Implementation: `std::process::Command` in Rust, synchronous
+- Token cost: 3 tokens for a verified, error-handled shell call
+
+**2. `env` builtin — environment variable access**
+- `env "VAR"` → `t` or nil
+- Compose with `??`: `env "HOME"??"/tmp"`
+- Implementation: `std::env::var()` in Rust
+- Token cost: 2 tokens
+
+### Tier 2: High value (parallel execution)
+
+**3. `par{...}` block — parallel execution**
+- Execute all statements concurrently, collect results
+- `[a,b,c]=par{sh "cmd1";sh "cmd2";sh "cmd3"}`
+- Implementation: thread pool or tokio tasks
+- Requires async runtime (already planned in G4)
+
+**4. `@!` parallel foreach**
+- `rs=@! x xs{sh +"curl " x}`
+- Drop-in parallel replacement for `@`
+- Nushell's `par-each` validates this exact pattern
+
+### Tier 3: Nice to have (polish)
+
+**5. Process timeout on sh**
+- `sh "cmd" timeout:60`
+- Kill process after N seconds
+- Essential for reliability but can default initially
+
+**6. Working directory on sh**
+- `sh "cmd" cwd:"/path"`
+- Alternative: `sh "cd /path && cmd"` (bash handles it)
+
+**7. Structured shell output helpers**
+- `spl (sh! "ls") "\n"` already works for line splitting
+- JSON parsing is a tool concern, not a language concern
+
+---
+
+## 11. Design Tensions
+
+### Opaque commands vs verified commands
+
+`sh "git status"` is opaque — ilo cannot verify the command is valid.
+This breaks the "closed world" principle. Options:
+
+1. **Accept the break** — `sh` is the escape hatch. Tools are verified,
+   shell commands are not. This is pragmatic and matches Deno's `--allow-run`.
+
+2. **Typed command wrappers** — `git.status()` instead of `sh "git status"`.
+   Maximum verification but enormous surface area. Not practical.
+
+3. **Command allowlists** — `sh "cmd" allow:["git"]` restricts to known
+   executables. Partial verification. Good for production, unnecessary for dev.
+
+**Recommendation:** Option 1 for now. `sh` is explicitly unverified. The
+program declares it uses `sh`. The verifier knows. The runtime audits.
+
+### Token cost of safety
+
+```
+# Minimal (3 tokens, no error handling)
+sh! "cargo test"
+
+# With error handling (8 tokens)
+r=sh "cargo test";?r{^e:^+"test failed: "e;~o:o}
+
+# With timeout (5 tokens)
+sh "cargo test" timeout:120
+```
+
+The `!` auto-unwrap makes the common case cheap. Explicit error handling
+is available when needed. This matches ilo's existing pattern for `get`/`$`.
+
+### Shell-in-process vs fork
+
+Bun Shell proves shell-in-process works. For ilo:
+
+- **Phase 1:** Fork `/bin/sh` or use `std::process::Command`. Simplest,
+  most compatible, works everywhere.
+- **Phase 2 (future):** Embed a shell parser for built-in commands (ls, echo,
+  cat). Faster, no fork overhead, cross-platform.
+- **Phase 3 (future):** Full pipeline execution in-process, like Nushell.
+  Structured output from every stage.
+
+Phase 1 is sufficient for agent use cases. Agents execute single commands
+and capture output — they don't need in-process pipelines.
+
+---
+
+## 12. Token Cost Comparison
+
+How many tokens to run a shell command and handle the result:
+
+| Pattern | Python | Bash (raw) | ilo (proposed) |
+|---------|--------|------------|----------------|
+| Run command, get output | `subprocess.run(cmd, capture_output=True)` (6 tokens) | `output=$(cmd)` (3 tokens) | `sh! "cmd"` (3 tokens) |
+| Check success | `if result.returncode == 0:` (5 tokens) | `if [ $? -eq 0 ]` (7 tokens) | `r=sh "cmd";?r{~o:use o;^e:handle e}` (10 tokens) or `sh! "cmd"` (3 tokens) |
+| Run + parse JSON | `json.loads(subprocess.check_output(cmd))` (4 tokens) | `cmd \| jq '.field'` (4 tokens) | `d=sh! "cmd";parse-json d` (5 tokens, with tool) |
+| Run + get lines | `result.stdout.splitlines()` (3 tokens) | `cmd \| while read line` (5 tokens) | `spl (sh! "cmd") "\n"` (5 tokens) |
+| Parallel 3 commands | `asyncio.gather(...)` (~15 tokens) | `cmd1 & cmd2 & cmd3 & wait` (7 tokens) | `par{sh "a";sh "b";sh "c"}` (8 tokens) |
+| Env var with default | `os.environ.get("K", "d")` (6 tokens) | `${K:-d}` (1 token) | `env "K"??"d"` (4 tokens) |
+
+ilo is competitive with bash on token count and far ahead on safety/verification.
+The `!` operator is the key — it makes error-handled execution as cheap as
+fire-and-forget.
+
+---
+
+## 13. Open Questions
+
+1. **Should `sh` be a keyword or a builtin?** Builtin is consistent with `get`,
+   `len`, `str`, etc. Keyword would allow special parsing (e.g., `sh git status`
+   without quotes). Recommendation: builtin with string arg.
+
+2. **Should `sh` capture stderr separately?** Current proposal: Ok=stdout,
+   Err=stderr. Alternative: Ok=record{out:t;err:t;code:n} for full access.
+   The record approach is more powerful but costs more tokens to destructure.
+
+3. **Should there be a `sh` variant that returns exit code as number?**
+   e.g., `shc "cmd"` → `n` (just the code). Useful for `test -f file` patterns.
+   Low priority — `sh "test -f file"` with Ok/Err is sufficient.
+
+4. **How should `sh` handle binary output?** stdout can be binary (images,
+   archives). Current `t` type loses data. Future: `B` (bytes) type.
+   Low priority — agents rarely produce binary output from shell commands.
+
+5. **Should ilo support stdin piping to `sh`?** `sh "grep foo" stdin:data`.
+   Useful for text processing. Medium priority.
+
+6. **What is the right default timeout?** 30s covers most commands. Test suites
+   may need 300s+. No timeout risks hanging. Recommendation: 30s default,
+   overridable.
+
+---
+
+## Sources
+
+- [Nushell Parallelism](https://www.nushell.sh/book/parallelism.html)
+- [Nushell Pipelines](https://www.nushell.sh/book/pipelines.html)
+- [Nushell Environment](https://www.nushell.sh/book/environment.html)
+- [Nushell External Command Execution (DeepWiki)](https://deepwiki.com/nushell/nushell/4.3-external-command-execution)
+- [Bun Shell Documentation](https://bun.com/docs/runtime/shell)
+- [Bun.$ API Reference](https://bun.com/reference/bun/$)
+- [The Bun Shell Blog Post](https://bun.sh/blog/the-bun-shell)
+- [Bun Joins Anthropic](https://bun.com/blog/bun-joins-anthropic)
+- [Anthropic Acquires Bun](https://www.anthropic.com/news/anthropic-acquires-bun-as-claude-code-reaches-usd1b-milestone)
+- [Deno Security and Permissions](https://docs.deno.com/runtime/fundamentals/security/)
+- [Deno Permissions Manual](https://deno.land/manual/getting_started/permissions)
+- [Deno 2.5 Permissions in Config](https://deno.com/blog/v2.5)
+- [Fish Shell vs Bash vs Zsh Comparison 2026](https://www.bitdoze.com/fish-shell-vs-bash-vs-zsh/)
+- [Bash vs Zsh vs Fish Linux Shell Comparison 2025](https://an4t.com/bash-vs-zsh-vs-fish-linux-shell-comparison/)
+- [PowerShell Objects and Data Piping](https://www.varonis.com/blog/how-to-use-powershell-objects-and-data-piping)
+- [Mastering the PowerShell Pipeline](https://shahin.page/article/mastering-the-powershell-pipeline-objects-parameter-binding-and-troubleshooting)
+- [Claude Code Overview](https://code.claude.com/docs/en/overview)
+- [Anthropic Claude Code System Prompts](https://github.com/Piebald-AI/claude-code-system-prompts)
+- [OpenAI Codex CLI](https://github.com/openai/codex)
+- [Codex CLI Features](https://developers.openai.com/codex/cli/features/)
+- [Codex Shell Execution (DeepWiki)](https://deepwiki.com/openai/codex/5.2-model-provider-configuration)
+- [AgentCgroup: OS Resources of AI Agents](https://arxiv.org/html/2602.09345v2)
+- [Code Execution with MCP (Anthropic)](https://www.anthropic.com/engineering/code-execution-with-mcp)
+- [AI Coding Tools: The Agentic CLI Era](https://thenewstack.io/ai-coding-tools-in-2025-welcome-to-the-agentic-cli-era/)
+- [Nushell for DevOps (Medium)](https://medium.com/@denismarshalltumakov/nushell-for-devops-a-practical-guide-f8142434e778)
+- [Nushell Structured Data (JDriven)](https://jdriven.com/blog/2025/10/nushell)
+```
+
+---
+
+The document covers all six shell technologies, focuses on what AI coding agents actually use (grounded in Claude Code and Codex CLI patterns), and synthesizes concrete recommendations for ilo. Key findings:
+
+1. **`sh` builtin is the highest-priority addition** -- 3 tokens for a verified, error-handled shell call. Returns `R t t` matching the existing `get` pattern. Auto-unwrap with `!` makes the common case cheap.
+
+2. **`env` builtin for environment variables** -- 2 tokens, composable with `??` for defaults. Nushell's `$env.VAR?` pattern validates the nil-returning design.
+
+3. **`par{...}` for parallel execution** -- Nushell's `par-each` validates this exact need. Start with explicit `par{}` blocks, evolve toward runtime auto-parallelization from the dependency graph.
+
+4. **Deno validates ilo's closed-world verifier** -- but Deno's `--allow-run` lesson is important: `sh` is always an escape hatch that breaks static verification. The mitigation is visibility and auditability, not restriction.
+
+5. **Bun Shell's acquisition by Anthropic** signals investment in JS-native shell execution. Its key insights (shell-in-process, automatic escaping, structured output formats) inform ilo's implementation direction.
+
+6. **Agents use shell commands in single-shot, capture-output patterns** -- no background processes, no interactive input, no job control. ilo's `sh` can be simple: spawn, wait, capture stdout/stderr, return Result.

--- a/research/swift-kotlin-research.md
+++ b/research/swift-kotlin-research.md
@@ -1,0 +1,853 @@
+# Swift & Kotlin: Capabilities Relevant to an Agent Language
+
+Research into Swift and Kotlin features evaluated against ilo's manifesto: **total tokens from intent to working code**. Both languages have strong Optional/Result/concurrency patterns. This document catalogs what they offer and extracts what matters for ilo.
+
+---
+
+## 1. File I/O
+
+### Swift
+
+`FileManager` + URL-based access. Two patterns:
+
+```swift
+// Modern (Data/String init with URL)
+let data = try Data(contentsOf: URL(fileURLWithPath: "/tmp/data.json"))
+let text = try String(contentsOfFile: "/tmp/file.txt", encoding: .utf8)
+try text.write(toFile: "/tmp/out.txt", atomically: true, encoding: .utf8)
+
+// FileManager for existence/attributes/directory operations
+FileManager.default.fileExists(atPath: path)
+FileManager.default.contentsOfDirectory(atPath: path)
+```
+
+Errors are thrown — integrates with `try/catch`. No async file I/O in stdlib (Foundation is synchronous for disk ops).
+
+### Kotlin
+
+`java.io.File` + `kotlin.io` extensions:
+
+```kotlin
+val text = File("/tmp/file.txt").readText()
+File("/tmp/out.txt").writeText(content)
+File("/tmp/data").readLines()       // List<String>
+File("/tmp/data").bufferedReader().useLines { lines -> ... }
+```
+
+Extension functions on `File` (`readText()`, `writeText()`, `readLines()`) make file ops single-expression. `use` / `useLines` handle resource cleanup automatically (like `try-with-resources` but as a scope function).
+
+### Relevance to ilo
+
+File I/O is a **tool concern**, not a language concern (see OPEN.md: "Format parsing is a tool concern"). Agents compose tool results; tools handle filesystem access. If ilo adds a file builtin, the model is the same as `get`:
+
+```
+tool read"Read file" path:t>R t t timeout:5
+tool write"Write file" path:t content:t>R _ t timeout:5
+```
+
+**Key takeaway:** Both Swift and Kotlin prove that file I/O benefits from Result-typed returns (Swift throws, Kotlin exceptions) rather than silent failure. ilo already has this via `R ok err` on tools. No language-level file API needed — it's a tool declaration.
+
+---
+
+## 2. Networking
+
+### Swift
+
+`URLSession` with async/await (Swift 5.5+):
+
+```swift
+let (data, response) = try await URLSession.shared.data(from: url)
+let (data, response) = try await URLSession.shared.data(for: request)
+```
+
+Pre-async: completion handler callbacks (verbose, error-prone). The async version is dramatically more concise and natural.
+
+### Kotlin
+
+`kotlinx-coroutines` + `ktor-client` or `java.net.URL`:
+
+```kotlin
+// Simple (blocking)
+val body = URL("https://api.example.com/data").readText()
+
+// Ktor (async, structured)
+val client = HttpClient(CIO)
+val response: HttpResponse = client.get("https://api.example.com/data")
+val body: String = response.body()
+```
+
+Kotlin coroutines make async networking look synchronous — `suspend` functions are called like regular functions.
+
+### Relevance to ilo
+
+ilo already has `get url` / `$url` returning `R t t`. The language-level API is a single builtin, not a library. The insight from Swift/Kotlin: **async/await makes networking code look synchronous**. ilo sidesteps this entirely — the runtime handles blocking; the language stays sequential. If ilo adds async tool calls, the model would be transparent (tools block from the program's perspective, runtime parallelizes underneath).
+
+**Key takeaway:** Swift's async/await and Kotlin's coroutines solve the problem of making async code readable. ilo doesn't need this at the language level because tool calls are inherently opaque — the runtime decides execution strategy. The `get` builtin and `tool` declarations are sufficient.
+
+---
+
+## 3. Process Execution
+
+### Swift
+
+`Process` class (Foundation):
+
+```swift
+let process = Process()
+process.executableURL = URL(fileURLWithPath: "/usr/bin/ls")
+process.arguments = ["-la"]
+let pipe = Pipe()
+process.standardOutput = pipe
+try process.run()
+process.waitUntilExit()
+let data = pipe.fileHandleForReading.readDataToEndOfFile()
+```
+
+Verbose. Requires setting up pipes, waiting, reading. Process termination status via `process.terminationStatus`.
+
+### Kotlin
+
+`ProcessBuilder` (JDK):
+
+```kotlin
+val process = ProcessBuilder("ls", "-la")
+    .redirectErrorStream(true)
+    .start()
+val output = process.inputStream.bufferedReader().readText()
+val exitCode = process.waitFor()
+```
+
+Slightly less verbose than Swift. Kotlin extension functions make it cleaner, but it's still the JDK `ProcessBuilder` underneath.
+
+### Relevance to ilo
+
+Process execution is another tool concern. An ilo tool declaration:
+
+```
+tool exec"Run command" cmd:t args:L t>R t t timeout:30
+```
+
+Neither Swift nor Kotlin has a one-liner for "run command, get output or error." Both require ~5-10 lines of setup. ilo's tool model is strictly better for this use case — the complexity lives in the tool provider, the program just calls `exec! "ls" ["-la"]`.
+
+**Key takeaway:** No language primitives needed. Tool declarations handle process execution with typed results and timeout/retry semantics that neither Swift nor Kotlin provides natively.
+
+---
+
+## 4. Data Formats
+
+### Swift
+
+`Codable` protocol + `JSONDecoder`/`JSONEncoder`:
+
+```swift
+struct User: Codable {
+    let name: String
+    let age: Int
+}
+let user = try JSONDecoder().decode(User.self, from: jsonData)
+let json = try JSONEncoder().encode(user)
+```
+
+Codable is compile-time. The struct definition IS the schema. `PropertyListDecoder`/`Encoder` handles plist. Custom `CodingKeys` for field name mapping.
+
+### Kotlin
+
+`kotlinx.serialization` (compile-time) or Gson/Jackson (reflection):
+
+```kotlin
+@Serializable
+data class User(val name: String, val age: Int)
+val user = Json.decodeFromString<User>(jsonString)
+val json = Json.encodeToString(user)
+```
+
+`data class` + `@Serializable` is the idiomatic pattern. The data class definition IS the schema.
+
+### Relevance to ilo
+
+This is the strongest parallel to ilo's existing design. Both Swift's `Codable` and Kotlin's `@Serializable` demonstrate the principle that **type definitions ARE schemas**. ilo already does this:
+
+```
+type user{name:t;age:n}
+```
+
+This record definition serves as both the in-language type and the JSON schema for tool boundaries. From OPEN.md: "Tool declarations ARE schemas — `tool name"desc" params>return` is a schema declaration." MCP's `inputSchema`/`outputSchema` map directly to ilo records.
+
+The key difference: Swift and Kotlin require explicit encode/decode calls. ilo's runtime handles the JSON-to-Value mapping transparently at tool boundaries. The agent never writes serialization code.
+
+**Key takeaway:** ilo's `type` declarations already serve the role of `Codable`/`@Serializable`. No serialization API needed in the language — the runtime maps JSON to typed records automatically. This saves significant tokens vs Swift/Kotlin where agents would need to write decode/encode calls.
+
+---
+
+## 5. String Manipulation
+
+### Swift
+
+String interpolation + Regex (Swift 5.7+):
+
+```swift
+let msg = "Hello, \(name)! You have \(count) items."
+let regex = /\d{3}-\d{4}/
+if let match = input.firstMatch(of: regex) { ... }
+// String is a Collection — subscriptable, iterable
+name.prefix(3)
+name.split(separator: " ")
+name.contains("@")
+```
+
+Swift's `Regex` builder (5.7+) is compile-time checked. String interpolation is the primary string-building mechanism.
+
+### Kotlin
+
+String templates + Regex:
+
+```kotlin
+val msg = "Hello, $name! You have $count items."
+val regex = """\d{3}-\d{4}""".toRegex()
+regex.find(input)?.value
+name.take(3)
+name.split(" ")
+name.contains("@")
+```
+
+Triple-quoted raw strings avoid escaping. Extension functions (`take`, `split`, `contains`) make string ops chainable.
+
+### Relevance to ilo
+
+ilo handles string operations via builtins and operators:
+
+```
++name " has " +str count " items"    -- string concat (prefix)
+spl t " "                             -- split
+has t "@"                             -- contains
+slc t 0 3                             -- substring
+```
+
+**String interpolation** is the notable absence. Both Swift (`\(expr)`) and Kotlin (`$expr`) save tokens vs manual concatenation. In ilo:
+
+```
+-- Current: 7 tokens for a 3-part string
++"Hello, " +name "!"
+
+-- Hypothetical interpolation: fewer tokens?
+-- Not clear — interpolation syntax adds { } or \ delimiters
+-- And prefix + is already a single token per concat
+```
+
+Analysis: With prefix notation, string concatenation is already terse (`+a b` = 3 tokens per concat). Interpolation would save tokens only for 3+ segments where the `+` nesting gets deep. But interpolation requires a new syntax form (string with embedded expressions), adding to the grammar surface. The manifesto says "one way to do things" — having both concat and interpolation violates this.
+
+**Regex:** Not needed as a language feature. ilo delegates format parsing to tools (see OPEN.md). A regex tool (`tool match"Regex match" t:t pat:t>R L t t`) is sufficient.
+
+**Key takeaway:** String concat via `+` is already token-competitive with interpolation for short strings. Regex is a tool concern. Neither feature justifies expanding ilo's grammar.
+
+---
+
+## 6. Concurrency
+
+### Swift
+
+Structured concurrency (Swift 5.5+):
+
+```swift
+// async/await
+let result = try await fetchUser(id)
+
+// TaskGroup — parallel execution
+try await withThrowingTaskGroup(of: User.self) { group in
+    for id in ids {
+        group.addTask { try await fetchUser(id) }
+    }
+    for try await user in group { ... }
+}
+
+// Actors — thread-safe state
+actor UserCache {
+    var cache: [String: User] = [:]
+    func get(_ id: String) async -> User? { cache[id] }
+}
+```
+
+Three layers: `async/await` (sequential async), `TaskGroup` (structured parallelism), `actor` (safe shared state). All integrated with the type system — the compiler enforces data isolation.
+
+### Kotlin
+
+Coroutines + Flow:
+
+```kotlin
+// suspend functions (async/await equivalent)
+suspend fun fetchUser(id: String): User = ...
+
+// Structured concurrency
+coroutineScope {
+    val user = async { fetchUser(id) }
+    val profile = async { fetchProfile(id) }
+    combine(user.await(), profile.await())
+}
+
+// Flow (reactive streams)
+flow { emit(fetchUser(id)) }
+    .map { it.name }
+    .collect { println(it) }
+```
+
+`coroutineScope` enforces structured concurrency — child coroutines must complete before the scope exits. `Flow` is cold (lazy), like Kotlin's answer to reactive streams.
+
+### Relevance to ilo
+
+Concurrency is **the single most important design decision** for ilo's future, and both Swift and Kotlin validate the same approach: **structured concurrency with transparent syntax**.
+
+Today ilo is fully sequential. The runtime blocks on tool calls. For agent workflows, this is a real limitation — fetching 3 independent API responses sequentially wastes time.
+
+The Swift/Kotlin model suggests ilo could add parallel tool execution **without changing the language syntax**:
+
+```
+-- These tools are independent — runtime could execute in parallel
+u=get-user! uid
+p=get-profile! uid
+o=get-orders! uid
+-- This depends on all three — blocks until all complete
+notify u p o
+```
+
+The runtime (not the language) would analyze the dependency graph and parallelize independent tool calls. This aligns with ilo's "graph-native" principle — the call graph reveals parallelism opportunities.
+
+If explicit parallelism is needed, a minimal syntax:
+
+```
+-- Hypothetical: all[] executes tools in parallel, returns list
+rs=all[get-user uid, get-profile uid, get-orders uid]
+```
+
+**Actors and shared state:** Not relevant. ilo programs are short-lived, tool-orchestration scripts — not long-running services. There is no shared mutable state to protect.
+
+**Key takeaway:** Both Swift and Kotlin prove that structured concurrency (scoped parallelism with automatic cancellation) is the right model. ilo should get this for free from the runtime's dependency graph analysis, not from language syntax. The zero-syntax-cost approach: runtime detects independent tool calls and parallelizes them. This saves agents from ever writing concurrency code.
+
+---
+
+## 7. Error Handling
+
+### Swift
+
+`throws` / `try` / `catch` + `Result` + `Optional`:
+
+```swift
+// throws/try/catch
+func fetchUser(_ id: String) throws -> User { ... }
+do {
+    let user = try fetchUser(id)
+} catch {
+    print("Failed: \(error)")
+}
+
+// try? — convert to Optional
+let user = try? fetchUser(id)    // User?
+
+// try! — force unwrap (crash on error)
+let user = try! fetchUser(id)    // User (crashes if error)
+
+// Result type
+func fetch(_ url: URL) -> Result<Data, Error> { ... }
+switch result {
+case .success(let data): ...
+case .failure(let error): ...
+}
+```
+
+Three error-handling styles: exceptions (`try/catch`), optionals (`try?`), and explicit `Result`. The `try?` bridge between exceptions and optionals is particularly elegant — it says "I don't care about the error details, just give me nil on failure."
+
+### Kotlin
+
+Exceptions + `Result` + `runCatching`:
+
+```kotlin
+// Traditional try/catch
+try {
+    val user = fetchUser(id)
+} catch (e: Exception) {
+    println("Failed: ${e.message}")
+}
+
+// runCatching — wraps in Result
+val result = runCatching { fetchUser(id) }
+result.getOrNull()           // User?
+result.getOrElse { default } // User
+result.map { it.name }       // Result<String>
+result.fold(
+    onSuccess = { use(it) },
+    onFailure = { handle(it) }
+)
+```
+
+`runCatching` bridges exceptions into `Result`. The `fold`/`map`/`getOrElse` combinators on `Result` allow functional error handling without `try/catch`.
+
+### Relevance to ilo
+
+ilo's error handling is already more concise than both Swift and Kotlin:
+
+| Pattern | Swift | Kotlin | ilo |
+|---------|-------|--------|-----|
+| Call + handle error | `do { try f() } catch { ... }` (5+ tokens) | `try { f() } catch (e) { ... }` (5+ tokens) | `f x;?{^e:handle;~v:use}` (7 tokens) |
+| Propagate error | `let x = try f()` | `val x = f()` (throws) | `x=f! x` (3 tokens) |
+| Error to nil | `try? f()` | `runCatching { f() }.getOrNull()` | would need `O` type |
+| Default on error | `(try? f()) ?? default` | `runCatching { f() }.getOrElse { default }` | `f x;?{^_:default;~v:v}` |
+
+ilo's `!` auto-unwrap is equivalent to Swift's `try` and Rust's `?` — propagate the error, give me the value. At 1 token (`!` on the function name), it's the most concise of all three.
+
+**Swift's `try?` pattern** is notable: convert a Result/throw to Optional. This would map to ilo as:
+
+```
+-- Hypothetical: f? converts Err to nil (drops error detail)
+x=f? uid         -- R ok err → O ok
+x??default       -- O ok → value with fallback
+```
+
+This two-step pattern (`f? args` + `??`) would be 4 tokens total for "call, ignore error, use default." Currently it takes ~8 tokens with full match syntax. But this requires the `O` (Optional) type from Phase E2.
+
+**Key takeaway:** ilo's `!` auto-unwrap is already best-in-class for error propagation. The gap is in the "I don't care about the error, just give me a default" pattern. Swift's `try?` + `??` and Kotlin's `getOrElse` both solve this in 2-3 tokens. ilo could match this with the `O` type + `??` nil-coalescing (both already planned in TYPE-SYSTEM.md and CONTROL-FLOW.md).
+
+---
+
+## 8. Optional Chaining / Null Safety
+
+### Swift
+
+Optional chaining + nil coalescing + unwrap patterns:
+
+```swift
+// Optional chaining — short-circuits on nil
+let city = user?.address?.city          // String?
+
+// Nil coalescing
+let name = user?.name ?? "Unknown"      // String
+
+// guard let — unwrap or exit scope
+guard let user = fetchUser(id) else { return nil }
+
+// if let — unwrap in scope
+if let user = fetchUser(id) {
+    use(user)
+}
+
+// Optional map/flatMap
+let upper = name.map { $0.uppercased() }    // String?
+```
+
+Swift makes nil-handling **pervasive and cheap**. The `?.` chain + `??` default pattern handles 90% of optional cases in 1-2 tokens per step.
+
+### Kotlin
+
+Null safety is baked into the type system:
+
+```kotlin
+// ?. safe call — short-circuits on null
+val city = user?.address?.city          // String?
+
+// ?: Elvis operator (nil coalescing)
+val name = user?.name ?: "Unknown"      // String
+
+// !! force unwrap (throws on null)
+val name = user!!.name                  // String (throws NPE if null)
+
+// let scope function — unwrap + operate
+user?.let { sendEmail(it) }
+
+// Smart cast — null check promotes type
+if (user != null) {
+    user.name    // compiler knows user is non-null here
+}
+```
+
+Kotlin's approach is nearly identical to Swift's but with `?:` instead of `??` and `!!` for force-unwrap.
+
+### Relevance to ilo
+
+ilo already has the key pieces:
+
+| Feature | Swift | Kotlin | ilo (current) | ilo (planned) |
+|---------|-------|--------|---------------|---------------|
+| Safe navigation | `?.` | `?.` | `.?` (implemented) | -- |
+| Nil coalescing | `??` | `?:` | `??` (implemented) | -- |
+| Force unwrap | `!` | `!!` | `!` (auto-unwrap on R) | extend to `O` |
+| Optional type | `T?` / `Optional<T>` | `T?` | -- | `O n` (Phase E2) |
+
+ilo chose `.?` over `?.` to avoid ambiguity with the `?` match operator. And `??` over `?:` because `?:` conflicts with match arm syntax (`pattern:body`). These are the right choices for ilo's sigil-heavy grammar.
+
+**What ilo is missing vs Swift/Kotlin:**
+
+1. **Typed optionals.** Swift and Kotlin enforce null safety at compile time. ilo currently allows nil at runtime in any position. The `O` type (Phase E2) would close this gap — the verifier would force `.?` or `??` when accessing optional fields.
+
+2. **Optional map/flatMap.** Swift's `optional.map { transform }` and Kotlin's `?.let { transform }` apply a function to the inner value if present. ilo's equivalent would be a match: `?v{~x:transform x;_:_}` (7 tokens). With the pipe operator: `v>>transform` wouldn't nil-check. A dedicated `v.?>>transform` pattern would need design work.
+
+3. **Smart casts / guard let.** Swift's `guard let x = expr else { return }` and Kotlin's smart casts narrow the type after a nil check. ilo's match arms (`?v{~x:use x}`) serve the same purpose but don't narrow the type in subsequent statements — once you exit the match, the binding is gone. This is fine for ilo's small-function style, where match arms contain the entire remaining logic.
+
+**Key takeaway:** ilo's `.?` and `??` already provide the core chaining and defaulting patterns from Swift/Kotlin. The main gap is compile-time optional typing (`O` type) — Phase E2 in TYPE-SYSTEM.md. Once `O` is added, ilo's null safety will be on par with Swift/Kotlin in capability but significantly more concise in syntax.
+
+---
+
+## 9. Pattern Matching
+
+### Swift
+
+`switch` with exhaustiveness checking:
+
+```swift
+switch status {
+case .pending: handlePending()
+case .active: handleActive()
+case .closed: handleClosed()
+// compiler error if a case is missing
+}
+
+// Value binding in patterns
+switch result {
+case .success(let data): use(data)
+case .failure(let error): handle(error)
+}
+
+// Where clauses
+switch score {
+case let x where x >= 90: "A"
+case let x where x >= 80: "B"
+default: "C"
+}
+
+// Tuple patterns, enum associated values, etc.
+```
+
+Swift requires exhaustive matching on enums — the compiler catches missing cases.
+
+### Kotlin
+
+`when` expression:
+
+```kotlin
+when (status) {
+    Status.PENDING -> handlePending()
+    Status.ACTIVE -> handleActive()
+    Status.CLOSED -> handleClosed()
+    // exhaustive when sealed class/enum used
+}
+
+// Value binding
+when (val result = fetchUser()) {
+    is Success -> use(result.data)
+    is Failure -> handle(result.error)
+}
+
+// Guard-like conditions
+when {
+    score >= 90 -> "A"
+    score >= 80 -> "B"
+    else -> "C"
+}
+```
+
+Kotlin's `when` is more flexible than `switch` — it can match on type (`is`), conditions (no subject), and ranges (`in 1..10`). Exhaustive only for sealed hierarchies.
+
+### Relevance to ilo
+
+ilo's `?` match with exhaustiveness checking (ILO-T024) already covers the core patterns:
+
+```
+-- Result matching (like Swift .success/.failure)
+?r{~v:use v;^e:handle e}
+
+-- Value matching (like Swift case "gold":)
+?tier{"gold":100;"silver":50;_:10}
+
+-- Guard chains (like Kotlin's when{})
+>=sp 1000 "gold";>=sp 500 "silver";"bronze"
+```
+
+**What Swift/Kotlin have that ilo doesn't (yet):**
+
+1. **Enum/sum type matching.** Swift and Kotlin enforce exhaustiveness on enums. ilo only matches on text literals, numbers, and Result variants. Phase E3 (sum types) in TYPE-SYSTEM.md would add:
+   ```
+   enum status{pending;active;closed}
+   ?s{pending:...;active:...;closed:...}   -- exhaustiveness checked
+   ```
+
+2. **Where clauses / range patterns.** Swift's `case let x where x >= 90` and Kotlin's `in 1..10` combine binding with conditions. ilo's guard chains (`>=sp 1000 "gold"`) serve the same purpose without a special pattern syntax — and are more concise.
+
+3. **Type patterns.** Kotlin's `is` pattern matches on runtime type. ilo's F12 (Type pattern matching) in CONTROL-FLOW.md addresses this for the `t` escape-hatch case where tools return untyped data.
+
+**Key takeaway:** ilo's guard chains are already more concise than Swift/Kotlin pattern matching for conditional logic. The main gap is enum exhaustiveness (Phase E3). Guard-style matching is the right design for an agent language — it avoids the syntactic overhead of `switch`/`when` blocks while providing the same safety guarantees via the verifier.
+
+---
+
+## 10. Type System
+
+### Swift
+
+Protocols, generics, associated types, opaque types:
+
+```swift
+protocol Describable {
+    var description: String { get }
+}
+
+func process<T: Describable>(_ item: T) -> String { item.description }
+
+// Associated types
+protocol Container {
+    associatedtype Item
+    func get() -> Item
+}
+
+// Opaque types (some)
+func makeView() -> some View { Text("Hello") }
+```
+
+Swift's type system is rich — protocol-oriented programming is the dominant paradigm. Generics with constraints, existentials (`any Protocol`), and opaque return types (`some Protocol`) provide multiple abstraction layers.
+
+### Kotlin
+
+Generics, sealed classes, extension functions, data classes:
+
+```kotlin
+// Generics
+fun <T> firstOrNull(list: List<T>): T? = list.firstOrNull()
+
+// Sealed class (sum type)
+sealed class Result<out T> {
+    data class Success<T>(val data: T) : Result<T>()
+    data class Failure(val error: String) : Result<Nothing>()
+}
+
+// Extension functions
+fun String.isPalindrome(): Boolean = this == this.reversed()
+
+// Data class (record/struct with auto-generated equals, hashCode, copy)
+data class User(val name: String, val age: Int)
+```
+
+Kotlin's type system is pragmatic — `data class` eliminates boilerplate, `sealed class` enables exhaustive matching, extension functions add capabilities without inheritance.
+
+### Relevance to ilo
+
+**What ilo has today:**
+
+From TYPE-SYSTEM.md: 7 type constructors (`n`, `t`, `b`, `_`, `L`, `R`, named records). Everything is monomorphic. No generics, no protocols/interfaces, no type variables.
+
+**Swift/Kotlin features evaluated for ilo:**
+
+| Feature | Swift | Kotlin | ilo assessment |
+|---------|-------|--------|---------------|
+| Generics | Protocols + constraints | Bounded type params | Phase E5 — high value but high cost. Needed for `map`/`filter`/`fold` builtins. Without generics, list processing requires manual loops. |
+| Protocols/Interfaces | Protocol-oriented programming | Interfaces + default methods | Phase E6 — lowest priority. Agents generate concrete code, not abstract interfaces. Deferred until real use cases emerge. |
+| Sum types | enum with associated values | sealed class | Phase E3 — medium priority. Needed for exhaustive matching beyond Result. `enum status{pending;active;closed}` |
+| Data classes / records | struct (value type) | data class (auto equals/copy) | Already have `type name{fields}` + `with` for update. ilo's records are equivalent to Kotlin's `data class`. |
+| Extension functions | Protocol extensions | `fun Type.method()` | Not applicable. ilo has no method syntax — all functions are free-standing. Extension functions solve a problem (adding methods to types you don't own) that doesn't exist in ilo's model. |
+| Opaque types | `some Protocol` | N/A (reified generics) | Not applicable. Opaque types hide implementation details — an abstraction concern. Agents generate concrete types. |
+| Associated types | `associatedtype` | N/A | Not applicable. Gates on protocols, which are deferred. |
+
+**Kotlin's scope functions (let, run, apply, also, with):**
+
+```kotlin
+user?.let { sendEmail(it) }                    // operate on non-null
+User("Alice", 30).apply { validate() }         // configure object
+fetchUser(id).also { log(it) }                 // side-effect + pass through
+with(config) { host = "localhost"; port = 8080 } // multiple operations on same object
+```
+
+Scope functions are a convenience for reducing repetition of a receiver expression. In ilo:
+- `let` equivalent: match arm `?v{~x:use x}` or future `v.?>>func`
+- `apply`/`also` equivalent: bind + operate + return original — `x=expr;sideeffect x;x`
+- `with` equivalent: record `with` syntax — `obj with field:val`
+
+ilo's `with` expression already covers the `apply`/`with` use case. The others are handled by binding.
+
+**Key takeaway:** ilo's type system is deliberately minimal — the manifesto says type annotations cost tokens, and the sweet spot is "catch common errors with cheap annotations." The priority ordering from TYPE-SYSTEM.md (aliases > optionals > sum types > maps > generics > traits) is validated by this Swift/Kotlin analysis. Agents don't need protocols, generics, or extension functions for tool orchestration. They need Optional (`O`) to catch nil crashes, sum types for exhaustive tool-status matching, and eventually generics for list-processing builtins.
+
+---
+
+## 11. Kotlin Coroutines & Structured Concurrency (detailed)
+
+```kotlin
+// Sequential
+suspend fun fetchBoth(id: String): Pair<User, Profile> {
+    val user = fetchUser(id)       // suspends, waits
+    val profile = fetchProfile(id) // suspends, waits
+    return Pair(user, profile)
+}
+
+// Parallel (structured)
+suspend fun fetchBoth(id: String): Pair<User, Profile> = coroutineScope {
+    val user = async { fetchUser(id) }
+    val profile = async { fetchProfile(id) }
+    Pair(user.await(), profile.await())
+}
+
+// Structured concurrency — cancellation propagates
+coroutineScope {
+    launch { longRunning() }    // cancelled if scope fails
+    launch { anotherTask() }   // cancelled if scope fails
+}
+
+// Flow (cold reactive stream)
+fun userUpdates(): Flow<User> = flow {
+    while (true) {
+        emit(fetchLatestUser())
+        delay(1000)
+    }
+}
+```
+
+**Key property of structured concurrency:** child tasks cannot outlive their parent scope. If the parent is cancelled, all children are cancelled. This prevents leaked goroutines/threads.
+
+### Relevance to ilo
+
+Structured concurrency maps perfectly to ilo's tool-orchestration model. Consider a multi-tool workflow:
+
+```
+-- ilo today (sequential)
+u=get-user! uid
+p=get-profile! uid
+o=get-orders! uid
+r=build-report u p o
+send-email! u.email r
+```
+
+The runtime's dependency graph reveals that `get-user`, `get-profile`, and `get-orders` are independent (no data dependencies). `build-report` depends on all three. `send-email` depends on `build-report`.
+
+A structured-concurrency runtime would:
+1. Execute `get-user`, `get-profile`, `get-orders` in parallel
+2. Wait for all three to complete
+3. Execute `build-report`
+4. Execute `send-email`
+
+**No syntax changes required.** The dependency graph IS the concurrency model. This is ilo's "graph-native" principle applied to execution.
+
+If a tool times out or fails, structured cancellation means: cancel sibling tasks, propagate `^e` to the caller. The `!` auto-unwrap handles this naturally.
+
+**Flow/Streams:** Not relevant for ilo's target use case (short-lived tool orchestration). Agents don't build reactive pipelines. If streaming is ever needed, it would be a tool concern (a tool that emits chunks, not a language construct).
+
+---
+
+## 12. Kotlin Extension Functions (detailed)
+
+```kotlin
+fun String.wordCount(): Int = this.split(" ").size
+fun List<Int>.median(): Double = sorted().let { it[it.size / 2].toDouble() }
+fun <T> T.also(block: (T) -> Unit): T { block(this); return this }
+```
+
+Extension functions let you add methods to types you don't own. They compile to static functions with the receiver as the first argument — they're syntactic sugar.
+
+### Relevance to ilo
+
+ilo's functions are already free-standing with the "subject" as the first argument:
+
+```
+len xs        -- Kotlin equivalent: xs.len()
+spl t " "     -- Kotlin equivalent: t.split(" ")
+has t "@"     -- Kotlin equivalent: t.contains("@")
+```
+
+In Kotlin, extension functions enable chaining: `text.split(" ").filter { it.isNotEmpty() }.joinToString(",")`. In ilo, the pipe operator (`>>`) serves the same purpose:
+
+```
+spl t " ">>flt empty>>cat ","
+```
+
+Extension functions solve the "discoverability" problem — `text.` in an IDE shows all available operations. ilo doesn't have IDEs (yet), and the closed-world principle means all available operations are in the spec. An agent doesn't need auto-complete; it needs the spec.
+
+**Key takeaway:** Extension functions are IDE-oriented syntactic sugar. ilo's free-standing functions + pipe operator provide the same chaining capability. The "one way to do things" principle argues against adding method syntax.
+
+---
+
+## 13. Kotlin Data Classes (detailed)
+
+```kotlin
+data class User(val name: String, val age: Int)
+// Auto-generates: equals(), hashCode(), toString(), copy(), componentN()
+
+val user = User("Alice", 30)
+val updated = user.copy(age = 31)        // structural update
+val (name, age) = user                    // destructuring
+```
+
+### Relevance to ilo
+
+ilo records already provide the equivalent:
+
+```
+type user{name:t;age:n}
+u=user name:"Alice" age:30
+u2=u with age:31                -- structural update (like copy())
+```
+
+The missing piece is **destructuring** (F7 in CONTROL-FLOW.md):
+
+```
+-- Proposed: {n;a}=u  (bind name→u.name, age→u.age by field name)
+-- Current:  n=u.name;a=u.age  (2 statements)
+```
+
+Destructuring saves 1 token per field. For a 3-field record, that's 3 tokens saved minus 1 for the `{}=` syntax = 2 net tokens. Modest savings but high frequency.
+
+**Key takeaway:** ilo records already match Kotlin data classes in capability. Destructuring bind is the one gap worth closing.
+
+---
+
+## Synthesis: What Matters for an Agent Language
+
+### Already in ilo (no action needed)
+
+| Capability | Swift/Kotlin pattern | ilo equivalent |
+|-----------|---------------------|----------------|
+| Error propagation | `try`/`throws` / exceptions | `!` auto-unwrap |
+| Result type | `Result<T,E>` | `R ok err` |
+| Safe navigation | `?.` | `.?` |
+| Nil coalescing | `??` / `?:` | `??` |
+| Pattern matching | `switch`/`when` exhaustive | `?` match + ILO-T024 |
+| Data classes/records | `data class` / `struct` | `type name{fields}` + `with` |
+| Record update | `.copy()` | `with` expression |
+| JSON schema mapping | `Codable` / `@Serializable` | `type` declarations = schemas |
+| Free-standing functions | Extension functions (compiled) | All functions are free-standing |
+| Chaining | Method chaining / extension chains | `>>` pipe operator |
+
+### Planned features validated by Swift/Kotlin (proceed as designed)
+
+| Feature | ilo Phase | Swift/Kotlin validation |
+|---------|-----------|------------------------|
+| Optional type (`O n`) | E2 | Both languages center their null-safety on compile-time optionals. The verifier catching nil crashes pre-execution would save ~150 tokens per prevented retry. |
+| Sum types / enums | E3 | Swift enums with associated values and Kotlin sealed classes both demonstrate that exhaustive matching on user-defined variants is essential for reliable code. |
+| Generics | E5 | Both languages need generics for `map`/`filter`/`fold`. ilo can defer this longer because `@` loops + bind-first handle most cases. |
+| Destructuring bind | F7 | Kotlin destructuring (`val (a, b) = pair`) and Swift tuple patterns both reduce tokens. Modest savings per use but high frequency. |
+
+### New insights from this research
+
+1. **Runtime-level structured concurrency (zero syntax cost).** Both Swift (TaskGroup) and Kotlin (coroutineScope) prove that structured concurrency is the right model. ilo's graph-native principle enables this at the runtime level — the dependency graph reveals parallelism. No `async`/`await` keywords needed. This is the highest-leverage insight: agents get parallel tool execution without writing concurrency code.
+
+2. **Error-to-Optional bridge.** Swift's `try?` pattern (convert error to nil, then nil-coalesce) is a 2-token pattern for "call with fallback." ilo could support this as `f? args` (like `!` but converts Err to nil instead of propagating). Combined with `??`, this gives: `f? uid ?? default` — 4 tokens for call-with-fallback vs 8+ tokens with full match. This gates on the `O` type (Phase E2).
+
+3. **Scope functions are unnecessary.** Kotlin's `let`/`run`/`apply`/`also`/`with` are 5 different ways to operate on a value in a scope. ilo's `with` expression + bind + match cover all these cases. Adding scope functions would violate "one way to do things."
+
+4. **Protocol/interface abstraction is unnecessary for agents.** Both Swift (protocol-oriented) and Kotlin (interface + default methods) emphasize abstraction. Agents generate concrete code for specific tasks — they don't build reusable libraries. Phase E6 (traits) is correctly deferred.
+
+5. **Extension functions are IDE sugar.** They solve discoverability (`text.` shows available ops in an IDE). Agents don't use IDEs — they read the spec. ilo's free-standing functions are the right model.
+
+### Priority ordering (revised)
+
+Based on this analysis, the token-savings priority for features inspired by Swift/Kotlin:
+
+```
+Highest impact:
+1. Runtime parallel tool execution (zero syntax, graph-based)       — new insight
+2. O type + verifier nil safety (Phase E2)                          — validated
+3. Error-to-Optional bridge: f? args (Swift try? equivalent)        — new insight
+4. Sum types for exhaustive matching (Phase E3)                     — validated
+
+Medium impact:
+5. Destructuring bind (Phase F7)                                    — validated
+6. Generics for map/filter/fold (Phase E5)                          — validated
+
+Low impact / not needed:
+7. String interpolation                                             — prefix + is sufficient
+8. Protocols/interfaces                                             — agents don't abstract
+9. Extension functions / scope functions                            — free functions + pipe suffice
+10. Regex as language feature                                       — tool concern
+11. Explicit async/await keywords                                   — runtime handles this
+12. Method syntax                                                   — violates one-way principle
+```

--- a/research/universal-stdlib-gaps.md
+++ b/research/universal-stdlib-gaps.md
@@ -1,0 +1,725 @@
+# Universal Standard Library Gaps: Cross-Language Analysis for ilo
+
+What every language's users install first reveals what every language's stdlib gets wrong. This document catalogs the "practically required" third-party packages across Python, JavaScript/TypeScript, Rust, Go, and Ruby -- packages so universal they feel like missing stdlib features. Each package represents a capability gap that real programs hit immediately.
+
+The organizing question for ilo: **which of these universal gaps should ilo address as builtins, which as tools, and which should it ignore?**
+
+---
+
+## 1. Python: Top Packages and What They Reveal
+
+PyPI serves over 300 billion downloads annually. The top packages by downloads are dominated by transitive dependencies (urllib3, certifi, idna, charset-normalizer are all pulled in by requests). Filtering to direct-use packages reveals the real demand signal.
+
+### Top 15 Direct-Use Packages
+
+| Rank | Package | Downloads/yr | What It Provides | Stdlib Gap |
+|------|---------|-------------|-----------------|-----------|
+| 1 | **requests** | ~15B | HTTP that actually works | urllib is unusable for real HTTP |
+| 2 | **numpy** | ~10B | Numeric arrays and math | No array computing in stdlib |
+| 3 | **boto3** | ~7B | AWS SDK | No cloud integration |
+| 4 | **python-dateutil** | ~7B | Date parsing and arithmetic | datetime is painful |
+| 5 | **pydantic** | ~4B | Data validation and schemas | No runtime type validation |
+| 6 | **pytest** | ~3B | Testing framework | unittest is verbose and outdated |
+| 7 | **click/typer** | ~3B | CLI framework | argparse is ceremony-heavy |
+| 8 | **httpx** | ~2.5B | Async HTTP + HTTP/2 | urllib has no async, no HTTP/2 |
+| 9 | **python-dotenv** | ~2B | .env file loading | No env-file support |
+| 10 | **SQLAlchemy** | ~1.5B | Database ORM | sqlite3 is raw SQL only |
+| 11 | **Pillow** | ~1.5B | Image manipulation | No image processing |
+| 12 | **black/ruff** | ~1.2B | Formatting/linting | No built-in formatter |
+| 13 | **beautifulsoup4** | ~1B | HTML parsing | html.parser is minimal |
+| 14 | **FastAPI** | ~800M | Web framework | No web framework |
+| 15 | **cryptography** | ~800M | Modern crypto | hashlib is limited |
+
+### Gap Domains
+
+- **HTTP**: requests, httpx, aiohttp -- stdlib urllib is universally rejected
+- **Data Validation**: pydantic -- no runtime schema enforcement
+- **Dates**: python-dateutil -- datetime needs external help for parsing
+- **Testing**: pytest -- unittest is too verbose
+- **CLI**: click, typer -- argparse is ceremony
+- **Environment**: python-dotenv -- no .env loading
+- **Database**: SQLAlchemy -- no ORM
+- **Formatting**: black, ruff -- no canonical formatter (until recently)
+- **Web**: FastAPI, Flask, Django -- no web framework
+- **Crypto**: cryptography -- hashlib is too limited
+
+---
+
+## 2. JavaScript/TypeScript: Top Packages and What They Reveal
+
+npm hosts over 2.2 million packages. The most depended-on packages reveal fundamental language gaps.
+
+### Top 15 Direct-Use Packages
+
+| Rank | Package | Dependents | What It Provides | Stdlib Gap |
+|------|---------|-----------|-----------------|-----------|
+| 1 | **lodash** | 69K+ | Utility functions | Missing array/object helpers |
+| 2 | **chalk** | 40K+ | Terminal colors | No terminal styling |
+| 3 | **commander/yargs** | 32K+ | CLI parsing | No CLI framework |
+| 4 | **express** | 27K+ | HTTP server | http module is raw |
+| 5 | **axios** | 16K+ | HTTP client | fetch was missing until 2022 |
+| 6 | **dotenv** | 15K+ | .env file loading | No env-file support |
+| 7 | **uuid** | 14K+ | UUID generation | crypto.randomUUID only recent |
+| 8 | **zod** | ~12K | Runtime validation | TypeScript types vanish at runtime |
+| 9 | **date-fns/dayjs** | ~10K | Date manipulation | Date object is broken |
+| 10 | **winston/pino** | ~8K | Structured logging | console.log is unstructured |
+| 11 | **jest/vitest** | ~8K | Testing framework | No built-in test runner (until Node 20) |
+| 12 | **pg/mysql2** | ~7K | Database clients | No database support |
+| 13 | **prettier/eslint** | ~7K | Formatting/linting | No canonical formatter |
+| 14 | **socket.io** | ~5K | WebSocket abstraction | WebSocket API is low-level |
+| 15 | **next.js** | ~5K | Meta-framework | No full-stack framework |
+
+### Gap Domains
+
+- **Utility Functions**: lodash -- Array.prototype is insufficient
+- **HTTP Client**: axios -- fetch was missing for a decade
+- **HTTP Server**: express, fastify, hono -- http.createServer is primitive
+- **Validation**: zod, joi, yup -- TS types don't exist at runtime
+- **Dates**: date-fns, dayjs, luxon, moment -- Date is broken (Temporal arriving)
+- **Environment**: dotenv -- no .env loading
+- **CLI**: commander, yargs -- no argument parser
+- **Terminal**: chalk -- no color/styling API
+- **Logging**: winston, pino -- console.log is not structured
+- **Testing**: jest, vitest -- only recently addressed by Node test runner
+- **ID Generation**: uuid -- only recently addressed by crypto.randomUUID
+
+---
+
+## 3. Rust: Top Crates and What They Reveal
+
+crates.io hosts over 200,000 crates. Serde alone has 145M+ downloads, making it the most depended-on crate by a large margin.
+
+### Top 15 Direct-Use Crates
+
+| Rank | Crate | Downloads | What It Provides | Stdlib Gap |
+|------|-------|----------|-----------------|-----------|
+| 1 | **serde** | 145M+ | Serialization framework | No derive-based serialization |
+| 2 | **serde_json** | 120M+ | JSON support for serde | No JSON in stdlib |
+| 3 | **tokio** | 100M+ | Async runtime | No async runtime in stdlib |
+| 4 | **rand** | 37M+ | Random number generation | No random in stdlib |
+| 5 | **anyhow** | 52M+ | Application error handling | Error handling is verbose |
+| 6 | **thiserror** | 50M+ | Library error derive | Custom errors need boilerplate |
+| 7 | **clap** | 45M+ | CLI argument parsing | No CLI parser |
+| 8 | **tracing** | 40M+ | Structured logging | log crate is basic |
+| 9 | **reqwest** | 35M+ | HTTP client | No HTTP client in stdlib |
+| 10 | **chrono** | 30M+ | Date/time handling | std::time is minimal |
+| 11 | **regex** | 28M+ | Regular expressions | No regex in stdlib |
+| 12 | **uuid** | 25M+ | UUID generation | No UUID in stdlib |
+| 13 | **hyper** | 22M+ | HTTP implementation | No HTTP in stdlib |
+| 14 | **axum** | 42M+ | Web framework | No web framework |
+| 15 | **sqlx** | 15M+ | Async SQL | No database support |
+
+### Gap Domains
+
+- **Serialization**: serde, serde_json -- THE fundamental gap; every program needs it
+- **Async Runtime**: tokio -- Rust has async syntax but no runtime
+- **Error Handling**: anyhow, thiserror -- std::error::Error is too bare
+- **HTTP**: reqwest, hyper, axum -- no networking at all
+- **Random**: rand -- no random number generation
+- **CLI**: clap -- no argument parser
+- **Dates**: chrono -- std::time has no calendar
+- **Regex**: regex -- no pattern matching engine
+- **Logging**: tracing -- no structured logging
+- **UUID**: uuid -- no ID generation
+- **Database**: sqlx, diesel -- no database support
+
+Rust's stdlib is deliberately minimal ("batteries not included"), making the gap analysis especially revealing. The Rust community has effectively standardized around specific crates for each gap -- serde, tokio, clap, anyhow are de facto stdlib.
+
+---
+
+## 4. Go: Top Packages and What They Reveal
+
+Go has a large stdlib ("batteries included"), so the third-party packages reveal gaps where even Go's generous stdlib falls short.
+
+### Top 15 Direct-Use Packages
+
+| Rank | Package | Usage % | What It Provides | Stdlib Gap |
+|------|---------|--------|-----------------|-----------|
+| 1 | **testify** | ~60% | Test assertions and mocking | testing is assertion-free |
+| 2 | **gorilla/mux or chi** | ~30% | HTTP routing with params | net/http router is basic |
+| 3 | **cobra** | ~25% | CLI framework | flag is primitive |
+| 4 | **viper** | ~20% | Configuration management | No config library |
+| 5 | **zap/zerolog** | ~20% | Structured logging | log is unstructured |
+| 6 | **gorm** | ~18% | ORM | database/sql is raw |
+| 7 | **google/uuid** | ~15% | UUID generation | No UUID in stdlib |
+| 8 | **golang-jwt/jwt** | ~12% | JWT tokens | No JWT support |
+| 9 | **go-redis** | ~10% | Redis client | No Redis client |
+| 10 | **aws-sdk-go** | ~10% | AWS SDK | No cloud SDKs |
+| 11 | **gin/echo/fiber** | ~48%+ | Web framework | net/http is raw |
+| 12 | **grpc-go** | ~8% | gRPC client/server | No gRPC in stdlib |
+| 13 | **golangci-lint** | ~40% | Linter aggregator | go vet is limited |
+| 14 | **samber/lo** | growing | Lodash-like utilities | No generic collection helpers (pre-1.18) |
+| 15 | **godotenv** | ~5% | .env file loading | No env-file support |
+
+### Gap Domains
+
+- **Testing**: testify -- stdlib testing has no assertions
+- **HTTP Routing**: chi, gorilla/mux -- stdlib router lacks path parameters
+- **CLI**: cobra -- flag package is primitive
+- **Configuration**: viper -- no config file parsing
+- **Logging**: zap, zerolog -- log is unstructured
+- **Database/ORM**: gorm, sqlx -- database/sql is raw
+- **UUID**: google/uuid -- no ID generation
+- **Auth**: golang-jwt -- no JWT support
+- **Environment**: godotenv -- no .env loading
+- **Web Framework**: gin, echo, fiber -- net/http is too low-level for most
+
+Go's big stdlib (HTTP server, JSON, crypto, testing) means its gaps are in higher-level concerns: frameworks, assertions, configuration, and structured logging. The gap between "stdlib has it" and "developers install something else anyway" is instructive.
+
+---
+
+## 5. Ruby: Top Gems and What They Reveal
+
+RubyGems hosts the gems ecosystem. Rails dominance means many top gems are Rails-related.
+
+### Top 15 Direct-Use Gems
+
+| Rank | Gem | Downloads | What It Provides | Stdlib Gap |
+|------|-----|----------|-----------------|-----------|
+| 1 | **rails** | 500M+ | Full-stack web framework | No web framework |
+| 2 | **bundler** | 400M+ | Dependency management | No dependency manager (was separate) |
+| 3 | **rack** | 350M+ | HTTP server interface | No standard HTTP interface |
+| 4 | **nokogiri** | 300M+ | HTML/XML parsing | REXML is slow and limited |
+| 5 | **rspec** | 250M+ | Testing framework | Test::Unit is verbose |
+| 6 | **activesupport** | 250M+ | Core extensions | Missing string/date/hash helpers |
+| 7 | **devise** | 100M+ | Authentication | No auth framework |
+| 8 | **puma** | 100M+ | Web server | WEBrick is too slow |
+| 9 | **sidekiq** | 80M+ | Background jobs | No job queue |
+| 10 | **faraday/httparty** | 70M+ | HTTP client | Net::HTTP is verbose |
+| 11 | **rubocop** | 60M+ | Linter/formatter | No canonical formatter |
+| 12 | **dotenv** | 50M+ | .env file loading | No env-file support |
+| 13 | **pg** | 50M+ | PostgreSQL client | No database drivers |
+| 14 | **redis** | 40M+ | Redis client | No Redis support |
+| 15 | **faker** | 30M+ | Test data generation | No fake data generator |
+
+### Gap Domains
+
+- **Web Framework**: rails, sinatra -- no web framework
+- **HTTP Client**: faraday, httparty -- Net::HTTP is verbose
+- **HTML Parsing**: nokogiri -- REXML is limited
+- **Testing**: rspec -- Test::Unit is verbose
+- **Auth**: devise -- no auth framework
+- **Background Jobs**: sidekiq -- no job queue
+- **Environment**: dotenv -- no .env loading
+- **Database**: pg, mysql2 -- no database drivers beyond sqlite
+- **Formatting**: rubocop -- no canonical formatter
+
+---
+
+## 6. Cross-Language Gap Synthesis
+
+### Capability Domains That Appear in EVERY Language
+
+These are the universal gaps -- capabilities that no major language's stdlib adequately provides, forcing every ecosystem to reinvent the wheel.
+
+#### 6.1 HTTP Client (Usable, Not Raw)
+
+| Language | Stdlib | What People Actually Use | The Gap |
+|----------|--------|------------------------|---------|
+| Python | urllib | requests, httpx | urllib's API is hostile |
+| JS/TS | fetch (recent) | axios, got | fetch was missing for a decade |
+| Rust | (none) | reqwest | No HTTP at all |
+| Go | net/http | net/http (good enough) | Go is the exception |
+| Ruby | Net::HTTP | faraday, httparty | Net::HTTP is verbose |
+
+**Universal truth**: Every language needs a one-line HTTP GET and a three-line HTTP POST with JSON. Go is the only language where the stdlib is good enough, and even there people use frameworks on top.
+
+**ilo status**: `get url` / `$url` already provides this. `post url body` is planned. ilo is ahead of every language here -- 2 tokens for HTTP GET.
+
+#### 6.2 Environment Variable / .env Loading
+
+| Language | Stdlib | What People Actually Use |
+|----------|--------|------------------------|
+| Python | os.environ | python-dotenv |
+| JS/TS | process.env | dotenv |
+| Rust | std::env | dotenvy |
+| Go | os.Getenv | godotenv |
+| Ruby | ENV | dotenv |
+
+**Universal truth**: Every language can read env vars, but none loads .env files by default. The dotenv pattern is the single most cross-language package -- same concept, same name, five ecosystems.
+
+**ilo status**: `env key` is planned (I3). The .env loading question is a runtime concern, not a language concern. The runtime could load .env files before execution.
+
+#### 6.3 Data Validation / Runtime Schema Enforcement
+
+| Language | Stdlib | What People Actually Use |
+|----------|--------|------------------------|
+| Python | (none) | pydantic, attrs, dataclasses |
+| JS/TS | (TypeScript types vanish) | zod, joi, yup |
+| Rust | (serde + custom) | serde, validator |
+| Go | (struct tags) | go-playground/validator |
+| Ruby | (none) | ActiveModel validations, dry-validation |
+
+**Universal truth**: Static types are not enough. Programs need runtime validation of data from external sources (APIs, user input, config files). TypeScript makes this painfully obvious -- types disappear at runtime, so zod exists to bring them back.
+
+**ilo status**: ilo's tool declarations ARE runtime schemas. `tool get-user"..." uid:t>R profile t` declares the expected shape. The runtime validates tool responses against declared types. This is pydantic/zod built into the language, not bolted on. ilo is ahead of every language here.
+
+#### 6.4 CLI Argument Parsing
+
+| Language | Stdlib | What People Actually Use |
+|----------|--------|------------------------|
+| Python | argparse | click, typer |
+| JS/TS | process.argv | commander, yargs |
+| Rust | (none) | clap |
+| Go | flag | cobra |
+| Ruby | OptionParser | thor |
+
+**Universal truth**: Every language's built-in argument parser is either missing or insufficient for real CLI applications. The gap is between "parse flags" and "build a CLI application with subcommands, help text, and validation."
+
+**ilo status**: ilo passes CLI args directly to function parameters. No parser needed -- the function signature IS the interface. This is the right choice for agent programs. CLI parsing is a human concern (help text, tab completion, subcommands) that agents never need.
+
+#### 6.5 Date/Time Beyond Timestamps
+
+| Language | Stdlib | What People Actually Use |
+|----------|--------|------------------------|
+| Python | datetime | python-dateutil, arrow, pendulum |
+| JS/TS | Date (broken) | date-fns, dayjs, luxon, moment; Temporal arriving |
+| Rust | std::time (minimal) | chrono, time |
+| Go | time (good) | Go's time is adequate |
+| Ruby | Time/Date (OK) | ActiveSupport time extensions |
+
+**Universal truth**: Getting the current timestamp is easy. Parsing dates, formatting them, doing arithmetic, handling timezones -- every language struggles. JavaScript's Date is the worst offender, but even Python's datetime needs dateutil for basic parsing.
+
+**ilo status**: `now()` (timestamp) and `slp n` (sleep) are planned (I6). ISO 8601 formatting (`iso n`) and parsing (`ts t`) cover 90% of agent needs. Complex date manipulation is a tool concern.
+
+#### 6.6 UUID / Unique ID Generation
+
+| Language | Stdlib | What People Actually Use |
+|----------|--------|------------------------|
+| Python | uuid (good) | uuid (stdlib is fine!) |
+| JS/TS | crypto.randomUUID (recent) | uuid package |
+| Rust | (none) | uuid crate |
+| Go | (none) | google/uuid |
+| Ruby | SecureRandom.uuid | SecureRandom (stdlib is fine) |
+
+**Universal truth**: Programs need unique identifiers. Only Python and Ruby have adequate stdlib support. The rest need third-party packages. This is a trivially small feature with enormous reach.
+
+**ilo status**: `uid()` is planned. One token, one opcode. High value, low cost.
+
+#### 6.7 Structured Logging
+
+| Language | Stdlib | What People Actually Use |
+|----------|--------|------------------------|
+| Python | logging | structlog, loguru |
+| JS/TS | console.log | winston, pino, bunyan |
+| Rust | (none) | tracing, log + env_logger |
+| Go | log | zap, zerolog, slog (1.21) |
+| Ruby | Logger | Rails logger, semantic_logger |
+
+**Universal truth**: Every language has print-to-stdout. No language (until Go 1.21's slog) has structured logging in stdlib. The gap is between "print a string" and "emit a structured log event with severity, timestamp, and fields."
+
+**ilo status**: Not planned. Agent programs are short-lived scripts, not long-running services. stdout IS the logging mechanism. The agent framework that invokes ilo handles logging. This is a correct omission for ilo's use case.
+
+#### 6.8 Testing Framework
+
+| Language | Stdlib | What People Actually Use |
+|----------|--------|------------------------|
+| Python | unittest | pytest |
+| JS/TS | (none, until Node 20) | jest, vitest, mocha |
+| Rust | #[test] (good) | Built-in is good enough |
+| Go | testing (bare) | testify |
+| Ruby | Test::Unit | rspec |
+
+**Universal truth**: Every language's built-in test runner is either missing or insufficient. The gap is between "run a function and check if it panics" and "assertions, fixtures, parameterized tests, mocking."
+
+**ilo status**: Not planned. Agent programs are verified before execution. Testing is a human development concern. ilo's verifier catches type errors, missing functions, and exhaustiveness gaps -- the class of errors that testing catches in other languages. This is a correct omission.
+
+#### 6.9 Database Access / ORM
+
+| Language | Stdlib | What People Actually Use |
+|----------|--------|------------------------|
+| Python | sqlite3 | SQLAlchemy, Django ORM |
+| JS/TS | (none) | prisma, pg, mysql2, drizzle |
+| Rust | (none) | sqlx, diesel, sea-orm |
+| Go | database/sql (raw) | gorm, sqlx |
+| Ruby | (none) | ActiveRecord, Sequel |
+
+**Universal truth**: Programs need databases. No language provides a usable ORM or query builder in stdlib. Even Go's database/sql, which provides the interface, requires third-party drivers and most developers use an ORM on top.
+
+**ilo status**: Database access is a tool concern. `tool query"Run SQL" sql:t params:L t>R L record t` -- tools handle the driver, connection, and query execution. ilo composes the typed results. This is correct.
+
+#### 6.10 Code Formatting / Linting
+
+| Language | Stdlib | What People Actually Use |
+|----------|--------|------------------------|
+| Python | (none, until recently) | black, ruff, flake8 |
+| JS/TS | (none) | prettier, eslint |
+| Rust | rustfmt (built-in!) | rustfmt + clippy |
+| Go | gofmt (built-in!) | gofmt + golangci-lint |
+| Ruby | (none) | rubocop |
+
+**Universal truth**: Code needs a canonical format. Only Rust and Go ship with an official formatter. Python, JS, and Ruby all needed third-party solutions. The languages that ship formatters (Go, Rust) have notably less style debate.
+
+**ilo status**: Dense format is canonical. `dense(parse(dense(parse(src)))) == dense(parse(src))`. No formatting choices, no style debates. ilo is ahead of every language except Go and Rust here.
+
+#### 6.11 Hashing / Cryptographic Primitives
+
+| Language | Stdlib | What People Actually Use |
+|----------|--------|------------------------|
+| Python | hashlib, hmac | cryptography (for advanced) |
+| JS/TS | crypto.subtle | crypto (mostly adequate) |
+| Rust | (none) | sha2, hmac, ring |
+| Go | crypto/* (good) | crypto/* (stdlib is fine) |
+| Ruby | Digest, OpenSSL | OpenSSL (stdlib is fine) |
+
+**Universal truth**: SHA-256 and HMAC are needed for webhook verification, API authentication, and data integrity. Most languages have adequate stdlib support, but Rust has none.
+
+**ilo status**: `sha t` and `hmac key t` planned (I9). Correct scope -- webhook verification and API auth, not full encryption.
+
+#### 6.12 Random Number Generation
+
+| Language | Stdlib | What People Actually Use |
+|----------|--------|------------------------|
+| Python | random, secrets | random (stdlib is fine) |
+| JS/TS | Math.random() | crypto.getRandomValues, uuid |
+| Rust | (none) | rand crate |
+| Go | math/rand, crypto/rand | Both adequate |
+| Ruby | Random, SecureRandom | SecureRandom (stdlib is fine) |
+
+**Universal truth**: Programs need random numbers. Most languages provide this in stdlib, but Rust notably does not. The gap between "random float" and "cryptographically secure random" matters for security-sensitive applications.
+
+**ilo status**: `rnd()` / `rnd a b` planned. Should default to cryptographically secure.
+
+#### 6.13 Regex Engine
+
+| Language | Stdlib | What People Actually Use |
+|----------|--------|------------------------|
+| Python | re | re (stdlib is fine) |
+| JS/TS | RegExp (native) | Built-in is fine |
+| Rust | (none) | regex crate |
+| Go | regexp (good) | regexp (stdlib is fine) |
+| Ruby | Regexp (native) | Built-in is fine |
+
+**Universal truth**: Regex is in every language's stdlib except Rust. It is a fundamental text processing capability. LLMs are excellent at generating regex patterns, making this especially agent-relevant.
+
+**ilo status**: Planned (I8) as builtins behind a feature flag. `rgx pat text`, `rga pat text`, `rgs pat repl text`.
+
+#### 6.14 HTML/XML Parsing
+
+| Language | Stdlib | What People Actually Use |
+|----------|--------|------------------------|
+| Python | html.parser (minimal) | beautifulsoup4, lxml |
+| JS/TS | DOMParser (browser only) | fast-xml-parser, cheerio |
+| Rust | (none) | scraper, html5ever |
+| Go | html, xml (basic) | goquery |
+| Ruby | REXML (slow) | nokogiri |
+
+**Universal truth**: Web scraping and HTML processing need a real parser. No language provides one that developers are happy with.
+
+**ilo status**: Tool concern. HTML parsing is domain-specific. A tool like `tool scrape"Extract from HTML" html:t sel:t>R t t` handles it.
+
+#### 6.15 Web Framework / HTTP Server
+
+| Language | Stdlib | What People Actually Use |
+|----------|--------|------------------------|
+| Python | http.server (toy) | FastAPI, Flask, Django |
+| JS/TS | http.createServer | express, fastify, hono, next.js |
+| Rust | (none) | axum, actix-web, rocket |
+| Go | net/http (usable) | gin, echo, fiber |
+| Ruby | WEBrick (toy) | rails, sinatra |
+
+**Universal truth**: Every language needs a web framework. This is the most popular package category across all ecosystems.
+
+**ilo status**: Not planned. Agents consume APIs, they don't serve them. Correct omission.
+
+---
+
+## 7. Cross-Language Gap Analysis Matrix
+
+The master table. Each row is a capability that at least 3 of the 5 languages need third-party packages to address.
+
+| # | Capability | Python | JS/TS | Rust | Go | Ruby | Universal? | Agent-Relevant? |
+|---|-----------|--------|-------|------|-----|------|-----------|----------------|
+| 1 | **HTTP client (usable)** | requests | axios/fetch | reqwest | net/http (OK) | faraday | 4/5 | **YES** -- agents call APIs |
+| 2 | **Env var / .env loading** | dotenv | dotenv | dotenvy | godotenv | dotenv | **5/5** | **YES** -- agents need secrets |
+| 3 | **Data validation / schemas** | pydantic | zod | serde+validator | validator | dry-valid | **5/5** | **YES** -- agents handle external data |
+| 4 | **CLI parsing** | click | commander | clap | cobra | thor | **5/5** | No -- human concern |
+| 5 | **Date/time beyond timestamps** | dateutil | date-fns | chrono | time (OK) | activesupport | 4/5 | Partial -- timestamps yes, calendars no |
+| 6 | **UUID generation** | uuid (OK) | uuid | uuid | google/uuid | SecureRandom (OK) | 3/5 | **YES** -- agents create records |
+| 7 | **Structured logging** | structlog | pino | tracing | zap/slog | semantic_log | **5/5** | No -- runtime concern |
+| 8 | **Testing framework** | pytest | jest | built-in (OK) | testify | rspec | 4/5 | No -- human concern |
+| 9 | **Database / ORM** | SQLAlchemy | prisma | sqlx | gorm | ActiveRecord | **5/5** | Partial -- tool concern |
+| 10 | **Code formatting** | black | prettier | rustfmt (OK) | gofmt (OK) | rubocop | 3/5 | No -- human concern |
+| 11 | **Hashing (SHA/HMAC)** | hashlib (OK) | crypto (OK) | sha2/hmac | crypto (OK) | Digest (OK) | 1/5 | **YES** -- webhook verification |
+| 12 | **Random numbers** | random (OK) | Math.random | rand | math/rand (OK) | Random (OK) | 1/5 | **YES** -- ID gen, sampling |
+| 13 | **Regex** | re (OK) | RegExp (OK) | regex crate | regexp (OK) | Regexp (OK) | 1/5 | **YES** -- text extraction |
+| 14 | **HTML/XML parsing** | bs4/lxml | cheerio | scraper | goquery | nokogiri | **5/5** | Partial -- tool concern |
+| 15 | **Web framework** | FastAPI | express | axum | gin | rails | **5/5** | No -- agents don't serve |
+| 16 | **JSON parse/serialize** | json (OK) | JSON (OK) | serde_json | json (OK) | json (OK) | 1/5 | **YES** -- data interchange |
+| 17 | **Async runtime** | asyncio (OK-ish) | built-in | tokio | goroutines (OK) | (limited) | 2/5 | Partial -- runtime concern |
+| 18 | **Error handling ergonomics** | (exceptions) | (exceptions) | anyhow/thiserror | (if err!=nil) | (exceptions) | 2/5 | **YES** -- every call can fail |
+| 19 | **String replace/trim** | built-in (OK) | built-in (OK) | built-in (OK) | strings (OK) | built-in (OK) | 0/5 | **YES** -- text processing |
+| 20 | **Template/interpolation** | f-strings (OK) | template lit (OK) | format! (OK) | fmt (OK) | interpolation (OK) | 0/5 | **YES** -- building messages |
+
+---
+
+## 8. Human Concerns vs Agent Concerns
+
+Not all gaps matter equally for ilo. Classifying by who actually needs the capability:
+
+### Pure Human Concerns (ilo should NOT address)
+
+| Capability | Why Human-Only |
+|-----------|---------------|
+| CLI parsing (click, cobra, clap) | Help text, tab completion, subcommands -- agents pass positional args |
+| Testing framework (pytest, jest) | Agents don't write tests; the verifier catches errors |
+| Code formatting (black, prettier) | ilo has a canonical dense format |
+| Structured logging (pino, zap) | Agent programs are short-lived; stdout suffices |
+| Web framework (express, FastAPI) | Agents consume APIs, not serve them |
+| Background jobs (celery, sidekiq) | Infrastructure concern, not composition concern |
+| Auth framework (devise, passport) | Application concern, not language concern |
+
+### Pure Agent Concerns (ilo SHOULD address)
+
+| Capability | Why Agent-Critical |
+|-----------|-------------------|
+| HTTP client (usable GET/POST) | Agents call APIs constantly |
+| Environment variables | Agents need API keys and config from env |
+| Data validation / schemas | Agents handle untrusted external data |
+| JSON parse/serialize | Universal data interchange format |
+| UUID generation | Creating records, request IDs, correlation |
+| Hashing (SHA-256, HMAC) | Webhook verification, API auth signatures |
+| Error handling ergonomics | Every tool call can fail |
+| String manipulation | Building URLs, messages, payloads |
+| Shell execution | Running system commands (git, build tools) |
+| Regex | Extracting structured data from text |
+
+### Shared Concerns (address partially)
+
+| Capability | What Agents Need | What Humans Need |
+|-----------|-----------------|-----------------|
+| Date/time | Timestamps, ISO 8601, sleep | Calendars, timezones, formatting |
+| Database | Call a query tool | Connection pooling, migrations, ORM |
+| HTML parsing | Extract text from a page | DOM traversal, CSS selectors |
+| Random numbers | Generate IDs, nonces | Statistical distributions, seeding |
+| Async/parallel | Parallel tool calls | Event loops, streams, channels |
+
+---
+
+## 9. What This Means for ilo: Builtin vs Tool Boundary
+
+The cross-language analysis reveals a clear partition:
+
+### Tier 1: Must Be Builtins (every agent needs these, token cost of tool declaration is prohibitive)
+
+These capabilities appear in the "agent-critical" column AND are needed so frequently that declaring them as tools on every program wastes tokens.
+
+| Builtin | Capability | Cross-Language Evidence | ilo Status |
+|---------|-----------|------------------------|-----------|
+| `get url` | HTTP GET | 4/5 languages need third-party | Done |
+| `post url body` | HTTP POST | Same packages provide both GET and POST | Planned (G1) |
+| `env key` | Environment variables | dotenv in 5/5 languages | Planned (I3) |
+| `sha t` | SHA-256 hash | Used for webhook verification in every ecosystem | Planned (I9) |
+| `hmac key t` | HMAC signing | Required by Stripe, GitHub, AWS, Slack APIs | Planned (I9) |
+| `uid()` | UUID generation | 3/5 languages need third-party | Planned |
+| `now()` | Current timestamp | Every language has this but ilo doesn't yet | Planned (I6) |
+| `slp n` | Sleep/delay | Rate limiting, polling | Planned (I6) |
+| `rpl t old new` | String replace | Built-in everywhere but ilo | Planned |
+| `trm t` | Trim whitespace | Built-in everywhere but ilo | Planned |
+| `sh cmd` | Shell execution | Ruby backticks, subprocess, child_process | Planned |
+
+### Tier 2: Builtins Behind Feature Flags (important but not universal)
+
+These are valuable for many agent programs but add binary size or security surface.
+
+| Builtin | Capability | Feature Flag | Cross-Language Evidence |
+|---------|-----------|-------------|------------------------|
+| `rgx pat t` | Regex match | `regex` | 1/5 need third-party but every agent uses regex |
+| `rga pat t` | Regex find all | `regex` | Same |
+| `rgs pat rep t` | Regex replace | `regex` | Same |
+| `b64e t` | Base64 encode | `encoding` | Auth headers, binary data |
+| `b64d t` | Base64 decode | `encoding` | Same |
+| `urle t` | URL encode | `encoding` | Query string construction |
+| `urld t` | URL decode | `encoding` | Same |
+| `rd path` | Read file | `fs` | faraday/fs in every language |
+| `wr path data` | Write file | `fs` | Same |
+| `rnd()` | Random float | `crypto` | ID generation, sampling |
+| `iso n` | Timestamp to ISO 8601 | `time` | API date formatting |
+| `ts t` | ISO 8601 to timestamp | `time` | API date parsing |
+
+### Tier 3: Tool Concern (declare as tools, not builtins)
+
+These capabilities appear in every language's ecosystem but are too domain-specific, too complex, or too security-sensitive for language builtins.
+
+| Capability | Why Tool, Not Builtin | Equivalent Tool Declaration |
+|-----------|----------------------|---------------------------|
+| Database access | Drivers, connection pooling, query optimization | `tool query"Run SQL" sql:t>R L rec t` |
+| HTML/XML parsing | Complex parsers, CSS selectors, DOM | `tool scrape"Extract" html:t sel:t>R t t` |
+| Web framework | Agents don't serve HTTP | N/A |
+| Background jobs | Infrastructure concern | N/A |
+| Auth/JWT | Security-critical, complex | `tool verify-jwt"..." tok:t>R claims t` |
+| Email sending | External service | `tool send-email"..." to:t subj:t body:t>R _ t` |
+| Image processing | Domain-specific | `tool resize-img"..." path:t w:n h:n>R t t` |
+| CSV/YAML/TOML parsing | Format-specific | `tool parse-csv"..." data:t>R L L t t` |
+| Encryption | Dangerous to get wrong | `tool encrypt"..." data:t key:t>R t t` |
+
+### Tier 4: Not Needed (ilo's design eliminates the need)
+
+These capabilities are major package categories in other languages but ilo's design makes them irrelevant.
+
+| Capability | Why ilo Doesn't Need It |
+|-----------|------------------------|
+| CLI parsing | Function parameters ARE the interface |
+| Testing framework | Verifier catches type/call/exhaustiveness errors |
+| Code formatter | Dense format is canonical and non-configurable |
+| Structured logging | Short-lived scripts; stdout is the log |
+| ORM/query builder | Tools return typed records; composition is ilo's job |
+| Data validation library | Tool declarations ARE schemas; runtime validates |
+| Template engine | `+` concat in prefix notation is sufficient |
+| Package manager | Self-contained programs; no imports, no dependencies |
+| Async/await syntax | Runtime parallelizes independent calls from DAG |
+
+---
+
+## 10. The "ilo Advantage" -- Gaps Already Closed by Design
+
+The most interesting finding is not what ilo needs to add, but what ilo's design already eliminates:
+
+### 10.1 Data Validation (pydantic/zod equivalent)
+
+In Python, you install pydantic to validate API responses. In TypeScript, you install zod because types vanish at runtime. In ilo:
+
+```
+tool get-user"Retrieve user" uid:t>R profile t
+type profile{id:t;name:t;email:t;verified:b}
+```
+
+The tool declaration IS the schema. The runtime validates responses against it. The agent never writes validation code. This eliminates an entire category of packages.
+
+**Token savings vs Python/pydantic**: ~50 tokens per validated API call.
+
+### 10.2 Error Handling Ergonomics (anyhow/thiserror equivalent)
+
+Rust developers install anyhow to avoid writing `impl Display for MyError`. Go developers write `if err != nil` on every third line. In ilo:
+
+```
+d=get-user! uid          -- auto-unwrap: propagate error or give me the value
+get-user uid;?{^e:^+"Failed: "e;~d:use d}  -- explicit handling with context
+```
+
+The `!` operator is Rust's `?` operator, Go's `if err != nil { return err }`, and Python's `try/except` -- all in one token.
+
+### 10.3 Code Formatting (black/prettier equivalent)
+
+ilo has exactly one format: dense. No configuration, no debates, no packages to install.
+
+### 10.4 Package Management (npm/pip/cargo equivalent)
+
+ilo programs are self-contained. No imports, no dependencies, no lock files, no node_modules. Tools are declared in the program. The complexity of package management -- which spawned entire ecosystems (npm, pip, cargo, bundler) -- does not exist.
+
+### 10.5 CLI Parsing (click/cobra/clap equivalent)
+
+```bash
+ilo 'f x:n y:n>n;+x y' 3 4
+```
+
+Function parameters are the CLI interface. No argparse, no commander, no clap. The function signature provides types, arity, and names. The runtime handles conversion.
+
+---
+
+## 11. Priority Ranking for ilo Implementation
+
+Based on the cross-language evidence, ranked by (frequency of need) x (token savings) x (agent relevance):
+
+### Critical (blocks real agent workflows)
+
+1. **`env key`** -- every agent needs API keys. dotenv is in 5/5 ecosystems. 2 tokens.
+2. **`post url body`** -- every API interaction beyond GET. 3 tokens.
+3. **`sh cmd`** -- universal escape hatch. Ruby/PHP proved this works. 2 tokens.
+4. **JSON builtins** (`jsn t`, `ser v`) -- universal interchange format. 2 tokens each.
+
+### High (common agent tasks)
+
+5. **`uid()`** -- record creation, request correlation. 1 token.
+6. **`now()`** -- timestamps, timing, cache keys. 1 token.
+7. **`sha t` / `hmac key t`** -- webhook verification, API auth. 2-3 tokens.
+8. **`rpl t old new`** -- string replacement. Used in every program. 4 tokens.
+9. **`trm t`** -- whitespace cleanup from API responses. 2 tokens.
+10. **`slp n`** -- rate limiting, polling intervals. 2 tokens.
+
+### Medium (important but deferrable)
+
+11. **Regex** (`rgx`, `rga`, `rgs`) -- text extraction. Feature flag. 3 tokens each.
+12. **Encoding** (`b64e`, `b64d`, `urle`, `urld`) -- auth headers, URL construction. 2 tokens each.
+13. **File I/O** (`rd`, `wr`) -- local file access. Feature flag. 2-3 tokens.
+14. **Time formatting** (`iso n`, `ts t`) -- API date handling. 2 tokens each.
+15. **`upr t` / `lwr t`** -- case conversion. 2 tokens each.
+
+### Low (nice to have, can wait)
+
+16. **Random** (`rnd()`, `rnd a b`) -- ID generation (uid covers most cases). 1-3 tokens.
+17. **Modulo** (`%a b`) -- cycling, divisibility. 3 tokens.
+18. **Power** (`pow a b`) -- exponential backoff. 3 tokens.
+19. **`pfx t p` / `sfx t s`** -- prefix/suffix check (workaround with `slc` + `=`). 3 tokens.
+20. **Parallel execution** (`par{...}`) -- needs runtime design. Variable tokens.
+
+---
+
+## 12. The Universal Lesson
+
+The cross-language analysis reveals a hierarchy of software needs:
+
+```
+Layer 0: Compute (math, logic, control flow)         -- every language has this
+Layer 1: Text processing (strings, regex, encoding)  -- most languages have this
+Layer 2: I/O (HTTP, files, processes, env vars)       -- stdlib quality varies wildly
+Layer 3: Data interchange (JSON, validation, schemas) -- almost always third-party
+Layer 4: Frameworks (web, testing, CLI, ORM)          -- always third-party
+Layer 5: Domain (images, ML, crypto, cloud)           -- always third-party
+```
+
+ilo should own Layers 0-2 as builtins, handle Layer 3 at the tool boundary (schemas are built-in, format parsing is tools), and leave Layers 4-5 entirely to tools.
+
+The packages that every language installs first -- requests, dotenv, pydantic/zod, uuid -- map to Layers 2-3. These are the gaps ilo must fill. The packages that build ecosystems -- express, pytest, SQLAlchemy -- map to Layers 4-5. These are tool concerns.
+
+The deepest insight: **ilo's tool declaration system eliminates Layer 3 entirely.** No other language does this. Tool declarations are schemas, schemas are validation, validation is the tool boundary. What pydantic is to Python and zod is to TypeScript, `tool name"desc" params>return` is to ilo -- but built into the language, not installed after.
+
+---
+
+## 13. Comparison with ilo's Existing Research
+
+This analysis aligns with and extends the existing research files:
+
+- **go-stdlib-research.md**: Confirmed Go's stdlib strengths (HTTP, JSON, crypto). Go's gaps (testing assertions, routing, structured logging) are human concerns that ilo correctly omits.
+- **python-stdlib-analysis.md**: Confirmed the priority ranking (HTTP > env > shell > validation). Python's biggest lessons: `R` type is better than exceptions, tool declarations beat pydantic.
+- **js-ts-ecosystem.md**: Confirmed the validation gap (zod) is ilo's biggest advantage. TypeScript types vanishing at runtime is THE problem ilo's tool schemas solve.
+- **ruby-php-research.md**: Confirmed shell execution (`sh`) as high priority. Ruby's backtick pattern validates the design.
+- **swift-kotlin-research.md**: Confirmed structured concurrency should be runtime-level, not syntax-level. Optional type (`O`) is validated by both Swift and Kotlin.
+
+### New findings not in existing research
+
+1. **The dotenv pattern** is the single most universal package across all 5 ecosystems -- same name, same concept, five languages. This validates `env` as critical priority.
+2. **UUID generation** appears as a gap in 3/5 languages, stronger signal than expected.
+3. **The Layer 0-5 hierarchy** provides a principled framework for the builtin/tool boundary.
+4. **ilo's tool declarations already solve Layer 3** -- this was implicit in the existing research but not explicitly called out as ilo's biggest advantage over all five ecosystems.
+
+---
+
+## Appendix A: Data Sources
+
+Package download statistics and dependency counts sourced from:
+
+- Python: [PyPI Stats](https://pypistats.org/), [Top PyPI Packages](https://hugovk.github.io/top-pypi-packages/)
+- JavaScript: [npm trends](https://npmtrends.com/), [npm rank](https://gist.github.com/anvaka/8e8fa57c7ee1350e3491), [npm-high-impact](https://github.com/wooorm/npm-high-impact)
+- Rust: [crates.io](https://crates.io/crates?sort=recent-downloads), [lib.rs/stats](https://lib.rs/stats), [State of the Crates 2025](https://ohadravid.github.io/posts/2024-12-state-of-the-crates/)
+- Go: [JetBrains Go Ecosystem 2025](https://blog.jetbrains.com/go/2025/11/10/go-language-trends-ecosystem-2025/), [Go packages by import count](https://medium.com/skyline-ai/most-imported-golang-packages-some-insights-fb12915a07)
+- Ruby: [RubyGems Stats](https://rubygems.org/stats), [BestGems](https://bestgems.org/), [Ruby Toolbox](https://www.ruby-toolbox.com/)
+
+## Appendix B: Methodology
+
+"Practically required" is defined as:
+1. Package appears in the top 15 by downloads or dependents in its ecosystem
+2. Package addresses a capability gap (not just a framework preference)
+3. The capability it provides is used by >50% of non-trivial programs in that language
+4. No adequate stdlib alternative exists (or the stdlib alternative is universally rejected)
+
+Packages that are primarily transitive dependencies (urllib3, certifi, idna in Python; tslib, supports-color in JS) are excluded from the direct-use rankings.
+
+"Agent-relevant" is defined as: an AI agent composing tool calls would need this capability, as opposed to a human developer building an application.
+
+---
+
+## See Also
+
+- [essential-packages-analysis.md](essential-packages-analysis.md) — complementary analysis: same phenomenon from the "what developers install" angle
+- [OPEN.md](OPEN.md) — builtin naming decisions consolidating proposals from both documents

--- a/research/web-runner.md
+++ b/research/web-runner.md
@@ -1,0 +1,419 @@
+# Web Runner for ilo — Design Exploration
+
+A browser-based playground where you paste ilo code, click run, and see output. No install, no server — the ilo interpreter runs client-side as WebAssembly.
+
+## Why this fits ilo unusually well
+
+Most language playgrounds need file trees, package management, and multi-file support. ilo doesn't. Programs are single-line expressions or small function blocks. The entire interaction model is: input box, output box, run button. That's it.
+
+ilo's design constraints make this even better:
+- **Closed vocabulary** — no imports, no packages, no filesystem. Nothing to stub out.
+- **Verification before execution** — errors show before the program runs. The playground can display type errors, arity mismatches, and scope issues live as you type.
+- **Dense syntax** — a meaningful program fits in a single line. No scrolling, no editor chrome needed.
+- **Self-contained units** — each function declares everything it needs. No hidden global state.
+
+Compare: the Rust Playground needs a server farm to compile code. The Go Playground runs on Google's servers. ilo can run entirely on the client because the interpreter is small and programs are tiny.
+
+## Architecture: Rust interpreter compiled to WASM
+
+```
+User's browser
+┌──────────────────────────────────────────────┐
+│  HTML page                                   │
+│  ┌──────────────────────┐  ┌──────────────┐  │
+│  │  Input (textarea or  │  │  Output      │  │
+│  │  CodeMirror)         │  │  (<pre>)     │  │
+│  └──────────┬───────────┘  └──────▲───────┘  │
+│             │ source string       │ result   │
+│             ▼                     │          │
+│  ┌──────────────────────────────────────┐    │
+│  │  ilo.wasm                            │    │
+│  │  lex → parse → verify → interpret    │    │
+│  │  (Rust compiled to wasm32)           │    │
+│  └──────────────────────────────────────┘    │
+└──────────────────────────────────────────────┘
+```
+
+No server. No backend. The `.wasm` file is a static asset served from GitHub Pages or any CDN.
+
+### What compiles to WASM
+
+The pipeline that needs to ship: **lexer** (313 LOC) + **parser** (3,084 LOC) + **AST** (~400 LOC) + **verifier** (2,507 LOC) + **interpreter** (2,281 LOC). Total: ~8,500 lines of Rust.
+
+Not included: JIT backends (Cranelift, ARM64, LLVM), CLI argument parsing, benchmarking, file I/O, the Python transpiler. These are excluded via feature flags or `#[cfg]` gates.
+
+### What about the VM?
+
+The register VM (~4,600 LOC) could also compile to WASM. It's faster than the interpreter (10.7x for numeric code) and has no platform-specific dependencies — no `mmap`, no `libc`, no signal handlers. The main cost is binary size.
+
+**Recommendation:** start with the interpreter (simpler, smaller WASM binary), add the VM as an option later if performance matters. For the tiny programs a playground runs, the interpreter is fast enough.
+
+### The HTTP builtin problem
+
+`get`/`$` uses `minreq` for synchronous HTTP. That won't work in WASM — browsers don't allow synchronous network requests from the main thread.
+
+Options:
+1. **Disable it** — compile with `--no-default-features` (the `http` feature flag already exists). `get` returns `Err "http not available in playground"`. Clean, honest, zero complexity.
+2. **Replace with browser `fetch`** — use `wasm-bindgen-futures` + `web-sys` to call `fetch()`. Requires making the interpreter async, which is a significant change.
+3. **Web Worker + sync XMLHttpRequest** — run the WASM in a Worker where synchronous XHR is technically available. Hacky but avoids async changes to the interpreter.
+
+**Recommendation:** option 1 for v1. The playground is for learning syntax and testing logic, not for making HTTP calls. Add a note: "HTTP builtins require the CLI."
+
+## Build tooling
+
+### wasm-pack + wasm-bindgen
+
+The standard Rust→WASM pipeline. `wasm-pack build` compiles the crate, runs `wasm-bindgen` to generate JS glue code, and produces a `pkg/` directory ready to import.
+
+```toml
+# Cargo.toml — add a library target for WASM
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wasm-bindgen = "0.2"
+```
+
+```rust
+// src/lib.rs — WASM entry point
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn run(source: &str, args: &str) -> String {
+    // args is comma-separated: "5,10,hello"
+    let arg_list = parse_args(args);
+
+    let tokens = match lexer::lex(source) {
+        Ok(t) => t,
+        Err(e) => return format_error(&e, source),
+    };
+
+    let token_spans = tokens.into_iter()
+        .map(|(t, r)| (t, Span { start: r.start, end: r.end }))
+        .collect();
+
+    let (program, parse_errors) = parser::parse(token_spans);
+    if !parse_errors.is_empty() {
+        return format_errors(&parse_errors, source);
+    }
+
+    if let Err(verify_errors) = verify::verify(&program) {
+        return format_errors(&verify_errors, source);
+    }
+
+    match interpreter::run(&program, None, arg_list) {
+        Ok(val) => val.to_string(),
+        Err(e) => format_runtime_error(&e, source),
+    }
+}
+
+#[wasm_bindgen]
+pub fn check(source: &str) -> String {
+    // Returns verification errors as JSON (for live error display)
+    // ... lex → parse → verify, return errors as JSON array
+}
+
+#[wasm_bindgen]
+pub fn format_code(source: &str) -> String {
+    // Returns formatted code (dense or expanded)
+    // ... lex → parse → format
+}
+```
+
+### Build command
+
+```bash
+wasm-pack build --target web --no-default-features
+# Produces: pkg/ilo_bg.wasm, pkg/ilo.js, pkg/ilo.d.ts
+```
+
+`--no-default-features` excludes `cranelift` and `http`. The binary should be small — logos (lexer), serde/serde_json (AST serialization), and thiserror are the only remaining dependencies.
+
+### Expected binary size
+
+Rough estimate based on similar projects (Rust interpreters compiled to WASM):
+- Interpreter + lexer + parser + verifier: **200–500KB** gzipped
+- With `wasm-opt -Oz`: potentially under **300KB** gzipped
+- Without serde (if we skip JSON AST output in WASM mode): **150–300KB** gzipped
+
+For comparison: CodeMirror is ~150KB gzipped. The total page weight would be under 1MB.
+
+## Frontend: minimal HTML
+
+ilo's playground doesn't need a framework. The entire frontend fits in a single HTML file.
+
+```
+playground/
+  index.html      — the page (textarea, output, run button, examples)
+  pkg/
+    ilo_bg.wasm    — compiled interpreter
+    ilo.js         — wasm-bindgen glue
+```
+
+### Editor choice
+
+| Option | Size | Syntax highlighting | Mobile | Complexity |
+|--------|------|---------------------|--------|------------|
+| `<textarea>` | 0KB | No | Yes | None |
+| CodeMirror 6 | ~150KB gz | Custom grammar | Yes | Moderate |
+| Monaco | ~2MB gz | Custom grammar | Poor | High |
+
+**Recommendation:** start with a `<textarea>` and monospace font. ilo programs are short — syntax highlighting is nice-to-have, not essential. Add CodeMirror later if demand justifies it.
+
+CodeMirror 6 is the right upgrade path: modular (import only what you need), good mobile support, and well-suited to small custom languages. Monaco is overkill — it's VS Code's editor and pulls in 2MB of JavaScript.
+
+### Minimal HTML sketch
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>ilo playground</title>
+  <style>
+    body { font-family: system-ui; max-width: 800px; margin: 2rem auto; }
+    textarea, pre { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 14px; width: 100%; }
+    textarea { height: 80px; resize: vertical; }
+    pre { background: #f5f5f5; padding: 1rem; min-height: 2rem; white-space: pre-wrap; }
+    .error { color: #c00; }
+    button { margin: 0.5rem 0; }
+    .args { width: 200px; font-family: monospace; }
+  </style>
+</head>
+<body>
+  <h1>ilo playground</h1>
+  <textarea id="code" spellcheck="false">f x:n>n;*x 2</textarea>
+  <div>
+    <label>args: <input class="args" id="args" value="21"></label>
+    <button id="run">Run</button>
+    <select id="examples">
+      <option value="">Examples...</option>
+      <option value="f x:n>n;*x 2|5">double</option>
+      <option value="tot p:n q:n r:n>n;s=*p q;t=*s r;+s t|10,20,0.1">total+tax</option>
+      <option value="f xs:L n>n;@x xs{>x 10{ret x}};0|3,7,15,2">first >= 10</option>
+    </select>
+  </div>
+  <pre id="output"></pre>
+  <script type="module">
+    import init, { run, check } from './pkg/ilo.js';
+    await init();
+
+    const code = document.getElementById('code');
+    const args = document.getElementById('args');
+    const output = document.getElementById('output');
+
+    document.getElementById('run').onclick = () => {
+      output.className = '';
+      const result = run(code.value, args.value);
+      if (result.startsWith('error:')) {
+        output.className = 'error';
+      }
+      output.textContent = result;
+    };
+
+    // Live error checking as you type
+    let timer;
+    code.oninput = () => {
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        const errors = check(code.value);
+        // Show inline error hints...
+      }, 300);
+    };
+
+    // Example selector
+    document.getElementById('examples').onchange = (e) => {
+      if (!e.target.value) return;
+      const [src, a] = e.target.value.split('|');
+      code.value = src;
+      args.value = a || '';
+      e.target.selectedIndex = 0;
+    };
+  </script>
+</body>
+</html>
+```
+
+Total frontend: ~80 lines of HTML/CSS/JS. No build step, no bundler, no dependencies.
+
+## Precedents: how other languages do it
+
+### Fully client-side (WASM interpreter/compiler in browser)
+
+| Language | Architecture | Notes |
+|----------|-------------|-------|
+| **Gleam** | Rust compiler → WASM, emits JS, runs JS in browser | Compiler compiled to WASM, virtual in-memory filesystem |
+| **Loxcraft** | Rust Lox interpreter → WASM via `wasm-pack` | Closest analogue to what ilo would build. Hosted on GitHub Pages. |
+| **Adventlang** | Go interpreter → WASM, runs in Web Worker pool | Documents the Worker timeout pattern for infinite loops |
+| **Roc** | REPL on roc-lang.org runs via WASM | Early/alpha but functional |
+| **Lua** | C interpreter compiled to WASM | ~150KB, near-instant startup |
+| **SQLite** | C library compiled to WASM | Proves large C codebases work in WASM |
+| **Ruby (ruby.wasm)** | CRuby compiled to WASM via Emscripten | ~30MB — much larger than ilo would be |
+
+### Server-side execution (ilo should NOT do this)
+
+| Language | Architecture | Why server-side |
+|----------|-------------|-----------------|
+| **Rust** | play.rust-lang.org, Docker containers on AWS | Compiler is enormous (>100MB), needs native code gen |
+| **Go** | go.dev/play, Google servers | Compiler + runtime are large |
+| **Python** | Various, often server-side | CPython has filesystem/OS deps |
+
+ilo's interpreter is small enough (~8.5K LOC, no heavy dependencies) that client-side is the obvious choice. No server to maintain, no security sandbox to build, no scaling concerns.
+
+### Loxcraft is the closest analogue
+
+Loxcraft (a Lox interpreter in Rust) is compiled to WASM via `wasm-pack` and hosted on GitHub Pages. It demonstrates the exact pattern ilo would follow: Rust interpreter → WASM → browser. The difference is that ilo's interpreter is larger (2,281 vs ~1,000 LOC) but the architecture is identical.
+
+### The Gleam model for richer features
+
+Gleam compiles its Rust-based compiler to WASM and runs it entirely in the browser. Key lessons:
+- They inject a virtual in-memory filesystem instead of real FS access
+- They expose a JS API from the WASM module (not a CLI interface)
+- The WASM module is loaded once, then called repeatedly
+- No server infrastructure needed
+
+ilo is simpler than Gleam because ilo doesn't need a virtual filesystem at all — programs are strings, not files.
+
+### The Adventlang model for infinite loop handling
+
+Adventlang (a Go interpreter compiled to WASM) runs in a Web Worker pool. When a user clicks "Run", an idle Worker is consumed. If execution exceeds a timeout, `worker.terminate()` kills it. Key insight from Adventlang's design: **a running WASM module cannot be paused or stopped mid-execution** — the only option is terminating the Worker. This is why the Web Worker approach is essential, not optional.
+
+## Features beyond "run"
+
+Once the core runner works, several features come naturally:
+
+### Live verification (as you type)
+The verifier runs on every keystroke (debounced 200–300ms). Type errors, undefined variables, and arity mismatches appear instantly — before clicking Run. This is the killer feature. No other playground gives you verified error codes in real-time for a language this small.
+
+### Format toggle
+A button that reformats between dense wire format (for LLMs) and expanded human-readable format. Uses the existing `codegen::fmt` module.
+
+### Share via URL
+Encode the program in the URL hash: `playground.ilo-lang.org/#f%20x:n>n;*x%202`. ilo programs are short enough that URL encoding works without a URL shortener. No server needed.
+
+### Spec sidebar
+Display the compact spec (`ilo -ai` output) in a collapsible sidebar. Agents and humans can reference it while writing code.
+
+### AST inspector
+Toggle to show the parsed AST as JSON (the existing `serde_json::to_string_pretty(&program)` output). Useful for language developers and curious users.
+
+### Python transpile
+Show the Python equivalent alongside the output. Uses the existing `codegen::python::emit` module. Good for teaching — "here's what this ilo code means in Python."
+
+## Security and sandboxing
+
+WASM in the browser is already sandboxed:
+- **Memory isolation** — WASM linear memory is separate from the page's memory. The interpreter can't touch the DOM or read cookies.
+- **No filesystem access** — `wasm32-unknown-unknown` has no WASI, no file system. The interpreter physically cannot read files.
+- **No network access** — with the `http` feature disabled, there are no network calls. Even if enabled, CORS policies apply.
+- **CPU limits** — a `setTimeout` watchdog in JS can kill the WASM execution if it runs too long (catches infinite loops). The interpreter's main loop can also check a fuel counter.
+
+### Infinite loop protection
+
+The interpreter doesn't currently have a fuel/step counter. Two options:
+
+1. **JS-side timeout** — run the interpreter in a Web Worker with a `setTimeout` kill switch (e.g., 5 seconds). If it doesn't respond, terminate the Worker and show "execution timed out."
+
+2. **Rust-side fuel counter** — add a step limit to the interpreter's `eval` loop. Every expression evaluation decrements a counter; at zero, return an error. This is more precise but requires modifying the interpreter.
+
+**Recommendation:** option 1 for v1 (zero interpreter changes). Option 2 later if needed.
+
+## WASM-specific concerns
+
+### Dependencies that won't compile to WASM
+
+| Dependency | Used for | WASM-compatible? | Action |
+|-----------|----------|-------------------|--------|
+| `logos` | Lexer | Yes (pure Rust, no I/O) | Keep |
+| `serde` + `serde_json` | AST serialization | Yes | Keep |
+| `thiserror` | Error types | Yes | Keep |
+| `libc` | Listed in Cargo.toml | Not on `wasm32-unknown-unknown` | Gate behind `#[cfg(not(target_arch = "wasm32"))]` |
+| `minreq` | HTTP GET | No (needs TCP) | Excluded by `--no-default-features` |
+| `cranelift-*` | JIT compilation | No (needs native codegen) | Excluded by `--no-default-features` |
+| `inkwell` (LLVM) | JIT compilation | No | Excluded by feature flag |
+
+The only issue is `libc`. It's listed as a non-optional dependency in `Cargo.toml`. Need to check where it's used — it may only be needed for the ARM64 JIT (`jit_arm64.rs` uses `mmap`/`mprotect`). If so, make it optional or gate the import.
+
+### println! / eprintln!
+
+The interpreter uses `eprintln!` for tool call debug output (line 419). In WASM, `eprintln!` goes to the browser console via `wasm-bindgen`'s default panic hook. For the playground, we should capture output to a string buffer instead of printing to stderr.
+
+The `run()` function in `interpreter/mod.rs` returns a `Value`, not printed text. This is already correct for the playground — we call `run()` and display `val.to_string()`. The `eprintln!` in tool call logging is debug-only and can be left as-is (goes to console) or gated.
+
+### build.rs (compact spec generation)
+
+`build.rs` reads `SPEC.md` at compile time. This works fine with `wasm-pack` — the build script runs on the host, not in WASM. The generated `spec_ai.txt` is embedded via `include_str!`. No issue.
+
+## Implementation plan
+
+### Phase 1: Minimal runner (1–2 days)
+
+1. Add `[lib]` target to `Cargo.toml` with `crate-type = ["cdylib", "rlib"]`
+2. Create `src/lib.rs` with `#[wasm_bindgen]` entry points: `run(source, args)`, `check(source)`, `format_code(source)`
+3. Gate `libc` dependency behind `#[cfg(not(target_arch = "wasm32"))]`
+4. Build with `wasm-pack build --target web --no-default-features`
+5. Create `playground/index.html` with textarea, args input, run button, output pane
+6. Test locally with a static file server
+
+### Phase 2: Polish (1 day)
+
+7. Add example programs dropdown
+8. Add share-via-URL-hash
+9. Add format toggle (dense ↔ expanded)
+10. Add live verification on keystroke
+11. Web Worker for infinite loop protection
+12. Deploy to GitHub Pages
+
+### Phase 3: Rich features (optional, later)
+
+13. CodeMirror 6 with custom ilo grammar (syntax highlighting, bracket matching)
+14. AST inspector panel
+15. Python transpile view
+16. Spec reference sidebar
+17. VM backend as a toggle (faster execution)
+
+## Open questions
+
+### Should the playground support multi-function programs?
+
+Currently the CLI auto-detects the first function or lets you name one. The playground could:
+- **Always run the first function** — simplest, matches how most examples work
+- **Show a function picker** — dropdown populated from the AST after parsing
+- **Run all top-level expressions** — REPL-like behavior
+
+**Leaning toward:** function picker, populated automatically. It's a `<select>` element populated from `program.declarations`, zero-effort UX.
+
+### Should `println`-style output be supported?
+
+ilo currently has no `print` builtin — functions return values. The playground shows the return value. If `print` is added later, the playground would need stdout capture (a string buffer passed to the interpreter). This is straightforward but not needed today.
+
+### Hosting
+
+Options:
+- **GitHub Pages** — free, automatic from a branch or `/docs` folder, custom domain support
+- **Cloudflare Pages** — free, global CDN, faster for international users
+- **Netlify** — free tier, similar to Cloudflare Pages
+
+All work since the playground is entirely static files. No server, no database, no API. GitHub Pages is simplest since the code is already on GitHub.
+
+## Relationship to other work
+
+- **TODO.md line 595** lists "Playground — web-based editor with live evaluation (WASM target)" as a future item under Tooling.
+- The `http` feature flag (`Cargo.toml:8`) already separates networking from the core — the playground build excludes it cleanly.
+- The `codegen::fmt` module provides both dense and expanded formatting — the playground can offer both views.
+- The `codegen::python` transpiler can show Python equivalents of ilo code.
+- The diagnostic system (ANSI/JSON/text modes) can emit JSON errors for the playground to render.
+
+## Summary
+
+| Aspect | Decision |
+|--------|----------|
+| Execution | Client-side WASM (interpreter backend) |
+| Build tool | `wasm-pack` + `wasm-bindgen` |
+| Editor | `<textarea>` for v1, CodeMirror 6 later |
+| HTTP builtin | Disabled (returns error string) |
+| Infinite loop protection | Web Worker timeout for v1 |
+| Frontend framework | None — single HTML file |
+| Hosting | GitHub Pages |
+| Binary size (est.) | 200–500KB gzipped |
+| Effort | 2–3 days for a working playground |


### PR DESCRIPTION
## Summary
Extracted from #63 (the sprawling exploration branch). These are the 15 new research documents.

**Browser/Web:**
- `playwright-for-ilo.md` — Playwright tool server design
- `web-runner.md` — client-side WASM playground feasibility

**Agent Ecosystem:**
- `agent-framework-tool-mechanics.md` — tool-calling patterns across Anthropic, OpenAI, MCP, LangChain, etc.
- `coding-agents-research.md` — Claude Code, Codex, Cursor, Kilo, Copilot landscape
- `mcp-protocol-research.md` — MCP wire format, primitives, tool discovery

**Language Ecosystem Analysis:**
- `python-stdlib-analysis.md`, `js-ts-ecosystem.md`, `go-stdlib-research.md`
- `rust-capabilities-research.md`, `swift-kotlin-research.md`, `ruby-php-research.md`
- `lua-elixir-research.md`, `shell-languages-research.md`

**Cross-cutting:**
- `essential-packages-analysis.md` — universally-installed packages per language
- `universal-stdlib-gaps.md` — what agents need that stdlibs don't provide

## Test plan
- [x] No code changes — docs only