### PR TITLE
chore: rename formatter flags, fix tagline, clarify backends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ilo"
 version = "0.3.0"
 edition = "2024"
-description = "ilo — a constructed language for AI agents"
+description = "ilo — a programming language for AI agents"
 license = "MIT"
 repository = "https://github.com/danieljohnmorris/ilo-lang"
 homepage = "https://github.com/danieljohnmorris/ilo-lang"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ilo
 
-*ilo* — Toki Pona for "tool" ([sona.pona.la/wiki/ilo](https://sona.pona.la/wiki/ilo)). A constructed language for AI agents.
+*ilo* — Toki Pona for "tool" ([sona.pona.la/wiki/ilo](https://sona.pona.la/wiki/ilo)). A programming language for AI agents.
 
 Languages were designed for humans — visual parsing, readable syntax, spatial navigation. AI agents are not humans. They generate tokens. Every token costs latency, money, and context window. The only metric that matters is **total tokens from intent to working code**.
 
@@ -119,13 +119,13 @@ ilo -ai                      # same as ilo help ai
 
 **Backends:**
 
-By default, ilo uses Cranelift JIT and falls back to the interpreter for non-JIT-eligible functions.
+ilo programs can run interpreted or compiled. The default is JIT compilation via Cranelift — every program is verified before execution (all calls resolve, all types align), so the compiler can trust the code and generate efficient native machine code. Falls back to the interpreter for functions using strings, lists, or records (not yet JIT-eligible).
 
 ```bash
 ilo 'code' args              # default: Cranelift JIT → interpreter fallback
 ilo 'code' --run-interp ...  # tree-walking interpreter
-ilo 'code' --run-vm ...      # register VM
-ilo 'code' --run-cranelift . # Cranelift JIT
+ilo 'code' --run-vm ...      # register VM (bytecode compiled)
+ilo 'code' --run-cranelift . # Cranelift JIT (compiled to native code)
 ilo 'code' --run-jit ...     # custom ARM64 JIT (macOS Apple Silicon only)
 ```
 
@@ -186,11 +186,11 @@ NO_COLOR=1 ilo 'code'       # disable colour
 
 **Formatter:**
 
-Newlines are for humans — agents don't need them. An entire ilo program can be one line. Dense output is the default:
+Newlines are for humans — agents don't need them. An entire ilo program can be one line:
 
 ```bash
-ilo 'code' --fmt              # reformat (dense wire format)
-ilo 'code' --fmt-expanded     # reformat (expanded human format)
+ilo 'code' --dense / -d       # reformat (dense wire format)
+ilo 'code' --expanded / -e    # reformat (expanded human format)
 ```
 
 **Other modes:**

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,14 +154,14 @@ fn main() {
         } else if args.len() > 2 && args[2] == "ai" {
             print!("{}", compact_spec());
         } else {
-            println!("ilo — a constructed language for AI agents\n");
+            println!("ilo — a programming language for AI agents\n");
             println!("Usage:");
             println!("  ilo <code> [args...]              Run (Cranelift JIT, falls back to interpreter)");
             println!("  ilo <file.ilo> [args...]          Run from file");
             println!("  ilo <code> func [args...]         Run a specific function");
             println!("  ilo <code> --emit python          Transpile to Python");
-            println!("  ilo <code> --fmt                  Reformat (dense wire format)");
-            println!("  ilo <code> --fmt-expanded          Reformat (expanded human format)");
+            println!("  ilo <code> --dense / -d             Reformat (dense wire format)");
+            println!("  ilo <code> --expanded / -e          Reformat (expanded human format)");
             println!("  ilo <code>                        Print AST as JSON (no args)");
             println!("  ilo <code> --bench func [args...] Benchmark a function");
             println!("  ilo help lang                     Show language specification");
@@ -274,9 +274,9 @@ fn main() {
             eprintln!("Unknown emit target. Supported: python");
             std::process::exit(1);
         }
-    } else if args.len() > m && args[m] == "--fmt" {
+    } else if args.len() > m && matches!(args[m].as_str(), "--dense" | "-d" | "--fmt") {
         println!("{}", codegen::fmt::format(&program, codegen::fmt::FmtMode::Dense));
-    } else if args.len() > m && args[m] == "--fmt-expanded" {
+    } else if args.len() > m && matches!(args[m].as_str(), "--expanded" | "-e" | "--fmt-expanded") {
         print!("{}", codegen::fmt::format(&program, codegen::fmt::FmtMode::Expanded));
     } else if args.len() > m && args[m] == "--run-jit" {
         // --run-jit [func] [args...] — ARM64 JIT (aarch64 only)


### PR DESCRIPTION
## Summary
- **Formatter flags**: add `--dense`/`-d` and `--expanded`/`-e` as primary flags (`--fmt`/`--fmt-expanded` kept as aliases)
- **Tagline**: "constructed language" → "programming language" (README, Cargo.toml, CLI help)
- **Backends**: clarify that ilo runs JIT-compiled or interpreted, add descriptions to each backend option

## Test plan
- [x] `cargo test` — 1091 tests pass (integration test uses `--fmt` alias, still works)