### PR TITLE
feat: destructuring bind — {a;b}=expr

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ ilo program.ilo --bench tot 10 20 30  # benchmark
 cargo test
 ```
 
-1091 tests: lexer, parser, interpreter, VM, verifier, codegen, diagnostic, formatter, and CLI integration tests.
+1112 tests: lexer, parser, interpreter, VM, verifier, codegen, diagnostic, formatter, and CLI integration tests.
 
 ## Documentation
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -397,6 +397,12 @@ p.x
 ord.addr.country
 ```
 
+Destructure:
+```
+{x;y}=p
+```
+Binds `x` to `p.x` and `y` to `p.y`. All named fields must exist on the record.
+
 Update:
 ```
 ord with total:fin cost:sh

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,7 @@
 8. **Cranelift JIT gaps** — nil coalesce, safe nav, while, break/continue, range, early return
 9. ~~**Verifier gaps**~~ ✅ — unreachable code warning (`ILO-T029`) and `brk`/`cnt` outside loop (`ILO-T028`) both implemented
 10. **Optional type** (E2) — typed nullability with `O n`
-11. **Destructuring bind** (F8) — `{a;b}=expr`
+11. ~~**Destructuring bind**~~ ✅ (F8) — `{a;b}=expr`
 
 See detailed specs for each below.
 
@@ -387,22 +387,23 @@ Index-based loops without constructing a list. Avoids list allocation for numeri
 - [x] Tests: basic range, range with expressions, range variable in body, empty range (start >= end), range + break/continue
 - [x] SPEC.md: documented range syntax
 
-##### F8. Destructuring bind — `{a;b}=expr` (medium priority)
+##### F8. Destructuring bind — `{a;b}=expr` ✅
 
 Extract multiple record fields into local variables in one statement.
 
-- [ ] Syntax: `{a;b;c}=expr` — bind `a` to `expr.a`, `b` to `expr.b`, `c` to `expr.c`
-- [ ] Field names match variable names (ilo convention: short field names)
-- [ ] Parser: recognise `{` at statement start followed by identifiers + `}=`
-- [ ] AST: add `Stmt::Destructure { bindings: Vec<String>, value: Expr }`
-- [ ] Interpreter: evaluate expression, extract each named field, bind to scope
-- [ ] VM: compile expression → register, emit `OP_GETFIELD` for each binding
-- [ ] Verifier: expression must be a record type with all named fields present. Bind each variable to its field's type
+- [x] Syntax: `{a;b;c}=expr` — bind `a` to `expr.a`, `b` to `expr.b`, `c` to `expr.c`
+- [x] Field names match variable names (ilo convention: short field names)
+- [x] Parser: recognise `{` at statement start followed by identifiers + `}=`
+- [x] AST: add `Stmt::Destructure { bindings: Vec<String>, value: Expr }`
+- [x] Interpreter: evaluate expression, extract each named field, bind to scope
+- [x] VM: compile expression → register, emit `OP_RECFLD` for each binding
+- [x] Verifier: expression must be a record type with all named fields present. Bind each variable to its field's type
 - [ ] Renaming syntax (deferred): `{name:n;email:e}=expr` — bind `n` to `expr.name`. Lower priority
 - [ ] Cranelift JIT: sequence of field loads from record
-- [ ] Python codegen: emit as `a, b, c = expr.a, expr.b, expr.c`
-- [ ] Tests: basic destructure, missing field error, type inference from fields, destructure in loop body
-- [ ] SPEC.md: document destructuring syntax
+- [x] Python codegen: emit as `a = p["a"]; b = p["b"]`
+- [x] Formatter: `{a;b}=expr` (dense) / `{a;b} = expr` (expanded)
+- [x] Tests: basic destructure, missing field error, type inference from fields, destructure in loop body
+- [x] SPEC.md: document destructuring syntax
 
 **Token comparison:**
 ```

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -182,6 +182,12 @@ pub enum Stmt {
     /// `cnt` — skip to next iteration of enclosing loop
     Continue,
 
+    /// `{a;b;c}=expr` — destructure record fields into local bindings
+    Destructure {
+        bindings: Vec<String>,
+        value: Expr,
+    },
+
     /// Expression as statement (last expr is return value)
     Expr(Expr),
 }

--- a/src/codegen/fmt.rs
+++ b/src/codegen/fmt.rs
@@ -189,6 +189,9 @@ fn fmt_body_dense(stmts: &[Spanned<Stmt>]) -> String {
 fn fmt_stmt_dense(stmt: &Stmt) -> String {
     match stmt {
         Stmt::Let { name, value } => format!("{}={}", name, fmt_expr(value, FmtMode::Dense)),
+        Stmt::Destructure { bindings, value } => {
+            format!("{{{}}}={}", bindings.join(";"), fmt_expr(value, FmtMode::Dense))
+        }
         Stmt::Guard { condition, negated, body, else_body } => {
             let prefix = if *negated { "!" } else { "" };
             let main = format!("{}{}{{{}}}", prefix, fmt_expr(condition, FmtMode::Dense), fmt_body_dense(body));
@@ -244,6 +247,14 @@ fn fmt_stmt_expanded(out: &mut String, stmt: &Stmt, indent_level: usize) {
             out.push_str(&ind);
             out.push_str(name);
             out.push_str(" = ");
+            out.push_str(&fmt_expr(value, FmtMode::Expanded));
+            out.push('\n');
+        }
+        Stmt::Destructure { bindings, value } => {
+            out.push_str(&ind);
+            out.push('{');
+            out.push_str(&bindings.join(";"));
+            out.push_str("} = ");
             out.push_str(&fmt_expr(value, FmtMode::Expanded));
             out.push('\n');
         }
@@ -1049,5 +1060,24 @@ mod tests {
     #[test]
     fn round_trip_safe_field() {
         assert_round_trip("f x:n>n;x.?name");
+    }
+
+    // ---- Destructuring bind tests ----
+
+    #[test]
+    fn dense_destructure() {
+        let s = dense("type pt{x:n;y:n}\nf p:pt>n;{x;y}=p;+x y");
+        assert!(s.contains("{x;y}=p"), "got: {s}");
+    }
+
+    #[test]
+    fn expanded_destructure() {
+        let s = expanded("type pt{x:n;y:n}\nf p:pt>n;{x;y}=p;+x y");
+        assert!(s.contains("{x;y} = p"), "got: {s}");
+    }
+
+    #[test]
+    fn round_trip_destructure() {
+        assert_round_trip("type pt{x:n;y:n}\nf p:pt>n;{x;y}=p;+x y");
     }
 }

--- a/src/codegen/python.rs
+++ b/src/codegen/python.rs
@@ -42,6 +42,7 @@ fn stmt_uses_unwrap(stmt: &Stmt) -> bool {
         Stmt::Break(Some(e)) => expr_uses_unwrap(e),
         Stmt::Break(None) => false,
         Stmt::Continue => false,
+        Stmt::Destructure { value, .. } => expr_uses_unwrap(value),
         Stmt::Expr(e) => expr_uses_unwrap(e),
     }
 }
@@ -142,6 +143,13 @@ fn emit_stmt(out: &mut String, stmt: &Stmt, level: usize, implicit_return: bool)
             let val = emit_expr(out, level, value);
             indent(out, level);
             out.push_str(&format!("{} = {}\n", py_name(name), val));
+        }
+        Stmt::Destructure { bindings, value } => {
+            let record = emit_expr(out, level, value);
+            for binding in bindings {
+                indent(out, level);
+                out.push_str(&format!("{} = {}[\"{}\"]\n", py_name(binding), record, binding));
+            }
         }
         Stmt::Guard { condition, negated, body, else_body } => {
             let cond = emit_expr(out, level, condition);
@@ -1189,5 +1197,12 @@ mod tests {
     fn emit_safe_index() {
         let py = parse_and_emit("f xs:L n>n;xs.?0");
         assert!(py.contains("is not None else None"), "got: {py}");
+    }
+
+    #[test]
+    fn emit_destructure() {
+        let py = parse_and_emit("type pt{x:n;y:n}\nf p:pt>n;{x;y}=p;+x y");
+        assert!(py.contains("[\"x\"]"), "got: {py}");
+        assert!(py.contains("[\"y\"]"), "got: {py}");
     }
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -489,6 +489,21 @@ fn eval_stmt(env: &mut Env, stmt: &Stmt, is_last: bool) -> Result<Option<BodyRes
             env.set(name, val);
             Ok(None)
         }
+        Stmt::Destructure { bindings, value } => {
+            let val = eval_expr(env, value)?;
+            match val {
+                Value::Record { fields, .. } => {
+                    for binding in bindings {
+                        let field_val = fields.get(binding).cloned().ok_or_else(|| {
+                            RuntimeError::new("ILO-R005", format!("no field '{}' on record", binding))
+                        })?;
+                        env.set(binding, field_val);
+                    }
+                    Ok(None)
+                }
+                _ => Err(RuntimeError::new("ILO-R005", "destructure requires a record".to_string())),
+            }
+        }
         Stmt::Guard { condition, negated, body, else_body } => {
             let cond = eval_expr(env, condition)?;
             let truth = is_truthy(&cond);
@@ -2576,5 +2591,45 @@ mod tests {
     fn ok_srt_empty_list() {
         let source = "f>L n;srt []";
         assert_eq!(run_str(source, Some("f"), vec![]), Value::List(vec![]));
+    }
+
+    // ---- Destructuring bind tests ----
+
+    #[test]
+    fn destructure_basic() {
+        let source = "type pt{x:n;y:n} f>n;p=pt x:3 y:4;{x;y}=p;+x y";
+        assert_eq!(run_str(source, Some("f"), vec![]), Value::Number(7.0));
+    }
+
+    #[test]
+    fn destructure_single_field() {
+        let source = "type pt{x:n;y:n} f>n;p=pt x:10 y:20;{x}=p;x";
+        assert_eq!(run_str(source, Some("f"), vec![]), Value::Number(10.0));
+    }
+
+    #[test]
+    fn destructure_with_text_fields() {
+        let source = "type usr{name:t;email:t} f>t;u=usr name:\"alice\" email:\"a@b\";{name;email}=u;name";
+        assert_eq!(run_str(source, Some("f"), vec![]), Value::Text("alice".to_string()));
+    }
+
+    #[test]
+    fn destructure_in_loop() {
+        // Destructure inside a foreach — last iteration value is returned
+        let source = "type pt{x:n;y:n} f>n;ps=[pt x:1 y:2,pt x:3 y:4];@p ps{{x;y}=p;+x y}";
+        assert_eq!(run_str(source, Some("f"), vec![]), Value::Number(7.0));
+    }
+
+    #[test]
+    fn destructure_non_record_error() {
+        let err = run_str_err("f x:n>n;{a}=x;a", Some("f"), vec![Value::Number(5.0)]);
+        assert!(err.contains("destructure requires a record"), "got: {}", err);
+    }
+
+    #[test]
+    fn destructure_missing_field_error() {
+        let source = "type pt{x:n;y:n} f>n;p=pt x:3 y:4;{x;z}=p;x";
+        let err = run_str_err(source, Some("f"), vec![]);
+        assert!(err.contains("no field 'z'"), "got: {}", err);
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -462,6 +462,9 @@ impl Parser {
                 self.expect(&Token::RBrace)?;
                 Ok(Stmt::While { condition, body })
             }
+            Some(Token::LBrace) if self.is_destructure_pattern() => {
+                self.parse_destructure()
+            }
             Some(Token::Ident(_)) => {
                 // Check for let binding: ident '='
                 if self.pos + 1 < self.tokens.len() && self.token_at(self.pos + 1) == Some(&Token::Eq) {
@@ -509,6 +512,40 @@ impl Parser {
         self.expect(&Token::Eq)?;
         let value = self.parse_expr()?;
         Ok(Stmt::Let { name, value })
+    }
+
+    /// Lookahead: `{ident;ident...}=` — destructure pattern
+    fn is_destructure_pattern(&self) -> bool {
+        let mut pos = self.pos + 1; // skip `{`
+        loop {
+            match self.token_at(pos) {
+                Some(Token::Ident(_)) => pos += 1,
+                Some(Token::Semi) => pos += 1,
+                Some(Token::RBrace) => {
+                    return self.token_at(pos + 1) == Some(&Token::Eq);
+                }
+                _ => return false,
+            }
+        }
+    }
+
+    /// `{a;b;c}=expr` — destructure record fields into bindings
+    fn parse_destructure(&mut self) -> Result<Stmt> {
+        self.expect(&Token::LBrace)?;
+        let mut bindings = Vec::new();
+        loop {
+            let name = self.expect_ident()?;
+            bindings.push(name);
+            if self.peek() == Some(&Token::Semi) {
+                self.advance(); // consume `;`
+            } else {
+                break;
+            }
+        }
+        self.expect(&Token::RBrace)?;
+        self.expect(&Token::Eq)?;
+        let value = self.parse_expr()?;
+        Ok(Stmt::Destructure { bindings, value })
     }
 
     /// `?{arms}` or `?expr{arms}`
@@ -3165,6 +3202,54 @@ mod tests {
                 other => panic!("expected Call, got {:?}", other),
             },
             _ => panic!("expected function"),
+        }
+    }
+
+    // ---- Destructuring bind tests ----
+
+    #[test]
+    fn parse_destructure_two_fields() {
+        let prog = parse_str("type pt{x:n;y:n} f p:pt>n;{x;y}=p;+x y");
+        let func = match &prog.declarations[1] {
+            Decl::Function { body, .. } => body,
+            _ => panic!("expected function"),
+        };
+        match &func[0].node {
+            Stmt::Destructure { bindings, value } => {
+                assert_eq!(bindings, &["x", "y"]);
+                assert!(matches!(value, Expr::Ref(name) if name == "p"));
+            }
+            other => panic!("expected Destructure, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_destructure_single_field() {
+        let prog = parse_str("type pt{x:n} f p:pt>n;{x}=p;x");
+        let func = match &prog.declarations[1] {
+            Decl::Function { body, .. } => body,
+            _ => panic!("expected function"),
+        };
+        match &func[0].node {
+            Stmt::Destructure { bindings, .. } => {
+                assert_eq!(bindings, &["x"]);
+            }
+            other => panic!("expected Destructure, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_destructure_three_fields() {
+        let prog = parse_str("type pt{a:n;b:t;c:b} f p:pt>n;{a;b;c}=p;a");
+        let func = match &prog.declarations[1] {
+            Decl::Function { body, .. } => body,
+            _ => panic!("expected function"),
+        };
+        match &func[0].node {
+            Stmt::Destructure { bindings, .. } => {
+                assert_eq!(bindings, &["a", "b", "c"]);
+            }
+            other => panic!("expected Destructure, got {:?}", other),
         }
     }
 }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -56,6 +56,7 @@ struct FuncSig {
     return_type: Ty,
 }
 
+#[derive(Clone)]
 struct TypeDef {
     fields: Vec<(String, Ty)>,
 }
@@ -778,6 +779,54 @@ impl VerifyContext {
             Stmt::Let { name, value } => {
                 let ty = self.infer_expr(func, scope, value, span);
                 scope_insert(scope, name.clone(), ty);
+                Ty::Nil
+            }
+            Stmt::Destructure { bindings, value } => {
+                let record_ty = self.infer_expr(func, scope, value, span);
+                match &record_ty {
+                    Ty::Named(type_name) => {
+                        if let Some(type_def) = self.types.get(type_name).cloned() {
+                            for binding in bindings {
+                                if let Some((_, fty)) = type_def.fields.iter().find(|(n, _)| n == binding) {
+                                    scope_insert(scope, binding.clone(), fty.clone());
+                                } else {
+                                    let field_names: Vec<String> = type_def.fields.iter().map(|(n, _)| n.clone()).collect();
+                                    let hint = closest_match(binding, field_names.iter())
+                                        .map(|s| format!("did you mean '{s}'?"));
+                                    self.err(
+                                        "ILO-T019",
+                                        func,
+                                        format!("no field '{binding}' on type '{type_name}'"),
+                                        hint,
+                                        Some(span),
+                                    );
+                                    scope_insert(scope, binding.clone(), Ty::Unknown);
+                                }
+                            }
+                        } else {
+                            for binding in bindings {
+                                scope_insert(scope, binding.clone(), Ty::Unknown);
+                            }
+                        }
+                    }
+                    Ty::Unknown => {
+                        for binding in bindings {
+                            scope_insert(scope, binding.clone(), Ty::Unknown);
+                        }
+                    }
+                    other => {
+                        self.err(
+                            "ILO-T009",
+                            func,
+                            format!("destructure requires a record type, got {other}"),
+                            None,
+                            Some(span),
+                        );
+                        for binding in bindings {
+                            scope_insert(scope, binding.clone(), Ty::Unknown);
+                        }
+                    }
+                }
                 Ty::Nil
             }
             Stmt::Guard { condition, body, else_body, .. } => {
@@ -2987,5 +3036,36 @@ mod tests {
     fn alias_complex_type() {
         // alias with nested L and R
         assert!(parse_and_verify("alias deep L R n t\nf>deep;[~1, ~2]").is_ok());
+    }
+
+    // ---- Destructuring bind tests ----
+
+    #[test]
+    fn destructure_ok() {
+        assert!(parse_and_verify("type pt{x:n;y:n}\nf p:pt>n;{x;y}=p;+x y").is_ok());
+    }
+
+    #[test]
+    fn destructure_infers_types() {
+        // After destructuring, x should be n and usable in arithmetic
+        assert!(parse_and_verify("type pt{x:n;y:n}\nf p:pt>n;{x;y}=p;*x y").is_ok());
+    }
+
+    #[test]
+    fn destructure_wrong_field() {
+        let errs = parse_and_verify("type pt{x:n;y:n}\nf p:pt>n;{x;z}=p;x").unwrap_err();
+        assert!(errs.iter().any(|e| e.code == "ILO-T019" && e.message.contains("no field 'z'")));
+    }
+
+    #[test]
+    fn destructure_non_record() {
+        let errs = parse_and_verify("f x:n>n;{a}=x;a").unwrap_err();
+        assert!(errs.iter().any(|e| e.message.contains("destructure requires a record")));
+    }
+
+    #[test]
+    fn destructure_text_type_error() {
+        let errs = parse_and_verify("f x:t>n;{a}=x;a").unwrap_err();
+        assert!(errs.iter().any(|e| e.message.contains("destructure requires a record")));
     }
 }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -385,9 +385,8 @@ impl RegCompiler {
 
                 self.current.reg_count = self.max_reg;
                 self.chunks.push(self.current.clone());
-            } else {
-                self.chunks.push(Chunk::new(0));
             }
+            // TypeDef, Alias, Error — no chunk emitted (not in func_names)
         }
 
         if let Some(e) = self.first_error {
@@ -419,6 +418,22 @@ impl RegCompiler {
                 } else {
                     let reg = self.compile_expr(value);
                     self.add_local(name, reg);
+                }
+                None
+            }
+
+            Stmt::Destructure { bindings, value } => {
+                let record_reg = self.compile_expr(value);
+                for binding in bindings {
+                    let ki = self.current.add_const(Value::Text(binding.clone()));
+                    assert!(ki <= 255, "constant pool overflow: field name index {} exceeds 8-bit limit in OP_RECFLD", ki);
+                    if let Some(existing_reg) = self.resolve_local(binding) {
+                        self.emit_abc(OP_RECFLD, existing_reg, record_reg, ki as u8);
+                    } else {
+                        let field_reg = self.alloc_reg();
+                        self.emit_abc(OP_RECFLD, field_reg, record_reg, ki as u8);
+                        self.add_local(binding, field_reg);
+                    }
                 }
                 None
             }
@@ -4850,5 +4865,25 @@ mod tests {
         // .?0 on a list returns the element
         let source = "f>n;xs=[10,20,30];xs.?0";
         assert_eq!(vm_run(source, Some("f"), vec![]), Value::Number(10.0));
+    }
+
+    // ---- Destructuring bind tests ----
+
+    #[test]
+    fn vm_destructure_basic() {
+        let source = "type pt{x:n;y:n} f>n;p=pt x:3 y:4;{x;y}=p;+x y";
+        assert_eq!(vm_run(source, Some("f"), vec![]), Value::Number(7.0));
+    }
+
+    #[test]
+    fn vm_destructure_single_field() {
+        let source = "type pt{x:n;y:n} f>n;p=pt x:10 y:20;{y}=p;y";
+        assert_eq!(vm_run(source, Some("f"), vec![]), Value::Number(20.0));
+    }
+
+    #[test]
+    fn vm_destructure_in_loop() {
+        let source = "type pt{x:n;y:n} f>n;ps=[pt x:1 y:2,pt x:3 y:4];@p ps{{x;y}=p;+x y}";
+        assert_eq!(vm_run(source, Some("f"), vec![]), Value::Number(7.0));
     }
 }


### PR DESCRIPTION
## Summary
- Adds destructuring bind syntax: `{x;y}=record_expr` extracts named fields into local bindings
- Saves 4 tokens vs manual field access (`{x;y}=p` vs `x=p.x;y=p.y`)
- Full implementation: parser, AST, interpreter, VM, verifier (type inference + field validation), Python codegen, formatter
- Fixes pre-existing VM bug where `TypeDef` declarations pushed empty chunks, causing function index misalignment when types and functions coexist

## Test plan
- [x] 3 parser tests: two-field, single-field, three-field destructure
- [x] 6 interpreter tests: basic, single field, text fields, loop, non-record error, missing field error
- [x] 3 VM tests: basic, single field, loop
- [x] 5 verifier tests: ok, type inference, wrong field, non-record, text type
- [x] 3 formatter tests: dense, expanded, round-trip
- [x] 1 Python codegen test
- [x] All 1112 tests pass
- [x] No new clippy warnings