### PR TITLE
fix(main): remove unnecessary unsafe env set

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -808,8 +808,7 @@ fn load_env_file(path: &str) {
             let key = key.trim();
             let val = val.trim();
             if !key.is_empty() && std::env::var(key).is_err() {
-                // SAFETY: single-threaded at this point (before any spawning)
-                unsafe { std::env::set_var(key, val); }
+                std::env::set_var(key, val);
             }
         }
     }


### PR DESCRIPTION
Remove unnecessary unsafe from .env loader (uses safe std::env::set_var). Behavior unchanged; still respects existing env vars and runs before spawning threads.