### PR TITLE
fix(tools): JSON output without unwrap panic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -177,7 +177,13 @@ fn tools_cmd(args: &[String]) {
                     }));
                 }
             }
-            println!("{}", serde_json::to_string_pretty(&items).unwrap());
+            match serde_json::to_string_pretty(&items) {
+                Ok(s) => println!("{}", s),
+                Err(e) => {
+                    eprintln!("failed to render JSON: {}", e);
+                    std::process::exit(1);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
 no longer panics on serialization errors; prints a clear error to stderr and exits non‑zero. No functional change for valid cases.