### PR TITLE
fix(jit-arm64): handle mprotect failure

### DIFF
--- a/src/vm/jit_arm64.rs
+++ b/src/vm/jit_arm64.rs
@@ -280,8 +280,11 @@ impl Arm64Emitter {
             // Switch to execute-only
             pthread_jit_write_protect_np(1);
 
-            // Make executable
-            libc::mprotect(ptr, alloc_size, libc::PROT_READ | libc::PROT_EXEC);
+            // Make executable; if this fails, clean up and bail
+            if libc::mprotect(ptr, alloc_size, libc::PROT_READ | libc::PROT_EXEC) != 0 {
+                libc::munmap(ptr, alloc_size);
+                return None;
+            }
 
             // Flush instruction cache
             sys_icache_invalidate(ptr, alloc_size);


### PR DESCRIPTION
Arm64 JIT now checks mprotect return value; on failure, it unmaps the allocation and returns None instead of proceeding with potentially RWX memory.