### PR TITLE
docs: mark multi-function boundary as already fixed

### DIFF
--- a/research/TODO.md
+++ b/research/TODO.md
@@ -28,7 +28,7 @@ Discovered during a Claude Code session using ilo as a bash/python replacement. 
 
 ### Diagnostics
 - [x] **`//` warning inside string literals** — cross-language warning now strips string contents before pattern matching. URLs in strings no longer trigger false positives.
-- [ ] **Multi-function boundary diagnostic** — non-last functions ending with bare refs or function calls silently produce wrong results due to greedy parsing. Emit an error (ILO-P020) pointing at the ambiguous ending with a suggestion to wrap in parens or end with a binary op.
+- [x] **Multi-function boundary diagnostic** — already fixed by `is_fn_decl_start()` in `can_start_operand()` (commit 2b9ff66). Parser detects `Ident >` (zero-param) and `Ident Ident :` (parameterized) boundaries, preventing greedy arg consumption. All valid multi-function programs parse correctly; no additional diagnostic needed.
 - [ ] **Guard-in-loop lint** — guards inside `@`/`wh` loops cause early function return, not loop-iteration skip. Emit a warning (ILO-W001) suggesting ternary `{then}{else}` when a guard appears inside a loop body.
 
 ### DX


### PR DESCRIPTION
## Summary
- Multi-function boundary parsing issue was already fixed in commit 2b9ff66
- `is_fn_decl_start()` in `can_start_operand()` correctly detects all valid function boundaries
- No additional diagnostic (ILO-P020) needed — parser handles all valid programs correctly
- Updated TODO.md to mark item as complete

## Test plan
- [x] Verified parser handles `f xs:n>n;len xs g>n;2` (zero-param boundary)
- [x] Verified parser handles `f xs:n>n;len xs g y:n>n;*y 2` (parameterized boundary)
- [x] Verified parser handles `f x:n>n;double x double a:n>n;*a 2` (cross-function call)
- [x] Tested multiple edge cases — no silent misparse found