### PR TITLE
feat: guard-in-loop warning (ILO-W001)

### DIFF
--- a/research/TODO.md
+++ b/research/TODO.md
@@ -29,7 +29,7 @@ Discovered during a Claude Code session using ilo as a bash/python replacement. 
 ### Diagnostics
 - [x] **`//` warning inside string literals** — cross-language warning now strips string contents before pattern matching. URLs in strings no longer trigger false positives.
 - [x] **Multi-function boundary diagnostic** — already fixed by `is_fn_decl_start()` in `can_start_operand()` (commit 2b9ff66). Parser detects `Ident >` (zero-param) and `Ident Ident :` (parameterized) boundaries, preventing greedy arg consumption. All valid multi-function programs parse correctly; no additional diagnostic needed.
-- [ ] **Guard-in-loop lint** — guards inside `@`/`wh` loops cause early function return, not loop-iteration skip. Emit a warning (ILO-W001) suggesting ternary `{then}{else}` when a guard appears inside a loop body.
+- [x] **Guard-in-loop lint** — verifier emits ILO-W001 when a guard without else appears inside `@`/`wh`/range loops. Suggests ternary `{then}{else}` or `brk`/`cnt` for loop control.
 
 ### DX
 - [ ] **Idiomatic hints on successful runs** — walk the AST after execution and suggest canonical forms. E.g. `(a + b)` → `hint: +a b saves 2 tokens`, `==a b` → `hint: =a b saves 1 token`. Teaches idiomatic ilo as you go. Output channels: **TTY** → stderr (human sees it), **JSON/serv mode** → `"hints"` field in response (LLM sees it), **plain pipe** → nothing. Disable with `-nh` / `--no-hints`.

--- a/src/diagnostic/registry.rs
+++ b/src/diagnostic/registry.rs
@@ -622,6 +622,33 @@ never be executed.
 "#,
     },
 
+    // ── Warnings ─────────────────────────────────────────────────────────────
+    ErrorEntry {
+        code: "ILO-W001",
+        short: "guard without else inside loop",
+        long: r#"## ILO-W001: guard without else inside loop
+
+A guard statement (`cond{body}`) without an `{else}` branch inside a loop
+(`@`/`wh`) causes an early **function** return when the condition is true,
+not a loop-iteration skip. This is usually not what you want.
+
+**Example that triggers this:**
+
+    f xs:L n>n;r=0;@ xs x{>=x 10{r= +r x};r}
+
+When `x >= 10`, the guard returns `+r x` from the **function**, not just
+from the current iteration.
+
+**Fix — use ternary (then/else):**
+
+    f xs:L n>n;r=0;@ xs x{>=x 10{r= +r x}{r};r}
+
+Or use `cnt` to skip the iteration:
+
+    f xs:L n>n;r=0;@ xs x{<x 10{cnt};r= +r x;r}
+"#,
+    },
+
     // ── Runtime ──────────────────────────────────────────────────────────────
     ErrorEntry {
         code: "ILO-R001",

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1331,6 +1331,18 @@ impl VerifyContext {
             Stmt::Guard { condition, body, else_body, .. } => {
                 let _ = self.infer_expr(func, scope, condition, span);
 
+                // Warn if a guard without else appears inside a loop — it causes early
+                // function return, not iteration skip. Suggest ternary {then}{else} instead.
+                if self.in_loop && else_body.is_none() {
+                    self.warn(
+                        "ILO-W001",
+                        func,
+                        "guard without else inside loop causes early function return, not iteration skip".to_string(),
+                        Some("use ternary form: cond{then}{else} or brk/cnt for loop control".to_string()),
+                        Some(span),
+                    );
+                }
+
                 // Warn if braceless guard body is a single identifier matching a function name.
                 if body.len() == 1
                     && let Stmt::Expr(Expr::Ref(ref name)) = body[0].node
@@ -3427,6 +3439,49 @@ mod tests {
     #[test]
     fn brk_inside_guard_inside_loop() {
         assert!(parse_and_verify("f>_;i=0;wh <i 5{>i 3{brk};i=+i 1}").is_ok());
+    }
+
+    // ---- Guard-in-loop warning (ILO-W001) ----
+
+    #[test]
+    fn guard_in_foreach_warns() {
+        let result = parse_and_verify_full("f xs:L n>n;r=0;@x xs{>=x 10{r= +r x}};r");
+        assert!(result.errors.is_empty());
+        let w001: Vec<_> = result.warnings.iter().filter(|w| w.code == "ILO-W001").collect();
+        assert_eq!(w001.len(), 1);
+        assert!(w001[0].message.contains("guard without else inside loop"));
+    }
+
+    #[test]
+    fn guard_in_while_warns() {
+        let result = parse_and_verify_full("f>n;i=0;wh <i 10{>i 5{ret i};i= +i 1};i");
+        assert!(result.errors.is_empty());
+        let w001: Vec<_> = result.warnings.iter().filter(|w| w.code == "ILO-W001").collect();
+        assert_eq!(w001.len(), 1);
+    }
+
+    #[test]
+    fn guard_in_range_warns() {
+        let result = parse_and_verify_full("f>n;r=0;@i 0..10{>=i 5{r= +r i}};r");
+        assert!(result.errors.is_empty());
+        let w001: Vec<_> = result.warnings.iter().filter(|w| w.code == "ILO-W001").collect();
+        assert_eq!(w001.len(), 1);
+    }
+
+    #[test]
+    fn guard_with_else_in_loop_no_warning() {
+        // Ternary form {then}{else} is fine — no early return
+        let result = parse_and_verify_full("f xs:L n>n;r=0;@x xs{>=x 10{r= +r x}{r}};r");
+        let w001: Vec<_> = result.warnings.iter().filter(|w| w.code == "ILO-W001").collect();
+        assert_eq!(w001.len(), 0);
+    }
+
+    #[test]
+    fn guard_outside_loop_no_warning() {
+        // Guard at function level is normal — no warning
+        let result = parse_and_verify_full("f x:n>n;>=x 0{x};-x");
+        let w001: Vec<_> = result.warnings.iter().filter(|w| w.code == "ILO-W001").collect();
+        assert_eq!(w001.len(), 0);
     }
 
     // ---- Unreachable code warnings (ILO-T029) ----


### PR DESCRIPTION
## Summary
- Verifier emits ILO-W001 warning when a guard without else appears inside a loop (`@`/`wh`/range)
- Guards cause early function return, not iteration skip — a common mistake
- Suggests ternary `{then}{else}` or `brk`/`cnt` for loop control
- Added ILO-W001 to error registry with `--explain` documentation

## Test plan
- [x] `guard_in_foreach_warns` — foreach loop triggers warning
- [x] `guard_in_while_warns` — while loop triggers warning  
- [x] `guard_in_range_warns` — range loop triggers warning
- [x] `guard_with_else_in_loop_no_warning` — ternary form does not warn
- [x] `guard_outside_loop_no_warning` — function-level guard does not warn
- [x] All 2,270 tests pass