### PR TITLE
feat: add mod builtin for modulo / remainder

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -248,6 +248,7 @@ Called like functions, compiled to dedicated opcodes.
 | `abs n` | absolute value | `n` |
 | `min a b` | minimum of two numbers | `n` |
 | `max a b` | maximum of two numbers | `n` |
+| `mod a b` | remainder (modulo); errors on zero divisor | `n` |
 | `flr n` | floor (round toward negative infinity) | `n` |
 | `cel n` | ceiling (round toward positive infinity) | `n` |
 | `rnd` | random float in [0, 1) | `n` |

--- a/research/TODO.md
+++ b/research/TODO.md
@@ -35,7 +35,7 @@ Discovered during a Claude Code session using ilo as a bash/python replacement. 
 - [ ] **Idiomatic hints on successful runs** — walk the AST after execution and suggest canonical forms. E.g. `(a + b)` → `hint: +a b saves 2 tokens`, `==a b` → `hint: =a b saves 1 token`. Teaches idiomatic ilo as you go. Output channels: **TTY** → stderr (human sees it), **JSON/serv mode** → `"hints"` field in response (LLM sees it), **plain pipe** → nothing. Disable with `-nh` / `--no-hints`.
 
 ### Nice-to-have
-- [ ] **Modulo builtin** — `mod a b` or `%a b`. Currently requires `flr /a b` then `*` then compare. Common enough (FizzBuzz, even/odd checks) to justify a builtin.
+- [x] **Modulo builtin** — `mod a b` returns remainder. Implemented across verifier, interpreter, and VM with division-by-zero check.
 
 ### Testing
 - [ ] **Parser coverage 85% → 90%+** — lowest coverage module. The multi-function boundary and `==` lexing issues suggest more edge case tests are needed.

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -393,6 +393,18 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             other => Err(RuntimeError::new("ILO-R009", format!("abs requires a number, got {:?}", other))),
         };
     }
+    if name == "mod" && args.len() == 2 {
+        return match (&args[0], &args[1]) {
+            (Value::Number(a), Value::Number(b)) => {
+                if *b == 0.0 {
+                    Err(RuntimeError::new("ILO-R003", "modulo by zero".to_string()))
+                } else {
+                    Ok(Value::Number(a % b))
+                }
+            }
+            _ => Err(RuntimeError::new("ILO-R009", "mod requires two numbers".to_string())),
+        };
+    }
     if (name == "min" || name == "max") && args.len() == 2 {
         return match (&args[0], &args[1]) {
             (Value::Number(a), Value::Number(b)) => {

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -242,6 +242,7 @@ const BUILTINS: &[(&str, &[&str], &str)] = &[
     ("cel", &["n"], "n"),
     ("min", &["n", "n"], "n"),
     ("max", &["n", "n"], "n"),
+    ("mod", &["n", "n"], "n"),
     ("get", &["t"], "R t t"),
     ("get", &["t", "M t t"], "R t t"),
     ("post", &["t", "t"], "R t t"),
@@ -363,7 +364,7 @@ fn builtin_check_args(name: &str, arg_types: &[Ty], func_ctx: &str, span: Option
             }
             (Ty::Number, errors)
         }
-        "min" | "max" => {
+        "min" | "max" | "mod" => {
             for (i, arg) in arg_types.iter().enumerate() {
                 if !compatible(arg, &Ty::Number) {
                     errors.push(VerifyError {

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -148,6 +148,7 @@ pub(crate) const OP_UNQ: u8 = 82;       // R[A] = unq(R[B])   — deduplicate li
 pub(crate) const OP_POST: u8 = 83;      // R[A] = http_post(R[B], R[C])  (returns R t t)
 pub(crate) const OP_GETH: u8 = 84;      // R[A] = http_get(R[B], headers=R[C])  (returns R t t)
 pub(crate) const OP_POSTH: u8 = 85;     // ABx: R[A] = http_post(R[B], body=R[bx>>8], headers=R[bx&0xFF])
+pub(crate) const OP_MOD: u8 = 86;       // R[A] = R[B] % R[C]  (modulo / remainder)
 
 // ABx mode — register + 16-bit operand
 pub(crate) const OP_LOADK: u8 = 20;
@@ -1192,6 +1193,14 @@ impl RegCompiler {
                     let ra = self.alloc_reg();
                     let op = if function == "min" { OP_MIN } else { OP_MAX };
                     self.emit_abc(op, ra, rb, rc);
+                    self.reg_is_num[ra as usize] = true;
+                    return ra;
+                }
+                if function == "mod" && args.len() == 2 {
+                    let rb = self.compile_expr(&args[0]);
+                    let rc = self.compile_expr(&args[1]);
+                    let ra = self.alloc_reg();
+                    self.emit_abc(OP_MOD, ra, rb, rc);
                     self.reg_is_num[ra as usize] = true;
                     return ra;
                 }
@@ -3647,6 +3656,21 @@ impl<'a> VM<'a> {
                     let result = if op == OP_MIN { nb.min(nc) } else { nb.max(nc) };
                     reg_set!(a, NanVal::number(result));
                 }
+                OP_MOD => {
+                    let a = ((inst >> 16) & 0xFF) as usize + base;
+                    let b = ((inst >> 8) & 0xFF) as usize + base;
+                    let c = (inst & 0xFF) as usize + base;
+                    let vb = reg!(b);
+                    let vc = reg!(c);
+                    if !vb.is_number() || !vc.is_number() {
+                        return Err(VmError::Type("mod requires numbers"));
+                    }
+                    let nc = vc.as_number();
+                    if nc == 0.0 {
+                        return Err(VmError::Type("modulo by zero"));
+                    }
+                    reg_set!(a, NanVal::number(vb.as_number() % nc));
+                }
                 OP_FLR | OP_CEL => {
                     let a = ((inst >> 16) & 0xFF) as usize + base;
                     let b = ((inst >> 8) & 0xFF) as usize + base;
@@ -5801,6 +5825,21 @@ mod tests {
     fn vm_min_negative() {
         let source = "f>n;min -5 2";
         assert_eq!(vm_run(source, Some("f"), vec![]), Value::Number(-5.0));
+    }
+
+    #[test]
+    fn vm_mod() {
+        assert_eq!(vm_run("f>n;mod 10 3", Some("f"), vec![]), Value::Number(1.0));
+    }
+
+    #[test]
+    fn vm_mod_negative() {
+        assert_eq!(vm_run("f>n;mod -7 3", Some("f"), vec![]), Value::Number(-1.0));
+    }
+
+    #[test]
+    fn vm_mod_float() {
+        assert_eq!(vm_run("f>n;mod 5.5 2.0", Some("f"), vec![]), Value::Number(1.5));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `mod a b` returns the remainder of `a / b`
- Errors on division by zero (ILO-R003)
- Implemented across verifier, interpreter, and VM (OP_MOD opcode 86)
- Updated SPEC.md and TODO.md

## Test plan
- [x] `vm_mod` — `mod 10 3` = 1
- [x] `vm_mod_negative` — `mod -7 3` = -1
- [x] `vm_mod_float` — `mod 5.5 2.0` = 1.5
- [x] All 2,273 tests pass