### PR TITLE
Fix plugin install docs — marketplace step + Claude surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ ilo ships as an [Agent Skill](https://agentskills.io) — install the plugin and
 | Surface | How to use ilo |
 |---------|---------------|
 | **Claude Code** (CLI) | Add marketplace then install (see [Install](#install)) |
-| **Claude Cowork** (web) | Install the ilo plugin from Browse Plugins → the agent can write and run ilo |
-| **Claude API / Console** | Paste `ilo help ai` into the system prompt (see context loading below) |
+| **Claude Cowork** (web) | Coming soon |
+| **Claude API / Console** | Run `ilo help ai` locally, paste the output into your system prompt |
 
 **Other agents** (Codex, Cursor, GitHub Copilot, etc.):
 


### PR DESCRIPTION
## Summary
- Install section: add `/plugin marketplace add` step before `/plugin install`
- Claude Code row: link to Install section
- Claude Cowork: mark as coming soon
- Claude API/Console: clarify to run `ilo help ai` locally and paste the output

## Test plan
- [ ] README renders correctly