### PR TITLE
fix: move test example files to examples/, unbreak CI

### DIFF
--- a/examples/01-simple-function.ilo
+++ b/examples/01-simple-function.ilo
@@ -1,0 +1,1 @@
+tot p:n q:n r:n>n;s=*p q;t=*s r;+s t

--- a/examples/02-with-dependencies.ilo
+++ b/examples/02-with-dependencies.ilo
@@ -1,0 +1,1 @@
+prc ord:order>R order t;vld ord.addr;?{^_:^"Invalid shipping address"};sh=shipping ord.weight ord.addr.country;dc=discount ord.subtotal ord.code;fin=+(-ord.subtotal dc)sh;~ord with total:fin cost:sh

--- a/examples/03-data-transform.ilo
+++ b/examples/03-data-transform.ilo
@@ -1,0 +1,2 @@
+cls sp:n>t;>=sp 1000{"gold"};>=sp 500{"silver"};"bronze"
+sms cs:L customer>L summary;@c cs{lv=cls c.spent;dc=?lv{"gold":20;"silver":10;"bronze":5};summary name:c.name level:lv discount:dc}

--- a/examples/04-tool-interaction.ilo
+++ b/examples/04-tool-interaction.ilo
@@ -1,0 +1,1 @@
+ntf uid:t msg:t>R _ t;get-user uid;?{^e:^+"Lookup failed: "e;~d:!d.verified{^"Email not verified"};send-email d.email "Notification" msg;?{^e:^+"Send failed: "e;~_:~_}}

--- a/examples/05-workflow.ilo
+++ b/examples/05-workflow.ilo
@@ -1,0 +1,1 @@
+chk pid:t amt:n its:L item>R receipt t;reserve its;?{^e:^+"Inventory unavailable: "e;~rid:charge pid amt;?{^e:release rid;^+"Payment failed: "e;~cid:oid=make-id();~receipt oid:oid cid:cid rid:rid}}

--- a/src/codegen/fmt.rs
+++ b/src/codegen/fmt.rs
@@ -754,7 +754,7 @@ mod tests {
     fn round_trip_example_01() {
         assert_round_trip(
             &std::fs::read_to_string(
-                "research/explorations/idea9-ultra-dense-short/01-simple-function.ilo",
+                "examples/01-simple-function.ilo",
             )
             .unwrap(),
         );
@@ -764,7 +764,7 @@ mod tests {
     fn round_trip_example_02() {
         assert_round_trip(
             &std::fs::read_to_string(
-                "research/explorations/idea9-ultra-dense-short/02-with-dependencies.ilo",
+                "examples/02-with-dependencies.ilo",
             )
             .unwrap(),
         );
@@ -774,7 +774,7 @@ mod tests {
     fn round_trip_example_03() {
         assert_round_trip(
             &std::fs::read_to_string(
-                "research/explorations/idea9-ultra-dense-short/03-data-transform.ilo",
+                "examples/03-data-transform.ilo",
             )
             .unwrap(),
         );
@@ -784,7 +784,7 @@ mod tests {
     fn round_trip_example_04() {
         assert_round_trip(
             &std::fs::read_to_string(
-                "research/explorations/idea9-ultra-dense-short/04-tool-interaction.ilo",
+                "examples/04-tool-interaction.ilo",
             )
             .unwrap(),
         );
@@ -794,7 +794,7 @@ mod tests {
     fn round_trip_example_05() {
         assert_round_trip(
             &std::fs::read_to_string(
-                "research/explorations/idea9-ultra-dense-short/05-workflow.ilo",
+                "examples/05-workflow.ilo",
             )
             .unwrap(),
         );
@@ -816,7 +816,7 @@ mod tests {
     fn idempotent_example_04() {
         assert_idempotent(
             &std::fs::read_to_string(
-                "research/explorations/idea9-ultra-dense-short/04-tool-interaction.ilo",
+                "examples/04-tool-interaction.ilo",
             )
             .unwrap(),
         );
@@ -826,7 +826,7 @@ mod tests {
     fn idempotent_example_05() {
         assert_idempotent(
             &std::fs::read_to_string(
-                "research/explorations/idea9-ultra-dense-short/05-workflow.ilo",
+                "examples/05-workflow.ilo",
             )
             .unwrap(),
         );
@@ -888,7 +888,7 @@ mod tests {
     fn expanded_multiple_decls_separated_by_blank_line() {
         let s = expanded(
             &std::fs::read_to_string(
-                "research/explorations/idea9-ultra-dense-short/03-data-transform.ilo",
+                "examples/03-data-transform.ilo",
             )
             .unwrap(),
         );
@@ -906,7 +906,7 @@ mod tests {
     fn expanded_workflow() {
         let s = expanded(
             &std::fs::read_to_string(
-                "research/explorations/idea9-ultra-dense-short/05-workflow.ilo",
+                "examples/05-workflow.ilo",
             )
             .unwrap(),
         );

--- a/src/codegen/python.rs
+++ b/src/codegen/python.rs
@@ -888,33 +888,33 @@ mod tests {
 
     #[test]
     fn emit_example_01() {
-        let py = parse_file_and_emit("research/explorations/idea9-ultra-dense-short/01-simple-function.ilo");
+        let py = parse_file_and_emit("examples/01-simple-function.ilo");
         assert!(py.contains("def tot("));
         assert!(py.contains("return (s + t)"));
     }
 
     #[test]
     fn emit_example_02() {
-        let py = parse_file_and_emit("research/explorations/idea9-ultra-dense-short/02-with-dependencies.ilo");
+        let py = parse_file_and_emit("examples/02-with-dependencies.ilo");
         assert!(py.contains("def prc("));
     }
 
     #[test]
     fn emit_example_03() {
-        let py = parse_file_and_emit("research/explorations/idea9-ultra-dense-short/03-data-transform.ilo");
+        let py = parse_file_and_emit("examples/03-data-transform.ilo");
         assert!(py.contains("def cls("));
         assert!(py.contains("def sms("));
     }
 
     #[test]
     fn emit_example_04() {
-        let py = parse_file_and_emit("research/explorations/idea9-ultra-dense-short/04-tool-interaction.ilo");
+        let py = parse_file_and_emit("examples/04-tool-interaction.ilo");
         assert!(py.contains("def ntf("));
     }
 
     #[test]
     fn emit_example_05() {
-        let py = parse_file_and_emit("research/explorations/idea9-ultra-dense-short/05-workflow.ilo");
+        let py = parse_file_and_emit("examples/05-workflow.ilo");
         assert!(py.contains("def chk("));
     }
 

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1751,7 +1751,7 @@ mod tests {
     #[test]
     fn interpret_tot() {
         // tot p:n q:n r:n>n;s=*p q;t=*s r;+s t
-        let source = std::fs::read_to_string("research/explorations/idea9-ultra-dense-short/01-simple-function.ilo").unwrap();
+        let source = std::fs::read_to_string("examples/01-simple-function.ilo").unwrap();
         let result = run_str(
             &source,
             Some("tot"),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2168,7 +2168,7 @@ mod tests {
 
     #[test]
     fn parse_example_01_simple_function() {
-        let prog = parse_file("research/explorations/idea9-ultra-dense-short/01-simple-function.ilo");
+        let prog = parse_file("examples/01-simple-function.ilo");
         assert_eq!(prog.declarations.len(), 1);
         let Decl::Function { name, params, return_type, body, .. } = &prog.declarations[0] else { panic!("expected function") };
         assert_eq!(name, "tot");
@@ -2179,7 +2179,7 @@ mod tests {
 
     #[test]
     fn parse_example_02_with_dependencies() {
-        let prog = parse_file("research/explorations/idea9-ultra-dense-short/02-with-dependencies.ilo");
+        let prog = parse_file("examples/02-with-dependencies.ilo");
         assert_eq!(prog.declarations.len(), 1);
         let Decl::Function { name, return_type, .. } = &prog.declarations[0] else { panic!("expected function") };
         assert_eq!(name, "prc");

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -5306,7 +5306,7 @@ mod tests {
 
     #[test]
     fn vm_tot() {
-        let source = std::fs::read_to_string("research/explorations/idea9-ultra-dense-short/01-simple-function.ilo").unwrap();
+        let source = std::fs::read_to_string("examples/01-simple-function.ilo").unwrap();
         let result = vm_run(
             &source,
             Some("tot"),


### PR DESCRIPTION
## Summary
- Move 5 `.ilo` example files from `research/explorations/` (gitignored) to `examples/` (tracked)
- Update 18 test path references across 5 source files
- Fixes all 18 CI test failures that started when `research/` was gitignored

## Test plan
- [x] `cargo test --bin ilo` — 2117 passed