### PR TITLE
fix: scoped RAII for ACTIVE_REGISTRY pointer

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1978,30 +1978,30 @@ fn run_bench(program: &ast::Program, func_name: Option<&str>, args: &[interprete
         let chunk = &compiled.chunks[fi];
         let nan_consts = &compiled.nan_constants[fi];
         let nan_args: Vec<u64> = args.iter().map(|v| vm::NanVal::from_value(v).0).collect();
-        // SAFETY: `compiled` outlives the entire bench loop below.
-        unsafe { vm::set_active_registry(&compiled); }
-        if let Some(jit_func) = vm::jit_cranelift::compile(chunk, nan_consts, &compiled) {
-            for _ in 0..100 {
-                let _ = vm::jit_cranelift::call(&jit_func, &nan_args);
-            }
+        vm::with_active_registry(&compiled, || {
+            if let Some(jit_func) = vm::jit_cranelift::compile(chunk, nan_consts, &compiled) {
+                for _ in 0..100 {
+                    let _ = vm::jit_cranelift::call(&jit_func, &nan_args);
+                }
 
-            let start = Instant::now();
-            let mut jit_result_bits = 0u64;
-            for _ in 0..iterations {
-                jit_result_bits = vm::jit_cranelift::call(&jit_func, &nan_args).expect("Cranelift JIT error during benchmark");
-            }
-            let jit_dur = start.elapsed();
-            let ns = jit_dur.as_nanos() / iterations as u128;
-            jit_cranelift_ns = Some(ns);
+                let start = Instant::now();
+                let mut jit_result_bits = 0u64;
+                for _ in 0..iterations {
+                    jit_result_bits = vm::jit_cranelift::call(&jit_func, &nan_args).expect("Cranelift JIT error during benchmark");
+                }
+                let jit_dur = start.elapsed();
+                let ns = jit_dur.as_nanos() / iterations as u128;
+                jit_cranelift_ns = Some(ns);
 
-            let jit_result = vm::NanVal(jit_result_bits).to_value();
-            println!("Cranelift JIT");
-            println!("  result:     {}", jit_result);
-            println!("  iterations: {}", iterations);
-            println!("  total:      {:.2}ms", jit_dur.as_nanos() as f64 / 1e6);
-            println!("  per call:   {}ns", ns);
-            println!();
-        }
+                let jit_result = vm::NanVal(jit_result_bits).to_value();
+                println!("Cranelift JIT");
+                println!("  result:     {}", jit_result);
+                println!("  iterations: {}", iterations);
+                println!("  total:      {:.2}ms", jit_dur.as_nanos() as f64 / 1e6);
+                println!("  per call:   {}ns", ns);
+                println!();
+            }
+        });
     }
 
     #[allow(unused_variables)]

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -1288,10 +1288,10 @@ pub(crate) fn call(func: &JitFunction, args: &[u64]) -> Option<u64> {
 
 /// Compile and call in one shot (convenience wrapper).
 pub(crate) fn compile_and_call(chunk: &Chunk, nan_consts: &[NanVal], args: &[u64], program: &CompiledProgram) -> Option<u64> {
-    // Set active registry for arena record field name resolution
-    ACTIVE_REGISTRY.with(|r| r.set(&program.type_registry as *const TypeRegistry));
-    let func = compile(chunk, nan_consts, program)?;
-    call(&func, args)
+    with_active_registry(program, || {
+        let func = compile(chunk, nan_consts, program)?;
+        call(&func, args)
+    })
 }
 
 #[cfg(test)]

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -1988,16 +1988,43 @@ thread_local! {
     static ACTIVE_REGISTRY: std::cell::Cell<*const TypeRegistry> = const { std::cell::Cell::new(std::ptr::null()) };
 }
 
-/// Set the active TypeRegistry for arena record field name resolution.
+/// Run `f` with the active `TypeRegistry` pointer set to `program.type_registry`.
 ///
-/// # Safety
-/// The caller must ensure that `program` outlives any JIT invocation that runs
-/// on this thread while the pointer is active. Specifically, `program` must not
-/// be dropped until after all `jit_arena_reset()` calls that dereference
-/// `ACTIVE_REGISTRY` have completed. In practice: call this once before the
-/// bench/run loop and keep `program` alive for the duration of the loop.
-pub unsafe fn set_active_registry(program: &CompiledProgram) {
+/// The pointer is only live for the duration of `f`; it is unconditionally
+/// cleared (set to null) when `f` returns **or panics**, so there is no risk
+/// of a dangling pointer after `program` is dropped.
+pub fn with_active_registry<R>(program: &CompiledProgram, f: impl FnOnce() -> R) -> R {
+    struct ClearGuard;
+    impl Drop for ClearGuard {
+        fn drop(&mut self) {
+            ACTIVE_REGISTRY.with(|r| r.set(std::ptr::null()));
+        }
+    }
+
     ACTIVE_REGISTRY.with(|r| r.set(&program.type_registry as *const TypeRegistry));
+    let _guard = ClearGuard;
+    f()
+}
+
+/// Clear the active `TypeRegistry` pointer.
+///
+/// Called at the end of `VM::execute()` where wrapping in a closure is
+/// impractical. The `execute` method also uses `ActiveRegistryGuard` to ensure
+/// the pointer is cleared on early return or panic.
+fn clear_active_registry() {
+    ACTIVE_REGISTRY.with(|r| r.set(std::ptr::null()));
+}
+
+/// RAII guard that clears `ACTIVE_REGISTRY` on drop.
+///
+/// Used inside `VM::execute()` to guarantee cleanup even on `?` early returns
+/// or panics.
+pub(crate) struct ActiveRegistryGuard;
+
+impl Drop for ActiveRegistryGuard {
+    fn drop(&mut self) {
+        clear_active_registry();
+    }
 }
 
 /// Get a raw pointer to the JIT arena (for passing to jit_recnew).
@@ -2530,8 +2557,10 @@ impl<'a> VM<'a> {
     #[allow(unused_unsafe)]
     fn execute(&mut self) -> VmResult<Value> {
         // Set active registry for arena record promotion in nanval_to_json and JIT callbacks.
-        // SAFETY: `self.program` is owned by the VM and outlives `execute()`.
+        // `self.program` is owned by the VM and outlives `execute()`.
+        // The guard ensures the pointer is cleared on return or panic.
         ACTIVE_REGISTRY.with(|r| r.set(&self.program.type_registry as *const TypeRegistry));
+        let _registry_guard = ActiveRegistryGuard;
         // SAFETY: execute() is only called from call() after setup_call() has pushed
         // a frame, so frames is non-empty.
         let frame = unsafe { self.frames.last().unwrap_unchecked() };


### PR DESCRIPTION
## Summary
Replace unsafe `set_active_registry` with safe scoped APIs.

- New `with_active_registry<R>(program, f)` — closure-based, guarantees pointer cleared on all exit paths
- New `ActiveRegistryGuard` RAII for VM `execute()` method
- `ClearGuard` drop impl handles panics
- Eliminates the `unsafe` API entirely — no more raw pointer management at call sites

## Test plan
- [x] All 2,320 tests pass
- [x] Clippy clean
- [x] No performance overhead (same thread-local access pattern)