### PR TITLE
test: interpreter + codegen coverage (21 tests)

### DIFF
--- a/src/codegen/fmt.rs
+++ b/src/codegen/fmt.rs
@@ -1243,4 +1243,30 @@ mod tests {
         let s = dense("f x:n>b;<=x 10");
         assert!(s.contains("<=x 10"), "got: {s}");
     }
+
+    // ── Record with no fields (L449) ────────────────────────────────────────
+
+    #[test]
+    fn fmt_record_no_fields() {
+        // Directly construct an Expr::Record with no fields to exercise L449
+        let expr = Expr::Record { type_name: "empty".to_string(), fields: vec![] };
+        let s = fmt_expr(&expr, FmtMode::Dense);
+        assert_eq!(s, "empty", "expected bare type name for empty record, got: {s}");
+    }
+
+    // ── Ternary formatting (L463-464) ───────────────────────────────────────
+
+    #[test]
+    fn dense_ternary_prefix() {
+        let s = dense("f x:n>n;?=x 0 10 20");
+        assert!(s.contains("?=x 0 10 20"), "got: {s}");
+    }
+
+    // ── Literal::Nil formatting (L491) ──────────────────────────────────────
+
+    #[test]
+    fn dense_literal_nil() {
+        let s = dense("f>O n;nil");
+        assert!(s.contains("nil"), "got: {s}");
+    }
 }

--- a/src/codegen/python.rs
+++ b/src/codegen/python.rs
@@ -1657,4 +1657,83 @@ mod tests {
         let py = emit(&prog);
         assert!(!py.contains("use"), "Use should produce no output: {py}");
     }
+
+    // ── type_to_py coverage (L6-12) ─────────────────────────────────────────
+
+    #[test]
+    fn type_to_py_text() {
+        assert_eq!(type_to_py(&Type::Text), "str");
+    }
+
+    #[test]
+    fn type_to_py_bool() {
+        assert_eq!(type_to_py(&Type::Bool), "bool");
+    }
+
+    #[test]
+    fn type_to_py_list() {
+        assert_eq!(type_to_py(&Type::List(Box::new(Type::Number))), "list");
+    }
+
+    #[test]
+    fn type_to_py_map() {
+        assert_eq!(type_to_py(&Type::Map(Box::new(Type::Text), Box::new(Type::Number))), "dict");
+    }
+
+    #[test]
+    fn type_to_py_optional() {
+        assert_eq!(type_to_py(&Type::Optional(Box::new(Type::Number))), "object | None");
+    }
+
+    #[test]
+    fn type_to_py_sum() {
+        assert_eq!(type_to_py(&Type::Sum(vec!["a".into(), "b".into()])), "str");
+    }
+
+    #[test]
+    fn type_to_py_wildcard() {
+        assert_eq!(type_to_py(&Type::Named("custom".into())), "object");
+    }
+
+    // ── Ternary codegen (L583-587) ──────────────────────────────────────────
+
+    #[test]
+    fn emit_ternary() {
+        let py = parse_and_emit("f x:n>n;?=x 0 10 20");
+        assert!(py.contains("10 if"), "expected ternary: {py}");
+        assert!(py.contains("else 20"), "expected else clause: {py}");
+    }
+
+    // ── expr_uses_unwrap for Ternary (L167-168) ────────────────────────────
+
+    #[test]
+    fn emit_ternary_with_unwrap() {
+        // Directly test expr_uses_unwrap with a synthetic Ternary containing an unwrap call
+        let ternary = Expr::Ternary {
+            condition: Box::new(Expr::Literal(Literal::Bool(true))),
+            then_expr: Box::new(Expr::Call {
+                function: "g".into(),
+                args: vec![],
+                unwrap: true,
+            }),
+            else_expr: Box::new(Expr::Literal(Literal::Number(0.0))),
+        };
+        assert!(expr_uses_unwrap(&ternary), "ternary with unwrap call should be detected");
+    }
+
+    // ── rou codegen (L505) ──────────────────────────────────────────────────
+
+    #[test]
+    fn emit_rou() {
+        let py = parse_and_emit("f x:n>n;rou x");
+        assert!(py.contains("float(round("), "expected round call: {py}");
+    }
+
+    // ── Literal::Nil codegen (L775) ─────────────────────────────────────────
+
+    #[test]
+    fn emit_literal_nil() {
+        let py = parse_and_emit("f>O n;nil");
+        assert!(py.contains("None"), "expected None for nil: {py}");
+    }
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -5272,4 +5272,85 @@ mod tests {
         let result = run_str("f>_;cnt", Some("f"), vec![]);
         assert_eq!(result, Value::Nil);
     }
+
+    // ── Builtin::Mod (L399-407) ──────────────────────────────────────────────
+
+    #[test]
+    fn interpret_mod_normal() {
+        let result = run_str("f a:n b:n>n;mod a b", Some("f"), vec![Value::Number(10.0), Value::Number(3.0)]);
+        assert_eq!(result, Value::Number(1.0));
+    }
+
+    #[test]
+    fn interpret_mod_by_zero() {
+        let prog = parse_program("f a:n b:n>n;mod a b");
+        let err = run(&prog, Some("f"), vec![Value::Number(10.0), Value::Number(0.0)]).unwrap_err();
+        assert!(err.to_string().contains("modulo by zero"), "got: {err}");
+    }
+
+    #[test]
+    fn interpret_mod_non_numbers() {
+        let prog = parse_program(r#"f a:t b:t>_;mod a b"#);
+        let err = run(&prog, Some("f"), vec![Value::Text("a".into()), Value::Text("b".into())]).unwrap_err();
+        assert!(err.to_string().contains("mod requires two numbers"), "got: {err}");
+    }
+
+    // ── Builtin::Rou (round, L425) ──────────────────────────────────────────
+
+    #[test]
+    fn interpret_round() {
+        let result = run_str("f x:n>n;rou x", Some("f"), vec![Value::Number(3.7)]);
+        assert_eq!(result, Value::Number(4.0));
+        let result2 = run_str("f x:n>n;rou x", Some("f"), vec![Value::Number(3.2)]);
+        assert_eq!(result2, Value::Number(3.0));
+    }
+
+    // ── Ternary expression (L1583-1588) ─────────────────────────────────────
+
+    #[test]
+    fn interpret_ternary_then() {
+        // Prefix ternary: ?=x 0 10 20 → if x==0 then 10 else 20
+        let result = run_str("f x:n>n;?=x 0 10 20", Some("f"), vec![Value::Number(0.0)]);
+        assert_eq!(result, Value::Number(10.0));
+    }
+
+    #[test]
+    fn interpret_ternary_else() {
+        let result = run_str("f x:n>n;?=x 0 10 20", Some("f"), vec![Value::Number(5.0)]);
+        assert_eq!(result, Value::Number(20.0));
+    }
+
+    // ── Literal::Nil in eval_literal (L1611) ────────────────────────────────
+
+    #[test]
+    fn interpret_literal_nil() {
+        let result = run_str("f>O n;nil", Some("f"), vec![]);
+        assert_eq!(result, Value::Nil);
+    }
+
+    // ── Pattern::TypeIs wildcard fallback (L1727) ───────────────────────────
+
+    #[test]
+    fn interpret_type_is_no_match() {
+        // Match a number against a text TypeIs pattern → falls through to wildcard
+        let result = run_str(r#"f x:n>t;?x{t v:"text";_:"other"}"#, Some("f"), vec![Value::Number(42.0)]);
+        assert_eq!(result, Value::Text("other".to_string()));
+    }
+
+    // ── Tool call with provider but no async runtime (L1160-1162) ───────────
+
+    #[test]
+    fn interpret_tool_call_with_provider_no_runtime() {
+        let source = r#"tool greet"say hello" name:t>R _ t timeout:5"#;
+        let prog = parse_program(source);
+        let provider = std::sync::Arc::new(crate::tools::StubProvider);
+        let result = run_with_tools(
+            &prog,
+            Some("greet"),
+            vec![Value::Text("world".into())],
+            provider,
+        )
+        .unwrap();
+        assert_eq!(result, Value::Ok(Box::new(Value::Nil)));
+    }
 }


### PR DESCRIPTION
## Summary
Add 21 tests covering uncovered lines in interpreter, Python codegen, and fmt codegen.

- **Interpreter** (8 tests): mod builtin, rou, ternary branches, nil literal, TypeIs fallback, tool call without runtime
- **Python codegen** (10 tests): type_to_py variants, ternary emit, rou, nil
- **Fmt codegen** (3 tests): empty record, ternary prefix, nil literal

## Test plan
- [x] All 2,321 tests pass, 73 ignored, clippy clean