### PR TITLE
feat: convert SKILL.md to Agent Skills spec-conformant format

### DIFF
--- a/skills/ilo/SKILL.md
+++ b/skills/ilo/SKILL.md
@@ -1,12 +1,11 @@
 ---
 name: ilo
 description: "Write, run, debug, and explain programs in ilo — a token-optimised programming language for AI agents. Use when the user asks to write ilo code, mentions .ilo files, asks about ilo syntax, wants to create token-optimised programs, or wants to convert code from other languages to ilo."
-argument-hint: "[task or code description]"
-allowed-tools:
-  - Bash
-  - Read
-  - Write
-  - Edit
+license: MIT
+compatibility: Requires the ilo binary (auto-installed by scripts/ensure-ilo.sh via GitHub releases or npm).
+allowed-tools: Bash Read Write Edit
+metadata:
+  argument-hint: "[task or code description]"
 ---
 
 # ilo Programming Language
@@ -16,7 +15,7 @@ allowed-tools:
 Before writing or running ilo code, ensure ilo is installed and up to date:
 
 ```bash
-${CLAUDE_SKILL_DIR}/scripts/ensure-ilo.sh
+scripts/ensure-ilo.sh
 ```
 
 Run this at the start of every ilo task. It installs ilo if missing, or updates it if a newer version is available.


### PR DESCRIPTION
## Summary

Aligns `skills/ilo/SKILL.md` with the open [Agent Skills specification](https://agentskills.io/specification) so the skill works in Claude Code, Claude Desktop, Codex, OpenCode, KiloCode, Cursor, Gemini CLI, and pi without per-tool tweaks.

### Three deviations fixed

1. **`argument-hint` was a top-level Claude-only field** -> moved to `metadata.argument-hint`. The spec reserves top-level keys and exposes `metadata` as the vendor-extension surface, so this keeps the Claude Code UX hint while staying spec-conformant.

2. **`allowed-tools` was a YAML list** -> changed to a space-separated string (`Bash Read Write Edit`) per the experimental spec field.

3. **Body referenced `${CLAUDE_SKILL_DIR}/scripts/ensure-ilo.sh`** -> replaced with the relative `scripts/ensure-ilo.sh`, which the spec recommends and which other agent runtimes resolve from the SKILL.md folder.

Also added optional `license` and `compatibility` frontmatter fields to help cross-tool consumers understand requirements at a glance.

The spec-conformant format is a subset of what Claude Code accepts, so publishing through `.claude-plugin/marketplace.json` continues to work unchanged. The `ensure-ilo.sh` script itself contains no Claude-specific paths and works from any cwd.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo build` succeeds
- [x] `cargo test` all green
- [x] `git diff --exit-code ai.txt` clean
- [ ] CI green on the PR