### PR TITLE
ci: upgrade deprecated GitHub Actions (Node.js 20, codecov-action)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,9 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Install cargo-nextest
-      uses: taiki-e/install-action@nextest
+      uses: taiki-e/install-action@v2
+      with:
+        tool: nextest
     - name: Build
       run: cargo build --verbose
     - name: Verify ai.txt is in sync with SPEC.md
@@ -35,9 +37,10 @@ jobs:
       run: cargo nextest run --profile ci
     - name: Upload test results to Codecov
       if: ${{ !cancelled() }}
-      uses: codecov/test-results-action@v1
+      uses: codecov/codecov-action@v6
       with:
         files: target/nextest/ci/junit.xml
+        report_type: test_results
         token: ${{ secrets.CODECOV_TOKEN }}
 
   coverage:
@@ -45,13 +48,15 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Install cargo-llvm-cov
-      uses: taiki-e/install-action@cargo-llvm-cov
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-llvm-cov
     - name: Build libilo.a (needed by AOT tests)
       run: cargo build
     - name: Generate coverage
       run: cargo llvm-cov --workspace --lcov --output-path lcov.info
     - name: Upload to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         files: lcov.info
         fail_ci_if_error: false


### PR DESCRIPTION
## Summary

Clears the three CI annotations on recent runs (e.g. PR #139 / run 25256518149):
1. build job, Node.js 20 deprecation
2. build job, codecov-action deprecation
3. coverage job, Node.js 20 deprecation

## Changes

| Action | Old | New | Rationale |
|---|---|---|---|
| `codecov/test-results-action` | `@v1` | replaced by `codecov/codecov-action@v6` with `report_type: test_results` | Upstream deprecated test-results-action, README directs users to migrate to the unified codecov-action |
| `codecov/codecov-action` (coverage) | `@v5` | `@v6` | v5 ran on Node.js 20; v6 supports Node.js 24 |
| `taiki-e/install-action` (nextest) | `@nextest` | `@v2` with `tool: nextest` | Avoid floating tag; pin to stable major |
| `taiki-e/install-action` (cargo-llvm-cov) | `@cargo-llvm-cov` | `@v2` with `tool: cargo-llvm-cov` | Avoid floating tag; pin to stable major |

`release.yml` was not modified - it does not use codecov-action and only runs on tag pushes (annotations were on PR/push runs).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build`
- [x] `cargo nextest run --profile ci` (3359 passed)
- [x] `git diff --exit-code ai.txt`
- [ ] CI passes without deprecation annotations