### PR TITLE
chore: release v0.10.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ilo",
       "source": "./",
       "description": "Write, run, debug, and explain programs in ilo — a token-optimised programming language for AI agents",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "author": {
         "name": "Daniel Morris"
       },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "ilo"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "clap",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ilo"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 rust-version = "1.85"
 description = "ilo — a programming language for AI agents"


### PR DESCRIPTION
## Summary

Patch release bumping `Cargo.toml` and `.claude-plugin/marketplace.json` to **v0.10.1**.

These are CI/infrastructure improvements only - no language API surface changes.

## In scope

- #138 - enforce rustfmt in CI
- #139 - align SKILL.md with Anthropic spec
- #140 - add CI tests for SKILL.md
- #141 - upgrade deprecated GitHub Actions
- #142 - add CI tests for Claude plugin marketplace bundle

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build`
- [x] `cargo nextest run --profile ci` (3374 passed)
- [x] `git diff --exit-code ai.txt` (clean)