### PR TITLE
ci: add skills-ref validate to lint job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,14 @@ jobs:
       run: cargo fmt --all -- --check
     - name: Clippy
       run: cargo clippy --workspace --all-targets -- -D warnings
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Install skills-ref (agentskills.io reference validator)
+      run: pip install git+https://github.com/agentskills/agentskills.git#subdirectory=skills-ref
+    - name: Validate Agent Skills spec conformance
+      run: skills-ref validate skills/ilo/
 
   skill-validate:
     # Validate skills/ilo/SKILL.md against the agentskills.io reference


### PR DESCRIPTION
## Summary

- Add the official agentskills.io reference validator (Python `skills-ref`, pip-installable from the `agentskills` repo `skills-ref` subdirectory) as a step inside the existing `lint` job.
- The previous skip was over-cautious: `skills-ref` ships a clean `pyproject.toml` and installs cleanly via `pip install git+https://github.com/agentskills/agentskills.git#subdirectory=skills-ref`.
- Catches Agent Skills spec drift on every PR (frontmatter shape, name format, description length, `allowed-tools`, optional fields).
- The existing npm-based `skill-validate` job is left in place; running both gives us cross-implementation coverage.

## Test plan

- [x] `skills-ref validate skills/ilo/` locally — `Valid skill: skills/ilo` (exit 0)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo build` clean
- [x] `git diff --exit-code ai.txt` clean
- [ ] CI green on PR (lint job picks up the new step)