### PR TITLE
chore: gitignore docs/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ site/
 .astro/
 node_modules/
 rust_out
+
+# Research / scratch docs (subagents leave reports here; not tracked)
+docs/


### PR DESCRIPTION
Adds `docs/` to .gitignore. Subagents that produce research/scratch markdown drop it under `docs/` by convention; we don't want that tracked. Closes the gap PR #145 surfaced (now closed without merge).