### PR TITLE
chore: gitignore tests/e2e/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ rust_out
 
 # Research / scratch docs (subagents leave reports here; not tracked)
 docs/
+
+# E2E test artefacts (subagent-produced logs; not tracked)
+tests/e2e/


### PR DESCRIPTION
Subagent E2E runs drop logs (codex.log, gemini.log, pi.log) under `tests/e2e/`. They're scratch artefacts, not tracked.