### PR TITLE
fix pi package peer-dep scope to @earendil-works

### DIFF
--- a/pi/extensions/ilo.ts
+++ b/pi/extensions/ilo.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { existsSync } from "node:fs";

--- a/pi/package.json
+++ b/pi/package.json
@@ -33,8 +33,10 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*",
-    "@mariozechner/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-agent-core": "*",
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-tui": "*",
     "typebox": "*"
   },
   "pi": {


### PR DESCRIPTION
## Summary

- Switch `pi/extensions/ilo.ts` to import from `@earendil-works/pi-coding-agent`
- Update `pi/package.json` peerDependencies to the five canonical packages listed in https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/packages.md - @earendil-works/{pi-ai,pi-agent-core,pi-coding-agent,pi-tui} and typebox

## Why

When I first wrote the package I read the type surface off my locally installed pi (0.66.1, published under `@mariozechner/*`). That scope is the pre-fork name. New pi installs from pi.dev pull from `@earendil-works/*` (currently 0.74.0), so the package as merged in #151 would fail to resolve peer deps on a fresh install.

The canonical doc explicitly lists which packages belong in peerDependencies, so this is now sourced from the upstream spec rather than my local environment.

## Test plan

- [x] Strict TypeScript check passes against `@earendil-works/pi-coding-agent@0.74.0` with the new imports
- [ ] After merge, tag a `v*` release; `publish-pi` job publishes `pi-ilo-lang` and a fresh `pi install npm:pi-ilo-lang` from pi.dev resolves all peer deps cleanly
- [ ] Package appears in https://pi.dev/packages once the npm registry crawl catches up