### PR TITLE
chore: release v0.10.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ilo",
       "source": "./",
       "description": "Write, run, debug, and explain programs in ilo — a token-optimised programming language for AI agents",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "author": {
         "name": "Daniel Morris"
       },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "ilo"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "clap",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ilo"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2024"
 rust-version = "1.85"
 description = "ilo — a programming language for AI agents"


### PR DESCRIPTION
## Summary

- Bump Cargo.toml, Cargo.lock, and .claude-plugin/marketplace.json from 0.10.1 to 0.10.2

## Why

This is the first release that includes:
- `pi-ilo-lang` (PR #151, #152) - the new Pi coding agent extension and `publish-pi` release job

After merge I'll tag `v0.10.2`. That triggers the existing release workflow plus the new `publish-pi` job, which npm-publishes `pi-ilo-lang@0.10.2` so it shows up at https://pi.dev/packages.

## Test plan

- [ ] All existing publish jobs (binaries, crates.io, npm ilo-lang) run to completion
- [ ] New `publish-pi` job runs after `release` and pushes `pi-ilo-lang@0.10.2` to npm
- [ ] `pi install npm:pi-ilo-lang` resolves on a fresh pi.dev install
- [ ] pi-ilo-lang appears in the pi.dev gallery once the crawler picks it up