### PR TITLE
Friendly errors for identifier-confusion cases

### DIFF
--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -226,14 +226,47 @@ pub fn normalize_newlines(source: &str) -> String {
 pub fn lex(source: &str) -> Result<Vec<(Token, std::ops::Range<usize>)>, LexError> {
     let normalized = normalize_newlines(source);
     let mut lexer = Token::lexer(&normalized);
-    let mut tokens = Vec::new();
+    let mut tokens: Vec<(Token, std::ops::Range<usize>)> = Vec::new();
 
     while let Some(result) = lexer.next() {
         match result {
-            Ok(token) => tokens.push((token, lexer.span())),
+            Ok(token) => {
+                let span = lexer.span();
+                // Detect uppercase mid-identifier: a single uppercase type sigil
+                // (L/R/F/O/M/S) sitting flush against a preceding ident.
+                if is_type_sigil(&token) {
+                    if let Some((Token::Ident(prev), prev_span)) = tokens.last() {
+                        if prev_span.end == span.start {
+                            let sigil_char = normalized[span.clone()].chars().next().unwrap();
+                            return Err(uppercase_mid_ident_error(
+                                prev,
+                                sigil_char,
+                                &normalized[span.end..],
+                                prev_span.start,
+                            ));
+                        }
+                    }
+                }
+                tokens.push((token, span));
+            }
             Err(()) => {
                 let span = lexer.span();
                 let bad = &normalized[span.clone()];
+                // Single uppercase ASCII letter directly after an ident is a
+                // mid-identifier capital (e.g. `isAgg` → `is` + bad `A`).
+                if bad.len() == 1
+                    && bad.chars().next().unwrap().is_ascii_uppercase()
+                    && let Some((Token::Ident(prev), prev_span)) = tokens.last()
+                    && prev_span.end == span.start
+                {
+                    let c = bad.chars().next().unwrap();
+                    return Err(uppercase_mid_ident_error(
+                        prev,
+                        c,
+                        &normalized[span.end..],
+                        prev_span.start,
+                    ));
+                }
                 let (code, suggestion) = lex_error_kind(bad);
                 return Err(LexError {
                     code,
@@ -245,7 +278,97 @@ pub fn lex(source: &str) -> Result<Vec<(Token, std::ops::Range<usize>)>, LexErro
         }
     }
 
+    // Post-lex: detect underscore-separated identifier fragments like
+    // `rev_ps` → Ident("rev"), Underscore, Ident("ps") with no whitespace.
+    for i in 0..tokens.len().saturating_sub(2) {
+        let (a, sa) = (&tokens[i].0, &tokens[i].1);
+        let (b, sb) = (&tokens[i + 1].0, &tokens[i + 1].1);
+        let (c, sc) = (&tokens[i + 2].0, &tokens[i + 2].1);
+        if matches!(a, Token::Ident(_))
+            && *b == Token::Underscore
+            && matches!(c, Token::Ident(_))
+            && sa.end == sb.start
+            && sb.end == sc.start
+        {
+            let Token::Ident(ap) = a else { unreachable!() };
+            let Token::Ident(cp) = c else { unreachable!() };
+            // Greedily collect any further `_ident` pairs in the same run.
+            let mut combined = format!("{ap}_{cp}");
+            let mut end = sc.end;
+            let mut j = i + 3;
+            while j + 1 < tokens.len()
+                && tokens[j].0 == Token::Underscore
+                && matches!(tokens[j + 1].0, Token::Ident(_))
+                && tokens[j - 1].1.end == tokens[j].1.start
+                && tokens[j].1.end == tokens[j + 1].1.start
+            {
+                if let Token::Ident(s) = &tokens[j + 1].0 {
+                    combined.push('_');
+                    combined.push_str(s);
+                }
+                end = tokens[j + 1].1.end;
+                j += 2;
+            }
+            return Err(LexError {
+                code: "ILO-L002",
+                position: sa.start,
+                snippet: normalized[sa.start..end].to_string(),
+                suggestion: format!(
+                    "underscores are not allowed in identifiers; use hyphens (e.g. `{}`)",
+                    combined.replace('_', "-")
+                ),
+            });
+        }
+    }
+
     Ok(tokens)
+}
+
+fn is_type_sigil(t: &Token) -> bool {
+    matches!(
+        t,
+        Token::ListType
+            | Token::ResultType
+            | Token::FnType
+            | Token::OptType
+            | Token::MapType
+            | Token::SumType
+    )
+}
+
+fn uppercase_mid_ident_error(
+    prev: &str,
+    cap: char,
+    rest_after_cap: &str,
+    start: usize,
+) -> LexError {
+    // Reconstruct the offending identifier by reading trailing [A-Za-z0-9-] chars
+    // so hyphenated tails like `isHello-world` are echoed in full.
+    let trailing: String = rest_after_cap
+        .chars()
+        .take_while(|c| c.is_ascii_alphanumeric() || *c == '-')
+        .collect();
+    let offset = prev.len();
+    let full = format!("{prev}{cap}{trailing}");
+    let lower = full.to_lowercase();
+    let hyphenated = {
+        let mut s = String::with_capacity(full.len() + 2);
+        for (i, c) in full.chars().enumerate() {
+            if i > 0 && c.is_ascii_uppercase() && !s.ends_with('-') {
+                s.push('-');
+            }
+            s.push(c.to_ascii_lowercase());
+        }
+        s
+    };
+    LexError {
+        code: "ILO-L003",
+        position: start,
+        snippet: full.clone(),
+        suggestion: format!(
+            "identifiers must be lowercase ASCII; got '{full}' (capital '{cap}' at offset {offset}). Use lowercase, e.g. `{hyphenated}` or `{lower}`"
+        ),
+    }
 }
 
 fn lex_error_kind(bad_token: &str) -> (&'static str, String) {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -80,42 +80,13 @@ impl Parser {
                 self.advance();
                 Ok(name)
             }
-            Some(Token::KwIf) => Err(self.error_hint(
-                "ILO-P011",
-                "`if` is a reserved word and cannot be used as an identifier".into(),
-                "ilo uses `cond{body}` for conditional branches".into(),
-            )),
-            Some(Token::KwReturn) => Err(self.error_hint(
-                "ILO-P011",
-                "`return` is a reserved word and cannot be used as an identifier".into(),
-                "ilo uses `ret expr` for early returns".into(),
-            )),
-            Some(Token::KwLet) => Err(self.error_hint(
-                "ILO-P011",
-                "`let` is a reserved word and cannot be used as an identifier".into(),
-                "ilo uses `name=expr` for bindings".into(),
-            )),
-            Some(Token::KwFn) => Err(self.error_hint(
-                "ILO-P011",
-                "`fn` is a reserved word and cannot be used as an identifier".into(),
-                "ilo defines functions as `name params>return;body`".into(),
-            )),
-            Some(Token::KwDef) => Err(self.error_hint(
-                "ILO-P011",
-                "`def` is a reserved word and cannot be used as an identifier".into(),
-                "ilo defines functions as `name params>return;body`".into(),
-            )),
-            Some(Token::KwVar) => Err(self.error_hint(
-                "ILO-P011",
-                "`var` is a reserved word and cannot be used as an identifier".into(),
-                "ilo uses `name=expr` for bindings".into(),
-            )),
-            Some(Token::KwConst) => Err(self.error_hint(
-                "ILO-P011",
-                "`const` is a reserved word and cannot be used as an identifier".into(),
-                "ilo uses `name=expr` for bindings".into(),
-            )),
-            Some(tok) => Err(self.error("ILO-P005", format!("expected identifier, got {:?}", tok))),
+            Some(tok) => {
+                if let Some((msg, hint)) = reserved_keyword_message(&tok) {
+                    Err(self.error_hint("ILO-P011", msg, hint))
+                } else {
+                    Err(self.error("ILO-P005", format!("expected identifier, got {:?}", tok)))
+                }
+            }
             None => Err(self.error("ILO-P006", "expected identifier, got EOF".into())),
         }
     }
@@ -240,6 +211,35 @@ impl Parser {
     }
 
     fn parse_decl(&mut self) -> Result<Decl> {
+        // Reserved-keyword binding attempts: `var=5`, `let=5`, `if=5`, ...
+        // Surface the friendly ILO-P011 message before any expression-level
+        // cascade fires.
+        if self.token_at(self.pos + 1) == Some(&Token::Eq)
+            && let Some(tok) = self.peek()
+            && let Some((msg, _)) = reserved_keyword_message(tok)
+        {
+            return Err(self.error_hint(
+                "ILO-P011",
+                msg,
+                "use `name=expr` for bindings (e.g. `count=5`)".to_string(),
+            ));
+        }
+        // Loop-control words `cnt`/`brk` used as binding names: `cnt=5`.
+        if let Some(Token::Ident(name)) = self.peek()
+            && (name == "cnt" || name == "brk")
+            && self.token_at(self.pos + 1) == Some(&Token::Eq)
+        {
+            let (word, role, alt) = if name == "cnt" {
+                ("cnt", "continue", "count")
+            } else {
+                ("brk", "break", "brake")
+            };
+            return Err(self.error_hint(
+                "ILO-P011",
+                format!("`{word}` is reserved for {role} (loop control) and cannot be used as an identifier"),
+                format!("pick a different name like `{alt}` or `{}`", &word[..1]),
+            ));
+        }
         match self.peek() {
             Some(Token::Type) => self.parse_type_decl(),
             Some(Token::Tool) => self.parse_tool_decl(),
@@ -640,6 +640,19 @@ impl Parser {
     }
 
     fn parse_stmt(&mut self) -> Result<Stmt> {
+        // Reserved-keyword binding attempts inside a function body: `var=5`,
+        // `let=5`, `if=5`, ... Surface the friendly ILO-P011 message before
+        // `parse_atom` cascades into a cryptic ILO-P009.
+        if self.token_at(self.pos + 1) == Some(&Token::Eq)
+            && let Some(tok) = self.peek()
+            && let Some((msg, _)) = reserved_keyword_message(tok)
+        {
+            return Err(self.error_hint(
+                "ILO-P011",
+                msg,
+                "use `name=expr` for bindings (e.g. `count=5`)".to_string(),
+            ));
+        }
         match self.peek() {
             Some(Token::Question) => {
                 if self.is_prefix_ternary() {
@@ -656,6 +669,13 @@ impl Parser {
                 Ok(Stmt::Return(value))
             }
             Some(Token::Ident(name)) if name == "brk" => {
+                if self.token_at(self.pos + 1) == Some(&Token::Eq) {
+                    return Err(self.error_hint(
+                        "ILO-P011",
+                        "`brk` is reserved for break (loop control) and cannot be used as an identifier".into(),
+                        "pick a different name like `brake` or `b`".into(),
+                    ));
+                }
                 self.advance(); // consume "brk"
                 // brk with optional value expression
                 let value = if self.at_body_end() {
@@ -666,6 +686,13 @@ impl Parser {
                 Ok(Stmt::Break(value))
             }
             Some(Token::Ident(name)) if name == "cnt" => {
+                if self.token_at(self.pos + 1) == Some(&Token::Eq) {
+                    return Err(self.error_hint(
+                        "ILO-P011",
+                        "`cnt` is reserved for continue (loop control) and cannot be used as an identifier".into(),
+                        "pick a different name like `count` or `c`".into(),
+                    ));
+                }
                 self.advance(); // consume "cnt"
                 Ok(Stmt::Continue)
             }
@@ -1875,6 +1902,24 @@ fn wrap_body_as_let(name: &str, mut body: Vec<Spanned<Stmt>>) -> Vec<Spanned<Stm
         }
     }
     body
+}
+
+/// Map a reserved-keyword token to its `(message, hint)` pair for ILO-P011.
+fn reserved_keyword_message(tok: &Token) -> Option<(String, String)> {
+    let (name, hint) = match tok {
+        Token::KwIf => ("if", "ilo uses `cond{body}` for conditional branches"),
+        Token::KwReturn => ("return", "ilo uses `ret expr` for early returns"),
+        Token::KwLet => ("let", "ilo uses `name=expr` for bindings"),
+        Token::KwFn => ("fn", "ilo defines functions as `name params>return;body`"),
+        Token::KwDef => ("def", "ilo defines functions as `name params>return;body`"),
+        Token::KwVar => ("var", "ilo uses `name=expr` for bindings"),
+        Token::KwConst => ("const", "ilo uses `name=expr` for bindings"),
+        _ => return None,
+    };
+    Some((
+        format!("`{name}` is a reserved word and cannot be used as an identifier"),
+        hint.to_string(),
+    ))
 }
 
 /// Check if an expression is a comparison or logical operator — eligible

--- a/tests/regression_friendly_errors.rs
+++ b/tests/regression_friendly_errors.rs
@@ -1,0 +1,250 @@
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_err(src: &str) -> String {
+    let out = ilo().arg(src).output().expect("failed to run ilo");
+    assert!(!out.status.success(), "expected failure for {src:?}");
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+fn run_ok(src: &str) {
+    let out = ilo().arg(src).output().expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "expected success for {src:?}, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ---- Reserved keywords as LHS of a binding ----
+
+fn assert_reserved_kw(src: &str, word: &str) {
+    let err = run_err(src);
+    assert!(err.contains("ILO-P011"), "{word}: stderr: {err}");
+    assert!(
+        err.contains(&format!("`{word}` is a reserved word")),
+        "{word}: stderr: {err}"
+    );
+}
+
+#[test]
+fn friendly_var_binding() {
+    assert_reserved_kw("var=5", "var");
+}
+
+#[test]
+fn friendly_let_binding() {
+    assert_reserved_kw("let=5", "let");
+}
+
+#[test]
+fn friendly_fn_binding() {
+    assert_reserved_kw("fn=5", "fn");
+}
+
+#[test]
+fn friendly_const_binding() {
+    assert_reserved_kw("const=5", "const");
+}
+
+#[test]
+fn friendly_if_binding() {
+    assert_reserved_kw("if=5", "if");
+}
+
+#[test]
+fn friendly_return_binding() {
+    assert_reserved_kw("return=5", "return");
+}
+
+#[test]
+fn friendly_def_binding() {
+    assert_reserved_kw("def=5", "def");
+}
+
+// ---- cnt / brk used as identifiers ----
+
+#[test]
+fn friendly_cnt_binding() {
+    let err = run_err("cnt=5");
+    assert!(err.contains("ILO-P011"), "stderr: {err}");
+    assert!(
+        err.contains("`cnt` is reserved for continue"),
+        "stderr: {err}"
+    );
+    assert!(err.contains("count"), "hint should suggest `count`: {err}");
+    // Should not cascade through to the verifier's ILO-T028.
+    assert!(!err.contains("ILO-T028"), "cascade leaked: {err}");
+}
+
+#[test]
+fn friendly_brk_binding() {
+    let err = run_err("brk=5");
+    assert!(err.contains("ILO-P011"), "stderr: {err}");
+    assert!(err.contains("`brk` is reserved for break"), "stderr: {err}");
+    assert!(!err.contains("ILO-T028"), "cascade leaked: {err}");
+}
+
+// ---- Underscore mid-identifier ----
+
+#[test]
+fn friendly_underscore_in_ident() {
+    let err = run_err("rev_ps=5");
+    assert!(err.contains("ILO-L002"), "stderr: {err}");
+    assert!(err.contains("underscores are not allowed"), "stderr: {err}");
+    assert!(err.contains("rev-ps"), "should suggest hyphen form: {err}");
+}
+
+// ---- Uppercase mid-identifier ----
+
+#[test]
+fn friendly_uppercase_in_ident() {
+    let err = run_err("isAgg=5");
+    assert!(err.contains("ILO-L003"), "stderr: {err}");
+    assert!(err.contains("lowercase"), "stderr: {err}");
+    assert!(err.contains("isAgg"), "should echo offender: {err}");
+    assert!(
+        err.contains("is-agg") || err.contains("isagg"),
+        "should suggest hyphen/lowercase form: {err}"
+    );
+}
+
+// ---- Negative regressions ----
+
+#[test]
+fn normal_binding_still_works() {
+    run_ok("f>n;count=5;count");
+}
+
+#[test]
+fn type_sigil_list_still_works() {
+    run_ok("f x:L n>n;0");
+}
+
+#[test]
+fn type_sigil_result_still_works() {
+    run_ok("f x:R t t>n;0");
+}
+
+#[test]
+fn type_sigil_fn_still_works() {
+    run_ok("f x:F n n>n;0");
+}
+
+#[test]
+fn type_sigil_opt_still_works() {
+    run_ok("f x:O n>n;0");
+}
+
+#[test]
+fn type_sigil_map_still_works() {
+    run_ok("f x:M t n>n;0");
+}
+
+#[test]
+fn type_sigil_sum_still_works() {
+    run_ok("f x:S n t>n;0");
+}
+
+// ---- Reserved keywords as binding LHS *inside* a function body ----
+// These must produce ILO-P011, not the cryptic ILO-P009 from parse_atom.
+
+fn assert_reserved_in_body(src: &str, word: &str) {
+    let err = run_err(src);
+    assert!(err.contains("ILO-P011"), "{word} in body: stderr: {err}");
+    assert!(
+        err.contains(&format!("`{word}` is a reserved word")),
+        "{word} in body: stderr: {err}"
+    );
+    assert!(
+        !err.contains("ILO-P009"),
+        "{word} in body should not cascade to ILO-P009: {err}"
+    );
+}
+
+#[test]
+fn friendly_var_binding_in_body() {
+    assert_reserved_in_body("f>n;var=5;var", "var");
+}
+
+#[test]
+fn friendly_let_binding_in_body() {
+    assert_reserved_in_body("f>n;let=5;let", "let");
+}
+
+#[test]
+fn friendly_fn_binding_in_body() {
+    assert_reserved_in_body("f>n;fn=5;fn", "fn");
+}
+
+#[test]
+fn friendly_const_binding_in_body() {
+    assert_reserved_in_body("f>n;const=5;const", "const");
+}
+
+#[test]
+fn friendly_if_binding_in_body() {
+    assert_reserved_in_body("f>n;if=5;if", "if");
+}
+
+#[test]
+fn friendly_return_binding_in_body() {
+    assert_reserved_in_body("f>n;return=5;return", "return");
+}
+
+#[test]
+fn friendly_def_binding_in_body() {
+    assert_reserved_in_body("f>n;def=5;def", "def");
+}
+
+// ---- Wildcard `_` in match/destructure patterns must still work ----
+
+#[test]
+fn bare_underscore_wildcard_still_works() {
+    // `_` as the match-all arm of a `?` match expression — a real,
+    // common ilo idiom. Should not trip the underscore-in-ident lexer
+    // heuristic (ILO-L002).
+    run_ok("desc n:n>t;?n{0:\"zero\";1:\"one\";_:\"many\"}");
+}
+
+// ---- Type sigils in *return-type* position ----
+
+#[test]
+fn type_sigil_list_return_still_works() {
+    run_ok("f x:n>L n;[]");
+}
+
+#[test]
+fn type_sigil_result_return_still_works() {
+    run_ok("g x:n>R t t;~\"ok\"");
+}
+
+// ---- Names starting with reserved prefixes must still bind ----
+
+#[test]
+fn names_starting_with_reserved_prefixes_bind() {
+    // `letter`, `variable`, `iffy`, `constant`, `function` should all
+    // lex as Ident, not as `KwLet`/`KwVar`/`KwIf`/`KwConst`/`KwFn`.
+    run_ok(
+        "f>n;letter=1;variable=2;iffy=3;constant=4;function=5;+ + + + letter variable iffy constant function",
+    );
+}
+
+// ---- Uppercase mid-identifier with hyphenated tail ----
+
+#[test]
+fn uppercase_mid_ident_includes_hyphenated_tail() {
+    let err = run_err("isHello-world=5");
+    assert!(err.contains("ILO-L003"), "stderr: {err}");
+    assert!(
+        err.contains("isHello-world"),
+        "should echo full hyphenated offender: {err}"
+    );
+    assert!(
+        err.contains("is-hello-world"),
+        "should suggest fully hyphenated form: {err}"
+    );
+}


### PR DESCRIPTION
## Summary

Four cryptic error paths around identifier confusion now produce single-retry-fixable friendly errors. Each one was costing an AI agent a wasted retry on every fresh program, which violates the manifesto's only metric: total tokens from intent to working code.

The doc cited `cnt` colliding with the natural "count" variable name **three times in one session**. That's the kind of token-bleed this PR is built for.

## What used to happen vs. what happens now

| Input | Before | After |
|---|---|---|
| `var=5` | `ILO-P009 expected expression, got KwVar` | `ILO-P011 \`var\` is a reserved word ... use \`name=expr\` for bindings (e.g. \`count=5\`)` |
| `let=5` / `fn=5` / `const=5` / `if=5` / `return=5` / `def=5` | same cryptic ILO-P009 cascade | same friendly ILO-P011 with the right rename hint per keyword |
| `cnt=5` | `ILO-P003 expected Greater, got Eq` + T028 cascade | `ILO-P011 \`cnt\` is reserved for continue (loop control); pick a different name like \`count\` or \`c\`` |
| `brk=5` | same cascade shape | `ILO-P011 \`brk\` is reserved for break (loop control)...` |
| `rev_ps=5` | `ILO-P003 expected Greater, got Underscore` then `undefined variable '_'` | `ILO-L002 underscores are not allowed in identifiers; use hyphens (e.g. \`rev-ps\`)` |
| `isAgg=5` | `ILO-L001 unexpected token 'A'` | `ILO-L003 identifiers must be lowercase ASCII; got 'isAgg' (capital 'A' at offset 2). Use lowercase, e.g. \`is-agg\` or \`isagg\`` |

## What's in the diff

1. **`parser/lexer: friendly errors for identifier-confusion cases`** — factored the existing `expect_ident` reserved-word path into a `reserved_keyword_message` helper, then wired it up at the two places where binding LHSs actually parse: `parse_decl` (top-level) and `parse_stmt` (function bodies). Added explicit `cnt`/`brk` guards in `parse_stmt` so they don't get caught by the trailing-equals trap. On the lexer side, added a post-lex scan that detects `_` sandwiched between two adjacent identifier tokens (emits ILO-L002), and a check for `Ident` immediately followed by a single-letter type sigil or logos error char (emits ILO-L003 with the full reconstructed identifier including hyphenated tails).

2. **`tests: regression coverage for friendly identifier errors`** — 30 tests covering every case above at both declaration scope and inside function bodies, plus negative regressions confirming bare `_` still works in destructure patterns, every type sigil still tokenises in parameter and return-type positions, and `letter`/`variable`/`iffy`/`constant`/`function` still bind as plain idents.

## Test plan

- [x] `cargo test --release --features cranelift` — 3413 passed, 0 failed, 74 ignored (3383 baseline + 30 new tests)
- [x] `cargo fmt --all -- --check` clean
- [x] Each of the four input cases above produces the friendly error rather than the cryptic cascade, at both top-level and inside function bodies
- [x] Code-reviewed by subagent; blocking and should-fix findings addressed (the reviewer caught that the initial implementation only fixed declaration scope, not function-body scope — fixed before commit)

## Follow-ups (not in this PR)

The assessment doc has more rough edges in the same area that would benefit from the same friendly-error treatment, but they're different code shapes and earn their own PR each. Notably: list-literal `[a b c]` vs `[1 2 3]` consistency, inline-mode phantom verifier errors, sibling helper functions ending in bare calls slurping the next identifier.