### PR TITLE
skill: document the three ways to run ilo from an agent

### DIFF
--- a/skills/ilo/SKILL.md
+++ b/skills/ilo/SKILL.md
@@ -20,7 +20,13 @@ scripts/ensure-ilo.sh
 
 Run this at the start of every ilo task. It installs ilo if missing, or updates it if a newer version is available.
 
-If you are running inside the pi coding agent with `pi-ilo-lang` installed, prefer the `ilo_run` and `ilo_repl` tools over shelling out: they take structured args and skip the per-call permission prompt.
+## Running ilo from an agent
+
+Three ways to execute ilo, in preference order:
+
+1. **Named tools (`ilo_run`, `ilo_repl`)** - if your agent exposes them (e.g. via `pi-ilo-lang` in pi), prefer them. Structured args, no per-call shell permission prompt.
+2. **`ilo serv`** - long-lived JSON request/response loop, runnable from any shell. Send a line `{"program": "...", "func": "...", "args": [...]}`, get one response line back. Use when you would otherwise spawn many short-lived `ilo` processes.
+3. **One-shot shell** - `ilo '<code>' [args...]` via the bash tool. Fine for a single call.
 
 ## Load the Full Spec
 


### PR DESCRIPTION
## Summary

- Replace the pi-specific line in \`skills/ilo/SKILL.md\` with a generic three-tier section: named tools (e.g. \`ilo_run\` / \`ilo_repl\`), \`ilo serv\` JSON loop, one-shot shell

## Why

One skill, one source of truth, used by every agent. The earlier line named pi explicitly; this version is agent-neutral and forward-compatible. \`ilo serv\` is a binary feature so it belongs in the general skill regardless of which agent is reading.

## Test plan

- [ ] After merge, cut a release; the Claude marketplace plugin and \`pi-ilo-lang\` both ship the updated skill
- [ ] Sync local \`~/.claude/skills/ilo/SKILL.md\` to match