### PR TITLE
chore: release v0.10.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ilo",
       "source": "./",
       "description": "Write, run, debug, and explain programs in ilo — a token-optimised programming language for AI agents",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "author": {
         "name": "Daniel Morris"
       },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "ilo"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "clap",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ilo"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2024"
 rust-version = "1.85"
 description = "ilo — a programming language for AI agents"


### PR DESCRIPTION
Skill update from PR #155 - the three ways to run ilo from an agent. Ships to npm (ilo-lang, pi-ilo-lang), crates.io, GitHub release on tag.