### PR TITLE
Fix tree-walker escaping function from match-in-loop tail

### DIFF
--- a/examples/match-in-loop.ilo
+++ b/examples/match-in-loop.ilo
@@ -1,0 +1,17 @@
+-- match as the tail of an @ loop body: value yields into the loop, not the caller.
+
+evens n:n>n;a=0;@i 0..n{r=mod i 2;?r{0:a=+a i;_:a}};+a 0
+
+label n:n>n;?n{0:0;_:n}
+
+-- engine-skip: jit
+-- run: evens 0
+-- out: 0
+-- run: evens 5
+-- out: 6
+-- run: evens 10
+-- out: 20
+-- run: label 0
+-- out: 0
+-- run: label 7
+-- out: 7

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1665,9 +1665,8 @@ fn serde_json_to_value(v: serde_json::Value) -> Value {
 
 fn eval_body(env: &mut Env, stmts: &[Spanned<Stmt>]) -> Result<BodyResult> {
     let mut last = Value::Nil;
-    for (i, spanned) in stmts.iter().enumerate() {
-        let is_last = i == stmts.len() - 1;
-        match eval_stmt(env, &spanned.node, is_last) {
+    for spanned in stmts.iter() {
+        match eval_stmt(env, &spanned.node) {
             Ok(Some(BodyResult::Return(v))) => return Ok(BodyResult::Return(v)),
             Ok(Some(BodyResult::Break(v))) => return Ok(BodyResult::Break(v)),
             Ok(Some(BodyResult::Continue)) => return Ok(BodyResult::Continue),
@@ -1691,7 +1690,7 @@ fn eval_body(env: &mut Env, stmts: &[Spanned<Stmt>]) -> Result<BodyResult> {
     Ok(BodyResult::Value(last))
 }
 
-fn eval_stmt(env: &mut Env, stmt: &Stmt, is_last: bool) -> Result<Option<BodyResult>> {
+fn eval_stmt(env: &mut Env, stmt: &Stmt) -> Result<Option<BodyResult>> {
     match stmt {
         Stmt::Let { name, value } => {
             let val = eval_expr(env, value)?;
@@ -1782,12 +1781,7 @@ fn eval_stmt(env: &mut Env, stmt: &Stmt, is_last: bool) -> Result<Option<BodyRes
                         BodyResult::Return(v) => return Ok(Some(BodyResult::Return(v))),
                         BodyResult::Break(v) => return Ok(Some(BodyResult::Break(v))),
                         BodyResult::Continue => return Ok(Some(BodyResult::Continue)),
-                        BodyResult::Value(v) => {
-                            if is_last {
-                                return Ok(Some(BodyResult::Return(v)));
-                            }
-                            return Ok(Some(BodyResult::Value(v)));
-                        }
+                        BodyResult::Value(v) => return Ok(Some(BodyResult::Value(v))),
                     }
                 }
             }

--- a/tests/regression_match_in_loop.rs
+++ b/tests/regression_match_in_loop.rs
@@ -1,0 +1,113 @@
+// Regression tests for tree-walker miscompile where a `?match{}` expression
+// at the tail of an `@` loop body silently early-returned from the enclosing
+// function instead of yielding into the loop body.
+//
+// Before the fix, `Stmt::Match` in the tree interpreter converted a
+// `BodyResult::Value(v)` into `BodyResult::Return(v)` whenever the match was
+// the last statement of any body — including a loop body. That escaped the
+// loop AND the function with the matched arm's value. VM and Cranelift were
+// correct; only the tree-walker mis-handled this. These tests pin the
+// cross-engine behaviour so the bug cannot silently come back.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+#[cfg(feature = "cranelift")]
+const ENGINES_ALL: &[&str] = &["--run-tree", "--run-vm", "--run-cranelift"];
+#[cfg(not(feature = "cranelift"))]
+const ENGINES_ALL: &[&str] = &["--run-tree", "--run-vm"];
+
+// Match-as-tail of an `@` loop must not escape the function. The function's
+// tail value (`5`) is what should be returned.
+const LOOP_TAIL: &str = r#"f>n;cs=["1"];@c cs{rn=num c;?rn{^_:99;~v:42}};5"#;
+
+#[test]
+fn match_in_loop_tail_cross_engine() {
+    for engine in ENGINES_ALL {
+        let out = run(engine, LOOP_TAIL, "f");
+        assert_eq!(out.trim(), "5", "{engine}: {out:?}");
+    }
+}
+
+// Sanity: match as the tail of a function (no surrounding loop) still returns
+// the matched arm's value. The fix must not break this case.
+const FN_TAIL: &str = r#"f>n;rn=num "1";?rn{^_:99;~v:42}"#;
+
+#[test]
+fn match_as_fn_tail_cross_engine() {
+    for engine in ENGINES_ALL {
+        let out = run(engine, FN_TAIL, "f");
+        assert_eq!(out.trim(), "42", "{engine}: {out:?}");
+    }
+}
+
+// Match arm body with side effects inside an `@` loop must run for every
+// iteration, mutate the accumulator, and reach the function's tail.
+const LOOP_SIDE_EFFECTS: &str =
+    r#"f>n;n=0;cs=["1","x","2","y","3"];@c cs{rn=num c;?rn{^_:n;~v:n=+n 1}};n"#;
+
+#[test]
+fn match_side_effects_in_loop_cross_engine() {
+    for engine in ENGINES_ALL {
+        let out = run(engine, LOOP_SIDE_EFFECTS, "f");
+        assert_eq!(out.trim(), "3", "{engine}: {out:?}");
+    }
+}
+
+// `brk` inside a match inside an `@` loop must still propagate to the loop
+// (not return from the function). Tail of the function returns the
+// accumulator after the loop exits early. The non-numeric arm fires a braced
+// guard with `brk`; the numeric arm increments.
+const BRK_IN_MATCH: &str =
+    r#"f>n;n=0;cs=["1","2","x","3"];@c cs{rn=num c;?rn{^_:1{brk}{n=n};~v:n=+n 1}};n"#;
+
+#[test]
+fn brk_in_match_in_loop_cross_engine() {
+    for engine in ENGINES_ALL {
+        let out = run(engine, BRK_IN_MATCH, "f");
+        assert_eq!(out.trim(), "2", "{engine}: {out:?}");
+    }
+}
+
+// Same shape as LOOP_TAIL but with a `wh` (while) loop instead of `@`. The
+// match at the tail of the while body must yield into the loop, not the
+// caller; the function's own tail (`5`) is what should be returned.
+const WHILE_LOOP_TAIL: &str = r#"f>n;i=0;wh <i 3{i=+i 1;rn=num "1";?rn{^_:99;~v:42}};5"#;
+
+#[test]
+fn match_in_while_loop_tail_cross_engine() {
+    for engine in ENGINES_ALL {
+        let out = run(engine, WHILE_LOOP_TAIL, "f");
+        assert_eq!(out.trim(), "5", "{engine}: {out:?}");
+    }
+}
+
+// `cnt` inside a match inside an `@` loop must propagate to the loop.
+// All non-numeric entries hit the wildcard arm and fire a braced-guard `cnt`;
+// numeric entries increment the accumulator.
+const CNT_IN_MATCH: &str =
+    r#"f>n;n=0;cs=["1","x","2","y","3"];@c cs{rn=num c;?rn{^_:1{cnt}{n=n};~v:n=+n 1}};n"#;
+
+#[test]
+fn cnt_in_match_in_loop_cross_engine() {
+    for engine in ENGINES_ALL {
+        let out = run(engine, CNT_IN_MATCH, "f");
+        assert_eq!(out.trim(), "3", "{engine}: {out:?}");
+    }
+}


### PR DESCRIPTION
## Summary

A `?match{}` expression at the tail of an `@` or `wh` loop body was silently early-returning the enclosing function with the match arm's value. Three personas independently reported this during assessment runs as "match arm silently exits the outer loop." VM and Cranelift were correct; only the tree-walker was wrong.

Engine-divergent silent miscompilation is the worst possible failure mode for an AI-targeted language: the program verifies, runs, returns the wrong number with no error signal, and the agent burns retries debugging logic that isn't broken. Same severity class as the slc/mset bug PR #150 fixed.

## Repro

```
ilo 'f>n;cs=["1"];@c cs{rn=num c;?rn{^_:99;~v:42}};5' --run-tree f
```

| Engine | Before | After |
|---|---|---|
| `--run-tree` | `42` ❌ | `5` ✓ |
| `--run-vm` | `5` ✓ | `5` ✓ |
| `--run-cranelift` | `5` ✓ | `5` ✓ |

## Root cause

`Stmt::Match` in `eval_stmt` had a special-case `if is_last { return BodyResult::Return(v) }` that fired whenever the match was the final statement of any body — function or loop. The function-body handler in `eval_body` already returns `BodyResult::Value(last)` for the function caller to convert into the function return, so the special-case at Stmt::Match was duplicating that logic incorrectly. Inside a loop body it made the match's value propagate as a function-level Return, bypassing whatever came after the loop.

## What's in the diff

1. **`interpreter: tree-walker no longer escapes function from match-in-loop tail`** — one-line removal of the `if is_last` branch in `Stmt::Match`'s `Value(v)` arm. `is_last` was the only consumer of that parameter and `eval_body` was the only caller of `eval_stmt`, so removed the plumbing entirely rather than leaving dead args that invite the special-case to come back.

2. **`tests + example: pin match-in-loop tail behaviour across engines`** — 6 cross-engine regression tests covering match-as-loop-tail, match-as-function-tail (sanity), side-effect arms, `cnt`/`brk` propagation, and the `wh`-loop analogue. `examples/match-in-loop.ilo` demonstrates both loop-tail and function-tail shapes with `-- run:` / `-- out:` directives so `tests/examples_engines.rs` exercises them across every engine.

## Test plan

- [x] `cargo test --release --features cranelift` — 3419 passed, 0 failed, 74 ignored (3413 baseline + 6 new)
- [x] `cargo fmt --all -- --check` clean
- [x] Repro returns identical output across tree, vm, cranelift
- [x] Function-tail match (no surrounding loop) still returns the match's value correctly
- [x] Code-reviewed by subagent; should-fix and nice-to-have findings addressed (full `is_last` plumbing removed, `wh`-loop test added, example expanded with function-tail sanity case, header comment trimmed)

## Follow-ups

The doc entry about `mset m k variable` silently storing wrong value when a `0` was previously bound was a stale-binary artefact of PR #150 — same root cause, already fixed there. Updated `ilo_assessment_feedback.md` to reflect this in the Addressed section.

The custom ARM64 JIT removal is in flight on a separate branch (`feature/remove-custom-jit`) — independent of this PR, no conflict.