### PR TITLE
Snake_case field names in dot-access position

### DIFF
--- a/examples/snake-fields.ilo
+++ b/examples/snake-fields.ilo
@@ -1,0 +1,13 @@
+-- Snake_case dot-access on records parsed from real-world JSON.
+stars j:t>R n t;r=jpar! j;r.stargazers_count
+trend j:t>R n t;r=jpar! j;r.change_1d
+cov j:t>R n t;r=jpar! j;r.people_vaccinated_per_hundred
+
+-- run: stars {"stargazers_count":42}
+-- out: 42
+
+-- run: trend {"change_1d":0.07}
+-- out: 0.07
+
+-- run: cov {"people_vaccinated_per_hundred":12.5}
+-- out: 12.5

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -278,6 +278,70 @@ pub fn lex(source: &str) -> Result<Vec<(Token, std::ops::Range<usize>)>, LexErro
         }
     }
 
+    // Post-lex: after `.` or `.?` (field access), accept JSON-style snake_case
+    // field names by merging contiguous `Ident (Underscore (Ident|Number))*`
+    // runs back into a single `Ident` token. Real-world JSON (which agents
+    // consume via `jpar!`) is overwhelmingly snake_case (`stargazers_count`,
+    // `change_1d`, ...), and dot-access on those keys is the canonical path.
+    // The strict identifier rule (lowercase + hyphens) still applies to
+    // bindings, so `my_var=5` keeps emitting ILO-L002 below.
+    let mut i = 0;
+    while i + 2 < tokens.len() {
+        let prev_is_dot = i > 0
+            && matches!(tokens[i - 1].0, Token::Dot | Token::DotQuestion)
+            && tokens[i - 1].1.end == tokens[i].1.start;
+        if !prev_is_dot {
+            i += 1;
+            continue;
+        }
+        if !matches!(tokens[i].0, Token::Ident(_)) {
+            i += 1;
+            continue;
+        }
+        // Greedily collect contiguous `_ (Ident | integer Number Ident?)`
+        // segments. Each `_Number` group may also absorb a trailing letter
+        // glued to the number (e.g. `change_1d`, `x_2y_3z`), and the loop
+        // continues afterward so alternating segments like
+        // `ema_20d_change_5d` stitch fully.
+        let mut j = i + 1;
+        let mut has_underscore = false;
+        while j + 1 < tokens.len()
+            && tokens[j].0 == Token::Underscore
+            && tokens[j - 1].1.end == tokens[j].1.start
+            && tokens[j].1.end == tokens[j + 1].1.start
+        {
+            match &tokens[j + 1].0 {
+                Token::Ident(_) => {
+                    has_underscore = true;
+                    j += 2;
+                }
+                Token::Number(n) if n.fract() == 0.0 && *n >= 0.0 => {
+                    has_underscore = true;
+                    j += 2;
+                    // Absorb a trailing letter glued to the number
+                    // (e.g. the `d` in `change_1d`).
+                    if j < tokens.len()
+                        && tokens[j - 1].1.end == tokens[j].1.start
+                        && matches!(tokens[j].0, Token::Ident(_))
+                    {
+                        j += 1;
+                    }
+                }
+                _ => break,
+            }
+        }
+        if !has_underscore {
+            i += 1;
+            continue;
+        }
+        let start = tokens[i].1.start;
+        let end = tokens[j - 1].1.end;
+        let merged = normalized[start..end].to_string();
+        let new_tok = (Token::Ident(merged), start..end);
+        tokens.splice(i..j, std::iter::once(new_tok));
+        i += 1;
+    }
+
     // Post-lex: detect underscore-separated identifier fragments like
     // `rev_ps` → Ident("rev"), Underscore, Ident("ps") with no whitespace.
     for i in 0..tokens.len().saturating_sub(2) {

--- a/tests/regression_snake_field_access.rs
+++ b/tests/regression_snake_field_access.rs
@@ -1,0 +1,255 @@
+// Regression tests for snake_case field access on records.
+//
+// Real-world JSON (consumed via `jpar!`) is overwhelmingly snake_case
+// (`stargazers_count`, `change_1d`, `people_vaccinated_per_hundred`).
+// The strict identifier rule (lowercase + hyphens) makes `r.snake_field`
+// trip ILO-L002 at the lexer. The fix special-cases the lexer post-pass:
+// after `Dot` / `DotQuestion`, contiguous `Ident (_ (Ident|int))*` runs are
+// merged back into a single `Ident` so the parser sees one field name.
+// Bindings (`my_var=5`) still emit ILO-L002.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str, args: &[&str]) -> String {
+    let mut cmd = ilo();
+    cmd.arg(src).arg(engine).arg(entry);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn run_err(src: &str) -> String {
+    let out = ilo()
+        .args([src, "--run-tree", "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(!out.status.success(), "expected failure for `{src}`");
+    String::from_utf8_lossy(&out.stderr).to_string()
+}
+
+// `r.stargazers_count` returns 42 across engines.
+const SIMPLE: &str = "f j:t>R n t;rec=jpar! j;rec.stargazers_count";
+
+fn check_simple(engine: &str) {
+    assert_eq!(
+        run(engine, SIMPLE, "f", &[r#"{"stargazers_count":42}"#]),
+        "42",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn snake_field_simple_tree() {
+    check_simple("--run-tree");
+}
+
+#[test]
+fn snake_field_simple_vm() {
+    check_simple("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn snake_field_simple_cranelift() {
+    check_simple("--run-cranelift");
+}
+
+// Multi-underscore field name.
+const MULTI: &str = "f j:t>R n t;r=jpar! j;r.people_vaccinated_per_hundred";
+
+fn check_multi(engine: &str) {
+    assert_eq!(
+        run(
+            engine,
+            MULTI,
+            "f",
+            &[r#"{"people_vaccinated_per_hundred":12.5}"#]
+        ),
+        "12.5",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn snake_field_multi_tree() {
+    check_multi("--run-tree");
+}
+
+#[test]
+fn snake_field_multi_vm() {
+    check_multi("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn snake_field_multi_cranelift() {
+    check_multi("--run-cranelift");
+}
+
+// Field name with a digit segment (`change_1d`).
+const DIGIT: &str = "f j:t>R n t;r=jpar! j;r.change_1d";
+
+fn check_digit(engine: &str) {
+    assert_eq!(
+        run(engine, DIGIT, "f", &[r#"{"change_1d":0.07}"#]),
+        "0.07",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn snake_field_digit_tree() {
+    check_digit("--run-tree");
+}
+
+#[test]
+fn snake_field_digit_vm() {
+    check_digit("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn snake_field_digit_cranelift() {
+    check_digit("--run-cranelift");
+}
+
+// Safe access (`.?`) on a snake_case field.
+#[test]
+fn snake_field_safe_access_tree() {
+    let out = run(
+        "--run-tree",
+        "f j:t>R n t;r=jpar! j;r.?stargazers_count",
+        "f",
+        &[r#"{"stargazers_count":7}"#],
+    );
+    assert_eq!(out, "7");
+}
+
+// ---- Negative regressions: PR #154 behaviour preserved ----
+
+#[test]
+fn bare_underscore_binding_still_errors() {
+    // `my_var=5` in a binding position must still emit ILO-L002 with the
+    // hyphen-suggestion friendly message.
+    let err = run_err("f>n;rev_ps=5;rev_ps");
+    assert!(err.contains("ILO-L002"), "stderr: {err}");
+    assert!(err.contains("underscores are not allowed"), "stderr: {err}");
+    assert!(err.contains("rev-ps"), "stderr: {err}");
+}
+
+#[test]
+fn dot_then_plain_ident_unchanged() {
+    // `r.foo` (no underscore) must still parse as a plain field access; the
+    // following identifier is a separate token.  Sanity that we didn't
+    // accidentally consume tokens beyond the field name.
+    let out = run(
+        "--run-tree",
+        "f j:t>R n t;r=jpar! j;r.foo",
+        "f",
+        &[r#"{"foo":3}"#],
+    );
+    assert_eq!(out, "3");
+}
+
+#[test]
+fn dot_then_ident_space_ident_keeps_tokens_separate() {
+    // `r.foo bar` must NOT merge `bar` into the field access. `bar` is a
+    // separate token and (since it isn't bound) the program should fail
+    // rather than evaluate `r.foo` successfully.
+    let err = run_err("f j:t>R n t;r=jpar! j;r.foo bar");
+    // We don't pin the exact error code; only that it didn't silently
+    // succeed treating `bar` as part of the field name.
+    assert!(!err.is_empty(), "expected an error, got empty stderr");
+}
+
+// Field name ending in a bare digit (`x_1`, no trailing letter).
+const BARE_DIGIT: &str = "f j:t>R n t;r=jpar! j;r.x_1";
+
+fn check_bare_digit(engine: &str) {
+    assert_eq!(
+        run(engine, BARE_DIGIT, "f", &[r#"{"x_1":11}"#]),
+        "11",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn snake_field_bare_digit_tree() {
+    check_bare_digit("--run-tree");
+}
+
+#[test]
+fn snake_field_bare_digit_vm() {
+    check_bare_digit("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn snake_field_bare_digit_cranelift() {
+    check_bare_digit("--run-cranelift");
+}
+
+// Alternating Ident/Number/Ident segments (`x_2y_3z`).
+const ALTERNATING: &str = "f j:t>R n t;r=jpar! j;r.x_2y_3z";
+
+fn check_alternating(engine: &str) {
+    assert_eq!(
+        run(engine, ALTERNATING, "f", &[r#"{"x_2y_3z":99}"#]),
+        "99",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn snake_field_alternating_tree() {
+    check_alternating("--run-tree");
+}
+
+#[test]
+fn snake_field_alternating_vm() {
+    check_alternating("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn snake_field_alternating_cranelift() {
+    check_alternating("--run-cranelift");
+}
+
+// Real-world shape: `ema_20d_change_5d` (two `_Number Ident` groups).
+const REAL_WORLD: &str = "f j:t>R n t;r=jpar! j;r.ema_20d_change_5d";
+
+fn check_real_world(engine: &str) {
+    assert_eq!(
+        run(engine, REAL_WORLD, "f", &[r#"{"ema_20d_change_5d":0.42}"#]),
+        "0.42",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn snake_field_real_world_tree() {
+    check_real_world("--run-tree");
+}
+
+#[test]
+fn snake_field_real_world_vm() {
+    check_real_world("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn snake_field_real_world_cranelift() {
+    check_real_world("--run-cranelift");
+}


### PR DESCRIPTION
## Summary

Resolves the doc-cited "real-world JSON is overwhelmingly snake_case, so dot-access is a minority path" friction. Every persona that touched real JSON in the assessment runs (`stargazers_count`, `change_1d`, `people_vaccinated_per_hundred`, `budget_authority_amount`, `ema_20d_change_5d`) had to fall back to the verbose `jpth!` per-field workaround because `r.snake_case` failed at the lexer.

Through the manifesto lens: every API call agents make against real-world endpoints used to require a token-expensive workaround. Now the natural dot-access form works.

## Approach

Lexer-cooperative — added a post-lex merge pass that runs immediately before PR #154's `ILO-L002` friendly-error scan. After consuming `Dot` or `DotQuestion`, contiguous `Ident (Underscore (Ident|Number Ident?))*` runs (with strict span-contiguity, no whitespace gaps) get spliced into a single `Token::Ident` using the original source slice. The L002 scan immediately below is byte-for-byte unchanged, so plain bindings like `my_var=5` still emit the friendly underscore error — only dot-access position gets the loosened identifier rule.

The merge handles three shapes uniformly inside one loop:
- `field_name` (`Ident _ Ident`)
- `change_1d` (`Ident _ Number Ident`)
- `ema_20d_change_5d` (alternating `Ident / Number-Ident` segments)

The trailing-letter-after-Number absorb lives inside the loop so each `_Number Ident?` group is consumed atomically and the loop continues. Without this, alternating real-world names like `ema_20d_change_5d` would only stitch the first two segments.

## What's in the diff

1. **`lexer: merge snake_case field names in dot-access position`** — `src/lexer/mod.rs` post-lex pass, +64 lines. No parser changes needed; `expect_ident()` after a `Dot` now sees one merged `Ident`.

2. **`tests + example: pin snake_case dot-access across engines`** — 22 cross-engine tests covering simple, multi-segment, digit-trailing-letter, bare-digit, alternating, and real-world shapes, plus negative regressions (`my_var=5` still errors with ILO-L002; `r.foo bar` keeps tokens separate). `examples/snake-fields.ilo` demonstrates the pattern with three `-- run:` / `-- out:` cases so `tests/examples_engines.rs` exercises each shape across every engine.

## Test plan

- [x] `cargo test --release --features cranelift` — full suite green, +10 new regression tests + 6 new example-engine cases
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --features cranelift -- -D warnings` clean
- [x] PR #154's 30 friendly-error tests still pass unchanged
- [x] `r.ema_20d_change_5d` shape (alternating segments) stitches correctly across tree/vm/cranelift
- [x] `my_var=5` bindings still emit ILO-L002 (binding-position underscore still flagged)
- [x] `r.foo bar` keeps tokens separate (no false merge across whitespace)
- [x] Code-reviewed by subagent; the alternating-segment stitching bug was caught and fixed before commit

## Follow-ups

- `r.foo._bar` (leading underscore on inner field) is not handled. Deferred — the doc-cited shapes are all flat snake_case, and starting a field with `_` is unusual in JSON.