### PR TITLE
Add at xs i builtin for nth-element list access

### DIFF
--- a/examples/at-indexing.ilo
+++ b/examples/at-indexing.ilo
@@ -1,0 +1,13 @@
+-- at xs i: i-th element of a list (0-indexed). Out-of-range is a runtime error.
+
+nth xs:L n i:n>n;at xs i
+last xs:L n>n;at xs -(len xs) 1
+
+-- run: nth [10,20,30] 1
+-- out: 20
+-- run: nth [10,20,30] 0
+-- out: 10
+-- run: nth [10,20,30] 2
+-- out: 30
+-- run: last [10,20,30]
+-- out: 30

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -24,6 +24,7 @@ pub enum Builtin {
     // Collections
     Len,
     Hd,
+    At,
     Tl,
     Rev,
     Srt,
@@ -95,6 +96,7 @@ impl Builtin {
             "avg" => Some(Builtin::Avg),
             "len" => Some(Builtin::Len),
             "hd" => Some(Builtin::Hd),
+            "at" => Some(Builtin::At),
             "tl" => Some(Builtin::Tl),
             "rev" => Some(Builtin::Rev),
             "srt" => Some(Builtin::Srt),
@@ -153,6 +155,7 @@ impl Builtin {
             Builtin::Avg => "avg",
             Builtin::Len => "len",
             Builtin::Hd => "hd",
+            Builtin::At => "at",
             Builtin::Tl => "tl",
             Builtin::Rev => "rev",
             Builtin::Srt => "srt",
@@ -207,10 +210,10 @@ mod tests {
     fn round_trip_all_builtins() {
         let all = [
             "str", "num", "abs", "flr", "cel", "rou", "min", "max", "mod", "sum", "avg", "len",
-            "hd", "tl", "rev", "srt", "slc", "unq", "flat", "has", "spl", "cat", "map", "flt",
-            "fld", "grp", "rnd", "now", "rd", "rdl", "rdb", "wr", "wrl", "prnt", "env", "trm",
-            "fmt", "rgx", "jpth", "jdmp", "jpar", "get", "post", "mmap", "mget", "mset", "mhas",
-            "mkeys", "mvals", "mdel",
+            "hd", "at", "tl", "rev", "srt", "slc", "unq", "flat", "has", "spl", "cat", "map",
+            "flt", "fld", "grp", "rnd", "now", "rd", "rdl", "rdb", "wr", "wrl", "prnt", "env",
+            "trm", "fmt", "rgx", "jpth", "jdmp", "jpar", "get", "post", "mmap", "mget", "mset",
+            "mhas", "mkeys", "mvals", "mdel",
         ];
         for name in &all {
             let b = Builtin::from_name(name).unwrap_or_else(|| panic!("missing builtin: {name}"));

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -622,6 +622,58 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             )),
         };
     }
+    if builtin == Some(Builtin::At) && args.len() == 2 {
+        let idx = match &args[1] {
+            Value::Number(n) => {
+                if *n < 0.0 || n.fract() != 0.0 {
+                    return Err(RuntimeError::new(
+                        "ILO-R009",
+                        "at: index must be a non-negative integer".to_string(),
+                    ));
+                }
+                *n as usize
+            }
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!("at: index must be a number, got {:?}", other),
+                ));
+            }
+        };
+        return match &args[0] {
+            Value::List(items) => {
+                if idx >= items.len() {
+                    Err(RuntimeError::new(
+                        "ILO-R009",
+                        format!(
+                            "at: index {idx} out of range for list of length {}",
+                            items.len()
+                        ),
+                    ))
+                } else {
+                    Ok(items[idx].clone())
+                }
+            }
+            Value::Text(s) => {
+                let chars: Vec<char> = s.chars().collect();
+                if idx >= chars.len() {
+                    Err(RuntimeError::new(
+                        "ILO-R009",
+                        format!(
+                            "at: index {idx} out of range for text of length {}",
+                            chars.len()
+                        ),
+                    ))
+                } else {
+                    Ok(Value::Text(chars[idx].to_string()))
+                }
+            }
+            other => Err(RuntimeError::new(
+                "ILO-R009",
+                format!("at requires a list or text, got {:?}", other),
+            )),
+        };
+    }
     if builtin == Some(Builtin::Tl) && args.len() == 1 {
         return match &args[0] {
             Value::List(items) => {

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -273,6 +273,7 @@ const BUILTINS: &[(&str, &[&str], &str)] = &[
     ("cat", &["L t", "t"], "t"),
     ("has", &["list_or_text", "any"], "b"),
     ("hd", &["list_or_text"], "any"),
+    ("at", &["list_or_text", "n"], "any"),
     ("tl", &["list_or_text"], "list_or_text"),
     ("rev", &["list_or_text"], "list_or_text"),
     ("srt", &["list_or_text"], "list_or_text"),
@@ -484,6 +485,37 @@ fn builtin_check_args(
                         code: "ILO-T013",
                         function: func_ctx.to_string(),
                         message: format!("'hd' expects a list or text, got {other}"),
+                        hint: None,
+                        span,
+                        is_warning: false,
+                    }),
+                }
+            }
+            (Ty::Unknown, errors)
+        }
+        "at" => {
+            // at xs i — returns the i-th element of xs (list or text)
+            if let Some(arg) = arg_types.get(1)
+                && !compatible(arg, &Ty::Number)
+            {
+                errors.push(VerifyError {
+                    code: "ILO-T013",
+                    function: func_ctx.to_string(),
+                    message: format!("'at' index must be n, got {arg}"),
+                    hint: None,
+                    span,
+                    is_warning: false,
+                });
+            }
+            if let Some(arg) = arg_types.first() {
+                match arg {
+                    Ty::List(inner) => return (*inner.clone(), errors),
+                    Ty::Text => return (Ty::Text, errors),
+                    Ty::Unknown => return (Ty::Unknown, errors),
+                    other => errors.push(VerifyError {
+                        code: "ILO-T013",
+                        function: func_ctx.to_string(),
+                        message: format!("'at' expects a list or text, got {other}"),
                         hint: None,
                         span,
                         is_warning: false,

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -62,6 +62,7 @@ struct HelperFuncs {
     cat: FuncId,
     has: FuncId,
     hd: FuncId,
+    at: FuncId,
     tl: FuncId,
     rev: FuncId,
     srt: FuncId,
@@ -173,6 +174,7 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         cat: declare_helper(module, "jit_cat", 2, 1),
         has: declare_helper(module, "jit_has", 2, 1),
         hd: declare_helper(module, "jit_hd", 1, 1),
+        at: declare_helper(module, "jit_at", 2, 1),
         tl: declare_helper(module, "jit_tl", 1, 1),
         rev: declare_helper(module, "jit_rev", 1, 1),
         srt: declare_helper(module, "jit_srt", 1, 1),
@@ -891,9 +893,9 @@ fn compile_function_body(
                 // Ops that write a non-numeric or unknown type to R[A].
                 OP_ADD | OP_SUB | OP_MUL | OP_DIV | OP_ADD_SS | OP_NEG | OP_WRAPOK | OP_WRAPERR
                 | OP_UNWRAP | OP_RECFLD | OP_RECFLD_NAME | OP_LISTGET | OP_INDEX | OP_STR
-                | OP_HD | OP_TL | OP_REV | OP_SRT | OP_SLC | OP_SPL | OP_CAT | OP_GET | OP_POST
-                | OP_GETH | OP_POSTH | OP_ENV | OP_JPTH | OP_JDMP | OP_JPAR | OP_MAPNEW
-                | OP_MGET | OP_MSET | OP_MDEL | OP_MKEYS | OP_MVALS | OP_LISTNEW
+                | OP_HD | OP_AT | OP_TL | OP_REV | OP_SRT | OP_SLC | OP_SPL | OP_CAT | OP_GET
+                | OP_POST | OP_GETH | OP_POSTH | OP_ENV | OP_JPTH | OP_JDMP | OP_JPAR
+                | OP_MAPNEW | OP_MGET | OP_MSET | OP_MDEL | OP_MKEYS | OP_MVALS | OP_LISTNEW
                 | OP_LISTAPPEND | OP_RECNEW | OP_RECWITH | OP_PRT | OP_RD | OP_RDL | OP_WR
                 | OP_WRL | OP_TRM | OP_UNQ | OP_NUM => {
                     non_num_write[a] = true;
@@ -1814,6 +1816,14 @@ fn compile_function_body(
                 let bv = builder.use_var(vars[b_idx]);
                 let fref = get_func_ref(&mut builder, module, helpers.hd);
                 let call_inst = builder.ins().call(fref, &[bv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_AT => {
+                let bv = builder.use_var(vars[b_idx]);
+                let cv = builder.use_var(vars[c_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.at);
+                let call_inst = builder.ins().call(fref, &[bv, cv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -68,6 +68,7 @@ struct HelperFuncs {
     cat: FuncId,
     has: FuncId,
     hd: FuncId,
+    at: FuncId,
     tl: FuncId,
     rev: FuncId,
     srt: FuncId,
@@ -168,6 +169,7 @@ fn register_helpers(builder: &mut JITBuilder) {
         ("jit_cat", jit_cat as *const u8),
         ("jit_has", jit_has as *const u8),
         ("jit_hd", jit_hd as *const u8),
+        ("jit_at", jit_at as *const u8),
         ("jit_tl", jit_tl as *const u8),
         ("jit_rev", jit_rev as *const u8),
         ("jit_srt", jit_srt as *const u8),
@@ -259,6 +261,7 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         cat: declare_helper(module, "jit_cat", 2, 1),
         has: declare_helper(module, "jit_has", 2, 1),
         hd: declare_helper(module, "jit_hd", 1, 1),
+        at: declare_helper(module, "jit_at", 2, 1),
         tl: declare_helper(module, "jit_tl", 1, 1),
         rev: declare_helper(module, "jit_rev", 1, 1),
         srt: declare_helper(module, "jit_srt", 1, 1),
@@ -858,7 +861,7 @@ fn compile_function_body(
                 | OP_NEG
                 | OP_WRAPOK | OP_WRAPERR | OP_UNWRAP
                 | OP_RECFLD | OP_RECFLD_NAME | OP_LISTGET | OP_INDEX
-                | OP_STR | OP_HD | OP_TL | OP_REV | OP_SRT | OP_SLC
+                | OP_STR | OP_HD | OP_AT | OP_TL | OP_REV | OP_SRT | OP_SLC
                 | OP_SPL | OP_CAT | OP_GET | OP_POST | OP_GETH | OP_POSTH
                 | OP_ENV | OP_JPTH | OP_JDMP | OP_JPAR
                 | OP_MAPNEW | OP_MGET | OP_MSET | OP_MDEL | OP_MKEYS | OP_MVALS
@@ -1842,6 +1845,14 @@ fn compile_function_body(
                 let bv = builder.use_var(vars[b_idx]);
                 let fref = get_func_ref(&mut builder, module, helpers.hd);
                 let call_inst = builder.ins().call(fref, &[bv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_AT => {
+                let bv = builder.use_var(vars[b_idx]);
+                let cv = builder.use_var(vars[c_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.at);
+                let call_inst = builder.ins().call(fref, &[bv, cv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -177,6 +177,7 @@ pub(crate) const OP_CMPK_NE_N: u8 = 95; // skip-if R[A] != K[C]  (f64)
 
 // ABC mode — type-specialized string concatenation (both operands known text, no type check)
 pub(crate) const OP_ADD_SS: u8 = 96; // R[A] = R[B] ++ R[C]  (both known text)
+pub(crate) const OP_AT: u8 = 103; // R[A] = at(R[B], R[C])  (i-th element of list/text)
 
 // ABx mode — register + 16-bit operand
 pub(crate) const OP_LOADK: u8 = 20;
@@ -1610,6 +1611,13 @@ impl RegCompiler {
                             self.emit_abc(OP_HD, ra, rb, 0);
                             return ra;
                         }
+                        (Builtin::At, 2) => {
+                            let rb = self.compile_expr(&args[0]);
+                            let rc = self.compile_expr(&args[1]);
+                            let ra = self.alloc_reg();
+                            self.emit_abc(OP_AT, ra, rb, rc);
+                            return ra;
+                        }
                         (Builtin::Tl, 1) => {
                             let rb = self.compile_expr(&args[0]);
                             let ra = self.alloc_reg();
@@ -2332,7 +2340,7 @@ fn chunk_is_all_numeric(chunk: &Chunk) -> bool {
             OP_RECNEW | OP_LISTNEW | OP_RECWITH | OP_WRAPOK | OP_WRAPERR | OP_STR | OP_CAT
             | OP_SPL | OP_REV | OP_SRT | OP_SLC | OP_UNQ | OP_LISTAPPEND | OP_JPAR | OP_JDMP
             | OP_ENV | OP_GET | OP_GETH | OP_POST | OP_POSTH | OP_RD | OP_RDL | OP_WR | OP_WRL
-            | OP_MAPNEW | OP_MGET | OP_MSET | OP_MKEYS | OP_MVALS | OP_HD | OP_TL => {
+            | OP_MAPNEW | OP_MGET | OP_MSET | OP_MKEYS | OP_MVALS | OP_HD | OP_AT | OP_TL => {
                 return false;
             }
             _ => {}
@@ -5364,6 +5372,48 @@ impl<'a> VM<'a> {
                     };
                     reg_set!(a, result);
                 }
+                OP_AT => {
+                    let a = ((inst >> 16) & 0xFF) as usize + base;
+                    let b = ((inst >> 8) & 0xFF) as usize + base;
+                    let c = (inst & 0xFF) as usize + base;
+                    let v = reg!(b);
+                    let i = reg!(c);
+                    if !i.is_number() {
+                        vm_err!(VmError::Type("at: index must be a number"));
+                    }
+                    let n = i.as_number();
+                    if n < 0.0 || n.fract() != 0.0 {
+                        vm_err!(VmError::Type("at: index must be a non-negative integer"));
+                    }
+                    let idx = n as usize;
+                    let result = if v.is_string() {
+                        let s = unsafe {
+                            match v.as_heap_ref() {
+                                HeapObj::Str(s) => s,
+                                _ => unreachable!(),
+                            }
+                        };
+                        let chars: Vec<char> = s.chars().collect();
+                        if idx >= chars.len() {
+                            vm_err!(VmError::Type("at: index out of range"));
+                        }
+                        NanVal::heap_string(chars[idx].to_string())
+                    } else if v.is_heap() {
+                        match unsafe { v.as_heap_ref() } {
+                            HeapObj::List(items) => {
+                                if idx >= items.len() {
+                                    vm_err!(VmError::Type("at: index out of range"));
+                                }
+                                items[idx].clone_rc();
+                                items[idx]
+                            }
+                            _ => vm_err!(VmError::Type("at requires a list or text")),
+                        }
+                    } else {
+                        vm_err!(VmError::Type("at requires a list or text"));
+                    };
+                    reg_set!(a, result);
+                }
                 OP_TL => {
                     let a = ((inst >> 16) & 0xFF) as usize + base;
                     let b = ((inst >> 8) & 0xFF) as usize + base;
@@ -6498,6 +6548,44 @@ pub(crate) extern "C" fn jit_hd(a: u64) -> u64 {
         }
         items[0].clone_rc();
         return items[0].0;
+    }
+    TAG_NIL
+}
+
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_at(a: u64, b: u64) -> u64 {
+    let v = NanVal(a);
+    let i = NanVal(b);
+    if !i.is_number() {
+        return TAG_NIL;
+    }
+    let n = i.as_number();
+    if n < 0.0 || n.fract() != 0.0 {
+        return TAG_NIL;
+    }
+    let idx = n as usize;
+    if v.is_string() {
+        let s = unsafe {
+            match v.as_heap_ref() {
+                HeapObj::Str(s) => s,
+                _ => unreachable!(),
+            }
+        };
+        let chars: Vec<char> = s.chars().collect();
+        if idx >= chars.len() {
+            return TAG_NIL;
+        }
+        return NanVal::heap_string(chars[idx].to_string()).0;
+    }
+    if v.is_heap()
+        && let HeapObj::List(items) = unsafe { v.as_heap_ref() }
+    {
+        if idx >= items.len() {
+            return TAG_NIL;
+        }
+        items[idx].clone_rc();
+        return items[idx].0;
     }
     TAG_NIL
 }

--- a/tests/regression_at_builtin.rs
+++ b/tests/regression_at_builtin.rs
@@ -1,0 +1,224 @@
+// Regression tests for the `at xs i` builtin — i-th element of a list or text.
+//
+// Mirrors `hd` semantics: out-of-range is a runtime error (tree/vm) or TAG_NIL
+// in cranelift JIT (which already returns nil for `hd` on empty list).
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+// Basic: index into a list of numbers.
+const NUM_SRC: &str = "f>n;xs=[10,20,30];at xs 1";
+
+fn check_num_index(engine: &str) {
+    assert_eq!(run(engine, NUM_SRC, "f"), "20", "engine={engine}");
+}
+
+#[test]
+fn at_num_index_tree() {
+    check_num_index("--run-tree");
+}
+
+#[test]
+fn at_num_index_vm() {
+    check_num_index("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn at_num_index_cranelift() {
+    check_num_index("--run-cranelift");
+}
+
+// Type variable: works on a list of text too.
+const TEXT_SRC: &str = "f>t;xs=[\"a\",\"b\",\"c\"];at xs 2";
+
+fn check_text_index(engine: &str) {
+    assert_eq!(run(engine, TEXT_SRC, "f"), "c", "engine={engine}");
+}
+
+#[test]
+fn at_text_index_tree() {
+    check_text_index("--run-tree");
+}
+
+#[test]
+fn at_text_index_vm() {
+    check_text_index("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn at_text_index_cranelift() {
+    check_text_index("--run-cranelift");
+}
+
+// First element with index 0.
+const FIRST_SRC: &str = "f>n;xs=[10,20,30];at xs 0";
+
+fn check_first(engine: &str) {
+    assert_eq!(run(engine, FIRST_SRC, "f"), "10", "engine={engine}");
+}
+
+#[test]
+fn at_first_tree() {
+    check_first("--run-tree");
+}
+
+#[test]
+fn at_first_vm() {
+    check_first("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn at_first_cranelift() {
+    check_first("--run-cranelift");
+}
+
+// Last element of a 3-element list via hardcoded index.
+const LAST_SRC: &str = "f>n;xs=[10,20,30];at xs 2";
+
+fn check_last(engine: &str) {
+    assert_eq!(run(engine, LAST_SRC, "f"), "30", "engine={engine}");
+}
+
+#[test]
+fn at_last_tree() {
+    check_last("--run-tree");
+}
+
+#[test]
+fn at_last_vm() {
+    check_last("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn at_last_cranelift() {
+    check_last("--run-cranelift");
+}
+
+// Out-of-range: tree and vm engines raise a runtime error.
+// Cranelift mirrors hd's JIT behaviour and returns nil (no error).
+const OOR_SRC: &str = "f>n;xs=[10,20,30];at xs 99";
+
+fn check_oor_error(engine: &str) {
+    let out = ilo()
+        .args([OOR_SRC, engine, "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "engine={engine}: expected runtime error for at xs 99, got stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("at") || stderr.contains("range") || stderr.contains("ILO-R009"),
+        "engine={engine}: expected at/range/ILO-R009 error, got stderr={stderr}"
+    );
+}
+
+#[test]
+fn at_out_of_range_tree() {
+    check_oor_error("--run-tree");
+}
+
+#[test]
+fn at_out_of_range_vm() {
+    check_oor_error("--run-vm");
+}
+
+// Cranelift JIT mirrors hd's behaviour: returns nil on out-of-range.
+#[test]
+#[cfg(feature = "cranelift")]
+fn at_out_of_range_cranelift() {
+    let out = ilo()
+        .args([OOR_SRC, "--run-cranelift", "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "cranelift: expected success returning nil for at xs 99, got stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("nil"),
+        "cranelift: expected stdout to contain nil, got {stdout}"
+    );
+}
+
+// Negative index: tree/vm error, cranelift returns nil.
+const NEG_SRC: &str = "f>n;xs=[10,20,30];at xs -1";
+
+#[test]
+fn at_negative_index_tree() {
+    let out = ilo()
+        .args([NEG_SRC, "--run-tree", "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "tree: expected error for at xs -1, got stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("non-negative") || stderr.contains("ILO-R009"),
+        "tree: expected non-negative/ILO-R009 error, got stderr={stderr}"
+    );
+}
+
+#[test]
+fn at_negative_index_vm() {
+    let out = ilo()
+        .args([NEG_SRC, "--run-vm", "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "vm: expected error for at xs -1, got stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("non-negative") || stderr.contains("at"),
+        "vm: expected non-negative/at error, got stderr={stderr}"
+    );
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn at_negative_index_cranelift() {
+    let out = ilo()
+        .args([NEG_SRC, "--run-cranelift", "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "cranelift: expected success returning nil for at xs -1, got stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("nil"),
+        "cranelift: expected stdout to contain nil, got {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

Every program in the assessment runs ended up writing a user-space `at xs i` helper because there's no built-in nth-element access for lists. The workaround was `slc xs n n+1; hd` — verbose for the common "give me the nth element" need. The spec's mention of `xs.0` as a "safe ending" misled multiple personas into trying dot access on lists, which fails (dot is records-only).

This PR adds `at xs i` as a core builtin across tree-walker, VM, and Cranelift JIT. One line in the agent's program instead of three.

## What's in the diff

1. **`builtins: add \`at xs i\` for nth-element list access`** — mirrors the existing `hd`/`tl`/`slc` precedent. New opcode `OP_AT = 103`, `jit_at` extern "C" helper, parallel arms in tree-walker, VM dispatch, Cranelift JIT, and AOT translator. Type signature `at xs:L a i:n>a` so the element type flows through.

   **Index validation**: non-negative integer required. Floats with non-zero fractional parts and negative numbers both error explicitly rather than silently saturating to 0 (default `f64 as usize` behaviour, a real correctness bug caught in review).

   **Out-of-range semantics**: matches the existing `hd`-on-empty-list per-engine divergence rather than introducing new asymmetry — tree-walker and VM raise an error (`ILO-R009`/`ILO-R004`), the JIT returns `nil`. The doc-noted asymmetry is inherited from `hd`; a future harmonization PR can address all three together.

2. **`tests + example: pin \`at xs i\` behaviour across engines`** — 18 cross-engine regression tests covering basic indexing, type-variable inference, first/last, positive out-of-range, and the new negative-index guard. `examples/at-indexing.ilo` demonstrates `nth` and `last` with `-- run:` / `-- out:` directives.

## Opcode collision pre-empted

The parallel `fix/math-builtins` branch claims opcodes 97-102 for `OP_POW`/`OP_SQRT`/`OP_LOG`/`OP_EXP`/`OP_SIN`/`OP_COS`. `OP_AT` is at **103** (one past the math block) so both can merge in either order.

## Test plan

- [x] `cargo test --release --features cranelift` — full suite green, +18 new tests
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --features cranelift -- -D warnings` clean
- [x] `at [10,20,30] 1` → `20` across all three engines
- [x] `at ["a","b","c"] 2` → `"c"` across all three engines (type-variable works)
- [x] `at xs -1` errors on tree/vm, returns nil on cranelift (negative-index guard verified)
- [x] `at xs 99` errors on tree/vm, returns nil on cranelift (positive out-of-range matches `hd` precedent)
- [x] Code-reviewed by subagent; the critical negative-index silent-zero bug was caught and fixed before commit

## Follow-up

- Harmonize `at`/`hd` out-of-range across all three engines (currently inherits per-engine divergence from `hd`).