### PR TITLE
Add fmt2 builtin: format number to N decimal places

### DIFF
--- a/examples/fmt2.ilo
+++ b/examples/fmt2.ilo
@@ -1,0 +1,37 @@
+-- fmt2 x digits: format a number to N decimal places, returning text.
+-- Half-to-even rounding (Rust's default for format!("{:.N$}")).
+-- Negative digits clamp to 0 (integer formatting). Digits > 20 clamp to 20.
+
+-- Format pi to two decimals
+pi-2>t;fmt2 3.14159265 2
+
+-- Whole number with zero decimals (no fractional part printed)
+one-int>t;fmt2 1.0 0
+
+-- Correlation coefficient, four decimals
+corr>t;fmt2 0.85025037 4
+
+-- Half-to-even (banker's rounding): 1.5 rounds to 2, 2.5 also rounds to 2
+round-up>t;fmt2 1.5 0
+round-down>t;fmt2 2.5 0
+
+-- Negative digits clamp to 0
+neg-digits>t;fmt2 3.7 -1
+
+-- Build a percentile-report line: "p95: 0.99"
+report v:n>t;cat ["p95: " fmt2 v 2] ""
+
+-- run: pi-2
+-- out: 3.14
+-- run: one-int
+-- out: 1
+-- run: corr
+-- out: 0.8503
+-- run: round-up
+-- out: 2
+-- run: round-down
+-- out: 2
+-- run: neg-digits
+-- out: 4
+-- run: report 0.987654
+-- out: p95: 0.99

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -68,6 +68,7 @@ pub enum Builtin {
     // String
     Trm,
     Fmt,
+    Fmt2,
     Rgx,
 
     // JSON
@@ -143,6 +144,7 @@ impl Builtin {
             "env" => Some(Builtin::Env),
             "trm" => Some(Builtin::Trm),
             "fmt" => Some(Builtin::Fmt),
+            "fmt2" => Some(Builtin::Fmt2),
             "rgx" => Some(Builtin::Rgx),
             "jpth" => Some(Builtin::Jpth),
             "jdmp" => Some(Builtin::Jdmp),
@@ -213,6 +215,7 @@ impl Builtin {
             Builtin::Env => "env",
             Builtin::Trm => "trm",
             Builtin::Fmt => "fmt",
+            Builtin::Fmt2 => "fmt2",
             Builtin::Rgx => "rgx",
             Builtin::Jpth => "jpth",
             Builtin::Jdmp => "jdmp",
@@ -246,8 +249,8 @@ mod tests {
             "exp", "sin", "cos", "tan", "log10", "log2", "atan2", "sum", "avg", "len", "hd", "at",
             "tl", "rev", "srt", "slc", "lst", "unq", "flat", "has", "spl", "cat", "map", "flt",
             "fld", "grp", "rnd", "now", "rd", "rdl", "rdb", "wr", "wrl", "prnt", "env", "trm",
-            "fmt", "rgx", "jpth", "jdmp", "jpar", "get", "post", "mmap", "mget", "mset", "mhas",
-            "mkeys", "mvals", "mdel",
+            "fmt", "fmt2", "rgx", "jpth", "jdmp", "jpar", "get", "post", "mmap", "mget", "mset",
+            "mhas", "mkeys", "mvals", "mdel",
         ];
         for name in &all {
             let b = Builtin::from_name(name).unwrap_or_else(|| panic!("missing builtin: {name}"));

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -7174,4 +7174,23 @@ mod tests {
         let err = run(&prog, Some("f"), vec![]).unwrap_err();
         assert!(format!("{err:?}").contains("non-negative integer"));
     }
+
+    // fmt2 error arm: non-number args bypass the verifier when calling
+    // call_function directly, exercising the runtime type guard.
+    #[test]
+    fn interp_fmt2_rejects_non_number_args() {
+        let mut env = Env::new();
+        let result = call_function(
+            &mut env,
+            "fmt2",
+            vec![Value::Text("hi".to_string()), Value::Number(2.0)],
+        );
+        let err = result.unwrap_err();
+        assert_eq!(err.code, "ILO-R009");
+        assert!(
+            err.message.contains("fmt2 requires two numbers"),
+            "got: {}",
+            err.message
+        );
+    }
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1081,6 +1081,22 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             )),
         };
     }
+    if builtin == Some(Builtin::Fmt2) && args.len() == 2 {
+        return match (&args[0], &args[1]) {
+            (Value::Number(x), Value::Number(d)) => {
+                let digits = if !d.is_finite() || *d <= 0.0 {
+                    0usize
+                } else {
+                    (*d as usize).min(20)
+                };
+                Ok(Value::Text(format!("{:.*}", digits, x)))
+            }
+            _ => Err(RuntimeError::new(
+                "ILO-R009",
+                "fmt2 requires two numbers (x, digits)".to_string(),
+            )),
+        };
+    }
     if builtin == Some(Builtin::Fmt) && !args.is_empty() {
         let template = match &args[0] {
             Value::Text(s) => s.clone(),

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -298,6 +298,7 @@ const BUILTINS: &[(&str, &[&str], &str)] = &[
     ("jdmp", &["any"], "t"),
     ("prnt", &["any"], "any"),
     ("fmt", &["t"], "t"), // variadic: fmt template arg1 arg2 … — checked specially
+    ("fmt2", &["n", "n"], "t"),
     ("jpar", &["t"], "R ? t"),
     // Higher-order: map/flt/fld take a function ref as first arg (special-cased in builtin_check_args)
     ("map", &["fn", "list"], "list"),
@@ -702,6 +703,22 @@ fn builtin_check_args(
                     span,
                     is_warning: false,
                 });
+            }
+            (Ty::Text, errors)
+        }
+        "fmt2" => {
+            // fmt2 x digits — format number x to `digits` decimal places, returning text.
+            for (i, arg) in arg_types.iter().enumerate() {
+                if !compatible(arg, &Ty::Number) {
+                    errors.push(VerifyError {
+                        code: "ILO-T013",
+                        function: func_ctx.to_string(),
+                        message: format!("'fmt2' arg {} expects n, got {arg}", i + 1),
+                        hint: None,
+                        span,
+                        is_warning: false,
+                    });
+                }
             }
             (Ty::Text, errors)
         }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -6442,4 +6442,38 @@ mod tests {
             errors
         );
     }
+
+    #[test]
+    fn verify_fmt2_rejects_non_number_arg() {
+        // First arg text — should produce ILO-T013 with arg-index 1.
+        let result = parse_and_verify(r#"f>t;fmt2 "hi" 2"#);
+        let errs = result.unwrap_err();
+        assert!(
+            errs.iter().any(
+                |e| e.code == "ILO-T013" && e.message.contains("'fmt2' arg 1 expects n, got t")
+            ),
+            "expected ILO-T013 for arg 1, got: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn verify_fmt2_rejects_non_number_second_arg() {
+        // Second arg text — ILO-T013 with arg-index 2.
+        let result = parse_and_verify(r#"f>t;fmt2 3.14 "two""#);
+        let errs = result.unwrap_err();
+        assert!(
+            errs.iter().any(
+                |e| e.code == "ILO-T013" && e.message.contains("'fmt2' arg 2 expects n, got t")
+            ),
+            "expected ILO-T013 for arg 2, got: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn verify_fmt2_valid_returns_text() {
+        // Sanity: valid call typechecks.
+        assert!(parse_and_verify("f>t;fmt2 3.14 2").is_ok());
+    }
 }

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -5295,4 +5295,11 @@ f a:t b:t>t;join a b"#,
             bytes.err()
         );
     }
+
+    // AOT codegen for OP_FMT2 — drives the jit_fmt2 helper call path.
+    #[test]
+    fn codegen_cov_fmt2() {
+        let bytes = compile_to_object_bytes("f>t;fmt2 3.14159 2");
+        assert!(bytes.is_ok(), "FMT2 codegen failed: {:?}", bytes.err());
+    }
 }

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -73,6 +73,7 @@ struct HelperFuncs {
     has: FuncId,
     hd: FuncId,
     at: FuncId,
+    fmt2: FuncId,
     tl: FuncId,
     rev: FuncId,
     srt: FuncId,
@@ -195,6 +196,7 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         has: declare_helper(module, "jit_has", 2, 1),
         hd: declare_helper(module, "jit_hd", 1, 1),
         at: declare_helper(module, "jit_at", 2, 1),
+        fmt2: declare_helper(module, "jit_fmt2", 2, 1),
         tl: declare_helper(module, "jit_tl", 1, 1),
         rev: declare_helper(module, "jit_rev", 1, 1),
         srt: declare_helper(module, "jit_srt", 1, 1),
@@ -914,8 +916,8 @@ fn compile_function_body(
                 // Ops that write a non-numeric or unknown type to R[A].
                 OP_ADD | OP_SUB | OP_MUL | OP_DIV | OP_ADD_SS | OP_NEG | OP_WRAPOK | OP_WRAPERR
                 | OP_UNWRAP | OP_RECFLD | OP_RECFLD_NAME | OP_LISTGET | OP_INDEX | OP_STR
-                | OP_HD | OP_AT | OP_TL | OP_REV | OP_SRT | OP_SLC | OP_SPL | OP_CAT | OP_GET
-                | OP_POST | OP_GETH | OP_POSTH | OP_ENV | OP_JPTH | OP_JDMP | OP_JPAR
+                | OP_HD | OP_AT | OP_FMT2 | OP_TL | OP_REV | OP_SRT | OP_SLC | OP_SPL | OP_CAT
+                | OP_GET | OP_POST | OP_GETH | OP_POSTH | OP_ENV | OP_JPTH | OP_JDMP | OP_JPAR
                 | OP_MAPNEW | OP_MGET | OP_MSET | OP_MDEL | OP_MKEYS | OP_MVALS | OP_LISTNEW
                 | OP_LISTAPPEND | OP_RECNEW | OP_RECWITH | OP_PRT | OP_RD | OP_RDL | OP_WR
                 | OP_WRL | OP_TRM | OP_UNQ | OP_NUM => {
@@ -1889,6 +1891,14 @@ fn compile_function_body(
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
                 let fref = get_func_ref(&mut builder, module, helpers.at);
+                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_FMT2 => {
+                let bv = builder.use_var(vars[b_idx]);
+                let cv = builder.use_var(vars[c_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.fmt2);
                 let call_inst = builder.ins().call(fref, &[bv, cv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -79,6 +79,7 @@ struct HelperFuncs {
     has: FuncId,
     hd: FuncId,
     at: FuncId,
+    fmt2: FuncId,
     tl: FuncId,
     rev: FuncId,
     srt: FuncId,
@@ -191,6 +192,7 @@ fn register_helpers(builder: &mut JITBuilder) {
         ("jit_has", jit_has as *const u8),
         ("jit_hd", jit_hd as *const u8),
         ("jit_at", jit_at as *const u8),
+        ("jit_fmt2", jit_fmt2 as *const u8),
         ("jit_tl", jit_tl as *const u8),
         ("jit_rev", jit_rev as *const u8),
         ("jit_srt", jit_srt as *const u8),
@@ -294,6 +296,7 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         has: declare_helper(module, "jit_has", 2, 1),
         hd: declare_helper(module, "jit_hd", 1, 1),
         at: declare_helper(module, "jit_at", 2, 1),
+        fmt2: declare_helper(module, "jit_fmt2", 2, 1),
         tl: declare_helper(module, "jit_tl", 1, 1),
         rev: declare_helper(module, "jit_rev", 1, 1),
         srt: declare_helper(module, "jit_srt", 1, 1),
@@ -895,7 +898,7 @@ fn compile_function_body(
                 | OP_NEG
                 | OP_WRAPOK | OP_WRAPERR | OP_UNWRAP
                 | OP_RECFLD | OP_RECFLD_NAME | OP_LISTGET | OP_INDEX
-                | OP_STR | OP_HD | OP_AT | OP_TL | OP_REV | OP_SRT | OP_SLC | OP_LST
+                | OP_STR | OP_HD | OP_AT | OP_FMT2 | OP_TL | OP_REV | OP_SRT | OP_SLC | OP_LST
                 | OP_SPL | OP_CAT | OP_GET | OP_POST | OP_GETH | OP_POSTH
                 | OP_ENV | OP_JPTH | OP_JDMP | OP_JPAR
                 | OP_MAPNEW | OP_MGET | OP_MSET | OP_MDEL | OP_MKEYS | OP_MVALS
@@ -1934,6 +1937,14 @@ fn compile_function_body(
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
                 let fref = get_func_ref(&mut builder, module, helpers.at);
+                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_FMT2 => {
+                let bv = builder.use_var(vars[b_idx]);
+                let cv = builder.use_var(vars[c_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.fmt2);
                 let call_inst = builder.ins().call(fref, &[bv, cv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -194,6 +194,9 @@ pub(crate) const OP_LOG10: u8 = 106; // R[A] = log10(R[B])
 pub(crate) const OP_LOG2: u8 = 107; // R[A] = log2(R[B])
 pub(crate) const OP_ATAN2: u8 = 108; // R[A] = atan2(R[B], R[C])  (y first, x second)
 
+// ABC mode — text formatting
+pub(crate) const OP_FMT2: u8 = 104; // R[A] = fmt2(R[B], R[C])  (format number to N decimal places → t)
+
 // ABx mode — register + 16-bit operand
 pub(crate) const OP_LOADK: u8 = 20;
 pub(crate) const OP_JMP: u8 = 21;
@@ -1676,6 +1679,13 @@ impl RegCompiler {
                             self.emit_abc(OP_AT, ra, rb, rc);
                             return ra;
                         }
+                        (Builtin::Fmt2, 2) => {
+                            let rb = self.compile_expr(&args[0]);
+                            let rc = self.compile_expr(&args[1]);
+                            let ra = self.alloc_reg();
+                            self.emit_abc(OP_FMT2, ra, rb, rc);
+                            return ra;
+                        }
                         (Builtin::Tl, 1) => {
                             let rb = self.compile_expr(&args[0]);
                             let ra = self.alloc_reg();
@@ -2476,7 +2486,7 @@ fn chunk_is_all_numeric(chunk: &Chunk) -> bool {
             | OP_SPL | OP_REV | OP_SRT | OP_SLC | OP_UNQ | OP_LISTAPPEND | OP_JPAR | OP_JDMP
             | OP_ENV | OP_GET | OP_GETH | OP_POST | OP_POSTH | OP_RD | OP_RDL | OP_WR | OP_WRL
             | OP_MAPNEW | OP_MGET | OP_MSET | OP_MKEYS | OP_MVALS | OP_HD | OP_AT | OP_LST
-            | OP_TL => {
+            | OP_TL | OP_FMT2 => {
                 return false;
             }
             _ => {}
@@ -5555,6 +5565,25 @@ impl<'a> VM<'a> {
                     };
                     reg_set!(a, result);
                 }
+                OP_FMT2 => {
+                    let a = ((inst >> 16) & 0xFF) as usize + base;
+                    let b = ((inst >> 8) & 0xFF) as usize + base;
+                    let c = (inst & 0xFF) as usize + base;
+                    let vb = reg!(b);
+                    let vc = reg!(c);
+                    if !vb.is_number() || !vc.is_number() {
+                        vm_err!(VmError::Type("fmt2 requires two numbers (x, digits)"));
+                    }
+                    let x = vb.as_number();
+                    let d = vc.as_number();
+                    let digits = if !d.is_finite() || d <= 0.0 {
+                        0usize
+                    } else {
+                        (d as usize).min(20)
+                    };
+                    let result = NanVal::heap_string(format!("{:.*}", digits, x));
+                    reg_set!(a, result);
+                }
                 OP_AT => {
                     let a = ((inst >> 16) & 0xFF) as usize + base;
                     let b = ((inst >> 8) & 0xFF) as usize + base;
@@ -6894,6 +6923,24 @@ pub(crate) extern "C" fn jit_hd(a: u64) -> u64 {
         return items[0].0;
     }
     TAG_NIL
+}
+
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_fmt2(a: u64, b: u64) -> u64 {
+    let va = NanVal(a);
+    let vb = NanVal(b);
+    if !va.is_number() || !vb.is_number() {
+        return TAG_NIL;
+    }
+    let x = va.as_number();
+    let d = vb.as_number();
+    let digits = if !d.is_finite() || d <= 0.0 {
+        0usize
+    } else {
+        (d as usize).min(20)
+    };
+    NanVal::heap_string(format!("{:.*}", digits, x)).0
 }
 
 #[cfg(feature = "cranelift")]

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -14017,6 +14017,79 @@ mod tests {
             let r = jit_listget(list.0, TAG_NIL);
             assert!(is_nil(r));
         }
+
+        // ── jit_fmt2 ──────────────────────────────────────────────────────
+
+        #[test]
+        fn jit_fmt2_basic() {
+            let r = jit_fmt2(num(3.14159), num(2.0));
+            let rv = NanVal(r);
+            assert!(rv.is_string());
+            let HeapObj::Str(s) = (unsafe { rv.as_heap_ref() }) else {
+                panic!("expected Str")
+            };
+            assert_eq!(s.clone(), "3.14");
+        }
+
+        #[test]
+        fn jit_fmt2_zero_digits() {
+            let r = jit_fmt2(num(1.0), num(0.0));
+            let rv = NanVal(r);
+            assert!(rv.is_string());
+            let HeapObj::Str(s) = (unsafe { rv.as_heap_ref() }) else {
+                panic!("expected Str")
+            };
+            assert_eq!(s.clone(), "1");
+        }
+
+        #[test]
+        fn jit_fmt2_negative_digits_clamped_to_zero() {
+            // d <= 0.0 branch — digits coerced to 0.
+            let r = jit_fmt2(num(2.7), num(-3.0));
+            let rv = NanVal(r);
+            assert!(rv.is_string());
+            let HeapObj::Str(s) = (unsafe { rv.as_heap_ref() }) else {
+                panic!("expected Str")
+            };
+            assert_eq!(s.clone(), "3");
+        }
+
+        #[test]
+        fn jit_fmt2_non_finite_digits_clamped_to_zero() {
+            // !d.is_finite() branch.
+            let r = jit_fmt2(num(2.7), num(f64::NAN));
+            let rv = NanVal(r);
+            assert!(rv.is_string());
+            let HeapObj::Str(s) = (unsafe { rv.as_heap_ref() }) else {
+                panic!("expected Str")
+            };
+            assert_eq!(s.clone(), "3");
+        }
+
+        #[test]
+        fn jit_fmt2_non_number_first_arg_returns_nil() {
+            let r = jit_fmt2(str_val("oops"), num(2.0));
+            assert!(is_nil(r));
+        }
+
+        #[test]
+        fn jit_fmt2_non_number_second_arg_returns_nil() {
+            let r = jit_fmt2(num(3.14), str_val("two"));
+            assert!(is_nil(r));
+        }
+
+        #[test]
+        fn jit_fmt2_digits_clamped_to_twenty() {
+            // digits >= 20 hits the .min(20) cap.
+            let r = jit_fmt2(num(1.0), num(50.0));
+            let rv = NanVal(r);
+            assert!(rv.is_string());
+            let HeapObj::Str(s) = (unsafe { rv.as_heap_ref() }) else {
+                panic!("expected Str")
+            };
+            // 20 zeros after the decimal point.
+            assert_eq!(s.clone(), format!("1.{}", "0".repeat(20)));
+        }
     }
 
     // ── VM execution path tests ───────────────────────────────────────────────

--- a/tests/regression_fmt2.rs
+++ b/tests/regression_fmt2.rs
@@ -1,0 +1,161 @@
+// Regression tests for the `fmt2 x digits` builtin — format a number to `digits`
+// decimal places, returning text. Uses Rust's standard half-to-even rounding
+// (the default for `format!("{:.N$}")`).
+//
+// Cross-engine: tree, vm, and (when enabled) cranelift JIT.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+// Basic: 3.14159 to 2 decimals → "3.14".
+const BASIC_SRC: &str = "f>t;fmt2 3.14159 2";
+
+fn check_basic(engine: &str) {
+    assert_eq!(run(engine, BASIC_SRC, "f"), "3.14", "engine={engine}");
+}
+
+#[test]
+fn fmt2_basic_tree() {
+    check_basic("--run-tree");
+}
+
+#[test]
+fn fmt2_basic_vm() {
+    check_basic("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn fmt2_basic_cranelift() {
+    check_basic("--run-cranelift");
+}
+
+// Zero decimals: integer-valued float prints without a fractional part.
+const ZERO_DIGITS_SRC: &str = "f>t;fmt2 1.0 0";
+
+fn check_zero_digits(engine: &str) {
+    assert_eq!(run(engine, ZERO_DIGITS_SRC, "f"), "1", "engine={engine}");
+}
+
+#[test]
+fn fmt2_zero_digits_tree() {
+    check_zero_digits("--run-tree");
+}
+
+#[test]
+fn fmt2_zero_digits_vm() {
+    check_zero_digits("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn fmt2_zero_digits_cranelift() {
+    check_zero_digits("--run-cranelift");
+}
+
+// Long fractional number, asymmetric truncation.
+const LONG_FRAC_SRC: &str = "f>t;fmt2 0.85025037 4";
+
+fn check_long_frac(engine: &str) {
+    assert_eq!(run(engine, LONG_FRAC_SRC, "f"), "0.8503", "engine={engine}");
+}
+
+#[test]
+fn fmt2_long_frac_tree() {
+    check_long_frac("--run-tree");
+}
+
+#[test]
+fn fmt2_long_frac_vm() {
+    check_long_frac("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn fmt2_long_frac_cranelift() {
+    check_long_frac("--run-cranelift");
+}
+
+// Half-to-even (banker's rounding): 1.5 → "2", 2.5 → "2".
+const HALF_EVEN_UP_SRC: &str = "f>t;fmt2 1.5 0";
+
+fn check_half_even_up(engine: &str) {
+    assert_eq!(run(engine, HALF_EVEN_UP_SRC, "f"), "2", "engine={engine}");
+}
+
+#[test]
+fn fmt2_half_even_up_tree() {
+    check_half_even_up("--run-tree");
+}
+
+#[test]
+fn fmt2_half_even_up_vm() {
+    check_half_even_up("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn fmt2_half_even_up_cranelift() {
+    check_half_even_up("--run-cranelift");
+}
+
+const HALF_EVEN_DOWN_SRC: &str = "f>t;fmt2 2.5 0";
+
+fn check_half_even_down(engine: &str) {
+    assert_eq!(run(engine, HALF_EVEN_DOWN_SRC, "f"), "2", "engine={engine}");
+}
+
+#[test]
+fn fmt2_half_even_down_tree() {
+    check_half_even_down("--run-tree");
+}
+
+#[test]
+fn fmt2_half_even_down_vm() {
+    check_half_even_down("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn fmt2_half_even_down_cranelift() {
+    check_half_even_down("--run-cranelift");
+}
+
+// Negative digits clamp to 0 (integer formatting). Use a literal -1.
+const NEG_DIGITS_SRC: &str = "f>t;fmt2 3.7 -1";
+
+fn check_neg_digits(engine: &str) {
+    assert_eq!(run(engine, NEG_DIGITS_SRC, "f"), "4", "engine={engine}");
+}
+
+#[test]
+fn fmt2_neg_digits_tree() {
+    check_neg_digits("--run-tree");
+}
+
+#[test]
+fn fmt2_neg_digits_vm() {
+    check_neg_digits("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn fmt2_neg_digits_cranelift() {
+    check_neg_digits("--run-cranelift");
+}


### PR DESCRIPTION
`prnt` dumps full-precision floats; agents producing analysis reports had to manually massage every number. `fmt2 x:n digits:n>t` rounds half-to-even (Rust default) and clamps digits to 0-20. New opcode allocated above the math block. Cross-engine tests + example with a formatted percentile report.