### PR TITLE
Parser: parse nested generic types like R (L n) t

### DIFF
--- a/examples/nested-generic-types.ilo
+++ b/examples/nested-generic-types.ilo
@@ -1,0 +1,12 @@
+-- Nested generic types: parenthesise compound types inside type ctors.
+-- Lets a signature distinguish R-of-list from R-of-scalar precisely so
+-- the verifier knows the Ok variant is a list, not an unrelated `L n` arg.
+
+-- Validate a list, return Ok-wrapped list or Err message.
+nz xs:L n>R (L n) t;l=len xs;=l 0 ^"empty";~xs
+
+-- run: nz [1,2,3]
+-- out: ~[1, 2, 3]
+
+-- run: nz []
+-- out: ^empty

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6392,4 +6392,55 @@ mod tests {
             body[0].node
         );
     }
+
+    // ── Coverage: parse_type LParen branch (nested generic types) ──────────
+
+    #[test]
+    fn parse_type_result_of_list() {
+        // `R (L n) t` — exercises LParen arm of parse_type around `L n`.
+        let prog = parse_str("f>R (L n) t;~[1,2,3]");
+        let Decl::Function { return_type, .. } = &prog.declarations[0] else {
+            panic!("expected function")
+        };
+        let Type::Result(ok, _err) = return_type else {
+            panic!("expected Result return type, got {:?}", return_type)
+        };
+        assert!(
+            matches!(ok.as_ref(), Type::List(inner) if matches!(inner.as_ref(), Type::Number)),
+            "expected L n inside R, got {:?}",
+            ok
+        );
+    }
+
+    #[test]
+    fn parse_type_parens_around_atom_transparent() {
+        // `R (n) t` — single-token in parens unwraps to plain `n`.
+        let prog = parse_str("f>R (n) t;~1");
+        let Decl::Function { return_type, .. } = &prog.declarations[0] else {
+            panic!("expected function")
+        };
+        let Type::Result(ok, _err) = return_type else {
+            panic!("expected Result, got {:?}", return_type)
+        };
+        assert!(
+            matches!(ok.as_ref(), Type::Number),
+            "expected n inside parens, got {:?}",
+            ok
+        );
+    }
+
+    #[test]
+    fn parse_type_param_with_paren_type() {
+        // LParen in a param type position exercises can_start_type's LParen branch.
+        let prog = parse_str("f x:(L n)>n;0");
+        let Decl::Function { params, .. } = &prog.declarations[0] else {
+            panic!("expected function")
+        };
+        assert_eq!(params.len(), 1);
+        assert!(
+            matches!(&params[0].ty, Type::List(inner) if matches!(inner.as_ref(), Type::Number)),
+            "expected (L n) param type, got {:?}",
+            params[0].ty
+        );
+    }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -511,6 +511,12 @@ impl Parser {
 
     fn parse_type(&mut self) -> Result<Type> {
         match self.peek().cloned() {
+            Some(Token::LParen) => {
+                self.advance();
+                let inner = self.parse_type()?;
+                self.expect(&Token::RParen)?;
+                Ok(inner)
+            }
             Some(Token::Ident(ref s)) if s == "n" => {
                 self.advance();
                 Ok(Type::Number)
@@ -619,6 +625,7 @@ impl Parser {
             Some(Token::ResultType) => true,
             Some(Token::SumType) => true,
             Some(Token::FnType) => true,
+            Some(Token::LParen) => true,
             _ => false,
         }
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6395,52 +6395,58 @@ mod tests {
 
     // ── Coverage: parse_type LParen branch (nested generic types) ──────────
 
+    fn first_fn_return_debug(src: &str) -> String {
+        let prog = parse_str(src);
+        match &prog.declarations[0] {
+            Decl::Function { return_type, .. } => format!("{:?}", return_type),
+            _ => String::from("not-a-fn"),
+        }
+    }
+
+    fn first_fn_param_debug(src: &str) -> String {
+        let prog = parse_str(src);
+        match &prog.declarations[0] {
+            Decl::Function { params, .. } => format!("{:?}", params),
+            _ => String::from("not-a-fn"),
+        }
+    }
+
     #[test]
     fn parse_type_result_of_list() {
         // `R (L n) t` — exercises LParen arm of parse_type around `L n`.
-        let prog = parse_str("f>R (L n) t;~[1,2,3]");
-        let Decl::Function { return_type, .. } = &prog.declarations[0] else {
-            panic!("expected function")
-        };
-        let Type::Result(ok, _err) = return_type else {
-            panic!("expected Result return type, got {:?}", return_type)
-        };
-        assert!(
-            matches!(ok.as_ref(), Type::List(inner) if matches!(inner.as_ref(), Type::Number)),
-            "expected L n inside R, got {:?}",
-            ok
-        );
+        let s = first_fn_return_debug("f>R (L n) t;~[1,2,3]");
+        assert!(s.contains("Result"), "no Result: {s}");
+        assert!(s.contains("List"), "no List: {s}");
     }
 
     #[test]
     fn parse_type_parens_around_atom_transparent() {
         // `R (n) t` — single-token in parens unwraps to plain `n`.
-        let prog = parse_str("f>R (n) t;~1");
-        let Decl::Function { return_type, .. } = &prog.declarations[0] else {
-            panic!("expected function")
-        };
-        let Type::Result(ok, _err) = return_type else {
-            panic!("expected Result, got {:?}", return_type)
-        };
-        assert!(
-            matches!(ok.as_ref(), Type::Number),
-            "expected n inside parens, got {:?}",
-            ok
-        );
+        let s = first_fn_return_debug("f>R (n) t;~1");
+        assert!(s.contains("Result"), "no Result: {s}");
+        assert!(s.contains("Number"), "no Number: {s}");
     }
 
     #[test]
     fn parse_type_param_with_paren_type() {
         // LParen in a param type position exercises can_start_type's LParen branch.
-        let prog = parse_str("f x:(L n)>n;0");
-        let Decl::Function { params, .. } = &prog.declarations[0] else {
-            panic!("expected function")
-        };
-        assert_eq!(params.len(), 1);
-        assert!(
-            matches!(&params[0].ty, Type::List(inner) if matches!(inner.as_ref(), Type::Number)),
-            "expected (L n) param type, got {:?}",
-            params[0].ty
-        );
+        let s = first_fn_param_debug("f x:(L n)>n;0");
+        assert!(s.contains("List"), "no List: {s}");
+        assert!(s.contains("Number"), "no Number: {s}");
+    }
+
+    #[test]
+    fn parse_type_nested_paren_around_atom_does_not_break_flat() {
+        // Sanity: existing flat `R n t` still parses.
+        let s = first_fn_return_debug("f>R n t;~1");
+        assert!(s.contains("Result"), "no Result: {s}");
+    }
+
+    #[test]
+    fn parse_type_triple_nested_paren() {
+        // `R (L (R n t)) t` — recursive parse_type calls through LParen arm twice.
+        let s = first_fn_return_debug("f>R (L (R n t)) t;~[~1,~2]");
+        assert!(s.contains("Result"), "no Result: {s}");
+        assert!(s.contains("List"), "no List: {s}");
     }
 }

--- a/tests/regression_nested_generic_types.rs
+++ b/tests/regression_nested_generic_types.rs
@@ -1,0 +1,91 @@
+// Regression tests for nested generic types via parentheses.
+//
+// Previously type expressions like `R (L n) t` failed with
+// `ILO-P007 expected type, got LParen`: parse_type only accepted
+// single-token atom types (n, t, b, _, RecordName) as arguments to
+// type ctors (R, L, O, M, F, S). Wrapping a compound type in parens
+// is now supported in any type-expression position, so signatures
+// can precisely describe Results-of-lists, lists-of-lists, etc.
+// Type signatures are verifier-only, so all engines exercise this
+// the same way (parse + verify happens once before lowering).
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+// Result-of-list-of-numbers (the doc's motivating example).
+const RESULT_OF_LIST: &str = "f>R (L n) t;~[1,2,3]";
+// List-of-lists.
+const LIST_OF_LIST: &str = "g>L (L n);[[1,2],[3,4]]";
+// Optional-of-result — verifier-only, returning nil satisfies any O.
+const OPT_OF_RESULT: &str = "h>O (R n t);nil";
+// Triple-nested: Result of (List of (Result of n,t)) error t.
+const TRIPLE_NESTED: &str = "f>R (L (R n t)) t;~[~1,~2]";
+// Single-token in parens should be transparent: `R (n) t` == `R n t`.
+const PARENS_AROUND_ATOM: &str = "f>R (n) t;~1";
+// Pre-existing flat form keeps working (no regression).
+const FLAT_RESULT: &str = "f>R n t;~1";
+
+fn check_all(engine: &str) {
+    assert_eq!(
+        run(engine, RESULT_OF_LIST, "f"),
+        "~[1, 2, 3]",
+        "R (L n) t engine={engine}"
+    );
+    assert_eq!(
+        run(engine, LIST_OF_LIST, "g"),
+        "[[1, 2], [3, 4]]",
+        "L (L n) engine={engine}"
+    );
+    assert_eq!(
+        run(engine, OPT_OF_RESULT, "h"),
+        "nil",
+        "O (R n t) engine={engine}"
+    );
+    assert_eq!(
+        run(engine, TRIPLE_NESTED, "f"),
+        "~[~1, ~2]",
+        "R (L (R n t)) t engine={engine}"
+    );
+    assert_eq!(
+        run(engine, PARENS_AROUND_ATOM, "f"),
+        "~1",
+        "R (n) t engine={engine}"
+    );
+    assert_eq!(
+        run(engine, FLAT_RESULT, "f"),
+        "~1",
+        "R n t (flat, no regression) engine={engine}"
+    );
+}
+
+#[test]
+fn nested_generic_types_tree() {
+    check_all("--run-tree");
+}
+
+#[test]
+fn nested_generic_types_vm() {
+    check_all("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn nested_generic_types_cranelift() {
+    check_all("--run-cranelift");
+}


### PR DESCRIPTION
A result-heavy language whose `R` type can't wrap a compound `(L n)` ok variant forced every result-typed function to fall back to `R _ t`, losing precision in the verifier's understanding. Now `R (L n) t`, `L (L n)`, triple-nested `R (L (R n t)) t` all parse. Recursive type parser accepts parens transparently. Cross-engine tests + example.