### PR TITLE
Add author section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,3 +187,7 @@ Per-call time (ns) across 8 micro-benchmarks. Lower is better. [Full results →
 4. **Language-agnostic** - structural tokens (`@`, `>`, `?`, `^`, `~`, `!`, `$`) over English words
 
 See the [manifesto](https://ilo-lang.ai/docs/manifesto/) for full rationale.
+
+## Author
+
+Built by [Daniel John Morris](https://danieljohnmorris.com), Technology Director at Cubitts. ilo is the language I wanted while building with LLMs and AI agents.


### PR DESCRIPTION
## Summary

The README has no author credit and no link to my personal site. Adds a short "Author" section at the bottom of the README linking danieljohnmorris.com.

## Why

Off-site SEO. The ilo-lang README is one of the highest-authority surfaces I have (high domain trust on GitHub), and Google reads outbound links from there as strong entity signals. Currently my personal site is being beaten in search rankings by an unrelated person's CV PDF; visible anchor text from authority pages is the lever that actually moves rankings.

## Test plan

- [x] Renders cleanly on GitHub