### PR TITLE
builtins: add lst xs i v for list update by index

### DIFF
--- a/examples/list-mutation.ilo
+++ b/examples/list-mutation.ilo
@@ -1,0 +1,13 @@
+-- lst xs i v: return a new list with element at index i replaced by v.
+-- Value-semantics: the original list is unchanged. Out-of-range is a runtime
+-- error on tree/vm engines (cranelift returns the list unchanged).
+--
+-- This replaces user-space rebuild loops for "increment bin i" patterns that
+-- previously rebuilt the entire list on every update.
+
+hist samples:L n bins:L n>L n;@s samples{c=at bins s;bins=lst bins s +c 1};bins
+
+-- run: hist [0,2,1,2,3,1,2,0] [0,0,0,0]
+-- out: [2, 2, 3, 1]
+-- run: hist [1,1,1] [0,0]
+-- out: [0, 3]

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -39,6 +39,7 @@ pub enum Builtin {
     Rev,
     Srt,
     Slc,
+    Lst,
     Unq,
     Flat,
     Has,
@@ -121,6 +122,7 @@ impl Builtin {
             "rev" => Some(Builtin::Rev),
             "srt" => Some(Builtin::Srt),
             "slc" => Some(Builtin::Slc),
+            "lst" => Some(Builtin::Lst),
             "unq" => Some(Builtin::Unq),
             "flat" => Some(Builtin::Flat),
             "has" => Some(Builtin::Has),
@@ -190,6 +192,7 @@ impl Builtin {
             Builtin::Rev => "rev",
             Builtin::Srt => "srt",
             Builtin::Slc => "slc",
+            Builtin::Lst => "lst",
             Builtin::Unq => "unq",
             Builtin::Flat => "flat",
             Builtin::Has => "has",
@@ -241,10 +244,10 @@ mod tests {
         let all = [
             "str", "num", "abs", "flr", "cel", "rou", "min", "max", "mod", "pow", "sqrt", "log",
             "exp", "sin", "cos", "tan", "log10", "log2", "atan2", "sum", "avg", "len", "hd", "at",
-            "tl", "rev", "srt", "slc", "unq", "flat", "has", "spl", "cat", "map", "flt", "fld",
-            "grp", "rnd", "now", "rd", "rdl", "rdb", "wr", "wrl", "prnt", "env", "trm", "fmt",
-            "rgx", "jpth", "jdmp", "jpar", "get", "post", "mmap", "mget", "mset", "mhas", "mkeys",
-            "mvals", "mdel",
+            "tl", "rev", "srt", "slc", "lst", "unq", "flat", "has", "spl", "cat", "map", "flt",
+            "fld", "grp", "rnd", "now", "rd", "rdl", "rdb", "wr", "wrl", "prnt", "env", "trm",
+            "fmt", "rgx", "jpth", "jdmp", "jpar", "get", "post", "mmap", "mget", "mset", "mhas",
+            "mkeys", "mvals", "mdel",
         ];
         for name in &all {
             let b = Builtin::from_name(name).unwrap_or_else(|| panic!("missing builtin: {name}"));

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -7106,4 +7106,56 @@ mod tests {
         let msg = format!("{err:?}");
         assert!(msg.contains("integer"), "got {msg}");
     }
+
+    // ---- lst xs i v: replace element at index, returning a new list ----
+
+    #[test]
+    fn interp_lst_happy() {
+        let source = "f>L n;lst [10,20,30] 1 99";
+        let result = run_str(source, Some("f"), vec![]);
+        assert_eq!(
+            result,
+            Value::List(vec![
+                Value::Number(10.0),
+                Value::Number(99.0),
+                Value::Number(30.0),
+            ])
+        );
+    }
+
+    #[test]
+    fn interp_lst_first_index() {
+        let source = "f>L n;lst [10,20,30] 0 7";
+        let result = run_str(source, Some("f"), vec![]);
+        assert_eq!(
+            result,
+            Value::List(vec![
+                Value::Number(7.0),
+                Value::Number(20.0),
+                Value::Number(30.0),
+            ])
+        );
+    }
+
+    #[test]
+    fn interp_lst_out_of_range_errors() {
+        let prog = parse_program("f>L n;lst [1,2,3] 5 0");
+        let err = run(&prog, Some("f"), vec![]).unwrap_err();
+        assert!(format!("{err:?}").contains("out of range"));
+    }
+
+    #[test]
+    fn interp_lst_negative_index_errors() {
+        let prog = parse_program("f>L n;lst [1,2,3] -1 0");
+        let err = run(&prog, Some("f"), vec![]).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("non-negative integer"), "got {msg}");
+    }
+
+    #[test]
+    fn interp_lst_fractional_index_errors() {
+        let prog = parse_program("f>L n;lst [1,2,3] 1.5 0");
+        let err = run(&prog, Some("f"), vec![]).unwrap_err();
+        assert!(format!("{err:?}").contains("non-negative integer"));
+    }
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -735,6 +735,46 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             )),
         };
     }
+    if builtin == Some(Builtin::Lst) && args.len() == 3 {
+        let idx = match &args[1] {
+            Value::Number(n) => {
+                if *n < 0.0 || n.fract() != 0.0 {
+                    return Err(RuntimeError::new(
+                        "ILO-R009",
+                        "lst: index must be a non-negative integer".to_string(),
+                    ));
+                }
+                *n as usize
+            }
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!("lst: index must be a number, got {:?}", other),
+                ));
+            }
+        };
+        return match &args[0] {
+            Value::List(items) => {
+                if idx >= items.len() {
+                    Err(RuntimeError::new(
+                        "ILO-R009",
+                        format!(
+                            "lst: index {idx} out of range for list of length {}",
+                            items.len()
+                        ),
+                    ))
+                } else {
+                    let mut new_items = items.clone();
+                    new_items[idx] = args[2].clone();
+                    Ok(Value::List(new_items))
+                }
+            }
+            other => Err(RuntimeError::new(
+                "ILO-R009",
+                format!("lst requires a list, got {:?}", other),
+            )),
+        };
+    }
     if builtin == Some(Builtin::Tl) && args.len() == 1 {
         return match &args[0] {
             Value::List(items) => {

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -6265,4 +6265,57 @@ mod tests {
             errs
         );
     }
+
+    // ---- lst xs i v verify coverage ----
+
+    #[test]
+    fn verify_lst_happy_path() {
+        let code = "f>L n;lst [1,2,3] 1 99";
+        assert!(parse_and_verify(code).is_ok());
+    }
+
+    #[test]
+    fn verify_lst_index_must_be_number() {
+        let code = r#"f>L n;lst [1,2,3] "x" 99"#;
+        let result = parse_and_verify(code);
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.message.contains("'lst' index must be n")),
+            "errors: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn verify_lst_value_type_mismatch() {
+        let code = r#"f>L n;lst [1,2,3] 1 "x""#;
+        let result = parse_and_verify(code);
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.message.contains("does not match list element type")),
+            "errors: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn verify_lst_first_arg_must_be_list() {
+        let code = r#"f>L n;lst "abc" 1 99"#;
+        let result = parse_and_verify(code);
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.message.contains("'lst' expects a list")),
+            "errors: {:?}",
+            errors
+        );
+    }
 }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -290,6 +290,7 @@ const BUILTINS: &[(&str, &[&str], &str)] = &[
     ("srt", &["fn", "list"], "list"),
     ("unq", &["list_or_text"], "list_or_text"),
     ("slc", &["list_or_text", "n", "n"], "list_or_text"),
+    ("lst", &["list", "n", "any"], "list"),
     ("rnd", &[], "n"),
     ("now", &[], "n"),
     ("env", &["t"], "R t t"),
@@ -562,6 +563,54 @@ fn builtin_check_args(
                         is_warning: false,
                     }),
                 }
+            }
+            (Ty::Unknown, errors)
+        }
+        "lst" => {
+            // lst xs i v — return new list with index i replaced by v.
+            // Type variable: list element type and value type must match.
+            if let Some(arg) = arg_types.get(1)
+                && !compatible(arg, &Ty::Number)
+            {
+                errors.push(VerifyError {
+                    code: "ILO-T013",
+                    function: func_ctx.to_string(),
+                    message: format!("'lst' index must be n, got {arg}"),
+                    hint: None,
+                    span,
+                    is_warning: false,
+                });
+            }
+            let list_ty = arg_types.first();
+            let val_ty = arg_types.get(2);
+            match list_ty {
+                Some(Ty::List(inner)) => {
+                    if let Some(v) = val_ty
+                        && !compatible(v, inner)
+                    {
+                        errors.push(VerifyError {
+                            code: "ILO-T013",
+                            function: func_ctx.to_string(),
+                            message: format!(
+                                "'lst' value type {v} does not match list element type {inner}"
+                            ),
+                            hint: None,
+                            span,
+                            is_warning: false,
+                        });
+                    }
+                    return (Ty::List(inner.clone()), errors);
+                }
+                Some(Ty::Unknown) => return (Ty::Unknown, errors),
+                Some(other) => errors.push(VerifyError {
+                    code: "ILO-T013",
+                    function: func_ctx.to_string(),
+                    message: format!("'lst' expects a list, got {other}"),
+                    hint: None,
+                    span,
+                    is_warning: false,
+                }),
+                None => {}
             }
             (Ty::Unknown, errors)
         }

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -83,6 +83,7 @@ struct HelperFuncs {
     rev: FuncId,
     srt: FuncId,
     slc: FuncId,
+    lst: FuncId,
     listappend: FuncId,
     index: FuncId,
     recfld: FuncId,
@@ -194,6 +195,7 @@ fn register_helpers(builder: &mut JITBuilder) {
         ("jit_rev", jit_rev as *const u8),
         ("jit_srt", jit_srt as *const u8),
         ("jit_slc", jit_slc as *const u8),
+        ("jit_lst", jit_lst as *const u8),
         ("jit_listappend", jit_listappend as *const u8),
         ("jit_index", jit_index as *const u8),
         ("jit_recfld", jit_recfld as *const u8),
@@ -296,6 +298,7 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         rev: declare_helper(module, "jit_rev", 1, 1),
         srt: declare_helper(module, "jit_srt", 1, 1),
         slc: declare_helper(module, "jit_slc", 3, 1),
+        lst: declare_helper(module, "jit_lst", 3, 1),
         listappend: declare_helper(module, "jit_listappend", 2, 1),
         index: declare_helper(module, "jit_index", 2, 1),
         recfld: declare_helper(module, "jit_recfld", 2, 1),
@@ -892,7 +895,7 @@ fn compile_function_body(
                 | OP_NEG
                 | OP_WRAPOK | OP_WRAPERR | OP_UNWRAP
                 | OP_RECFLD | OP_RECFLD_NAME | OP_LISTGET | OP_INDEX
-                | OP_STR | OP_HD | OP_AT | OP_TL | OP_REV | OP_SRT | OP_SLC
+                | OP_STR | OP_HD | OP_AT | OP_TL | OP_REV | OP_SRT | OP_SLC | OP_LST
                 | OP_SPL | OP_CAT | OP_GET | OP_POST | OP_GETH | OP_POSTH
                 | OP_ENV | OP_JPTH | OP_JDMP | OP_JPAR
                 | OP_MAPNEW | OP_MGET | OP_MSET | OP_MDEL | OP_MKEYS | OP_MVALS
@@ -1965,6 +1968,19 @@ fn compile_function_body(
                 let d_idx = ((data_inst >> 16) & 0xFF) as usize;
                 let dv = builder.use_var(vars[d_idx]);
                 let fref = get_func_ref(&mut builder, module, helpers.slc);
+                let call_inst = builder.ins().call(fref, &[bv, cv, dv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_LST => {
+                // lst(R[B], R[C], R[D]) — D in data word A field
+                let bv = builder.use_var(vars[b_idx]);
+                let cv = builder.use_var(vars[c_idx]);
+                let data_inst = chunk.code[ip + 1];
+                skip_next = true;
+                let d_idx = ((data_inst >> 16) & 0xFF) as usize;
+                let dv = builder.use_var(vars[d_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.lst);
                 let call_inst = builder.ins().call(fref, &[bv, cv, dv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -178,6 +178,8 @@ pub(crate) const OP_CMPK_NE_N: u8 = 95; // skip-if R[A] != K[C]  (f64)
 // ABC mode — type-specialized string concatenation (both operands known text, no type check)
 pub(crate) const OP_ADD_SS: u8 = 96; // R[A] = R[B] ++ R[C]  (both known text)
 pub(crate) const OP_AT: u8 = 103; // R[A] = at(R[B], R[C])  (i-th element of list/text)
+// Two-word instruction: OP_LST A=result B=list C=index; data word A=value_reg
+pub(crate) const OP_LST: u8 = 110; // R[A] = list-replace(R[B], R[C], R[D])  (new list with index C replaced by D)
 
 // ABC mode — transcendental math (f64, std::f64 backed, NaN on domain error)
 pub(crate) const OP_POW: u8 = 97; // R[A] = pow(R[B], R[C])
@@ -1704,6 +1706,18 @@ impl RegCompiler {
                             self.emit_abc(0, rd, 0, 0);
                             return ra;
                         }
+                        (Builtin::Lst, 3) => {
+                            // lst list i v — two-instruction sequence:
+                            //   OP_LST   A=result  B=list  C=index
+                            //   data word: A=value_reg
+                            let rb = self.compile_expr(&args[0]);
+                            let rc = self.compile_expr(&args[1]);
+                            let rd = self.compile_expr(&args[2]);
+                            let ra = self.alloc_reg();
+                            self.emit_abc(OP_LST, ra, rb, rc);
+                            self.emit_abc(0, rd, 0, 0);
+                            return ra;
+                        }
                         (Builtin::Rnd, 0) => {
                             let ra = self.alloc_reg();
                             self.emit_abc(OP_RND0, ra, 0, 0);
@@ -2425,7 +2439,8 @@ fn chunk_is_all_numeric(chunk: &Chunk) -> bool {
             OP_RECNEW | OP_LISTNEW | OP_RECWITH | OP_WRAPOK | OP_WRAPERR | OP_STR | OP_CAT
             | OP_SPL | OP_REV | OP_SRT | OP_SLC | OP_UNQ | OP_LISTAPPEND | OP_JPAR | OP_JDMP
             | OP_ENV | OP_GET | OP_GETH | OP_POST | OP_POSTH | OP_RD | OP_RDL | OP_WR | OP_WRL
-            | OP_MAPNEW | OP_MGET | OP_MSET | OP_MKEYS | OP_MVALS | OP_HD | OP_AT | OP_TL => {
+            | OP_MAPNEW | OP_MGET | OP_MSET | OP_MKEYS | OP_MVALS | OP_HD | OP_AT | OP_LST
+            | OP_TL => {
                 return false;
             }
             _ => {}
@@ -5729,6 +5744,50 @@ impl<'a> VM<'a> {
                         vm_err!(VmError::Type("slc requires a list or text"));
                     }
                 }
+                OP_LST => {
+                    // Two-instruction sequence: OP_LST A=result B=list C=index; data word A=value_reg
+                    let a = ((inst >> 16) & 0xFF) as usize + base;
+                    let b = ((inst >> 8) & 0xFF) as usize + base;
+                    let c = (inst & 0xFF) as usize + base;
+                    // SAFETY: compiler always emits the data word immediately after OP_LST
+                    let data_inst = unsafe { *code.get_unchecked(ip) };
+                    ip += 1;
+                    let d = ((data_inst >> 16) & 0xFF) as usize + base;
+                    let vb = reg!(b);
+                    let vc = reg!(c);
+                    let vd = reg!(d);
+                    if !vc.is_number() {
+                        vm_err!(VmError::Type("lst: index must be a number"));
+                    }
+                    let n = vc.as_number();
+                    if n < 0.0 || n.fract() != 0.0 {
+                        vm_err!(VmError::Type("lst: index must be a non-negative integer"));
+                    }
+                    let idx = n as usize;
+                    if vb.is_heap() {
+                        match unsafe { vb.as_heap_ref() } {
+                            HeapObj::List(items) => {
+                                if idx >= items.len() {
+                                    vm_err!(VmError::Type("lst: index out of range"));
+                                }
+                                let mut new_items: Vec<NanVal> = Vec::with_capacity(items.len());
+                                for (i, v) in items.iter().enumerate() {
+                                    if i == idx {
+                                        vd.clone_rc();
+                                        new_items.push(vd);
+                                    } else {
+                                        v.clone_rc();
+                                        new_items.push(*v);
+                                    }
+                                }
+                                reg_set!(a, NanVal::heap_list(new_items));
+                            }
+                            _ => vm_err!(VmError::Type("lst requires a list")),
+                        }
+                    } else {
+                        vm_err!(VmError::Type("lst requires a list"));
+                    }
+                }
                 OP_LISTAPPEND => {
                     let a = ((inst >> 16) & 0xFF) as usize + base;
                     let b = ((inst >> 8) & 0xFF) as usize + base;
@@ -6840,6 +6899,41 @@ pub(crate) extern "C" fn jit_at(a: u64, b: u64) -> u64 {
         let idx = adjusted as usize;
         items[idx].clone_rc();
         return items[idx].0;
+    }
+    TAG_NIL
+}
+
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_lst(list: u64, idx: u64, val: u64) -> u64 {
+    let v = NanVal(list);
+    let i = NanVal(idx);
+    let new_val = NanVal(val);
+    if !i.is_number() {
+        return list;
+    }
+    let n = i.as_number();
+    if n < 0.0 || n.fract() != 0.0 {
+        return list;
+    }
+    let pos = n as usize;
+    if v.is_heap()
+        && let HeapObj::List(items) = unsafe { v.as_heap_ref() }
+    {
+        if pos >= items.len() {
+            return list;
+        }
+        let mut new_items: Vec<NanVal> = Vec::with_capacity(items.len());
+        for (i, item) in items.iter().enumerate() {
+            if i == pos {
+                new_val.clone_rc();
+                new_items.push(new_val);
+            } else {
+                item.clone_rc();
+                new_items.push(*item);
+            }
+        }
+        return NanVal::heap_list(new_items).0;
     }
     TAG_NIL
 }
@@ -8169,7 +8263,7 @@ pub(crate) fn find_block_leaders(code: &[u32]) -> Vec<usize> {
                 leaders.insert(i + 2);
                 leaders.insert(i + 3);
             }
-            OP_SLC | OP_MSET | OP_POSTH => {
+            OP_SLC | OP_LST | OP_MSET | OP_POSTH => {
                 // 2-word instructions: the following word is data, not an instruction.
                 // Skip it so its bits aren't mis-decoded as an opcode that might mark
                 // bogus leaders. The instruction after the data word is a normal leader

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -21217,4 +21217,115 @@ f>n;r=mk 10 20;+r.x r.y";
         let bits = jit_at(list.0, NanVal::number(0.5).0);
         assert_eq!(bits, TAG_NIL);
     }
+
+    // ---- OP_LST VM dispatch + jit_lst helper coverage ----
+
+    fn parse_for_vm_lst(source: &str) -> crate::ast::Program {
+        let tokens = crate::lexer::lex(source).unwrap();
+        let token_spans: Vec<(crate::lexer::Token, crate::ast::Span)> = tokens
+            .into_iter()
+            .map(|(t, r)| {
+                (
+                    t,
+                    crate::ast::Span {
+                        start: r.start,
+                        end: r.end,
+                    },
+                )
+            })
+            .collect();
+        let (prog, errors) = crate::parser::parse(token_spans);
+        assert!(errors.is_empty(), "parse errors: {:?}", errors);
+        prog
+    }
+
+    #[test]
+    fn vm_op_lst_happy() {
+        use crate::interpreter::Value;
+        let prog = parse_for_vm_lst("f>L n;lst [10,20,30] 1 99");
+        let compiled = compile(&prog).expect("compile lst");
+        let result = run(&compiled, Some("f"), vec![]).expect("run lst");
+        assert_eq!(
+            result,
+            Value::List(vec![
+                Value::Number(10.0),
+                Value::Number(99.0),
+                Value::Number(30.0),
+            ])
+        );
+    }
+
+    #[test]
+    fn vm_op_lst_out_of_range_errors() {
+        let prog = parse_for_vm_lst("f>L n;lst [1,2,3] 5 0");
+        let compiled = compile(&prog).expect("compile lst");
+        let err = run(&compiled, Some("f"), vec![]).unwrap_err();
+        assert!(format!("{err:?}").contains("out of range"));
+    }
+
+    #[cfg(feature = "cranelift")]
+    #[test]
+    fn jit_lst_happy() {
+        let list = NanVal::heap_list(vec![
+            NanVal::number(10.0),
+            NanVal::number(20.0),
+            NanVal::number(30.0),
+        ]);
+        let v = NanVal(jit_lst(
+            list.0,
+            NanVal::number(1.0).0,
+            NanVal::number(99.0).0,
+        ));
+        assert!(v.is_heap());
+        let items = unsafe {
+            match v.as_heap_ref() {
+                HeapObj::List(items) => items.clone(),
+                _ => panic!("expected list"),
+            }
+        };
+        assert_eq!(items.len(), 3);
+        assert_eq!(items[0].as_number(), 10.0);
+        assert_eq!(items[1].as_number(), 99.0);
+        assert_eq!(items[2].as_number(), 30.0);
+    }
+
+    #[cfg(feature = "cranelift")]
+    #[test]
+    fn jit_lst_out_of_range_returns_original() {
+        let list = NanVal::heap_list(vec![NanVal::number(1.0), NanVal::number(2.0)]);
+        let bits = jit_lst(list.0, NanVal::number(5.0).0, NanVal::number(99.0).0);
+        assert_eq!(bits, list.0);
+    }
+
+    #[cfg(feature = "cranelift")]
+    #[test]
+    fn jit_lst_negative_index_returns_original() {
+        let list = NanVal::heap_list(vec![NanVal::number(1.0), NanVal::number(2.0)]);
+        let bits = jit_lst(list.0, NanVal::number(-1.0).0, NanVal::number(99.0).0);
+        assert_eq!(bits, list.0);
+    }
+
+    #[cfg(feature = "cranelift")]
+    #[test]
+    fn jit_lst_fractional_index_returns_original() {
+        let list = NanVal::heap_list(vec![NanVal::number(1.0), NanVal::number(2.0)]);
+        let bits = jit_lst(list.0, NanVal::number(0.5).0, NanVal::number(99.0).0);
+        assert_eq!(bits, list.0);
+    }
+
+    #[cfg(feature = "cranelift")]
+    #[test]
+    fn jit_lst_non_number_index_returns_original() {
+        let list = NanVal::heap_list(vec![NanVal::number(1.0)]);
+        let bits = jit_lst(list.0, NanVal::boolean(true).0, NanVal::number(99.0).0);
+        assert_eq!(bits, list.0);
+    }
+
+    #[cfg(feature = "cranelift")]
+    #[test]
+    fn jit_lst_non_list_returns_nil() {
+        let s = NanVal::heap_string("abc".to_string());
+        let bits = jit_lst(s.0, NanVal::number(0.0).0, NanVal::number(99.0).0);
+        assert_eq!(bits, TAG_NIL);
+    }
 }

--- a/tests/regression_list_mutation.rs
+++ b/tests/regression_list_mutation.rs
@@ -1,0 +1,289 @@
+// Regression tests for the `lst xs i v` builtin — functional list update.
+//
+// Semantics:
+//   - Returns a new list with element at index `i` replaced by `v`.
+//   - The original list is never mutated (value semantics).
+//   - Type variable: list element type and replacement value must match.
+//   - Out-of-range / negative index:
+//       * tree and vm engines raise ILO-R004 / ILO-R009 runtime errors.
+//       * cranelift JIT returns the original list unchanged (no error).
+//     This mirrors `at`'s pattern of tree/vm strict, JIT permissive.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+// Basic: replace middle element of a numeric list.
+const NUM_SRC: &str = "f>L n;lst [10,20,30] 1 99";
+
+fn check_num(engine: &str) {
+    assert_eq!(run(engine, NUM_SRC, "f"), "[10, 99, 30]", "engine={engine}");
+}
+
+#[test]
+fn lst_num_tree() {
+    check_num("--run-tree");
+}
+
+#[test]
+fn lst_num_vm() {
+    check_num("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn lst_num_cranelift() {
+    check_num("--run-cranelift");
+}
+
+// Type variable: works on a list of text too, with same-type replacement.
+const TEXT_SRC: &str = "f>L t;lst [\"a\",\"b\",\"c\"] 2 \"X\"";
+
+fn check_text(engine: &str) {
+    assert_eq!(run(engine, TEXT_SRC, "f"), "[a, b, X]", "engine={engine}");
+}
+
+#[test]
+fn lst_text_tree() {
+    check_text("--run-tree");
+}
+
+#[test]
+fn lst_text_vm() {
+    check_text("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn lst_text_cranelift() {
+    check_text("--run-cranelift");
+}
+
+// First and last indices.
+#[test]
+fn lst_first_tree() {
+    assert_eq!(
+        run("--run-tree", "f>L n;lst [10,20,30] 0 99", "f"),
+        "[99, 20, 30]"
+    );
+}
+
+#[test]
+fn lst_first_vm() {
+    assert_eq!(
+        run("--run-vm", "f>L n;lst [10,20,30] 0 99", "f"),
+        "[99, 20, 30]"
+    );
+}
+
+#[test]
+fn lst_last_tree() {
+    assert_eq!(
+        run("--run-tree", "f>L n;lst [10,20,30] 2 99", "f"),
+        "[10, 20, 99]"
+    );
+}
+
+#[test]
+fn lst_last_vm() {
+    assert_eq!(
+        run("--run-vm", "f>L n;lst [10,20,30] 2 99", "f"),
+        "[10, 20, 99]"
+    );
+}
+
+// Original list is unchanged after lst returns a new list.
+const NO_MUT_SRC: &str = "f>L n;xs=[1,2,3];ys=lst xs 0 99;xs";
+
+fn check_no_mut(engine: &str) {
+    assert_eq!(run(engine, NO_MUT_SRC, "f"), "[1, 2, 3]", "engine={engine}");
+}
+
+#[test]
+fn lst_no_mutation_tree() {
+    check_no_mut("--run-tree");
+}
+
+#[test]
+fn lst_no_mutation_vm() {
+    check_no_mut("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn lst_no_mutation_cranelift() {
+    check_no_mut("--run-cranelift");
+}
+
+// Out-of-range: tree and vm engines raise a runtime error.
+const OOR_SRC: &str = "f>L n;lst [10,20,30] 99 42";
+
+fn check_oor_error(engine: &str) {
+    let out = ilo()
+        .args([OOR_SRC, engine, "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "engine={engine}: expected runtime error, got stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("lst") || stderr.contains("range") || stderr.contains("ILO-R"),
+        "engine={engine}: expected lst/range/ILO-R error, got stderr={stderr}"
+    );
+}
+
+#[test]
+fn lst_out_of_range_tree() {
+    check_oor_error("--run-tree");
+}
+
+#[test]
+fn lst_out_of_range_vm() {
+    check_oor_error("--run-vm");
+}
+
+// Cranelift JIT mirrors `at`'s permissive pattern: returns the original list
+// unchanged on out-of-range. Safer than nil because the caller can still chain.
+#[test]
+#[cfg(feature = "cranelift")]
+fn lst_out_of_range_cranelift() {
+    let out = ilo()
+        .args([OOR_SRC, "--run-cranelift", "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "cranelift: expected success returning original list, got stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("[10, 20, 30]"),
+        "cranelift: expected original list [10, 20, 30], got {stdout}"
+    );
+}
+
+// Negative index: tree/vm error, cranelift returns original list unchanged.
+const NEG_SRC: &str = "f>L n;lst [10,20,30] -1 42";
+
+#[test]
+fn lst_negative_tree() {
+    let out = ilo()
+        .args([NEG_SRC, "--run-tree", "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "tree: expected error for lst xs -1 v, got stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("non-negative") || stderr.contains("ILO-R"),
+        "tree: expected non-negative/ILO-R error, got stderr={stderr}"
+    );
+}
+
+#[test]
+fn lst_negative_vm() {
+    let out = ilo()
+        .args([NEG_SRC, "--run-vm", "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "vm: expected error for lst xs -1 v, got stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("non-negative") || stderr.contains("lst") || stderr.contains("ILO-R"),
+        "vm: expected non-negative/lst/ILO-R error, got stderr={stderr}"
+    );
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn lst_negative_cranelift() {
+    let out = ilo()
+        .args([NEG_SRC, "--run-cranelift", "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "cranelift: expected success returning original list, got stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("[10, 20, 30]"),
+        "cranelift: expected original list, got {stdout}"
+    );
+}
+
+// Type-variable enforcement: a text value in a numeric list is a verifier error.
+#[test]
+fn lst_type_mismatch_rejected() {
+    let out = ilo()
+        .args(["f>L n;lst [10,20,30] 1 \"X\"", "--run-tree", "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "expected verifier error for type mismatch, got stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("ILO-T013") || stderr.contains("does not match"),
+        "expected ILO-T013, got stderr={stderr}"
+    );
+}
+
+// Histogram bin-update shape — uses `lst` inside a loop to increment bins.
+// Exercises the value-semantics rebuild path that earthquake percentiles and
+// flight-delay histograms previously had to do in user space.
+const HISTOGRAM_SRC: &str = "f>L n;bins=[0,0,0,0];samples=[0,2,1,2,3,1,2,0];@s samples{c=at bins s;bins=lst bins s +c 1};bins";
+
+fn check_histogram(engine: &str) {
+    // 0 appears 2x, 1 appears 2x, 2 appears 3x, 3 appears 1x.
+    assert_eq!(
+        run(engine, HISTOGRAM_SRC, "f"),
+        "[2, 2, 3, 1]",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn lst_histogram_tree() {
+    check_histogram("--run-tree");
+}
+
+#[test]
+fn lst_histogram_vm() {
+    check_histogram("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn lst_histogram_cranelift() {
+    check_histogram("--run-cranelift");
+}


### PR DESCRIPTION
Doc cited histogram-bin updates requiring full list rebuild per increment, O(n²) for big histograms. Added `lst xs:L a i:n v:a>L a` returning a new list with index i replaced. Value semantics preserved. Negative/non-int index errors like `at`. Opcode 110. 23 cross-engine tests + histogram example.