### PR TITLE
main: skip verify errors in inline AST-dump mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2268,15 +2268,33 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
         had_errors = true;
     }
 
-    let verify_result = verify::verify(&program);
-    for w in &verify_result.warnings {
-        report_diagnostic(&Diagnostic::from(w).with_source(source.clone()), mode);
-    }
-    if !verify_result.errors.is_empty() {
-        for e in &verify_result.errors {
-            report_diagnostic(&Diagnostic::from(e).with_source(source.clone()), mode);
+    // Inline-no-func AST-dump mode: when running `ilo '<code>'` with no entry
+    // point and no other mode flag, the binary prints the AST and exits. This
+    // is an inspection path, not an execution path, so verify (which exists to
+    // gate execution) shouldn't gate it. Skipping verify here also avoids
+    // false-positive errors on builtins or partial snippets that users want to
+    // explore via the AST dump. Parse errors still gate (we can't dump an AST
+    // we couldn't parse).
+    let ast_dump_mode = !is_file
+        && r.rest.is_empty()
+        && !r.bench
+        && !r.explain
+        && r.emit.is_none()
+        && !r.dense
+        && !r.expanded
+        && matches!(r.effective_engine(), cli::Engine::Default);
+
+    if !ast_dump_mode {
+        let verify_result = verify::verify(&program);
+        for w in &verify_result.warnings {
+            report_diagnostic(&Diagnostic::from(w).with_source(source.clone()), mode);
         }
-        had_errors = true;
+        if !verify_result.errors.is_empty() {
+            for e in &verify_result.errors {
+                report_diagnostic(&Diagnostic::from(e).with_source(source.clone()), mode);
+            }
+            had_errors = true;
+        }
     }
 
     if had_errors {

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -28,13 +28,42 @@ fn ilo() -> Command {
 }
 
 /// Run an inline ilo snippet and return (exit_success, combined stderr).
+///
+/// Passes the first function name as an explicit entry-point arg so we
+/// exercise the execution path (where verify errors gate exit). Inline mode
+/// with no entry point is an AST-dump inspection path and intentionally
+/// skips verify gating; these tests are about the verifier itself, not the
+/// dispatch mode, so we route them through the execution path.
 fn run(code: &str) -> (bool, String) {
+    // Crude but sufficient for these snippets: the first identifier before
+    // a parameter list or `>` is the function name. All snippets here start
+    // with the function declaration (possibly preceded by a `type` decl).
+    let first_fn_name = first_function_name(code).unwrap_or("f");
     let out = ilo()
         .arg(code)
+        .arg(first_fn_name)
         .output()
         .unwrap_or_else(|e| panic!("failed to spawn ilo: {e}"));
     let stderr = String::from_utf8_lossy(&out.stderr).to_string();
     (out.status.success(), stderr)
+}
+
+/// Extract the first function name from a snippet by skipping any leading
+/// `type {...}` declarations and reading the next identifier. Returns None
+/// if no obvious function name is found (caller should default to "f").
+fn first_function_name(code: &str) -> Option<&str> {
+    let mut rest = code.trim_start();
+    // Skip leading `type name{...}` decls.
+    while let Some(stripped) = rest.strip_prefix("type ") {
+        // Find the closing `}` of the type body.
+        let close = stripped.find('}')?;
+        rest = stripped[close + 1..].trim_start();
+    }
+    // Read identifier characters (letters, digits, hyphen).
+    let end = rest
+        .find(|c: char| !c.is_ascii_alphanumeric() && c != '-' && c != '_')
+        .unwrap_or(rest.len());
+    if end == 0 { None } else { Some(&rest[..end]) }
 }
 
 /// Assert that `code` fails and that stderr contains `expected_code`.

--- a/tests/eval_inline.rs
+++ b/tests/eval_inline.rs
@@ -35,6 +35,65 @@ fn inline_no_args_outputs_ast() {
     );
 }
 
+// Inline-no-func AST-dump mode is an inspection path, not an execution path.
+// Verify errors on partial snippets (e.g. a function body that references
+// an undeclared name) should not gate the AST dump; the user is exploring
+// structure, not running code.
+#[test]
+fn inline_no_args_skips_verify_errors_on_partial_snippet() {
+    let out = ilo()
+        .args(["f>n;slc xs 0 1"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "expected AST dump to succeed without verify gating; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("\"slc\""),
+        "expected AST JSON containing the builtin call, got: {}",
+        stdout
+    );
+}
+
+// Regression: when a function name IS provided, verify must still gate
+// execution. A program that references an undeclared variable must still
+// produce a verify error and a non-zero exit.
+#[test]
+fn inline_with_func_arg_still_reports_verify_errors() {
+    let out = ilo()
+        .args(["f>n;slc xs 0 1", "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "expected verify error to gate execution when a func arg is given"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let combined = format!("{stderr}{stdout}");
+    assert!(
+        combined.contains("undefined variable") || combined.contains("ILO-T004"),
+        "expected an undefined-variable diagnostic; got stdout: {stdout}, stderr: {stderr}"
+    );
+}
+
+// A real lex/parse error must still gate the AST dump in inline-no-func
+// mode — we can't dump an AST we couldn't build.
+#[test]
+fn inline_no_args_parse_error_still_fatal() {
+    let out = ilo()
+        .args(["this is not valid ilo code @@##$$"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "expected parse error to gate AST dump"
+    );
+}
+
 // --- Inline code: multiple functions ---
 
 #[test]
@@ -667,8 +726,10 @@ fn json_flag_produces_json_error() {
 
 #[test]
 fn text_flag_produces_plain_error() {
+    // Pass a func arg so we exercise the execution path (where verify gates),
+    // not the inline-no-func AST-dump path (where verify is skipped).
     let out = ilo()
-        .args(["--text", "f x:n>n;+x \"hi\""])
+        .args(["--text", "f x:n>n;+x \"hi\"", "f", "1"])
         .output()
         .expect("failed to run ilo");
     assert!(!out.status.success());
@@ -689,7 +750,7 @@ fn text_flag_produces_plain_error() {
 #[test]
 fn ansi_flag_produces_colored_error() {
     let out = ilo()
-        .args(["--ansi", "f x:n>n;+x \"hi\""])
+        .args(["--ansi", "f x:n>n;+x \"hi\"", "f", "1"])
         .output()
         .expect("failed to run ilo");
     assert!(!out.status.success());
@@ -734,7 +795,7 @@ fn json_flag_parse_error_has_span() {
 #[test]
 fn text_flag_verify_error_has_function_note() {
     let out = ilo()
-        .args(["--text", "f x:n>n;+x \"hi\""])
+        .args(["--text", "f x:n>n;+x \"hi\"", "f", "1"])
         .output()
         .expect("failed to run ilo");
     assert!(!out.status.success());
@@ -769,7 +830,7 @@ fn mutual_exclusion_json_text() {
 #[test]
 fn no_color_env_produces_no_ansi() {
     let out = ilo()
-        .args(["f x:n>n;+x \"hi\""])
+        .args(["f x:n>n;+x \"hi\"", "f", "1"])
         .env("NO_COLOR", "1")
         .output()
         .expect("failed to run ilo");
@@ -1628,7 +1689,7 @@ fn unwrap_verifier_t026() {
 fn get_verifier_wrong_type() {
     // get with number arg should fail verification
     let out = ilo()
-        .args(["f x:n>R t t;get x"])
+        .args(["f x:n>R t t;get x", "f", "1"])
         .output()
         .expect("failed to run ilo");
     let stderr = String::from_utf8_lossy(&out.stderr);
@@ -1686,7 +1747,7 @@ fn dollar_bang_parses_inline() {
 fn post_verifier_wrong_type_url() {
     // first arg (url) must be t
     let out = ilo()
-        .args(["f x:n body:t>R t t;post x body"])
+        .args(["f x:n body:t>R t t;post x body", "f", "1", "b"])
         .output()
         .expect("failed to run ilo");
     let stderr = String::from_utf8_lossy(&out.stderr);
@@ -1700,7 +1761,7 @@ fn post_verifier_wrong_type_url() {
 fn post_verifier_wrong_type_body() {
     // second arg (body) must be t
     let out = ilo()
-        .args(["f url:t x:n>R t t;post url x"])
+        .args(["f url:t x:n>R t t;post url x", "f", "u", "1"])
         .output()
         .expect("failed to run ilo");
     let stderr = String::from_utf8_lossy(&out.stderr);


### PR DESCRIPTION
ilo '<code>' with no func arg used to print AST then run verify, producing phantom undefined-variable errors on builtins like `slc`. First-time users testing snippets saw misleading errors. Option B: skip verify gating in AST-dump mode (no file, no func, no engine flag). Parse errors still gate. Real verify errors still surface when called with explicit func arg.