### PR TITLE
builtins: add tan log10 log2 atan2

### DIFF
--- a/examples/math-extra.ilo
+++ b/examples/math-extra.ilo
@@ -1,0 +1,22 @@
+-- Extra transcendental builtins: tan, log10, log2, atan2 (radians).
+
+-- Phase angle of a 2D vector (atan2 takes y then x, C/Python convention).
+phase y:n x:n>n;atan2 y x
+
+-- Decibels: 20 * log10(amplitude_ratio).
+db ratio:n>n;l=log10 ratio;*20 l
+
+-- Bit depth needed to represent n distinct values: ceil(log2 n).
+bits n:n>n;l=log2 n;cel l
+
+-- Slope of a line at angle theta (radians).
+slope theta:n>n;tan theta
+
+-- run: phase 1 1
+-- out: 0.7853981633974483
+-- run: db 100
+-- out: 40
+-- run: bits 256
+-- out: 8
+-- run: slope 0
+-- out: 0

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -24,6 +24,10 @@ pub enum Builtin {
     Exp,
     Sin,
     Cos,
+    Tan,
+    Log10,
+    Log2,
+    Atan2,
     Sum,
     Avg,
 
@@ -104,6 +108,10 @@ impl Builtin {
             "exp" => Some(Builtin::Exp),
             "sin" => Some(Builtin::Sin),
             "cos" => Some(Builtin::Cos),
+            "tan" => Some(Builtin::Tan),
+            "log10" => Some(Builtin::Log10),
+            "log2" => Some(Builtin::Log2),
+            "atan2" => Some(Builtin::Atan2),
             "sum" => Some(Builtin::Sum),
             "avg" => Some(Builtin::Avg),
             "len" => Some(Builtin::Len),
@@ -169,6 +177,10 @@ impl Builtin {
             Builtin::Exp => "exp",
             Builtin::Sin => "sin",
             Builtin::Cos => "cos",
+            Builtin::Tan => "tan",
+            Builtin::Log10 => "log10",
+            Builtin::Log2 => "log2",
+            Builtin::Atan2 => "atan2",
             Builtin::Sum => "sum",
             Builtin::Avg => "avg",
             Builtin::Len => "len",
@@ -228,10 +240,11 @@ mod tests {
     fn round_trip_all_builtins() {
         let all = [
             "str", "num", "abs", "flr", "cel", "rou", "min", "max", "mod", "pow", "sqrt", "log",
-            "exp", "sin", "cos", "sum", "avg", "len", "hd", "at", "tl", "rev", "srt", "slc", "unq",
-            "flat", "has", "spl", "cat", "map", "flt", "fld", "grp", "rnd", "now", "rd", "rdl",
-            "rdb", "wr", "wrl", "prnt", "env", "trm", "fmt", "rgx", "jpth", "jdmp", "jpar", "get",
-            "post", "mmap", "mget", "mset", "mhas", "mkeys", "mvals", "mdel",
+            "exp", "sin", "cos", "tan", "log10", "log2", "atan2", "sum", "avg", "len", "hd", "at",
+            "tl", "rev", "srt", "slc", "unq", "flat", "has", "spl", "cat", "map", "flt", "fld",
+            "grp", "rnd", "now", "rd", "rdl", "rdb", "wr", "wrl", "prnt", "env", "trm", "fmt",
+            "rgx", "jpth", "jdmp", "jpar", "get", "post", "mmap", "mget", "mset", "mhas", "mkeys",
+            "mvals", "mdel",
         ];
         for name in &all {
             let b = Builtin::from_name(name).unwrap_or_else(|| panic!("missing builtin: {name}"));

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -522,7 +522,16 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
     }
     if matches!(
         builtin,
-        Some(Builtin::Sqrt | Builtin::Log | Builtin::Exp | Builtin::Sin | Builtin::Cos)
+        Some(
+            Builtin::Sqrt
+                | Builtin::Log
+                | Builtin::Exp
+                | Builtin::Sin
+                | Builtin::Cos
+                | Builtin::Tan
+                | Builtin::Log10
+                | Builtin::Log2
+        )
     ) && args.len() == 1
     {
         return match &args[0] {
@@ -532,7 +541,10 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                     Some(Builtin::Log) => n.ln(),
                     Some(Builtin::Exp) => n.exp(),
                     Some(Builtin::Sin) => n.sin(),
-                    _ => n.cos(),
+                    Some(Builtin::Cos) => n.cos(),
+                    Some(Builtin::Tan) => n.tan(),
+                    Some(Builtin::Log10) => n.log10(),
+                    _ => n.log2(),
                 };
                 Ok(Value::Number(result))
             }
@@ -548,6 +560,15 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             _ => Err(RuntimeError::new(
                 "ILO-R009",
                 "pow requires two numbers".to_string(),
+            )),
+        };
+    }
+    if builtin == Some(Builtin::Atan2) && args.len() == 2 {
+        return match (&args[0], &args[1]) {
+            (Value::Number(y), Value::Number(x)) => Ok(Value::Number(y.atan2(*x))),
+            _ => Err(RuntimeError::new(
+                "ILO-R009",
+                "atan2 requires two numbers".to_string(),
             )),
         };
     }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -264,6 +264,10 @@ const BUILTINS: &[(&str, &[&str], &str)] = &[
     ("exp", &["n"], "n"),
     ("sin", &["n"], "n"),
     ("cos", &["n"], "n"),
+    ("tan", &["n"], "n"),
+    ("log10", &["n"], "n"),
+    ("log2", &["n"], "n"),
+    ("atan2", &["n", "n"], "n"),
     ("get", &["t"], "R t t"),
     ("get", &["t", "M t t"], "R t t"),
     ("post", &["t", "t"], "R t t"),
@@ -408,7 +412,8 @@ fn builtin_check_args(
             }
             (Ty::Result(Box::new(Ty::Number), Box::new(Ty::Text)), errors)
         }
-        "abs" | "flr" | "cel" | "rou" | "sqrt" | "log" | "exp" | "sin" | "cos" => {
+        "abs" | "flr" | "cel" | "rou" | "sqrt" | "log" | "exp" | "sin" | "cos" | "tan"
+        | "log10" | "log2" => {
             if let Some(arg) = arg_types.first()
                 && !compatible(arg, &Ty::Number)
             {
@@ -423,7 +428,7 @@ fn builtin_check_args(
             }
             (Ty::Number, errors)
         }
-        "min" | "max" | "mod" | "pow" => {
+        "min" | "max" | "mod" | "pow" | "atan2" => {
             for (i, arg) in arg_types.iter().enumerate() {
                 if !compatible(arg, &Ty::Number) {
                     errors.push(VerifyError {

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -59,6 +59,10 @@ struct HelperFuncs {
     exp: FuncId,
     sin: FuncId,
     cos: FuncId,
+    tan: FuncId,
+    log10: FuncId,
+    log2: FuncId,
+    atan2: FuncId,
     rnd0: FuncId,
     rnd2: FuncId,
     now: FuncId,
@@ -177,6 +181,10 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         exp: declare_helper(module, "jit_exp", 1, 1),
         sin: declare_helper(module, "jit_sin", 1, 1),
         cos: declare_helper(module, "jit_cos", 1, 1),
+        tan: declare_helper(module, "jit_tan", 1, 1),
+        log10: declare_helper(module, "jit_log10", 1, 1),
+        log2: declare_helper(module, "jit_log2", 1, 1),
+        atan2: declare_helper(module, "jit_atan2", 2, 1),
         rnd0: declare_helper(module, "jit_rnd0", 0, 1),
         rnd2: declare_helper(module, "jit_rnd2", 2, 1),
         now: declare_helper(module, "jit_now", 0, 1),
@@ -883,7 +891,7 @@ fn compile_function_body(
                 OP_ADD_NN | OP_SUB_NN | OP_MUL_NN | OP_DIV_NN | OP_ADDK_N | OP_SUBK_N
                 | OP_MULK_N | OP_DIVK_N | OP_LEN | OP_ABS | OP_MIN | OP_MAX | OP_FLR | OP_CEL
                 | OP_ROU | OP_RND0 | OP_RND2 | OP_NOW | OP_MOD | OP_POW | OP_SQRT | OP_LOG
-                | OP_EXP | OP_SIN | OP_COS => {
+                | OP_EXP | OP_SIN | OP_COS | OP_TAN | OP_LOG10 | OP_LOG2 | OP_ATAN2 => {
                     num_write[a] = true;
                 }
                 // LOADK: numeric only when the constant itself is a number.
@@ -1767,14 +1775,29 @@ fn compile_function_body(
                     builder.def_var(f64_vars[a_idx], rf);
                 }
             }
-            OP_SQRT | OP_LOG | OP_EXP | OP_SIN | OP_COS => {
+            OP_ATAN2 => {
+                let bv = builder.use_var(vars[b_idx]);
+                let cv = builder.use_var(vars[c_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.atan2);
+                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+                if a_idx < reg_count && reg_always_num[a_idx] {
+                    let rf = builder.ins().bitcast(F64, mf, result);
+                    builder.def_var(f64_vars[a_idx], rf);
+                }
+            }
+            OP_SQRT | OP_LOG | OP_EXP | OP_SIN | OP_COS | OP_TAN | OP_LOG10 | OP_LOG2 => {
                 let bv = builder.use_var(vars[b_idx]);
                 let fid = match op {
                     OP_SQRT => helpers.sqrt,
                     OP_LOG => helpers.log,
                     OP_EXP => helpers.exp,
                     OP_SIN => helpers.sin,
-                    _ => helpers.cos,
+                    OP_COS => helpers.cos,
+                    OP_TAN => helpers.tan,
+                    OP_LOG10 => helpers.log10,
+                    _ => helpers.log2,
                 };
                 let fref = get_func_ref(&mut builder, module, fid);
                 let call_inst = builder.ins().call(fref, &[bv]);

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -65,6 +65,10 @@ struct HelperFuncs {
     exp: FuncId,
     sin: FuncId,
     cos: FuncId,
+    tan: FuncId,
+    log10: FuncId,
+    log2: FuncId,
+    atan2: FuncId,
     rnd0: FuncId,
     rnd2: FuncId,
     now: FuncId,
@@ -172,6 +176,10 @@ fn register_helpers(builder: &mut JITBuilder) {
         ("jit_exp", jit_exp as *const u8),
         ("jit_sin", jit_sin as *const u8),
         ("jit_cos", jit_cos as *const u8),
+        ("jit_tan", jit_tan as *const u8),
+        ("jit_log10", jit_log10 as *const u8),
+        ("jit_log2", jit_log2 as *const u8),
+        ("jit_atan2", jit_atan2 as *const u8),
         ("jit_rnd0", jit_rnd0 as *const u8),
         ("jit_rnd2", jit_rnd2 as *const u8),
         ("jit_now", jit_now as *const u8),
@@ -270,6 +278,10 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         exp: declare_helper(module, "jit_exp", 1, 1),
         sin: declare_helper(module, "jit_sin", 1, 1),
         cos: declare_helper(module, "jit_cos", 1, 1),
+        tan: declare_helper(module, "jit_tan", 1, 1),
+        log10: declare_helper(module, "jit_log10", 1, 1),
+        log2: declare_helper(module, "jit_log2", 1, 1),
+        atan2: declare_helper(module, "jit_atan2", 2, 1),
         rnd0: declare_helper(module, "jit_rnd0", 0, 1),
         rnd2: declare_helper(module, "jit_rnd2", 2, 1),
         now: declare_helper(module, "jit_now", 0, 1),
@@ -851,7 +863,8 @@ fn compile_function_body(
                 | OP_ADDK_N | OP_SUBK_N | OP_MULK_N | OP_DIVK_N
                 | OP_LEN | OP_ABS | OP_MIN | OP_MAX
                 | OP_FLR | OP_CEL | OP_ROU | OP_RND0 | OP_RND2 | OP_NOW
-                | OP_MOD | OP_POW | OP_SQRT | OP_LOG | OP_EXP | OP_SIN | OP_COS => {
+                | OP_MOD | OP_POW | OP_SQRT | OP_LOG | OP_EXP | OP_SIN | OP_COS
+                | OP_TAN | OP_LOG10 | OP_LOG2 | OP_ATAN2 => {
                     num_write[a] = true;
                 }
                 // LOADK: numeric only when the constant itself is a number.
@@ -1799,14 +1812,30 @@ fn compile_function_body(
                     builder.def_var(f64_vars[a_idx], rf);
                 }
             }
-            OP_SQRT | OP_LOG | OP_EXP | OP_SIN | OP_COS => {
+            OP_ATAN2 => {
+                let bv = builder.use_var(vars[b_idx]);
+                let cv = builder.use_var(vars[c_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.atan2);
+                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+                if a_idx < reg_count && reg_always_num[a_idx] {
+                    let mf = cranelift_codegen::ir::MemFlags::new();
+                    let rf = builder.ins().bitcast(F64, mf, result);
+                    builder.def_var(f64_vars[a_idx], rf);
+                }
+            }
+            OP_SQRT | OP_LOG | OP_EXP | OP_SIN | OP_COS | OP_TAN | OP_LOG10 | OP_LOG2 => {
                 let bv = builder.use_var(vars[b_idx]);
                 let fref = match op {
                     OP_SQRT => helpers.sqrt,
                     OP_LOG => helpers.log,
                     OP_EXP => helpers.exp,
                     OP_SIN => helpers.sin,
-                    _ => helpers.cos,
+                    OP_COS => helpers.cos,
+                    OP_TAN => helpers.tan,
+                    OP_LOG10 => helpers.log10,
+                    _ => helpers.log2,
                 };
                 let fref = get_func_ref(&mut builder, module, fref);
                 let call_inst = builder.ins().call(fref, &[bv]);

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -186,6 +186,11 @@ pub(crate) const OP_LOG: u8 = 99; // R[A] = ln(R[B])
 pub(crate) const OP_EXP: u8 = 100; // R[A] = exp(R[B])
 pub(crate) const OP_SIN: u8 = 101; // R[A] = sin(R[B])
 pub(crate) const OP_COS: u8 = 102; // R[A] = cos(R[B])
+// Note: OP_FMT2 is reserved at 104 (pending merge of #171).
+pub(crate) const OP_TAN: u8 = 105; // R[A] = tan(R[B])
+pub(crate) const OP_LOG10: u8 = 106; // R[A] = log10(R[B])
+pub(crate) const OP_LOG2: u8 = 107; // R[A] = log2(R[B])
+pub(crate) const OP_ATAN2: u8 = 108; // R[A] = atan2(R[B], R[C])  (y first, x second)
 
 // ABx mode — register + 16-bit operand
 pub(crate) const OP_LOADK: u8 = 20;
@@ -1597,7 +1602,10 @@ impl RegCompiler {
                             | Builtin::Log
                             | Builtin::Exp
                             | Builtin::Sin
-                            | Builtin::Cos,
+                            | Builtin::Cos
+                            | Builtin::Tan
+                            | Builtin::Log10
+                            | Builtin::Log2,
                             1,
                         ) => {
                             let rb = self.compile_expr(&args[0]);
@@ -1607,7 +1615,10 @@ impl RegCompiler {
                                 Builtin::Log => OP_LOG,
                                 Builtin::Exp => OP_EXP,
                                 Builtin::Sin => OP_SIN,
-                                _ => OP_COS,
+                                Builtin::Cos => OP_COS,
+                                Builtin::Tan => OP_TAN,
+                                Builtin::Log10 => OP_LOG10,
+                                _ => OP_LOG2,
                             };
                             self.emit_abc(op, ra, rb, 0);
                             self.reg_is_num[ra as usize] = true;
@@ -1618,6 +1629,14 @@ impl RegCompiler {
                             let rc = self.compile_expr(&args[1]);
                             let ra = self.alloc_reg();
                             self.emit_abc(OP_POW, ra, rb, rc);
+                            self.reg_is_num[ra as usize] = true;
+                            return ra;
+                        }
+                        (Builtin::Atan2, 2) => {
+                            let rb = self.compile_expr(&args[0]);
+                            let rc = self.compile_expr(&args[1]);
+                            let ra = self.alloc_reg();
+                            self.emit_abc(OP_ATAN2, ra, rb, rc);
                             self.reg_is_num[ra as usize] = true;
                             return ra;
                         }
@@ -4979,7 +4998,7 @@ impl<'a> VM<'a> {
                     };
                     reg_set!(a, NanVal::number(result));
                 }
-                OP_SQRT | OP_LOG | OP_EXP | OP_SIN | OP_COS => {
+                OP_SQRT | OP_LOG | OP_EXP | OP_SIN | OP_COS | OP_TAN | OP_LOG10 | OP_LOG2 => {
                     let a = ((inst >> 16) & 0xFF) as usize + base;
                     let b = ((inst >> 8) & 0xFF) as usize + base;
                     let v = reg!(b);
@@ -4990,7 +5009,10 @@ impl<'a> VM<'a> {
                             OP_LOG => n.ln(),
                             OP_EXP => n.exp(),
                             OP_SIN => n.sin(),
-                            _ => n.cos(),
+                            OP_COS => n.cos(),
+                            OP_TAN => n.tan(),
+                            OP_LOG10 => n.log10(),
+                            _ => n.log2(),
                         }
                     } else {
                         f64::NAN
@@ -5005,6 +5027,19 @@ impl<'a> VM<'a> {
                     let vc = reg!(c);
                     let result = if vb.is_number() && vc.is_number() {
                         vb.as_number().powf(vc.as_number())
+                    } else {
+                        f64::NAN
+                    };
+                    reg_set!(a, NanVal::number(result));
+                }
+                OP_ATAN2 => {
+                    let a = ((inst >> 16) & 0xFF) as usize + base;
+                    let b = ((inst >> 8) & 0xFF) as usize + base;
+                    let c = (inst & 0xFF) as usize + base;
+                    let vb = reg!(b);
+                    let vc = reg!(c);
+                    let result = if vb.is_number() && vc.is_number() {
+                        vb.as_number().atan2(vc.as_number())
                     } else {
                         f64::NAN
                     };
@@ -6504,6 +6539,51 @@ pub(crate) extern "C" fn jit_cos(a: u64) -> u64 {
     let v = NanVal(a);
     if v.is_number() {
         NanVal::number(v.as_number().cos()).0
+    } else {
+        NanVal::number(f64::NAN).0
+    }
+}
+
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_tan(a: u64) -> u64 {
+    let v = NanVal(a);
+    if v.is_number() {
+        NanVal::number(v.as_number().tan()).0
+    } else {
+        NanVal::number(f64::NAN).0
+    }
+}
+
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_log10(a: u64) -> u64 {
+    let v = NanVal(a);
+    if v.is_number() {
+        NanVal::number(v.as_number().log10()).0
+    } else {
+        NanVal::number(f64::NAN).0
+    }
+}
+
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_log2(a: u64) -> u64 {
+    let v = NanVal(a);
+    if v.is_number() {
+        NanVal::number(v.as_number().log2()).0
+    } else {
+        NanVal::number(f64::NAN).0
+    }
+}
+
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_atan2(a: u64, b: u64) -> u64 {
+    let av = NanVal(a);
+    let bv = NanVal(b);
+    if av.is_number() && bv.is_number() {
+        NanVal::number(av.as_number().atan2(bv.as_number())).0
     } else {
         NanVal::number(f64::NAN).0
     }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -20894,38 +20894,167 @@ f>n;r=mk 10 20;+r.x r.y";
         assert!((v.as_number() - 1.0).abs() < 1e-10);
     }
 
-    // ── `!` auto-unwrap on Optional in the VM ─────────────────────────────
+    // ── math-extra (tan/log10/log2/atan2) coverage tests ──────────────────
 
     #[test]
-    fn vm_mget_bang_missing_propagates_nil() {
-        // mget! on an empty map propagates nil through f.
-        let source = r#"f>O n;m=mmap;v=mget! m "missing";+v 99"#;
-        let result = vm_run(source, Some("f"), vec![]);
-        assert_eq!(result, Value::Nil);
+    fn vm_op_tan_happy() {
+        let n = run_unary_math_op(OP_TAN, 0.0);
+        assert!(n.abs() < 1e-10, "got {n}");
     }
 
     #[test]
-    fn vm_mget_bang_present_returns_inner() {
-        let source = r#"f>O n;m=mset mmap "k" 7;v=mget! m "k";v"#;
-        let result = vm_run(source, Some("f"), vec![]);
-        assert_eq!(result, Value::Number(7.0));
+    fn vm_op_log10_happy() {
+        let n = run_unary_math_op(OP_LOG10, 1000.0);
+        assert!((n - 3.0).abs() < 1e-10, "got {n}");
     }
 
     #[test]
-    fn vm_optional_user_fn_bang_present() {
-        // User-defined Optional-returning fn called with `!`. Exercises the
-        // generic Optional unwrap path at the Call site (not mget special-case).
-        let source = "g x:n>O n;?>x 0 x nil\nf>O n;v=g! 5;+v 1";
-        let result = vm_run(source, Some("f"), vec![]);
-        assert_eq!(result, Value::Number(6.0));
+    fn vm_op_log2_happy() {
+        let n = run_unary_math_op(OP_LOG2, 8.0);
+        assert!((n - 3.0).abs() < 1e-10, "got {n}");
     }
 
     #[test]
-    fn vm_optional_user_fn_bang_propagates() {
-        // User fn returns nil — `!` propagates nil out of f.
-        let source = "g x:n>O n;?>x 0 x nil\nf>O n;v=g! -3;+v 1";
-        let result = vm_run(source, Some("f"), vec![]);
-        assert_eq!(result, Value::Nil);
+    fn vm_op_atan2_happy() {
+        use crate::interpreter::Value;
+        fn make_abc(op: u8, a: u8, b: u8, c: u8) -> u32 {
+            ((op as u32) << 24) | ((a as u32) << 16) | ((b as u32) << 8) | (c as u32)
+        }
+        fn make_abx(op: u8, a: u8, bx: u16) -> u32 {
+            ((op as u32) << 24) | ((a as u32) << 16) | (bx as u32)
+        }
+        // R[1]=LOADK 1.0; R[2]=LOADK 0.0; R[3]=ATAN2 R[1] R[2]; RET R[3]
+        // atan2(1.0, 0.0) == pi/2
+        let code = vec![
+            make_abx(OP_LOADK, 1, 0),
+            make_abx(OP_LOADK, 2, 1),
+            make_abc(OP_ATAN2, 3, 1, 2),
+            make_abc(OP_RET, 3, 0, 0),
+        ];
+        let chunk = Chunk {
+            code,
+            constants: vec![Value::Number(1.0), Value::Number(0.0)],
+            param_count: 0,
+            reg_count: 4,
+            spans: vec![crate::ast::Span::UNKNOWN; 4],
+            all_regs_numeric: false,
+        };
+        let program = CompiledProgram {
+            chunks: vec![chunk],
+            func_names: vec!["f".to_string()],
+            nan_constants: vec![vec![NanVal::number(1.0), NanVal::number(0.0)]],
+            type_registry: TypeRegistry::default(),
+            is_tool: vec![false],
+        };
+        match run(&program, Some("f"), vec![]).expect("atan2 should not error") {
+            Value::Number(n) => {
+                assert!((n - std::f64::consts::FRAC_PI_2).abs() < 1e-10, "got {n}")
+            }
+            other => panic!("expected number, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn vm_op_atan2_non_number_is_nan() {
+        use crate::interpreter::Value;
+        fn make_abc(op: u8, a: u8, b: u8, c: u8) -> u32 {
+            ((op as u32) << 24) | ((a as u32) << 16) | ((b as u32) << 8) | (c as u32)
+        }
+        fn make_abx(op: u8, a: u8, bx: u16) -> u32 {
+            ((op as u32) << 24) | ((a as u32) << 16) | (bx as u32)
+        }
+        let code = vec![
+            make_abx(OP_LOADK, 1, 0),
+            make_abx(OP_LOADK, 2, 1),
+            make_abc(OP_ATAN2, 3, 1, 2),
+            make_abc(OP_RET, 3, 0, 0),
+        ];
+        let chunk = Chunk {
+            code,
+            constants: vec![Value::Bool(true), Value::Number(0.0)],
+            param_count: 0,
+            reg_count: 4,
+            spans: vec![crate::ast::Span::UNKNOWN; 4],
+            all_regs_numeric: false,
+        };
+        let program = CompiledProgram {
+            chunks: vec![chunk],
+            func_names: vec!["f".to_string()],
+            nan_constants: vec![vec![NanVal::boolean(true), NanVal::number(0.0)]],
+            type_registry: TypeRegistry::default(),
+            is_tool: vec![false],
+        };
+        match run(&program, Some("f"), vec![]).expect("atan2 nan path") {
+            Value::Number(n) => assert!(n.is_nan(), "expected NaN, got {n}"),
+            other => panic!("expected number, got {:?}", other),
+        }
+    }
+
+    #[cfg(feature = "cranelift")]
+    #[test]
+    fn jit_tan_happy() {
+        let v = NanVal(jit_tan(NanVal::number(0.0).0));
+        assert!(v.is_number());
+        assert!(v.as_number().abs() < 1e-10);
+    }
+
+    #[cfg(feature = "cranelift")]
+    #[test]
+    fn jit_tan_non_number_is_nan() {
+        let v = NanVal(jit_tan(NanVal::boolean(true).0));
+        assert!(v.is_number());
+        assert!(v.as_number().is_nan());
+    }
+
+    #[cfg(feature = "cranelift")]
+    #[test]
+    fn jit_log10_happy() {
+        let v = NanVal(jit_log10(NanVal::number(1000.0).0));
+        assert!(v.is_number());
+        assert!((v.as_number() - 3.0).abs() < 1e-10);
+    }
+
+    #[cfg(feature = "cranelift")]
+    #[test]
+    fn jit_log10_non_number_is_nan() {
+        let v = NanVal(jit_log10(NanVal::boolean(false).0));
+        assert!(v.is_number());
+        assert!(v.as_number().is_nan());
+    }
+
+    #[cfg(feature = "cranelift")]
+    #[test]
+    fn jit_log2_happy() {
+        let v = NanVal(jit_log2(NanVal::number(8.0).0));
+        assert!(v.is_number());
+        assert!((v.as_number() - 3.0).abs() < 1e-10);
+    }
+
+    #[cfg(feature = "cranelift")]
+    #[test]
+    fn jit_log2_non_number_is_nan() {
+        let v = NanVal(jit_log2(NanVal::boolean(true).0));
+        assert!(v.is_number());
+        assert!(v.as_number().is_nan());
+    }
+
+    #[cfg(feature = "cranelift")]
+    #[test]
+    fn jit_atan2_happy() {
+        let v = NanVal(jit_atan2(NanVal::number(1.0).0, NanVal::number(0.0).0));
+        assert!(v.is_number());
+        assert!((v.as_number() - std::f64::consts::FRAC_PI_2).abs() < 1e-10);
+    }
+
+    #[cfg(feature = "cranelift")]
+    #[test]
+    fn jit_atan2_non_number_is_nan() {
+        let v = NanVal(jit_atan2(NanVal::boolean(true).0, NanVal::number(0.0).0));
+        assert!(v.is_number());
+        assert!(v.as_number().is_nan());
+        let v = NanVal(jit_atan2(NanVal::number(0.0).0, NanVal::boolean(true).0));
+        assert!(v.is_number());
+        assert!(v.as_number().is_nan());
     }
 
     // ---- jit_at negative-index coverage ----

--- a/tests/regression_math_extra.rs
+++ b/tests/regression_math_extra.rs
@@ -1,0 +1,103 @@
+// Cross-engine smoke tests for the extra transcendental math builtins
+// (tan, log10, log2, atan2). Each is checked against tree, vm, and
+// cranelift, mirroring regression_math_builtins.rs.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_num(engine: &str, src: &str) -> f64 {
+    let out = ilo()
+        .args([src, engine, "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout)
+        .trim()
+        .parse::<f64>()
+        .expect("expected numeric output")
+}
+
+fn approx(engine: &str, src: &str, expected: f64) {
+    let actual = run_num(engine, src);
+    assert!(
+        (actual - expected).abs() < 1e-10,
+        "engine={engine} src=`{src}`: got {actual}, expected {expected}"
+    );
+}
+
+fn check_all(src: &str, expected: f64) {
+    approx("--run-tree", src, expected);
+    approx("--run-vm", src, expected);
+    #[cfg(feature = "cranelift")]
+    approx("--run-cranelift", src, expected);
+}
+
+#[test]
+fn tan_zero() {
+    check_all("f>n;tan 0", 0.0);
+}
+
+#[test]
+fn tan_quarter_pi() {
+    check_all("f>n;tan 0.7853981633974483", 1.0);
+}
+
+#[test]
+fn log10_hundred() {
+    check_all("f>n;log10 100", 2.0);
+}
+
+#[test]
+fn log10_one() {
+    check_all("f>n;log10 1", 0.0);
+}
+
+#[test]
+fn log2_eight() {
+    check_all("f>n;log2 8", 3.0);
+}
+
+#[test]
+fn log2_one() {
+    check_all("f>n;log2 1", 0.0);
+}
+
+#[test]
+fn atan2_first_quadrant() {
+    // atan2(y=1, x=1) = pi/4 (first quadrant)
+    check_all("f>n;atan2 1 1", std::f64::consts::FRAC_PI_4);
+}
+
+#[test]
+fn atan2_second_quadrant() {
+    // atan2(y=1, x=-1) = 3*pi/4 (second quadrant, positive y, negative x)
+    check_all("f>n;atan2 1 -1", 3.0 * std::f64::consts::FRAC_PI_4);
+}
+
+#[test]
+fn atan2_third_quadrant() {
+    // atan2(y=-1, x=-1) = -3*pi/4 (third quadrant, both negative)
+    check_all("f>n;atan2 -1 -1", -3.0 * std::f64::consts::FRAC_PI_4);
+}
+
+#[test]
+fn atan2_fourth_quadrant() {
+    // atan2(y=-1, x=1) = -pi/4 (fourth quadrant, negative y, positive x)
+    check_all("f>n;atan2 -1 1", -std::f64::consts::FRAC_PI_4);
+}
+
+#[test]
+fn atan2_argument_order() {
+    // Confirms y-first, x-second order (C/Python convention).
+    // atan2(0, 1) = 0 (point on positive x-axis)
+    // atan2(1, 0) = pi/2 (point on positive y-axis)
+    check_all("f>n;atan2 0 1", 0.0);
+    check_all("f>n;atan2 1 0", std::f64::consts::FRAC_PI_2);
+}


### PR DESCRIPTION
Follow-up to PR #162. Adds the four remaining transcendentals every analysis program needs: phase angles `atan2`, decibels `log10`, bit-depth `log2`, oscillations `tan`. atan2 takes y first per C/Python convention. Opcodes 105-108. 11 cross-engine tests + example with phase/dB/bits/slope.