### PR TITLE
at: Python-style negative indexing

### DIFF
--- a/examples/at-indexing.ilo
+++ b/examples/at-indexing.ilo
@@ -1,7 +1,10 @@
--- at xs i: i-th element of a list (0-indexed). Out-of-range is a runtime error.
+-- at xs i: i-th element of a list (0-indexed).
+-- Negative i counts from the end: -1 is the last element.
+-- Out-of-range (i >= len or i < -len) is a runtime error.
 
 nth xs:L n i:n>n;at xs i
-last xs:L n>n;at xs -(len xs) 1
+last xs:L n>n;at xs -1
+penultimate xs:L n>n;at xs -2
 
 -- run: nth [10,20,30] 1
 -- out: 20
@@ -11,3 +14,5 @@ last xs:L n>n;at xs -(len xs) 1
 -- out: 30
 -- run: last [10,20,30]
 -- out: 30
+-- run: penultimate [10,20,30]
+-- out: 20

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -659,15 +659,15 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         };
     }
     if builtin == Some(Builtin::At) && args.len() == 2 {
-        let idx = match &args[1] {
+        let i = match &args[1] {
             Value::Number(n) => {
-                if *n < 0.0 || n.fract() != 0.0 {
+                if n.fract() != 0.0 {
                     return Err(RuntimeError::new(
                         "ILO-R009",
-                        "at: index must be a non-negative integer".to_string(),
+                        "at: index must be an integer".to_string(),
                     ));
                 }
-                *n as usize
+                *n as i64
             }
             other => {
                 return Err(RuntimeError::new(
@@ -678,30 +678,34 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         };
         return match &args[0] {
             Value::List(items) => {
-                if idx >= items.len() {
+                let len = items.len() as i64;
+                let adjusted = if i < 0 { i + len } else { i };
+                if adjusted < 0 || adjusted >= len {
                     Err(RuntimeError::new(
                         "ILO-R009",
                         format!(
-                            "at: index {idx} out of range for list of length {}",
+                            "at: index {i} out of range for list of length {}",
                             items.len()
                         ),
                     ))
                 } else {
-                    Ok(items[idx].clone())
+                    Ok(items[adjusted as usize].clone())
                 }
             }
             Value::Text(s) => {
                 let chars: Vec<char> = s.chars().collect();
-                if idx >= chars.len() {
+                let len = chars.len() as i64;
+                let adjusted = if i < 0 { i + len } else { i };
+                if adjusted < 0 || adjusted >= len {
                     Err(RuntimeError::new(
                         "ILO-R009",
                         format!(
-                            "at: index {idx} out of range for text of length {}",
+                            "at: index {i} out of range for text of length {}",
                             chars.len()
                         ),
                     ))
                 } else {
-                    Ok(Value::Text(chars[idx].to_string()))
+                    Ok(Value::Text(chars[adjusted as usize].to_string()))
                 }
             }
             other => Err(RuntimeError::new(

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -6998,4 +6998,51 @@ mod tests {
         let result = run_str(source, Some("f"), vec![]);
         assert_eq!(result, Value::Number(5.0));
     }
+
+    // ---- at xs i with negative indices (covers new interpreter arms) ----
+
+    #[test]
+    fn interp_at_list_negative_last() {
+        let source = "f>n;xs=[10,20,30];at xs -1";
+        let result = run_str(source, Some("f"), vec![]);
+        assert_eq!(result, Value::Number(30.0));
+    }
+
+    #[test]
+    fn interp_at_list_negative_first() {
+        let source = "f>n;xs=[10,20,30];at xs -3";
+        let result = run_str(source, Some("f"), vec![]);
+        assert_eq!(result, Value::Number(10.0));
+    }
+
+    #[test]
+    fn interp_at_text_negative_last() {
+        let source = r#"f>t;at "abc" -1"#;
+        let result = run_str(source, Some("f"), vec![]);
+        assert_eq!(result, Value::Text("c".to_string()));
+    }
+
+    #[test]
+    fn interp_at_list_negative_out_of_range() {
+        let prog = parse_program("f>n;xs=[10,20,30];at xs -4");
+        let err = run(&prog, Some("f"), vec![]).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("out of range"), "got {msg}");
+    }
+
+    #[test]
+    fn interp_at_text_negative_out_of_range() {
+        let prog = parse_program(r#"f>t;at "ab" -3"#);
+        let err = run(&prog, Some("f"), vec![]).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("out of range"), "got {msg}");
+    }
+
+    #[test]
+    fn interp_at_fractional_index_errors() {
+        let prog = parse_program("f>n;xs=[10,20,30];at xs 1.5");
+        let err = run(&prog, Some("f"), vec![]).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("integer"), "got {msg}");
+    }
 }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -5479,10 +5479,10 @@ impl<'a> VM<'a> {
                         vm_err!(VmError::Type("at: index must be a number"));
                     }
                     let n = i.as_number();
-                    if n < 0.0 || n.fract() != 0.0 {
-                        vm_err!(VmError::Type("at: index must be a non-negative integer"));
+                    if n.fract() != 0.0 {
+                        vm_err!(VmError::Type("at: index must be an integer"));
                     }
-                    let idx = n as usize;
+                    let raw = n as i64;
                     let result = if v.is_string() {
                         let s = unsafe {
                             match v.as_heap_ref() {
@@ -5491,16 +5491,21 @@ impl<'a> VM<'a> {
                             }
                         };
                         let chars: Vec<char> = s.chars().collect();
-                        if idx >= chars.len() {
+                        let len = chars.len() as i64;
+                        let adjusted = if raw < 0 { raw + len } else { raw };
+                        if adjusted < 0 || adjusted >= len {
                             vm_err!(VmError::Type("at: index out of range"));
                         }
-                        NanVal::heap_string(chars[idx].to_string())
+                        NanVal::heap_string(chars[adjusted as usize].to_string())
                     } else if v.is_heap() {
                         match unsafe { v.as_heap_ref() } {
                             HeapObj::List(items) => {
-                                if idx >= items.len() {
+                                let len = items.len() as i64;
+                                let adjusted = if raw < 0 { raw + len } else { raw };
+                                if adjusted < 0 || adjusted >= len {
                                     vm_err!(VmError::Type("at: index out of range"));
                                 }
+                                let idx = adjusted as usize;
                                 items[idx].clone_rc();
                                 items[idx]
                             }
@@ -6725,10 +6730,10 @@ pub(crate) extern "C" fn jit_at(a: u64, b: u64) -> u64 {
         return TAG_NIL;
     }
     let n = i.as_number();
-    if n < 0.0 || n.fract() != 0.0 {
+    if n.fract() != 0.0 {
         return TAG_NIL;
     }
-    let idx = n as usize;
+    let raw = n as i64;
     if v.is_string() {
         let s = unsafe {
             match v.as_heap_ref() {
@@ -6737,17 +6742,22 @@ pub(crate) extern "C" fn jit_at(a: u64, b: u64) -> u64 {
             }
         };
         let chars: Vec<char> = s.chars().collect();
-        if idx >= chars.len() {
+        let len = chars.len() as i64;
+        let adjusted = if raw < 0 { raw + len } else { raw };
+        if adjusted < 0 || adjusted >= len {
             return TAG_NIL;
         }
-        return NanVal::heap_string(chars[idx].to_string()).0;
+        return NanVal::heap_string(chars[adjusted as usize].to_string()).0;
     }
     if v.is_heap()
         && let HeapObj::List(items) = unsafe { v.as_heap_ref() }
     {
-        if idx >= items.len() {
+        let len = items.len() as i64;
+        let adjusted = if raw < 0 { raw + len } else { raw };
+        if adjusted < 0 || adjusted >= len {
             return TAG_NIL;
         }
+        let idx = adjusted as usize;
         items[idx].clone_rc();
         return items[idx].0;
     }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -20847,4 +20847,71 @@ f>n;r=mk 10 20;+r.x r.y";
         let result = vm_run(source, Some("f"), vec![]);
         assert_eq!(result, Value::Nil);
     }
+
+    // ---- jit_at negative-index coverage ----
+
+    #[cfg(feature = "cranelift")]
+    #[test]
+    fn jit_at_list_negative_last() {
+        let list = NanVal::heap_list(vec![
+            NanVal::number(10.0),
+            NanVal::number(20.0),
+            NanVal::number(30.0),
+        ]);
+        let v = NanVal(jit_at(list.0, NanVal::number(-1.0).0));
+        assert!(v.is_number());
+        assert_eq!(v.as_number(), 30.0);
+    }
+
+    #[cfg(feature = "cranelift")]
+    #[test]
+    fn jit_at_list_negative_first() {
+        let list = NanVal::heap_list(vec![
+            NanVal::number(10.0),
+            NanVal::number(20.0),
+            NanVal::number(30.0),
+        ]);
+        let v = NanVal(jit_at(list.0, NanVal::number(-3.0).0));
+        assert!(v.is_number());
+        assert_eq!(v.as_number(), 10.0);
+    }
+
+    #[cfg(feature = "cranelift")]
+    #[test]
+    fn jit_at_list_negative_out_of_range() {
+        let list = NanVal::heap_list(vec![NanVal::number(1.0), NanVal::number(2.0)]);
+        let bits = jit_at(list.0, NanVal::number(-3.0).0);
+        assert_eq!(bits, TAG_NIL);
+    }
+
+    #[cfg(feature = "cranelift")]
+    #[test]
+    fn jit_at_text_negative_last() {
+        let s = NanVal::heap_string("abc".to_string());
+        let v = NanVal(jit_at(s.0, NanVal::number(-1.0).0));
+        assert!(v.is_string());
+        let got = unsafe {
+            match v.as_heap_ref() {
+                HeapObj::Str(s) => s.clone(),
+                _ => panic!("expected string"),
+            }
+        };
+        assert_eq!(got, "c");
+    }
+
+    #[cfg(feature = "cranelift")]
+    #[test]
+    fn jit_at_text_negative_out_of_range() {
+        let s = NanVal::heap_string("ab".to_string());
+        let bits = jit_at(s.0, NanVal::number(-3.0).0);
+        assert_eq!(bits, TAG_NIL);
+    }
+
+    #[cfg(feature = "cranelift")]
+    #[test]
+    fn jit_at_fractional_index_returns_nil() {
+        let list = NanVal::heap_list(vec![NanVal::number(1.0)]);
+        let bits = jit_at(list.0, NanVal::number(0.5).0);
+        assert_eq!(bits, TAG_NIL);
+    }
 }

--- a/tests/regression_at_builtin.rs
+++ b/tests/regression_at_builtin.rs
@@ -165,55 +165,166 @@ fn at_out_of_range_cranelift() {
     );
 }
 
-// Negative index: tree/vm error, cranelift returns nil.
-const NEG_SRC: &str = "f>n;xs=[10,20,30];at xs -1";
+// Negative index: Python-style from-the-end indexing.
+// -1 = last element, -2 = second-to-last, etc.
+const NEG_LAST_SRC: &str = "f>n;xs=[10,20,30];at xs -1";
 
-#[test]
-fn at_negative_index_tree() {
-    let out = ilo()
-        .args([NEG_SRC, "--run-tree", "f"])
-        .output()
-        .expect("failed to run ilo");
-    assert!(
-        !out.status.success(),
-        "tree: expected error for at xs -1, got stdout={}",
-        String::from_utf8_lossy(&out.stdout)
-    );
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(
-        stderr.contains("non-negative") || stderr.contains("ILO-R009"),
-        "tree: expected non-negative/ILO-R009 error, got stderr={stderr}"
-    );
+fn check_neg_last(engine: &str) {
+    assert_eq!(run(engine, NEG_LAST_SRC, "f"), "30", "engine={engine}");
 }
 
 #[test]
-fn at_negative_index_vm() {
-    let out = ilo()
-        .args([NEG_SRC, "--run-vm", "f"])
-        .output()
-        .expect("failed to run ilo");
-    assert!(
-        !out.status.success(),
-        "vm: expected error for at xs -1, got stdout={}",
-        String::from_utf8_lossy(&out.stdout)
-    );
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(
-        stderr.contains("non-negative") || stderr.contains("at"),
-        "vm: expected non-negative/at error, got stderr={stderr}"
-    );
+fn at_negative_last_tree() {
+    check_neg_last("--run-tree");
+}
+
+#[test]
+fn at_negative_last_vm() {
+    check_neg_last("--run-vm");
 }
 
 #[test]
 #[cfg(feature = "cranelift")]
-fn at_negative_index_cranelift() {
+fn at_negative_last_cranelift() {
+    check_neg_last("--run-cranelift");
+}
+
+// -3 on a 3-element list reaches the first element.
+const NEG_FIRST_SRC: &str = "f>n;xs=[10,20,30];at xs -3";
+
+fn check_neg_first(engine: &str) {
+    assert_eq!(run(engine, NEG_FIRST_SRC, "f"), "10", "engine={engine}");
+}
+
+#[test]
+fn at_negative_first_tree() {
+    check_neg_first("--run-tree");
+}
+
+#[test]
+fn at_negative_first_vm() {
+    check_neg_first("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn at_negative_first_cranelift() {
+    check_neg_first("--run-cranelift");
+}
+
+// Negative index on text: -1 yields the last character.
+const NEG_TEXT_SRC: &str = "f>t;xs=[\"a\",\"b\",\"c\"];at xs -1";
+
+fn check_neg_text(engine: &str) {
+    assert_eq!(run(engine, NEG_TEXT_SRC, "f"), "c", "engine={engine}");
+}
+
+#[test]
+fn at_negative_text_tree() {
+    check_neg_text("--run-tree");
+}
+
+#[test]
+fn at_negative_text_vm() {
+    check_neg_text("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn at_negative_text_cranelift() {
+    check_neg_text("--run-cranelift");
+}
+
+// Out-of-range negative: -4 on a 3-element list errors (tree/vm); nil for cranelift.
+const NEG_OOR_SRC: &str = "f>n;xs=[10,20,30];at xs -4";
+
+fn check_neg_oor_error(engine: &str) {
     let out = ilo()
-        .args([NEG_SRC, "--run-cranelift", "f"])
+        .args([NEG_OOR_SRC, engine, "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "engine={engine}: expected runtime error for at xs -4, got stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("at") || stderr.contains("range") || stderr.contains("ILO-R009"),
+        "engine={engine}: expected at/range/ILO-R009 error, got stderr={stderr}"
+    );
+}
+
+#[test]
+fn at_negative_oor_tree() {
+    check_neg_oor_error("--run-tree");
+}
+
+#[test]
+fn at_negative_oor_vm() {
+    check_neg_oor_error("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn at_negative_oor_cranelift() {
+    let out = ilo()
+        .args([NEG_OOR_SRC, "--run-cranelift", "f"])
         .output()
         .expect("failed to run ilo");
     assert!(
         out.status.success(),
-        "cranelift: expected success returning nil for at xs -1, got stderr={}",
+        "cranelift: expected success returning nil for at xs -4, got stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("nil"),
+        "cranelift: expected stdout to contain nil, got {stdout}"
+    );
+}
+
+// Non-integer negative index still errors (the integer guard is preserved).
+const NEG_FLOAT_SRC: &str = "f>n;xs=[10,20,30];at xs -0.5";
+
+fn check_neg_float_error(engine: &str) {
+    let out = ilo()
+        .args([NEG_FLOAT_SRC, engine, "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "engine={engine}: expected error for at xs -0.5, got stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("integer") || stderr.contains("ILO-R009") || stderr.contains("at"),
+        "engine={engine}: expected integer/at error, got stderr={stderr}"
+    );
+}
+
+#[test]
+fn at_negative_float_tree() {
+    check_neg_float_error("--run-tree");
+}
+
+#[test]
+fn at_negative_float_vm() {
+    check_neg_float_error("--run-vm");
+}
+
+// Cranelift JIT mirrors hd's behaviour: returns nil on non-integer index.
+#[test]
+#[cfg(feature = "cranelift")]
+fn at_negative_float_cranelift() {
+    let out = ilo()
+        .args([NEG_FLOAT_SRC, "--run-cranelift", "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "cranelift: expected success returning nil for at xs -0.5, got stderr={}",
         String::from_utf8_lossy(&out.stderr)
     );
     let stdout = String::from_utf8_lossy(&out.stdout);


### PR DESCRIPTION
Follow-up to PR #161. Negative index wraps from end: `at xs -1` returns last, `at xs -2` second-last, etc. Integer-only guard preserved (`at xs -0.5` still errors). The verbose `at xs -(len xs) 1` workaround becomes `at xs -1`. 17 new cross-engine tests; old 'negative errors' tests replaced per the design change.