### PR TITLE
Parser: function calls compose as call args

### DIFF
--- a/examples/function-as-call-arg.ilo
+++ b/examples/function-as-call-arg.ilo
@@ -1,0 +1,18 @@
+-- Functions composed in argument position: no intermediate bindings needed.
+-- `str pct n 10` parses as one nested call. `hd tl xs` chains.
+-- HOF positions (e.g. fld's first arg) still take bare function refs --
+-- see examples/builtins-as-hof.ilo.
+
+dbl x:n>n;*x 2
+pct a:n b:n>n;*/ a b 100
+
+show n:n>t;str pct n 10
+snd xs:L n>n;hd tl xs
+dbd n:n>n;dbl n
+
+-- run: show 3
+-- out: 30
+-- run: snd [10,20,30]
+-- out: 20
+-- run: dbd 5
+-- out: 10

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -421,6 +421,12 @@ pub fn resolve_alias(name: &str) -> Option<&'static str> {
         .map(|(_, short)| *short)
 }
 
+/// Iterate over all (long_name, short_name) builtin alias pairs.
+/// Used by the parser to mirror arity/HOF metadata onto long-form names.
+pub fn all_builtin_aliases() -> impl Iterator<Item = (&'static str, &'static str)> {
+    BUILTIN_ALIASES.iter().copied()
+}
+
 /// Resolve aliases in all Call expressions throughout a program.
 /// Mutates function names in-place so downstream passes see only canonical names.
 pub fn resolve_aliases(program: &mut Program) {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,9 +1,20 @@
 use crate::ast::*;
 use crate::lexer::Token;
+use std::collections::HashMap;
 
 pub struct Parser {
     tokens: Vec<(Token, Span)>,
     pos: usize,
+    /// Known function arities, populated with builtins at construction
+    /// and extended with user-function headers as they're parsed.
+    /// Used by `parse_call_or_atom` to eagerly consume nested calls when an
+    /// Ident in arg position is a known function — so `prnt str nc` parses
+    /// as `prnt(str(nc))` without requiring parens.
+    fn_arity: HashMap<String, usize>,
+    /// For each known function, which parameter positions take a function
+    /// reference (HOF positions). A `true` at index i means "this arg
+    /// should be parsed as a bare ref, not eagerly expanded as a call".
+    fn_param_is_fn: HashMap<String, Vec<bool>>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -25,7 +36,13 @@ impl Parser {
             .into_iter()
             .filter(|(t, _)| *t != Token::Newline)
             .collect();
-        Parser { tokens, pos: 0 }
+        let (fn_arity, fn_param_is_fn) = builtin_arity_tables();
+        Parser {
+            tokens,
+            pos: 0,
+            fn_arity,
+            fn_param_is_fn,
+        }
     }
 
     fn peek(&self) -> Option<&Token> {
@@ -479,6 +496,11 @@ impl Parser {
         let start = self.peek_span();
         let name = self.expect_ident()?;
         let params = self.parse_params()?;
+        // Register arity + per-param fn-ref flags BEFORE parsing the body so
+        // recursive self-references inside the body benefit from eager
+        // call-arg expansion (e.g. `fac n:n>n;?=n 0{1}{*n fac -n 1}` —
+        // `fac -n 1` is parsed as a single nested call).
+        self.register_user_fn(&name, &params);
         self.expect(&Token::Greater)?;
         let return_type = self.parse_type()?;
         // The header/body boundary is normally a `;`, but a newline (filtered
@@ -1266,9 +1288,14 @@ impl Parser {
                 self.advance(); // consume !
             }
             // Parse additional args (operands until we hit >>, ;, }, etc.)
+            // Use call-arg parsing so nested calls inside a pipe target
+            // expand naturally (e.g. `xs >> map str` keeps `str` as a bare
+            // fn-ref since `map`'s first arg is a fn-ref position).
             let mut args = Vec::new();
             while self.can_start_operand() {
-                args.push(self.parse_operand()?);
+                let arg_idx = args.len();
+                let in_fn_pos = self.is_fn_ref_position(&func_name, arg_idx);
+                args.push(self.parse_call_arg(in_fn_pos)?);
             }
             // Piped value becomes last arg
             args.push(expr);
@@ -1536,6 +1563,79 @@ impl Parser {
         })
     }
 
+    /// Register a user function's arity and per-param fn-ref flags so that
+    /// call-arg parsing can eagerly consume nested calls when this function
+    /// is used as the outer callee.
+    fn register_user_fn(&mut self, name: &str, params: &[Param]) {
+        self.fn_arity.insert(name.to_string(), params.len());
+        let flags: Vec<bool> = params
+            .iter()
+            .map(|p| matches!(p.ty, Type::Fn(_, _)))
+            .collect();
+        self.fn_param_is_fn.insert(name.to_string(), flags);
+    }
+
+    /// Is arg position `arg_idx` of function `outer_name` a fn-ref position
+    /// (i.e. expects a function reference, not a regular value)? When true,
+    /// we must NOT eagerly expand an Ident in that position as a nested call.
+    fn is_fn_ref_position(&self, outer_name: &str, arg_idx: usize) -> bool {
+        self.fn_param_is_fn
+            .get(outer_name)
+            .and_then(|v| v.get(arg_idx).copied())
+            .unwrap_or(false)
+    }
+
+    /// Parse a single call argument. If `in_fn_ref_pos` is true, falls back
+    /// to plain `parse_operand` so an Ident stays as a bare ref (HOF use).
+    /// Otherwise, when the next token is an Ident naming a known function
+    /// with arity N, eagerly consume that Ident plus its N args as a nested
+    /// call — this lets agents write `prnt str nc` and `hd tl xs` naturally.
+    fn parse_call_arg(&mut self, in_fn_ref_pos: bool) -> Result<Expr> {
+        if !in_fn_ref_pos
+            && let Some(Token::Ident(name)) = self.peek()
+            && let Some(&arity) = self.fn_arity.get(name)
+            && arity > 0
+        {
+            // Don't eagerly expand if the Ident is followed by tokens that
+            // turn it into something other than a plain call (record fields,
+            // field/index access, postfix-bang, zero-arg paren form).
+            let next = self.token_at(self.pos + 1);
+            let is_record = matches!(next, Some(Token::Ident(_)))
+                && self.token_at(self.pos + 2) == Some(&Token::Colon);
+            let is_field = matches!(next, Some(Token::Dot) | Some(Token::DotQuestion));
+            let is_zero_arg_call =
+                next == Some(&Token::LParen) && self.token_at(self.pos + 2) == Some(&Token::RParen);
+            let is_unwrap = next == Some(&Token::Bang) && {
+                let ident_span = self.peek_span();
+                let bang_span = self
+                    .tokens
+                    .get(self.pos + 1)
+                    .map(|(_, s)| *s)
+                    .unwrap_or(Span::UNKNOWN);
+                ident_span.end > 0 && bang_span.start == ident_span.end
+            };
+            if !(is_record || is_field || is_zero_arg_call || is_unwrap) {
+                let inner_name = name.clone();
+                self.advance(); // consume the inner function ident
+                let mut inner_args = Vec::with_capacity(arity);
+                for i in 0..arity {
+                    if !self.can_start_operand() {
+                        // Underfilled — let the verifier report arity mismatch.
+                        break;
+                    }
+                    let inner_fn_pos = self.is_fn_ref_position(&inner_name, i);
+                    inner_args.push(self.parse_call_arg(inner_fn_pos)?);
+                }
+                return Ok(Expr::Call {
+                    function: inner_name,
+                    args: inner_args,
+                    unwrap: false,
+                });
+            }
+        }
+        self.parse_operand()
+    }
+
     /// Parse function call or plain atom
     /// call = IDENT atom+ (greedy, when not a record)
     /// Also handles zero-arg calls: `func()`
@@ -1577,7 +1677,9 @@ impl Parser {
             if unwrap {
                 let mut args = Vec::new();
                 while self.can_start_operand() {
-                    args.push(self.parse_operand()?);
+                    let arg_idx = args.len();
+                    let in_fn_pos = self.is_fn_ref_position(&name, arg_idx);
+                    args.push(self.parse_call_arg(in_fn_pos)?);
                 }
                 return Ok(Expr::Call {
                     function: name,
@@ -1618,7 +1720,9 @@ impl Parser {
                 }
                 let mut args = Vec::new();
                 while self.can_start_operand() {
-                    args.push(self.parse_operand()?);
+                    let arg_idx = args.len();
+                    let in_fn_pos = self.is_fn_ref_position(&name, arg_idx);
+                    args.push(self.parse_call_arg(in_fn_pos)?);
                     // After each arg, if next is infix, stop
                     if let Some(tok) = self.peek()
                         && Self::is_infix_or_suffix_op(tok)
@@ -1952,6 +2056,117 @@ impl Parser {
             None => Err(self.error("ILO-P014", "expected number, got EOF".into())),
         }
     }
+}
+
+/// Build the parser's static arity/HOF tables for builtins. These are used
+/// during call-arg parsing to eagerly consume nested calls in arg position
+/// (so `prnt str nc` parses as `prnt(str(nc))` instead of `prnt(str, nc)`).
+///
+/// Builtins with overloaded arities (`rnd`/`now` — 0 args, but also seen
+/// with args in `rnd`, plus `get`/`post`/`rd`/`rdb` 1-or-2-arg variants and
+/// `srt` 1-or-2-arg variants) get the BASE/canonical arity entered here.
+/// `srt`'s entry uses arity 2 with a fn-ref first position, which lets
+/// `srt cmp xs` expand and degrades gracefully for `srt xs` (the loop
+/// simply stops when no more operands are available).
+///
+/// Mutating-only HOFs (`map`/`flt`/`fld`/`grp`) get fn-ref flag on slot 0.
+fn builtin_arity_tables() -> (HashMap<String, usize>, HashMap<String, Vec<bool>>) {
+    // (name, arity, fn_ref_positions)
+    let entries: &[(&str, usize, &[usize])] = &[
+        // Conversion
+        ("str", 1, &[]),
+        ("num", 1, &[]),
+        // Math (unary)
+        ("abs", 1, &[]),
+        ("flr", 1, &[]),
+        ("cel", 1, &[]),
+        ("rou", 1, &[]),
+        ("sqrt", 1, &[]),
+        ("log", 1, &[]),
+        ("exp", 1, &[]),
+        ("sin", 1, &[]),
+        ("cos", 1, &[]),
+        // Math (binary)
+        ("min", 2, &[]),
+        ("max", 2, &[]),
+        ("mod", 2, &[]),
+        ("pow", 2, &[]),
+        // Aggregates
+        ("sum", 1, &[]),
+        ("avg", 1, &[]),
+        // Collections (unary)
+        ("len", 1, &[]),
+        ("hd", 1, &[]),
+        ("tl", 1, &[]),
+        ("rev", 1, &[]),
+        ("unq", 1, &[]),
+        ("flat", 1, &[]),
+        // Collections (binary)
+        ("at", 2, &[]),
+        ("has", 2, &[]),
+        ("spl", 2, &[]),
+        ("cat", 2, &[]),
+        // Collections (ternary)
+        ("slc", 3, &[]),
+        // Sort: 2-arg form (cmp, list) with fn-ref slot 0; 1-arg form
+        // (list) still parses because the loop stops when no operand
+        // follows. The 0th slot is a fn-ref position so `srt xs` keeps
+        // `xs` as a bare ref and doesn't try to expand it.
+        ("srt", 2, &[0]),
+        // Higher-order
+        ("map", 2, &[0]),
+        ("flt", 2, &[0]),
+        ("fld", 3, &[0]),
+        ("grp", 2, &[0]),
+        // I/O
+        ("prnt", 1, &[]),
+        ("wr", 2, &[]),
+        ("wrl", 2, &[]),
+        ("trm", 1, &[]),
+        // fmt is variadic (template + N args) — leave to greedy parsing
+        // JSON
+        ("jdmp", 1, &[]),
+        ("jpar", 1, &[]),
+        ("jpth", 2, &[]),
+        // Regex
+        ("rgx", 2, &[]),
+        // Map (associative)
+        ("mget", 2, &[]),
+        ("mset", 3, &[]),
+        ("mhas", 2, &[]),
+        ("mkeys", 1, &[]),
+        ("mvals", 1, &[]),
+        ("mdel", 2, &[]),
+        // Note: omitted by design — these have overloads or zero-arg forms
+        // best left to the existing greedy/zero-arg paths:
+        //   rnd, now, mmap (0-arg, special-cased above)
+        //   get, post, rd, rdb, rdl, env (variable arity / IO)
+        //   $ / get (path access via dollar prefix)
+    ];
+    let mut arity = HashMap::new();
+    let mut fn_flags = HashMap::new();
+    for (name, n, hof_slots) in entries {
+        arity.insert((*name).to_string(), *n);
+        let mut flags = vec![false; *n];
+        for &slot in *hof_slots {
+            if slot < flags.len() {
+                flags[slot] = true;
+            }
+        }
+        fn_flags.insert((*name).to_string(), flags);
+    }
+    // Mirror entries under their long-form aliases (e.g. `filter` → `flt`)
+    // so agents writing `filter pos xs` still get the HOF first-arg
+    // protection and arity-aware expansion.
+    for (long, short) in crate::ast::all_builtin_aliases() {
+        if let Some(n) = arity.get(short).copied() {
+            arity.insert(long.to_string(), n);
+        }
+        if let Some(flags) = fn_flags.get(short).cloned() {
+            fn_flags.insert(long.to_string(), flags);
+        }
+    }
+    (arity, fn_flags)
 }
 
 /// Extract the last expression from a body, falling back to Nil.

--- a/tests/regression_function_as_call_arg.rs
+++ b/tests/regression_function_as_call_arg.rs
@@ -1,0 +1,217 @@
+// Regression tests for function-as-call-arg composition.
+//
+// Background: when an agent writes `prnt str nc`, the parser previously
+// treated each token as a separate arg, parsing it as `prnt(str, nc)` —
+// 2 args to a 1-arg builtin — and erroring. Same for `hd tl xs`,
+// `prnt pct s 10`, `flr +*n 0.25`. Every program ended up doing
+// `sv=str nc;prnt sv` style 2-line bindings.
+//
+// The parser now keeps an arity table (builtins + user functions
+// registered as their headers are parsed). In arg position, if the next
+// Ident names a known function with arity N, we eagerly consume that
+// Ident plus N args as a nested call. HOF positions (map/flt/fld/grp
+// slot 0, srt slot 0) are excluded so bare-name function references
+// still work (`fld max xs 0`, `map dbl xs`, etc.).
+
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn write_src(tag: &str, src: &str) -> std::path::PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut path = std::env::temp_dir();
+    path.push(format!("ilo_fnarg_{tag}_{}_{n}.ilo", std::process::id()));
+    std::fs::write(&path, src).expect("write src");
+    path
+}
+
+fn run_ok(engine: &str, src: &str, entry: &str, args: &[&str]) -> String {
+    let path = write_src(entry, src);
+    let mut cmd = ilo();
+    cmd.arg(&path).arg(engine).arg(entry);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+// ── 1. prnt str nc — builtin inside 1-arg builtin ──────────────────────────
+const PRNT_STR_SRC: &str = "f nc:n>n;prnt str nc;nc";
+
+fn check_prnt_str(engine: &str) {
+    // `prnt str nc` should print "5" then return nc.
+    let out = run_ok(engine, PRNT_STR_SRC, "f", &["5"]);
+    // The printed line is "5"; the function also returns 5.
+    // Output is "5\n5" — we trimmed, so split on newline.
+    let lines: Vec<&str> = out.lines().collect();
+    assert_eq!(lines.first().copied(), Some("5"), "engine={engine}");
+}
+
+#[test]
+fn prnt_str_tree() {
+    check_prnt_str("--run-tree");
+}
+
+#[test]
+fn prnt_str_vm() {
+    check_prnt_str("--run-vm");
+}
+
+// ── 2. hd tl xs — two unary builtins composed ──────────────────────────────
+const HD_TL_SRC: &str = "f xs:L n>n;hd tl xs";
+
+fn check_hd_tl(engine: &str) {
+    // hd(tl([10,20,30])) = 20
+    assert_eq!(
+        run_ok(engine, HD_TL_SRC, "f", &["[10,20,30]"]),
+        "20",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn hd_tl_tree() {
+    check_hd_tl("--run-tree");
+}
+
+#[test]
+fn hd_tl_vm() {
+    check_hd_tl("--run-vm");
+}
+
+// ── 3. Mixing 3-arg outer with 2-arg inner ─────────────────────────────────
+// Define a 2-arg user `pct a b = a/b*100`, then call `prnt pct s 10`.
+// Outer prnt has arity 1 → it should eagerly consume `pct s 10` as a single
+// nested call. Result printed: 50.
+const PCT_SRC: &str = "pct a:n b:n>n;*/ a b 100\nf s:n>n;prnt pct s 10;s\n";
+
+fn check_pct(engine: &str) {
+    let out = run_ok(engine, PCT_SRC, "f", &["5"]);
+    let lines: Vec<&str> = out.lines().collect();
+    assert_eq!(lines.first().copied(), Some("50"), "engine={engine}");
+}
+
+#[test]
+fn pct_tree() {
+    check_pct("--run-tree");
+}
+
+#[test]
+fn pct_vm() {
+    check_pct("--run-vm");
+}
+
+// ── 4. Function-as-arg mixed with prefix-binop ─────────────────────────────
+// `flr +*n 0.25 0` → flr( (n*0.25) + 0 ).  Outer is flr (1-arg builtin).
+// Without the fix, the parser would treat each prefix-binop expression as a
+// separate arg. With the fix, flr stops after one arg (the prefix-binop
+// `+*n 0.25 0`), and the trailing... well there's no trailing here.
+// Simpler shape: `flr +*n 0.25`. But `+` requires 2 atoms — use `+*n 0.25 0`.
+const FLR_SRC: &str = "f n:n>n;flr +*n 0.25 0";
+
+fn check_flr(engine: &str) {
+    // n=10 → 10*0.25 = 2.5 → +0 = 2.5 → flr = 2
+    assert_eq!(
+        run_ok(engine, FLR_SRC, "f", &["10"]),
+        "2",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn flr_tree() {
+    check_flr("--run-tree");
+}
+
+#[test]
+fn flr_vm() {
+    check_flr("--run-vm");
+}
+
+// ── 5. PR #159 regression: prefix-binop in 3rd-arg position still works ────
+// `slc xs i +i 1` — outer slc has arity 3; the `+i 1` is a prefix-binop arg.
+const SLC_SRC: &str = "f>L n;ls=[10,20,30];i=0;slc ls i +i 1";
+
+fn check_slc(engine: &str) {
+    assert_eq!(run_ok(engine, SLC_SRC, "f", &[]), "[10]", "engine={engine}");
+}
+
+#[test]
+fn slc_prefix_arg_still_works_tree() {
+    check_slc("--run-tree");
+}
+
+#[test]
+fn slc_prefix_arg_still_works_vm() {
+    check_slc("--run-vm");
+}
+
+// ── 6. User function as inner call ─────────────────────────────────────────
+// `dbl x:n>n;*x 2` then `g>n;prnt dbl 5` → prints "10".
+const DBL_SRC: &str = "dbl x:n>n;*x 2\ng>n;prnt dbl 5;0\n";
+
+fn check_dbl(engine: &str) {
+    let out = run_ok(engine, DBL_SRC, "g", &[]);
+    let lines: Vec<&str> = out.lines().collect();
+    assert_eq!(lines.first().copied(), Some("10"), "engine={engine}");
+}
+
+#[test]
+fn user_fn_inner_tree() {
+    check_dbl("--run-tree");
+}
+
+#[test]
+fn user_fn_inner_vm() {
+    check_dbl("--run-vm");
+}
+
+// ── 7. HOF first-arg position stays a bare ref (PR #167 unchanged) ─────────
+// `fld max xs 0` — max is a 2-arg builtin, but it's in fld's fn-ref slot
+// so it must NOT eagerly consume `xs 0` as its args. xs must remain fld's
+// second arg.
+const FLD_MAX_SRC: &str = "f xs:L n>n;fld max xs 0";
+
+fn check_fld_max(engine: &str) {
+    assert_eq!(
+        run_ok(engine, FLD_MAX_SRC, "f", &["[3,1,4,1,5,9,2,6]"]),
+        "9",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn fld_max_hof_tree() {
+    check_fld_max("--run-tree");
+}
+// VM/Cranelift don't yet support bare-builtin HOF dispatch
+// (see tests/regression_builtins_as_hof.rs), so only tree is exercised here.
+
+// ── 8. Long-form alias keeps HOF semantics ─────────────────────────────────
+// `filter pos xs` — `filter` is an alias for `flt`; first arg is a fn-ref.
+const FILTER_SRC: &str = "pos x:n>b;>x 0\nmain xs:L n>L n;filter pos xs\n";
+
+fn check_filter(engine: &str) {
+    assert_eq!(
+        run_ok(engine, FILTER_SRC, "main", &["[-3,0,2,4]"]),
+        "[2, 4]",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn filter_alias_tree() {
+    check_filter("--run-tree");
+}
+// VM dispatch for bare user-fn HOF args isn't implemented yet — tree only.


### PR DESCRIPTION
Deferred follow-up from PR #159. Doc-cited `hd tl xs` doesn't chain; `prnt str nc` parses as `prnt(str, nc)` (2 args). Single-pass with forward references: builtin arities pre-registered, user fn arities registered as their headers parse. New `parse_call_arg(in_fn_ref_pos)` eagerly consumes nested calls when the inner is a known function with N args. Outer arity not clamped so over-arity verifier errors still surface. HOF args (`fld max xs 0`) preserved via fn-ref slot flag. 14 cross-engine tests + example.