### PR TITLE
tests: fix run_err to pass func arg in regression_param_fuzzy

### DIFF
--- a/tests/regression_param_fuzzy.rs
+++ b/tests/regression_param_fuzzy.rs
@@ -48,7 +48,12 @@ fn run_ok_all(src: &str, args: &[&str], expected: &str) {
 }
 
 fn run_err(src: &str) -> String {
-    let out = ilo().arg(src).output().expect("failed to spawn ilo");
+    // Pass `f` as the function arg so we hit the execution path; inline-no-func
+    // form is AST-dump mode (per PR #178) which skips verify errors.
+    let out = ilo()
+        .args([src, "f"])
+        .output()
+        .expect("failed to spawn ilo");
     assert!(
         !out.status.success(),
         "expected failure for {src:?}, stdout: {}",


### PR DESCRIPTION
PR #182 and #178 merged near-simultaneously and produced a test-contract conflict: param-fuzzy's `run_err` called `ilo '<src>'` with no function arg expecting verify errors, but #178 made inline-no-func mode the AST-dump path which skips verify errors. Main was broken on `calling_param_as_function_no_builtin_suggestion` and `genuinely_undefined_name_still_gets_suggestion`. Pass `f` as the function arg so verify errors fire on the execution path.