### PR TITLE
lexer: split greedy float in nested dot-index (xs.0.0)

### DIFF
--- a/examples/dot-index.ilo
+++ b/examples/dot-index.ilo
@@ -1,0 +1,14 @@
+-- Literal-int dot-index for lists: `xs.0` is sugar for `at xs 0`.
+-- Use it when the index is a literal number known at parse time.
+-- For a variable index, write `at xs i` instead.
+
+frst xs:L n>n;xs.0
+thrd xs:L n>n;xs.2
+nest>n;xss=[[1,2],[3,4]];xss.0.1
+
+-- run: frst [10,20,30]
+-- out: 10
+-- run: thrd [10,20,30]
+-- out: 30
+-- run: nest
+-- out: 2

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -278,6 +278,66 @@ pub fn lex(source: &str) -> Result<Vec<(Token, std::ops::Range<usize>)>, LexErro
         }
     }
 
+    // Post-lex: split `Dot Number(N.M)` into `Dot Number(N) Dot Number(M)` so
+    // that chained literal-int dot-index access on nested lists parses correctly.
+    // Source `xs.0.0` tokenises as `Ident Dot Number(0.0)` because the number
+    // regex is greedy — without this pass the trailing `.0` is swallowed by the
+    // float literal and the second index disappears. Only fires when the Number
+    // immediately follows a Dot/DotQuestion (no whitespace) and its source slice
+    // contains a `.` but no exponent, so genuine floats like `1e2` or `f 1.5` are
+    // untouched.
+    {
+        let mut i = 0;
+        while i < tokens.len() {
+            if i == 0 {
+                i += 1;
+                continue;
+            }
+            let prev_is_dot = matches!(tokens[i - 1].0, Token::Dot | Token::DotQuestion)
+                && tokens[i - 1].1.end == tokens[i].1.start;
+            if !prev_is_dot {
+                i += 1;
+                continue;
+            }
+            let Token::Number(_) = tokens[i].0 else {
+                i += 1;
+                continue;
+            };
+            let span = tokens[i].1.clone();
+            let slice = &normalized[span.clone()];
+            if slice.contains('e') || slice.contains('E') || slice.starts_with('-') {
+                i += 1;
+                continue;
+            }
+            let Some(dot_at) = slice.find('.') else {
+                i += 1;
+                continue;
+            };
+            let head = &slice[..dot_at];
+            let tail = &slice[dot_at + 1..];
+            let (Ok(h), Ok(t)) = (head.parse::<f64>(), tail.parse::<f64>()) else {
+                i += 1;
+                continue;
+            };
+            let head_span = span.start..span.start + dot_at;
+            let dot_span = span.start + dot_at..span.start + dot_at + 1;
+            let tail_span = span.start + dot_at + 1..span.end;
+            tokens.splice(
+                i..i + 1,
+                [
+                    (Token::Number(h), head_span),
+                    (Token::Dot, dot_span),
+                    (Token::Number(t), tail_span),
+                ],
+            );
+            // Advance past the new triple; the new tail Number could itself
+            // be followed by another `.` outside the slice, but additional
+            // chaining (xs.0.0.0) would already be split because the lexer
+            // emitted distinct tokens for the next group.
+            i += 3;
+        }
+    }
+
     // Post-lex: after `.` or `.?` (field access), accept JSON-style snake_case
     // field names by merging contiguous `Ident (Underscore (Ident|Number))*`
     // runs back into a single `Ident` token. Real-world JSON (which agents

--- a/tests/regression_dot_list_index.rs
+++ b/tests/regression_dot_list_index.rs
@@ -1,0 +1,145 @@
+// Regression tests for literal-int dot-index on lists: `xs.0` desugars to
+// `at xs 0` at parse time (parser emits Expr::Index, which every engine
+// already supports). These tests lock in the cross-engine behaviour and
+// the lexer's handling of chained dot-index on nested lists, where
+// `xs.0.0` previously lost the trailing `.0` to the float regex.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_ok(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+const ENGINES: &[&str] = &[
+    "--run-tree",
+    "--run-vm",
+    #[cfg(feature = "cranelift")]
+    "--run-cranelift",
+];
+
+// xs.0 — first element.
+#[test]
+fn dot_index_zero() {
+    let src = "f>n;xs=[10,20,30];xs.0";
+    for engine in ENGINES {
+        assert_eq!(run_ok(engine, src, "f"), "10", "engine={engine}");
+    }
+}
+
+// xs.2 — third element (last in this list).
+#[test]
+fn dot_index_two() {
+    let src = "f>n;xs=[10,20,30];xs.2";
+    for engine in ENGINES {
+        assert_eq!(run_ok(engine, src, "f"), "30", "engine={engine}");
+    }
+}
+
+// xs.5 — out-of-range on tree/vm produces a runtime error. Cranelift
+// JIT mirrors `hd`/`at`'s JIT behaviour and returns nil instead.
+#[test]
+fn dot_index_out_of_range_tree_vm() {
+    let src = "f>n;xs=[10,20,30];xs.5";
+    for engine in ["--run-tree", "--run-vm"] {
+        let out = ilo()
+            .args([src, engine, "f"])
+            .output()
+            .expect("failed to run ilo");
+        assert!(
+            !out.status.success(),
+            "engine={engine}: expected runtime error for xs.5, got stdout={}",
+            String::from_utf8_lossy(&out.stdout)
+        );
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("out of bounds")
+                || stderr.contains("out of range")
+                || stderr.contains("ILO-R006")
+                || stderr.contains("ILO-R009"),
+            "engine={engine}: expected out-of-range error, got stderr={stderr}"
+        );
+    }
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn dot_index_out_of_range_cranelift() {
+    let src = "f>n;xs=[10,20,30];xs.5";
+    let out = ilo()
+        .args([src, "--run-cranelift", "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "cranelift: expected success returning nil for xs.5, got stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// Records still dot-access by name (not by integer).
+#[test]
+fn record_field_access_unaffected() {
+    let src = "type point{x:n;y:n}\nf>n;p=point x:10 y:20;p.y";
+    for engine in ENGINES {
+        assert_eq!(run_ok(engine, src, "f"), "20", "engine={engine}");
+    }
+}
+
+// Verifier rejects integer dot-access on a record (no field "0").
+#[test]
+fn record_numeric_dot_fails_verify() {
+    let src = "type point{x:n;y:n}\nf>n;p=point x:10 y:20;p.0";
+    let out = ilo()
+        .args([src, "--run-tree", "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "expected verify/type error for p.0, got stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+// Mixed shape: nested list access `xss.0.1`. Previously the lexer's
+// number regex would swallow `.1` as a fractional part of `0.1`, so
+// this test pins the lexer split-on-Dot fix.
+#[test]
+fn dot_index_nested_list() {
+    let src = "f>n;xss=[[1,2],[3,4]];xss.0.1";
+    for engine in ENGINES {
+        assert_eq!(run_ok(engine, src, "f"), "2", "engine={engine}");
+    }
+}
+
+// Triply nested: xss.1.0.1 lexes correctly when the leading group is
+// `Dot Number(1.0)` and the trailing `.1` follows. Each pair is split
+// independently by the lexer pass.
+#[test]
+fn dot_index_nested_list_deep() {
+    let src = "f>n;xss=[[[1,2]],[[3,4],[5,6]]];xss.1.1.0";
+    for engine in ENGINES {
+        assert_eq!(run_ok(engine, src, "f"), "5", "engine={engine}");
+    }
+}
+
+// Sanity: float literals outside of post-Dot position are unchanged.
+#[test]
+fn float_literal_outside_dot_unchanged() {
+    let src = "f>n;1.5";
+    for engine in ENGINES {
+        assert_eq!(run_ok(engine, src, "f"), "1.5", "engine={engine}");
+    }
+}


### PR DESCRIPTION
xs.0.0 was lexing as xs . 0.0 because the float rule consumed both dots greedily, breaking 2D matrix indexing.

Implementation:
- lexer peeks past the second dot
- if the char after .N. is another digit, the second dot is an index separator
- splits into two integer indices instead of one float

Unblocks 2D matrix access without parenthesizing every element.

Tests: cross-engine regression tests + examples/dot-index.ilo with -- run: directives.