### PR TITLE
builtins: add transpose matmul dot for matrix work

### DIFF
--- a/examples/linalg-basic.ilo
+++ b/examples/linalg-basic.ilo
@@ -1,0 +1,19 @@
+-- Basic linalg builtins: transpose, matmul, dot.
+-- Hand-rolling these in ilo risks silent precision loss (manifesto class:
+-- same as expx Taylor), so they ship as host-vetted builtins.
+
+-- Transpose a fixed 2×3 matrix into a 3×2 matrix.
+trn>L (L n);transpose [[1,2,3],[4,5,6]]
+
+-- Matrix product of two 2×2 matrices.
+mm>L (L n);matmul [[1,2],[3,4]] [[5,6],[7,8]]
+
+-- Vector dot product: 1*4 + 2*5 + 3*6 = 32.
+dp>n;dot [1,2,3] [4,5,6]
+
+-- run: trn
+-- out: [[1, 4], [2, 5], [3, 6]]
+-- run: mm
+-- out: [[19, 22], [43, 50]]
+-- run: dp
+-- out: 32

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -39,6 +39,11 @@ pub enum Builtin {
     Fft,
     Ifft,
 
+    // Linear algebra
+    Transpose,
+    Matmul,
+    Dot,
+
     // Collections
     Len,
     Hd,
@@ -150,6 +155,9 @@ impl Builtin {
             "variance" => Some(Builtin::Variance),
             "fft" => Some(Builtin::Fft),
             "ifft" => Some(Builtin::Ifft),
+            "transpose" => Some(Builtin::Transpose),
+            "matmul" => Some(Builtin::Matmul),
+            "dot" => Some(Builtin::Dot),
             "len" => Some(Builtin::Len),
             "hd" => Some(Builtin::Hd),
             "at" => Some(Builtin::At),
@@ -247,6 +255,9 @@ impl Builtin {
             Builtin::Variance => "variance",
             Builtin::Fft => "fft",
             Builtin::Ifft => "ifft",
+            Builtin::Transpose => "transpose",
+            Builtin::Matmul => "matmul",
+            Builtin::Dot => "dot",
             Builtin::Len => "len",
             Builtin::Hd => "hd",
             Builtin::At => "at",
@@ -412,6 +423,9 @@ mod tests {
             "ifft",
             "window",
             "chunks",
+            "transpose",
+            "matmul",
+            "dot",
         ];
         for name in &all {
             let b = Builtin::from_name(name).unwrap_or_else(|| panic!("missing builtin: {name}"));

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -2178,6 +2178,231 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             .collect();
         return Ok(Value::Map(map));
     }
+    if builtin == Some(Builtin::Transpose) && args.len() == 1 {
+        let rows = match &args[0] {
+            Value::List(l) => l,
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!("transpose: arg must be a list of lists, got {:?}", other),
+                ));
+            }
+        };
+        if rows.is_empty() {
+            return Ok(Value::List(vec![]));
+        }
+        let mut row_data: Vec<&Vec<Value>> = Vec::with_capacity(rows.len());
+        let mut ncols: Option<usize> = None;
+        for row in rows {
+            match row {
+                Value::List(r) => {
+                    match ncols {
+                        None => ncols = Some(r.len()),
+                        Some(n) if n != r.len() => {
+                            return Err(RuntimeError::new(
+                                "ILO-R009",
+                                format!(
+                                    "transpose: ragged rows (expected {n} cols, got {})",
+                                    r.len()
+                                ),
+                            ));
+                        }
+                        _ => {}
+                    }
+                    row_data.push(r);
+                }
+                other => {
+                    return Err(RuntimeError::new(
+                        "ILO-R009",
+                        format!("transpose: rows must be lists, got {:?}", other),
+                    ));
+                }
+            }
+        }
+        let ncols = ncols.unwrap_or(0);
+        let mut result: Vec<Value> = Vec::with_capacity(ncols);
+        for j in 0..ncols {
+            let mut col: Vec<Value> = Vec::with_capacity(row_data.len());
+            for r in &row_data {
+                col.push(r[j].clone());
+            }
+            result.push(Value::List(col));
+        }
+        return Ok(Value::List(result));
+    }
+    if builtin == Some(Builtin::Matmul) && args.len() == 2 {
+        let a_rows = match &args[0] {
+            Value::List(l) => l,
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!("matmul: first arg must be a list of lists, got {:?}", other),
+                ));
+            }
+        };
+        let b_rows = match &args[1] {
+            Value::List(l) => l,
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!(
+                        "matmul: second arg must be a list of lists, got {:?}",
+                        other
+                    ),
+                ));
+            }
+        };
+        // Extract a as Vec<Vec<f64>>
+        let mut a: Vec<Vec<f64>> = Vec::with_capacity(a_rows.len());
+        let mut a_cols: Option<usize> = None;
+        for row in a_rows {
+            match row {
+                Value::List(r) => {
+                    match a_cols {
+                        None => a_cols = Some(r.len()),
+                        Some(n) if n != r.len() => {
+                            return Err(RuntimeError::new(
+                                "ILO-R009",
+                                format!(
+                                    "matmul: ragged rows in first arg (expected {n} cols, got {})",
+                                    r.len()
+                                ),
+                            ));
+                        }
+                        _ => {}
+                    }
+                    let mut nums = Vec::with_capacity(r.len());
+                    for v in r {
+                        match v {
+                            Value::Number(n) => nums.push(*n),
+                            other => {
+                                return Err(RuntimeError::new(
+                                    "ILO-R009",
+                                    format!("matmul: elements must be numbers, got {:?}", other),
+                                ));
+                            }
+                        }
+                    }
+                    a.push(nums);
+                }
+                other => {
+                    return Err(RuntimeError::new(
+                        "ILO-R009",
+                        format!("matmul: rows must be lists, got {:?}", other),
+                    ));
+                }
+            }
+        }
+        let mut b: Vec<Vec<f64>> = Vec::with_capacity(b_rows.len());
+        let mut b_cols: Option<usize> = None;
+        for row in b_rows {
+            match row {
+                Value::List(r) => {
+                    match b_cols {
+                        None => b_cols = Some(r.len()),
+                        Some(n) if n != r.len() => {
+                            return Err(RuntimeError::new(
+                                "ILO-R009",
+                                format!(
+                                    "matmul: ragged rows in second arg (expected {n} cols, got {})",
+                                    r.len()
+                                ),
+                            ));
+                        }
+                        _ => {}
+                    }
+                    let mut nums = Vec::with_capacity(r.len());
+                    for v in r {
+                        match v {
+                            Value::Number(n) => nums.push(*n),
+                            other => {
+                                return Err(RuntimeError::new(
+                                    "ILO-R009",
+                                    format!("matmul: elements must be numbers, got {:?}", other),
+                                ));
+                            }
+                        }
+                    }
+                    b.push(nums);
+                }
+                other => {
+                    return Err(RuntimeError::new(
+                        "ILO-R009",
+                        format!("matmul: rows must be lists, got {:?}", other),
+                    ));
+                }
+            }
+        }
+        let a_rows_n = a.len();
+        let a_cols_n = a_cols.unwrap_or(0);
+        let b_rows_n = b.len();
+        let b_cols_n = b_cols.unwrap_or(0);
+        if a_cols_n != b_rows_n {
+            return Err(RuntimeError::new(
+                "ILO-R009",
+                format!(
+                    "matmul: shape mismatch (a is {a_rows_n}x{a_cols_n}, b is {b_rows_n}x{b_cols_n})"
+                ),
+            ));
+        }
+        let mut out: Vec<Value> = Vec::with_capacity(a_rows_n);
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..a_rows_n {
+            let mut row: Vec<Value> = Vec::with_capacity(b_cols_n);
+            for j in 0..b_cols_n {
+                let mut s = 0.0_f64;
+                for k in 0..a_cols_n {
+                    s += a[i][k] * b[k][j];
+                }
+                row.push(Value::Number(s));
+            }
+            out.push(Value::List(row));
+        }
+        return Ok(Value::List(out));
+    }
+    if builtin == Some(Builtin::Dot) && args.len() == 2 {
+        let xs = match &args[0] {
+            Value::List(l) => l,
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!("dot: first arg must be a list, got {:?}", other),
+                ));
+            }
+        };
+        let ys = match &args[1] {
+            Value::List(l) => l,
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!("dot: second arg must be a list, got {:?}", other),
+                ));
+            }
+        };
+        if xs.len() != ys.len() {
+            return Err(RuntimeError::new(
+                "ILO-R009",
+                format!(
+                    "dot: length mismatch (xs has {}, ys has {})",
+                    xs.len(),
+                    ys.len()
+                ),
+            ));
+        }
+        let mut total = 0.0_f64;
+        for (x, y) in xs.iter().zip(ys.iter()) {
+            match (x, y) {
+                (Value::Number(a), Value::Number(b)) => total += a * b,
+                _ => {
+                    return Err(RuntimeError::new(
+                        "ILO-R009",
+                        "dot: list elements must be numbers".to_string(),
+                    ));
+                }
+            }
+        }
+        return Ok(Value::Number(total));
+    }
     if builtin == Some(Builtin::Sum) && args.len() == 1 {
         let items = match &args[0] {
             Value::List(l) => l,

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -333,6 +333,9 @@ const BUILTINS: &[(&str, &[&str], &str)] = &[
     ("variance", &["list"], "n"),
     ("fft", &["list"], "list"),
     ("ifft", &["list"], "list"),
+    ("transpose", &["L (L n)"], "L (L n)"),
+    ("matmul", &["L (L n)", "L (L n)"], "L (L n)"),
+    ("dot", &["L n", "L n"], "n"),
     ("rgx", &["t", "t"], "L t"),
     ("rgxsub", &["t", "t", "t"], "t"),
     // Map builtins (M k v type)
@@ -1708,6 +1711,73 @@ fn builtin_check_args(
                 _ => Ty::Map(Box::new(Ty::Unknown), Box::new(Ty::Unknown)),
             };
             (map_ty, errors)
+        }
+        "transpose" => {
+            // transpose m:L (L n) → L (L n)
+            if let Some(arg) = arg_types.first() {
+                let ok = match arg {
+                    Ty::List(inner) => matches!(inner.as_ref(), Ty::List(_) | Ty::Unknown),
+                    Ty::Unknown => true,
+                    _ => false,
+                };
+                if !ok {
+                    errors.push(VerifyError {
+                        code: "ILO-T013",
+                        function: func_ctx.to_string(),
+                        message: format!("'transpose' expects L (L n), got {arg}"),
+                        hint: None,
+                        span,
+                        is_warning: false,
+                    });
+                }
+            }
+            let ret = match arg_types.first() {
+                Some(ty @ Ty::List(inner)) if matches!(inner.as_ref(), Ty::List(_)) => ty.clone(),
+                _ => Ty::List(Box::new(Ty::List(Box::new(Ty::Number)))),
+            };
+            (ret, errors)
+        }
+        "matmul" => {
+            // matmul a:L (L n) b:L (L n) → L (L n)
+            for (i, arg) in arg_types.iter().enumerate() {
+                let ok = match arg {
+                    Ty::List(inner) => matches!(inner.as_ref(), Ty::List(_) | Ty::Unknown),
+                    Ty::Unknown => true,
+                    _ => false,
+                };
+                if !ok {
+                    errors.push(VerifyError {
+                        code: "ILO-T013",
+                        function: func_ctx.to_string(),
+                        message: format!("'matmul' arg {} must be L (L n), got {arg}", i + 1),
+                        hint: None,
+                        span,
+                        is_warning: false,
+                    });
+                }
+            }
+            (Ty::List(Box::new(Ty::List(Box::new(Ty::Number)))), errors)
+        }
+        "dot" => {
+            // dot xs:L n ys:L n → n
+            for (i, arg) in arg_types.iter().enumerate() {
+                let ok = match arg {
+                    Ty::List(inner) => compatible(inner, &Ty::Number),
+                    Ty::Unknown => true,
+                    _ => false,
+                };
+                if !ok {
+                    errors.push(VerifyError {
+                        code: "ILO-T013",
+                        function: func_ctx.to_string(),
+                        message: format!("'dot' arg {} must be L n, got {arg}", i + 1),
+                        hint: None,
+                        span,
+                        is_warning: false,
+                    });
+                }
+            }
+            (Ty::Number, errors)
         }
         _ => (Ty::Unknown, errors),
     }

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -64,6 +64,9 @@ struct HelperFuncs {
     log10: FuncId,
     log2: FuncId,
     atan2: FuncId,
+    transpose: FuncId,
+    matmul: FuncId,
+    dot: FuncId,
     rnd0: FuncId,
     rnd2: FuncId,
     now: FuncId,
@@ -213,6 +216,9 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         log10: declare_helper(module, "jit_log10", 1, 1),
         log2: declare_helper(module, "jit_log2", 1, 1),
         atan2: declare_helper(module, "jit_atan2", 2, 1),
+        transpose: declare_helper(module, "jit_transpose", 1, 1),
+        matmul: declare_helper(module, "jit_matmul", 2, 1),
+        dot: declare_helper(module, "jit_dot", 2, 1),
         rnd0: declare_helper(module, "jit_rnd0", 0, 1),
         rnd2: declare_helper(module, "jit_rnd2", 2, 1),
         now: declare_helper(module, "jit_now", 0, 1),
@@ -946,7 +952,7 @@ fn compile_function_body(
                 | OP_MULK_N | OP_DIVK_N | OP_LEN | OP_ABS | OP_MIN | OP_MAX | OP_FLR | OP_CEL
                 | OP_ROU | OP_RND0 | OP_RND2 | OP_NOW | OP_MOD | OP_CLAMP | OP_POW | OP_SQRT
                 | OP_LOG | OP_EXP | OP_SIN | OP_COS | OP_TAN | OP_LOG10 | OP_LOG2 | OP_ATAN2
-                | OP_MEDIAN | OP_QUANTILE | OP_STDEV | OP_VARIANCE => {
+                | OP_MEDIAN | OP_QUANTILE | OP_STDEV | OP_VARIANCE | OP_DOT => {
                     num_write[a] = true;
                 }
                 // LOADK: numeric only when the constant itself is a number.
@@ -976,7 +982,8 @@ fn compile_function_body(
                 | OP_RECWITH | OP_PRT | OP_RD | OP_RDL | OP_WR | OP_WRL | OP_TRM | OP_UPR
                 | OP_LWR | OP_CAP | OP_UNQ | OP_UNIQBY | OP_PARTITION | OP_FRQ | OP_NUM
                 | OP_RGXSUB | OP_ZIP | OP_ENUMERATE | OP_RANGE | OP_WINDOW | OP_CHUNKS
-                | OP_CUMSUM | OP_SETUNION | OP_SETINTER | OP_SETDIFF | OP_FFT | OP_IFFT => {
+                | OP_CUMSUM | OP_SETUNION | OP_SETINTER | OP_SETDIFF | OP_FFT | OP_IFFT
+                | OP_TRANSPOSE | OP_MATMUL => {
                     non_num_write[a] = true;
                     non_bool_write[a] = true;
                 }
@@ -1854,6 +1861,33 @@ fn compile_function_body(
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
                 let fref = get_func_ref(&mut builder, module, helpers.atan2);
+                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+                if a_idx < reg_count && reg_always_num[a_idx] {
+                    let rf = builder.ins().bitcast(F64, mf, result);
+                    builder.def_var(f64_vars[a_idx], rf);
+                }
+            }
+            OP_TRANSPOSE => {
+                let bv = builder.use_var(vars[b_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.transpose);
+                let call_inst = builder.ins().call(fref, &[bv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_MATMUL => {
+                let bv = builder.use_var(vars[b_idx]);
+                let cv = builder.use_var(vars[c_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.matmul);
+                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_DOT => {
+                let bv = builder.use_var(vars[b_idx]);
+                let cv = builder.use_var(vars[c_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.dot);
                 let call_inst = builder.ins().call(fref, &[bv, cv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -70,6 +70,9 @@ struct HelperFuncs {
     log10: FuncId,
     log2: FuncId,
     atan2: FuncId,
+    transpose: FuncId,
+    matmul: FuncId,
+    dot: FuncId,
     rnd0: FuncId,
     rnd2: FuncId,
     now: FuncId,
@@ -209,6 +212,9 @@ fn register_helpers(builder: &mut JITBuilder) {
         ("jit_log10", jit_log10 as *const u8),
         ("jit_log2", jit_log2 as *const u8),
         ("jit_atan2", jit_atan2 as *const u8),
+        ("jit_transpose", jit_transpose as *const u8),
+        ("jit_matmul", jit_matmul as *const u8),
+        ("jit_dot", jit_dot as *const u8),
         ("jit_rnd0", jit_rnd0 as *const u8),
         ("jit_rnd2", jit_rnd2 as *const u8),
         ("jit_now", jit_now as *const u8),
@@ -339,6 +345,9 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         log10: declare_helper(module, "jit_log10", 1, 1),
         log2: declare_helper(module, "jit_log2", 1, 1),
         atan2: declare_helper(module, "jit_atan2", 2, 1),
+        transpose: declare_helper(module, "jit_transpose", 1, 1),
+        matmul: declare_helper(module, "jit_matmul", 2, 1),
+        dot: declare_helper(module, "jit_dot", 2, 1),
         rnd0: declare_helper(module, "jit_rnd0", 0, 1),
         rnd2: declare_helper(module, "jit_rnd2", 2, 1),
         now: declare_helper(module, "jit_now", 0, 1),
@@ -949,7 +958,7 @@ fn compile_function_body(
                 | OP_FLR | OP_CEL | OP_ROU | OP_RND0 | OP_RND2 | OP_NOW
                 | OP_MOD | OP_CLAMP | OP_POW | OP_SQRT | OP_LOG | OP_EXP | OP_SIN | OP_COS
                 | OP_TAN | OP_LOG10 | OP_LOG2 | OP_ATAN2
-                | OP_MEDIAN | OP_QUANTILE | OP_STDEV | OP_VARIANCE => {
+                | OP_MEDIAN | OP_QUANTILE | OP_STDEV | OP_VARIANCE | OP_DOT => {
                     num_write[a] = true;
                 }
                 // LOADK: numeric only when the constant itself is a number.
@@ -988,7 +997,8 @@ fn compile_function_body(
                 | OP_LISTNEW | OP_LISTAPPEND
                 | OP_RECNEW | OP_RECWITH
                 | OP_PRT | OP_RD | OP_RDL | OP_WR | OP_WRL | OP_TRM | OP_UPR | OP_LWR | OP_CAP
-                | OP_UNQ | OP_UNIQBY | OP_PARTITION | OP_FRQ | OP_NUM | OP_RGXSUB => {
+                | OP_UNQ | OP_UNIQBY | OP_PARTITION | OP_FRQ | OP_NUM | OP_RGXSUB
+                | OP_TRANSPOSE | OP_MATMUL => {
                     non_num_write[a] = true;
                     non_bool_write[a] = true;
                 }
@@ -1923,6 +1933,34 @@ fn compile_function_body(
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
                 let fref = get_func_ref(&mut builder, module, helpers.atan2);
+                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+                if a_idx < reg_count && reg_always_num[a_idx] {
+                    let mf = cranelift_codegen::ir::MemFlags::new();
+                    let rf = builder.ins().bitcast(F64, mf, result);
+                    builder.def_var(f64_vars[a_idx], rf);
+                }
+            }
+            OP_TRANSPOSE => {
+                let bv = builder.use_var(vars[b_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.transpose);
+                let call_inst = builder.ins().call(fref, &[bv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_MATMUL => {
+                let bv = builder.use_var(vars[b_idx]);
+                let cv = builder.use_var(vars[c_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.matmul);
+                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_DOT => {
+                let bv = builder.use_var(vars[b_idx]);
+                let cv = builder.use_var(vars[c_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.dot);
                 let call_inst = builder.ins().call(fref, &[bv, cv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -239,6 +239,11 @@ pub(crate) const OP_SETUNION: u8 = 150; // R[A] = setunion(R[B], R[C])
 pub(crate) const OP_SETINTER: u8 = 151; // R[A] = setinter(R[B], R[C])
 pub(crate) const OP_SETDIFF: u8 = 152; // R[A] = setdiff(R[B], R[C])
 
+// Linear algebra basics.
+pub(crate) const OP_TRANSPOSE: u8 = 123; // R[A] = transpose(R[B])  (L (L n) -> L (L n))
+pub(crate) const OP_MATMUL: u8 = 124; // R[A] = matmul(R[B], R[C])
+pub(crate) const OP_DOT: u8 = 125; // R[A] = dot(R[B], R[C])  (vector dot product -> n)
+
 // ABx mode — register + 16-bit operand
 pub(crate) const OP_LOADK: u8 = 20;
 pub(crate) const OP_JMP: u8 = 21;
@@ -1700,6 +1705,27 @@ impl RegCompiler {
                             self.reg_is_num[ra as usize] = true;
                             return ra;
                         }
+                        (Builtin::Transpose, 1) => {
+                            let rb = self.compile_expr(&args[0]);
+                            let ra = self.alloc_reg();
+                            self.emit_abc(OP_TRANSPOSE, ra, rb, 0);
+                            return ra;
+                        }
+                        (Builtin::Matmul, 2) => {
+                            let rb = self.compile_expr(&args[0]);
+                            let rc = self.compile_expr(&args[1]);
+                            let ra = self.alloc_reg();
+                            self.emit_abc(OP_MATMUL, ra, rb, rc);
+                            return ra;
+                        }
+                        (Builtin::Dot, 2) => {
+                            let rb = self.compile_expr(&args[0]);
+                            let rc = self.compile_expr(&args[1]);
+                            let ra = self.alloc_reg();
+                            self.emit_abc(OP_DOT, ra, rb, rc);
+                            self.reg_is_num[ra as usize] = true;
+                            return ra;
+                        }
                         (Builtin::Spl, 2) => {
                             let rb = self.compile_expr(&args[0]);
                             let rc = self.compile_expr(&args[1]);
@@ -2704,7 +2730,7 @@ fn chunk_is_all_numeric(chunk: &Chunk) -> bool {
             | OP_MAPNEW | OP_MGET | OP_MSET | OP_MKEYS | OP_MVALS | OP_HD | OP_AT | OP_LST
             | OP_TL | OP_FMT2 | OP_RGXSUB | OP_ZIP | OP_ENUMERATE | OP_WINDOW | OP_FFT
             | OP_IFFT | OP_RANGE | OP_CHUNKS | OP_CUMSUM | OP_SETUNION | OP_SETINTER
-            | OP_SETDIFF => {
+            | OP_SETDIFF | OP_TRANSPOSE | OP_MATMUL => {
                 return false;
             }
             _ => {}
@@ -5402,6 +5428,183 @@ impl<'a> VM<'a> {
                     };
                     reg_set!(a, NanVal::number(result));
                 }
+                OP_TRANSPOSE => {
+                    let a = ((inst >> 16) & 0xFF) as usize + base;
+                    let b = ((inst >> 8) & 0xFF) as usize + base;
+                    let v = reg!(b);
+                    if !v.is_heap() {
+                        vm_err!(VmError::Type("transpose requires a list of lists"));
+                    }
+                    let rows = match unsafe { v.as_heap_ref() } {
+                        HeapObj::List(items) => items,
+                        _ => vm_err!(VmError::Type("transpose requires a list of lists")),
+                    };
+                    if rows.is_empty() {
+                        reg_set!(a, NanVal::heap_list(vec![]));
+                    } else {
+                        let mut row_refs: Vec<&Vec<NanVal>> = Vec::with_capacity(rows.len());
+                        let mut ncols: Option<usize> = None;
+                        let mut shape_err = false;
+                        for row in rows {
+                            if !row.is_heap() {
+                                shape_err = true;
+                                break;
+                            }
+                            let r = match unsafe { row.as_heap_ref() } {
+                                HeapObj::List(items) => items,
+                                _ => {
+                                    shape_err = true;
+                                    break;
+                                }
+                            };
+                            match ncols {
+                                None => ncols = Some(r.len()),
+                                Some(n) if n != r.len() => {
+                                    shape_err = true;
+                                    break;
+                                }
+                                _ => {}
+                            }
+                            row_refs.push(r);
+                        }
+                        if shape_err {
+                            vm_err!(VmError::Type("transpose: ragged rows"));
+                        }
+                        let ncols = ncols.unwrap_or(0);
+                        let mut result: Vec<NanVal> = Vec::with_capacity(ncols);
+                        for j in 0..ncols {
+                            let mut col: Vec<NanVal> = Vec::with_capacity(row_refs.len());
+                            for r in &row_refs {
+                                let v = r[j];
+                                v.clone_rc();
+                                col.push(v);
+                            }
+                            result.push(NanVal::heap_list(col));
+                        }
+                        reg_set!(a, NanVal::heap_list(result));
+                    }
+                }
+                OP_MATMUL => {
+                    let a = ((inst >> 16) & 0xFF) as usize + base;
+                    let b = ((inst >> 8) & 0xFF) as usize + base;
+                    let c = (inst & 0xFF) as usize + base;
+                    let va = reg!(b);
+                    let vb = reg!(c);
+                    if !va.is_heap() || !vb.is_heap() {
+                        vm_err!(VmError::Type("matmul requires lists of lists"));
+                    }
+                    let a_rows_v = match unsafe { va.as_heap_ref() } {
+                        HeapObj::List(items) => items,
+                        _ => vm_err!(VmError::Type("matmul requires lists of lists")),
+                    };
+                    let b_rows_v = match unsafe { vb.as_heap_ref() } {
+                        HeapObj::List(items) => items,
+                        _ => vm_err!(VmError::Type("matmul requires lists of lists")),
+                    };
+                    // Extract a as Vec<Vec<f64>>
+                    let mut a_mat: Vec<Vec<f64>> = Vec::with_capacity(a_rows_v.len());
+                    let mut a_cols: Option<usize> = None;
+                    for row in a_rows_v {
+                        if !row.is_heap() {
+                            vm_err!(VmError::Type("matmul: rows must be lists"));
+                        }
+                        let r = match unsafe { row.as_heap_ref() } {
+                            HeapObj::List(items) => items,
+                            _ => vm_err!(VmError::Type("matmul: rows must be lists")),
+                        };
+                        match a_cols {
+                            None => a_cols = Some(r.len()),
+                            Some(n) if n != r.len() => {
+                                vm_err!(VmError::Type("matmul: ragged rows in first arg"));
+                            }
+                            _ => {}
+                        }
+                        let mut nums = Vec::with_capacity(r.len());
+                        for v in r {
+                            if !v.is_number() {
+                                vm_err!(VmError::Type("matmul: elements must be numbers"));
+                            }
+                            nums.push(v.as_number());
+                        }
+                        a_mat.push(nums);
+                    }
+                    let mut b_mat: Vec<Vec<f64>> = Vec::with_capacity(b_rows_v.len());
+                    let mut b_cols: Option<usize> = None;
+                    for row in b_rows_v {
+                        if !row.is_heap() {
+                            vm_err!(VmError::Type("matmul: rows must be lists"));
+                        }
+                        let r = match unsafe { row.as_heap_ref() } {
+                            HeapObj::List(items) => items,
+                            _ => vm_err!(VmError::Type("matmul: rows must be lists")),
+                        };
+                        match b_cols {
+                            None => b_cols = Some(r.len()),
+                            Some(n) if n != r.len() => {
+                                vm_err!(VmError::Type("matmul: ragged rows in second arg"));
+                            }
+                            _ => {}
+                        }
+                        let mut nums = Vec::with_capacity(r.len());
+                        for v in r {
+                            if !v.is_number() {
+                                vm_err!(VmError::Type("matmul: elements must be numbers"));
+                            }
+                            nums.push(v.as_number());
+                        }
+                        b_mat.push(nums);
+                    }
+                    let a_rows_n = a_mat.len();
+                    let a_cols_n = a_cols.unwrap_or(0);
+                    let b_rows_n = b_mat.len();
+                    let b_cols_n = b_cols.unwrap_or(0);
+                    if a_cols_n != b_rows_n {
+                        vm_err!(VmError::Type("matmul: shape mismatch"));
+                    }
+                    let mut out: Vec<NanVal> = Vec::with_capacity(a_rows_n);
+                    #[allow(clippy::needless_range_loop)]
+                    for i in 0..a_rows_n {
+                        let mut row: Vec<NanVal> = Vec::with_capacity(b_cols_n);
+                        for j in 0..b_cols_n {
+                            let mut s = 0.0_f64;
+                            for k in 0..a_cols_n {
+                                s += a_mat[i][k] * b_mat[k][j];
+                            }
+                            row.push(NanVal::number(s));
+                        }
+                        out.push(NanVal::heap_list(row));
+                    }
+                    reg_set!(a, NanVal::heap_list(out));
+                }
+                OP_DOT => {
+                    let a = ((inst >> 16) & 0xFF) as usize + base;
+                    let b = ((inst >> 8) & 0xFF) as usize + base;
+                    let c = (inst & 0xFF) as usize + base;
+                    let va = reg!(b);
+                    let vb = reg!(c);
+                    if !va.is_heap() || !vb.is_heap() {
+                        vm_err!(VmError::Type("dot requires two lists"));
+                    }
+                    let xs = match unsafe { va.as_heap_ref() } {
+                        HeapObj::List(items) => items,
+                        _ => vm_err!(VmError::Type("dot requires two lists")),
+                    };
+                    let ys = match unsafe { vb.as_heap_ref() } {
+                        HeapObj::List(items) => items,
+                        _ => vm_err!(VmError::Type("dot requires two lists")),
+                    };
+                    if xs.len() != ys.len() {
+                        vm_err!(VmError::Type("dot: length mismatch"));
+                    }
+                    let mut total = 0.0_f64;
+                    for (x, y) in xs.iter().zip(ys.iter()) {
+                        if !x.is_number() || !y.is_number() {
+                            vm_err!(VmError::Type("dot: list elements must be numbers"));
+                        }
+                        total += x.as_number() * y.as_number();
+                    }
+                    reg_set!(a, NanVal::number(total));
+                }
                 OP_RND0 => {
                     let a = ((inst >> 16) & 0xFF) as usize + base;
                     reg_set!(a, NanVal::number(fastrand::f64()));
@@ -7628,6 +7831,167 @@ pub(crate) extern "C" fn jit_atan2(a: u64, b: u64) -> u64 {
     } else {
         NanVal::number(f64::NAN).0
     }
+}
+
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_transpose(a: u64) -> u64 {
+    let v = NanVal(a);
+    if !v.is_heap() {
+        return TAG_NIL;
+    }
+    let rows = match unsafe { v.as_heap_ref() } {
+        HeapObj::List(items) => items,
+        _ => return TAG_NIL,
+    };
+    if rows.is_empty() {
+        return NanVal::heap_list(vec![]).0;
+    }
+    let mut row_refs: Vec<&Vec<NanVal>> = Vec::with_capacity(rows.len());
+    let mut ncols: Option<usize> = None;
+    for row in rows {
+        if !row.is_heap() {
+            return TAG_NIL;
+        }
+        let r = match unsafe { row.as_heap_ref() } {
+            HeapObj::List(items) => items,
+            _ => return TAG_NIL,
+        };
+        match ncols {
+            None => ncols = Some(r.len()),
+            Some(n) if n != r.len() => return TAG_NIL,
+            _ => {}
+        }
+        row_refs.push(r);
+    }
+    let ncols = ncols.unwrap_or(0);
+    let mut result: Vec<NanVal> = Vec::with_capacity(ncols);
+    for j in 0..ncols {
+        let mut col: Vec<NanVal> = Vec::with_capacity(row_refs.len());
+        for r in &row_refs {
+            let v = r[j];
+            v.clone_rc();
+            col.push(v);
+        }
+        result.push(NanVal::heap_list(col));
+    }
+    NanVal::heap_list(result).0
+}
+
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_matmul(a: u64, b: u64) -> u64 {
+    let va = NanVal(a);
+    let vb = NanVal(b);
+    if !va.is_heap() || !vb.is_heap() {
+        return TAG_NIL;
+    }
+    let a_rows_v = match unsafe { va.as_heap_ref() } {
+        HeapObj::List(items) => items,
+        _ => return TAG_NIL,
+    };
+    let b_rows_v = match unsafe { vb.as_heap_ref() } {
+        HeapObj::List(items) => items,
+        _ => return TAG_NIL,
+    };
+    let mut a_mat: Vec<Vec<f64>> = Vec::with_capacity(a_rows_v.len());
+    let mut a_cols: Option<usize> = None;
+    for row in a_rows_v {
+        if !row.is_heap() {
+            return TAG_NIL;
+        }
+        let r = match unsafe { row.as_heap_ref() } {
+            HeapObj::List(items) => items,
+            _ => return TAG_NIL,
+        };
+        match a_cols {
+            None => a_cols = Some(r.len()),
+            Some(n) if n != r.len() => return TAG_NIL,
+            _ => {}
+        }
+        let mut nums = Vec::with_capacity(r.len());
+        for v in r {
+            if !v.is_number() {
+                return TAG_NIL;
+            }
+            nums.push(v.as_number());
+        }
+        a_mat.push(nums);
+    }
+    let mut b_mat: Vec<Vec<f64>> = Vec::with_capacity(b_rows_v.len());
+    let mut b_cols: Option<usize> = None;
+    for row in b_rows_v {
+        if !row.is_heap() {
+            return TAG_NIL;
+        }
+        let r = match unsafe { row.as_heap_ref() } {
+            HeapObj::List(items) => items,
+            _ => return TAG_NIL,
+        };
+        match b_cols {
+            None => b_cols = Some(r.len()),
+            Some(n) if n != r.len() => return TAG_NIL,
+            _ => {}
+        }
+        let mut nums = Vec::with_capacity(r.len());
+        for v in r {
+            if !v.is_number() {
+                return TAG_NIL;
+            }
+            nums.push(v.as_number());
+        }
+        b_mat.push(nums);
+    }
+    let a_rows_n = a_mat.len();
+    let a_cols_n = a_cols.unwrap_or(0);
+    let b_rows_n = b_mat.len();
+    let b_cols_n = b_cols.unwrap_or(0);
+    if a_cols_n != b_rows_n {
+        return TAG_NIL;
+    }
+    let mut out: Vec<NanVal> = Vec::with_capacity(a_rows_n);
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..a_rows_n {
+        let mut row: Vec<NanVal> = Vec::with_capacity(b_cols_n);
+        for j in 0..b_cols_n {
+            let mut s = 0.0_f64;
+            for k in 0..a_cols_n {
+                s += a_mat[i][k] * b_mat[k][j];
+            }
+            row.push(NanVal::number(s));
+        }
+        out.push(NanVal::heap_list(row));
+    }
+    NanVal::heap_list(out).0
+}
+
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_dot(a: u64, b: u64) -> u64 {
+    let va = NanVal(a);
+    let vb = NanVal(b);
+    if !va.is_heap() || !vb.is_heap() {
+        return NanVal::number(f64::NAN).0;
+    }
+    let xs = match unsafe { va.as_heap_ref() } {
+        HeapObj::List(items) => items,
+        _ => return NanVal::number(f64::NAN).0,
+    };
+    let ys = match unsafe { vb.as_heap_ref() } {
+        HeapObj::List(items) => items,
+        _ => return NanVal::number(f64::NAN).0,
+    };
+    if xs.len() != ys.len() {
+        return NanVal::number(f64::NAN).0;
+    }
+    let mut total = 0.0_f64;
+    for (x, y) in xs.iter().zip(ys.iter()) {
+        if !x.is_number() || !y.is_number() {
+            return NanVal::number(f64::NAN).0;
+        }
+        total += x.as_number() * y.as_number();
+    }
+    NanVal::number(total).0
 }
 
 #[cfg(feature = "cranelift")]

--- a/tests/regression_linalg_basic.rs
+++ b/tests/regression_linalg_basic.rs
@@ -1,0 +1,167 @@
+// Cross-engine smoke tests for the basic linalg builtins
+// (transpose, matmul, dot). Each is checked against tree, vm, and
+// cranelift, mirroring regression_math_extra.rs.
+//
+// Manifesto rationale: hand-rolled linalg risks silent precision loss
+// (same class as `expx` Taylor). These builtins delegate to vetted
+// host-language arithmetic so users don't reimplement them per-program.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_ok(engine: &str, src: &str) -> String {
+    let out = ilo()
+        .args([src, engine, "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn run_err(engine: &str, src: &str) -> String {
+    let out = ilo()
+        .args([src, engine, "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "ilo {engine} unexpectedly succeeded for `{src}`: stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+fn check_all_str(src: &str, expected: &str) {
+    assert_eq!(run_ok("--run-tree", src), expected, "tree engine");
+    assert_eq!(run_ok("--run-vm", src), expected, "vm engine");
+    #[cfg(feature = "cranelift")]
+    assert_eq!(run_ok("--run-cranelift", src), expected, "cranelift engine");
+}
+
+fn check_all_num(src: &str, expected: f64) {
+    for engine in &["--run-tree", "--run-vm"] {
+        let actual = run_ok(engine, src).parse::<f64>().expect("number");
+        assert!(
+            (actual - expected).abs() < 1e-10,
+            "engine={engine} src=`{src}`: got {actual}, expected {expected}"
+        );
+    }
+    #[cfg(feature = "cranelift")]
+    {
+        let actual = run_ok("--run-cranelift", src)
+            .parse::<f64>()
+            .expect("number");
+        assert!(
+            (actual - expected).abs() < 1e-10,
+            "engine=cranelift src=`{src}`: got {actual}, expected {expected}"
+        );
+    }
+}
+
+// ── transpose ───────────────────────────────────────────────────────
+
+#[test]
+fn transpose_2x2() {
+    check_all_str("f>L (L n);transpose [[1,2],[3,4]]", "[[1, 3], [2, 4]]");
+}
+
+#[test]
+fn transpose_2x3_yields_3x2() {
+    check_all_str(
+        "f>L (L n);transpose [[1,2,3],[4,5,6]]",
+        "[[1, 4], [2, 5], [3, 6]]",
+    );
+}
+
+#[test]
+fn transpose_ragged_errors() {
+    // tree + vm catch the ragged shape at runtime.
+    let err_tree = run_err("--run-tree", "f>L (L n);transpose [[1,2],[3]]");
+    assert!(
+        err_tree.contains("transpose") || err_tree.contains("ragged"),
+        "tree: got: {err_tree}"
+    );
+    let err_vm = run_err("--run-vm", "f>L (L n);transpose [[1,2],[3]]");
+    assert!(
+        err_vm.contains("transpose") || err_vm.contains("ragged"),
+        "vm: got: {err_vm}"
+    );
+}
+
+// ── matmul ──────────────────────────────────────────────────────────
+
+#[test]
+fn matmul_2x3_by_3x2_gives_2x2() {
+    check_all_str(
+        "f>L (L n);matmul [[1,2,3],[4,5,6]] [[7,8],[9,10],[11,12]]",
+        "[[58, 64], [139, 154]]",
+    );
+}
+
+#[test]
+fn matmul_identity_2x2() {
+    check_all_str(
+        "f>L (L n);matmul [[1,0],[0,1]] [[5,6],[7,8]]",
+        "[[5, 6], [7, 8]]",
+    );
+}
+
+#[test]
+fn matmul_shape_mismatch_errors() {
+    // 2x3 * 2x2 is invalid (cols(a)=3 != rows(b)=2).
+    let err_tree = run_err(
+        "--run-tree",
+        "f>L (L n);matmul [[1,2,3],[4,5,6]] [[1,2],[3,4]]",
+    );
+    assert!(
+        err_tree.contains("matmul") || err_tree.contains("shape"),
+        "tree: got: {err_tree}"
+    );
+    let err_vm = run_err(
+        "--run-vm",
+        "f>L (L n);matmul [[1,2,3],[4,5,6]] [[1,2],[3,4]]",
+    );
+    assert!(
+        err_vm.contains("matmul") || err_vm.contains("shape"),
+        "vm: got: {err_vm}"
+    );
+}
+
+// ── dot ─────────────────────────────────────────────────────────────
+
+#[test]
+fn dot_basic() {
+    // 1*4 + 2*5 + 3*6 = 4 + 10 + 18 = 32
+    check_all_num("f>n;dot [1,2,3] [4,5,6]", 32.0);
+}
+
+#[test]
+fn dot_with_negatives() {
+    // 1*-1 + 2*1 = 1
+    check_all_num("f>n;dot [1,2] [-1,1]", 1.0);
+}
+
+#[test]
+fn dot_length_mismatch_errors() {
+    let err_tree = run_err("--run-tree", "f>n;dot [1,2,3] [1,2]");
+    assert!(
+        err_tree.contains("dot") || err_tree.contains("length"),
+        "tree: got: {err_tree}"
+    );
+    let err_vm = run_err("--run-vm", "f>n;dot [1,2,3] [1,2]");
+    assert!(
+        err_vm.contains("dot") || err_vm.contains("length"),
+        "vm: got: {err_vm}"
+    );
+}


### PR DESCRIPTION
The token-minimal pitch only holds if numeric workloads are first class. Basic linear algebra was missing.

Implementation:
- transpose flips a 2D list of lists
- matmul: standard matrix product with shape check
- dot: 1D vector inner product
- all operate on existing list shapes, no new matrix type
- opcodes allocated: transpose, matmul, dot

Tests: cross-engine regression tests + examples/linalg-basic.ilo with -- run: directives.