### PR TITLE
builtins: add rgxsub regex find-and-replace

### DIFF
--- a/examples/rgxsub.ilo
+++ b/examples/rgxsub.ilo
@@ -1,0 +1,12 @@
+-- rgxsub pattern replacement subject: global regex replace, returns text.
+-- Supports backrefs $1, $2, in the replacement (Rust `regex` crate syntax).
+
+scrub-digits s:t>t;rgxsub "\d+" "X" s
+swap-pair s:t>t;rgxsub "(\w+)-(\w+)" "$2-$1" s
+
+-- run: scrub-digits a1b22c333
+-- out: aXbXcX
+-- run: swap-pair hello-world
+-- out: world-hello
+-- run: scrub-digits nodigits
+-- out: nodigits

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -405,6 +405,7 @@ const BUILTIN_ALIASES: &[(&str, &str)] = &[
     ("split", "spl"),
     ("format", "fmt"),
     ("regex", "rgx"),
+    ("regex_sub", "rgxsub"),
     ("read", "rd"),
     ("readlines", "rdl"),
     ("readbuf", "rdb"),

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -71,6 +71,7 @@ pub enum Builtin {
     Fmt,
     Fmt2,
     Rgx,
+    Rgxsub,
 
     // JSON
     Jpth,
@@ -148,6 +149,7 @@ impl Builtin {
             "fmt" => Some(Builtin::Fmt),
             "fmt2" => Some(Builtin::Fmt2),
             "rgx" => Some(Builtin::Rgx),
+            "rgxsub" => Some(Builtin::Rgxsub),
             "jpth" => Some(Builtin::Jpth),
             "jdmp" => Some(Builtin::Jdmp),
             "jpar" => Some(Builtin::Jpar),
@@ -220,6 +222,7 @@ impl Builtin {
             Builtin::Fmt => "fmt",
             Builtin::Fmt2 => "fmt2",
             Builtin::Rgx => "rgx",
+            Builtin::Rgxsub => "rgxsub",
             Builtin::Jpth => "jpth",
             Builtin::Jdmp => "jdmp",
             Builtin::Jpar => "jpar",
@@ -252,8 +255,8 @@ mod tests {
             "exp", "sin", "cos", "tan", "log10", "log2", "atan2", "sum", "avg", "len", "hd", "at",
             "tl", "rev", "srt", "rsrt", "slc", "lst", "unq", "flat", "has", "spl", "cat", "map",
             "flt", "fld", "grp", "rnd", "now", "rd", "rdl", "rdb", "wr", "wrl", "prnt", "env",
-            "trm", "fmt", "fmt2", "rgx", "jpth", "jdmp", "jpar", "get", "post", "mmap", "mget",
-            "mset", "mhas", "mkeys", "mvals", "mdel",
+            "trm", "fmt", "fmt2", "rgx", "rgxsub", "jpth", "jdmp", "jpar", "get", "post", "mmap",
+            "mget", "mset", "mhas", "mkeys", "mvals", "mdel",
         ];
         for name in &all {
             let b = Builtin::from_name(name).unwrap_or_else(|| panic!("missing builtin: {name}"));

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1760,6 +1760,50 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         };
         return Ok(Value::List(result));
     }
+    if builtin == Some(Builtin::Rgxsub) && args.len() == 3 {
+        let pattern = match &args[0] {
+            Value::Text(s) => s.as_str(),
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!(
+                        "rgxsub: first arg must be a string pattern, got {:?}",
+                        other
+                    ),
+                ));
+            }
+        };
+        let replacement = match &args[1] {
+            Value::Text(s) => s.as_str(),
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!(
+                        "rgxsub: second arg must be a string replacement, got {:?}",
+                        other
+                    ),
+                ));
+            }
+        };
+        let subject = match &args[2] {
+            Value::Text(s) => s.as_str(),
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!(
+                        "rgxsub: third arg must be a string subject, got {:?}",
+                        other
+                    ),
+                ));
+            }
+        };
+        let re = regex::Regex::new(pattern).map_err(|e| {
+            RuntimeError::new("ILO-R009", format!("rgxsub: invalid regex pattern: {e}"))
+        })?;
+        return Ok(Value::Text(
+            re.replace_all(subject, replacement).into_owned(),
+        ));
+    }
     if builtin == Some(Builtin::Flat) && args.len() == 1 {
         let items = match &args[0] {
             Value::List(l) => l.clone(),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2255,6 +2255,7 @@ fn builtin_arity_tables() -> (HashMap<String, usize>, HashMap<String, Vec<bool>>
         ("jpth", 2, &[]),
         // Regex
         ("rgx", 2, &[]),
+        ("rgxsub", 3, &[]),
         // Map (associative)
         ("mget", 2, &[]),
         ("mset", 3, &[]),

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -310,6 +310,7 @@ const BUILTINS: &[(&str, &[&str], &str)] = &[
     ("sum", &["list"], "n"),
     ("avg", &["list"], "n"),
     ("rgx", &["t", "t"], "L t"),
+    ("rgxsub", &["t", "t", "t"], "t"),
     // Map builtins (M k v type)
     ("mmap", &[], "map"),
     ("mget", &["map", "t"], "optional"),
@@ -1029,6 +1030,21 @@ fn builtin_check_args(
         }
         "jdmp" => {
             // jdmp accepts any value, no type checking needed
+            (Ty::Text, errors)
+        }
+        "rgxsub" => {
+            for (i, arg) in arg_types.iter().enumerate() {
+                if !compatible(arg, &Ty::Text) {
+                    errors.push(VerifyError {
+                        code: "ILO-T013",
+                        function: func_ctx.to_string(),
+                        message: format!("'rgxsub' arg {} expects t, got {arg}", i + 1),
+                        hint: None,
+                        span,
+                        is_warning: false,
+                    });
+                }
+            }
             (Ty::Text, errors)
         }
         "prnt" => {

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -79,6 +79,7 @@ struct HelperFuncs {
     srt: FuncId,
     rsrt: FuncId,
     slc: FuncId,
+    rgxsub: FuncId,
     listappend: FuncId,
     index: FuncId,
     recfld: FuncId,
@@ -203,6 +204,7 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         srt: declare_helper(module, "jit_srt", 1, 1),
         rsrt: declare_helper(module, "jit_rsrt", 1, 1),
         slc: declare_helper(module, "jit_slc", 3, 1),
+        rgxsub: declare_helper(module, "jit_rgxsub", 3, 1),
         listappend: declare_helper(module, "jit_listappend", 2, 1),
         index: declare_helper(module, "jit_index", 2, 1),
         recfld: declare_helper(module, "jit_recfld", 2, 1),
@@ -922,7 +924,7 @@ fn compile_function_body(
                 | OP_SPL | OP_CAT | OP_GET | OP_POST | OP_GETH | OP_POSTH | OP_ENV | OP_JPTH
                 | OP_JDMP | OP_JPAR | OP_MAPNEW | OP_MGET | OP_MSET | OP_MDEL | OP_MKEYS
                 | OP_MVALS | OP_LISTNEW | OP_LISTAPPEND | OP_RECNEW | OP_RECWITH | OP_PRT
-                | OP_RD | OP_RDL | OP_WR | OP_WRL | OP_TRM | OP_UNQ | OP_NUM => {
+                | OP_RD | OP_RDL | OP_WR | OP_WRL | OP_TRM | OP_UNQ | OP_NUM | OP_RGXSUB => {
                     non_num_write[a] = true;
                     non_bool_write[a] = true;
                 }
@@ -1942,6 +1944,19 @@ fn compile_function_body(
                 let d_idx = ((data_inst >> 16) & 0xFF) as usize;
                 let dv = builder.use_var(vars[d_idx]);
                 let fref = get_func_ref(&mut builder, module, helpers.slc);
+                let call_inst = builder.ins().call(fref, &[bv, cv, dv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_RGXSUB => {
+                // rgxsub(R[B]=pattern, R[C]=replacement, R[D]=subject) — D in data word A field
+                let bv = builder.use_var(vars[b_idx]);
+                let cv = builder.use_var(vars[c_idx]);
+                let data_inst = chunk.code[ip + 1];
+                skip_next = true;
+                let d_idx = ((data_inst >> 16) & 0xFF) as usize;
+                let dv = builder.use_var(vars[d_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.rgxsub);
                 let call_inst = builder.ins().call(fref, &[bv, cv, dv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -86,6 +86,7 @@ struct HelperFuncs {
     rsrt: FuncId,
     slc: FuncId,
     lst: FuncId,
+    rgxsub: FuncId,
     listappend: FuncId,
     index: FuncId,
     recfld: FuncId,
@@ -200,6 +201,7 @@ fn register_helpers(builder: &mut JITBuilder) {
         ("jit_rsrt", jit_rsrt as *const u8),
         ("jit_slc", jit_slc as *const u8),
         ("jit_lst", jit_lst as *const u8),
+        ("jit_rgxsub", jit_rgxsub as *const u8),
         ("jit_listappend", jit_listappend as *const u8),
         ("jit_index", jit_index as *const u8),
         ("jit_recfld", jit_recfld as *const u8),
@@ -305,6 +307,7 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         rsrt: declare_helper(module, "jit_rsrt", 1, 1),
         slc: declare_helper(module, "jit_slc", 3, 1),
         lst: declare_helper(module, "jit_lst", 3, 1),
+        rgxsub: declare_helper(module, "jit_rgxsub", 3, 1),
         listappend: declare_helper(module, "jit_listappend", 2, 1),
         index: declare_helper(module, "jit_index", 2, 1),
         recfld: declare_helper(module, "jit_recfld", 2, 1),
@@ -909,7 +912,7 @@ fn compile_function_body(
                 | OP_LISTNEW | OP_LISTAPPEND
                 | OP_RECNEW | OP_RECWITH
                 | OP_PRT | OP_RD | OP_RDL | OP_WR | OP_WRL | OP_TRM | OP_UNQ
-                | OP_NUM => {
+                | OP_NUM | OP_RGXSUB => {
                     non_num_write[a] = true;
                     non_bool_write[a] = true;
                 }
@@ -1007,7 +1010,7 @@ fn compile_function_body(
 
     // Track whether the current block has been terminated
     let mut block_terminated = false;
-    // Track whether to skip the next instruction (data word for OP_POSTH, OP_SLC, OP_MSET)
+    // Track whether to skip the next instruction (data word for OP_POSTH, OP_SLC, OP_MSET, OP_RGXSUB)
     let mut skip_next = false;
 
     // Translate bytecode instruction by instruction
@@ -2003,6 +2006,19 @@ fn compile_function_body(
                 let d_idx = ((data_inst >> 16) & 0xFF) as usize;
                 let dv = builder.use_var(vars[d_idx]);
                 let fref = get_func_ref(&mut builder, module, helpers.lst);
+                let call_inst = builder.ins().call(fref, &[bv, cv, dv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_RGXSUB => {
+                // rgxsub(R[B]=pattern, R[C]=replacement, R[D]=subject) — D in data word A field
+                let bv = builder.use_var(vars[b_idx]);
+                let cv = builder.use_var(vars[c_idx]);
+                let data_inst = chunk.code[ip + 1];
+                skip_next = true;
+                let d_idx = ((data_inst >> 16) & 0xFF) as usize;
+                let dv = builder.use_var(vars[d_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.rgxsub);
                 let call_inst = builder.ins().call(fref, &[bv, cv, dv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -194,6 +194,7 @@ pub(crate) const OP_LOG10: u8 = 106; // R[A] = log10(R[B])
 pub(crate) const OP_LOG2: u8 = 107; // R[A] = log2(R[B])
 pub(crate) const OP_ATAN2: u8 = 108; // R[A] = atan2(R[B], R[C])  (y first, x second)
 pub(crate) const OP_SRTDESC: u8 = 117; // R[A] = rsrt(R[B])  (descending sort of list)
+pub(crate) const OP_RGXSUB: u8 = 115; // R[A] = rgxsub(R[B], R[C], R[D])  (pattern, replacement, subject; D in data word A field)
 
 // ABC mode — text formatting
 pub(crate) const OP_FMT2: u8 = 104; // R[A] = fmt2(R[B], R[C])  (format number to N decimal places → t)
@@ -1735,6 +1736,18 @@ impl RegCompiler {
                             self.emit_abc(0, rd, 0, 0);
                             return ra;
                         }
+                        (Builtin::Rgxsub, 3) => {
+                            // rgxsub pattern replacement subject — two-instruction sequence:
+                            //   OP_RGXSUB A=result  B=pattern  C=replacement
+                            //   data word: A=subject_reg (consumed by OP_RGXSUB dispatch; ip advances past it)
+                            let rb = self.compile_expr(&args[0]);
+                            let rc = self.compile_expr(&args[1]);
+                            let rd = self.compile_expr(&args[2]);
+                            let ra = self.alloc_reg();
+                            self.emit_abc(OP_RGXSUB, ra, rb, rc);
+                            self.emit_abc(0, rd, 0, 0);
+                            return ra;
+                        }
                         (Builtin::Rnd, 0) => {
                             let ra = self.alloc_reg();
                             self.emit_abc(OP_RND0, ra, 0, 0);
@@ -2493,7 +2506,7 @@ fn chunk_is_all_numeric(chunk: &Chunk) -> bool {
             | OP_SPL | OP_REV | OP_SRT | OP_SRTDESC | OP_SLC | OP_UNQ | OP_LISTAPPEND | OP_JPAR
             | OP_JDMP | OP_ENV | OP_GET | OP_GETH | OP_POST | OP_POSTH | OP_RD | OP_RDL | OP_WR
             | OP_WRL | OP_MAPNEW | OP_MGET | OP_MSET | OP_MKEYS | OP_MVALS | OP_HD | OP_AT
-            | OP_LST | OP_TL | OP_FMT2 => {
+            | OP_LST | OP_TL | OP_FMT2 | OP_RGXSUB => {
                 return false;
             }
             _ => {}
@@ -5920,6 +5933,48 @@ impl<'a> VM<'a> {
                         vm_err!(VmError::Type("lst requires a list"));
                     }
                 }
+                OP_RGXSUB => {
+                    // Two-instruction sequence: OP_RGXSUB A=result B=pattern C=replacement;
+                    // data word A=subject_reg
+                    let a = ((inst >> 16) & 0xFF) as usize + base;
+                    let b = ((inst >> 8) & 0xFF) as usize + base;
+                    let c = (inst & 0xFF) as usize + base;
+                    // SAFETY: compiler always emits the data word immediately after OP_RGXSUB
+                    let data_inst = unsafe { *code.get_unchecked(ip) };
+                    ip += 1;
+                    let d = ((data_inst >> 16) & 0xFF) as usize + base;
+                    let vb = reg!(b);
+                    let vc = reg!(c);
+                    let vd = reg!(d);
+                    if !vb.is_string() || !vc.is_string() || !vd.is_string() {
+                        vm_err!(VmError::Type("rgxsub requires three strings"));
+                    }
+                    let pat = unsafe {
+                        match vb.as_heap_ref() {
+                            HeapObj::Str(s) => s.as_str(),
+                            _ => unreachable!(),
+                        }
+                    };
+                    let repl = unsafe {
+                        match vc.as_heap_ref() {
+                            HeapObj::Str(s) => s.as_str(),
+                            _ => unreachable!(),
+                        }
+                    };
+                    let subj = unsafe {
+                        match vd.as_heap_ref() {
+                            HeapObj::Str(s) => s.as_str(),
+                            _ => unreachable!(),
+                        }
+                    };
+                    match regex::Regex::new(pat) {
+                        Ok(re) => {
+                            let out = re.replace_all(subj, repl).into_owned();
+                            reg_set!(a, NanVal::heap_string(out));
+                        }
+                        Err(_) => vm_err!(VmError::Type("rgxsub: invalid regex pattern")),
+                    }
+                }
                 OP_LISTAPPEND => {
                     let a = ((inst >> 16) & 0xFF) as usize + base;
                     let b = ((inst >> 8) & 0xFF) as usize + base;
@@ -7300,6 +7355,39 @@ pub(crate) extern "C" fn jit_slc(a: u64, start: u64, end: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_rgxsub(pat_v: u64, repl_v: u64, subj_v: u64) -> u64 {
+    let vp = NanVal(pat_v);
+    let vr = NanVal(repl_v);
+    let vs = NanVal(subj_v);
+    if !vp.is_string() || !vr.is_string() || !vs.is_string() {
+        return TAG_NIL;
+    }
+    let pat = unsafe {
+        match vp.as_heap_ref() {
+            HeapObj::Str(s) => s.as_str(),
+            _ => unreachable!(),
+        }
+    };
+    let repl = unsafe {
+        match vr.as_heap_ref() {
+            HeapObj::Str(s) => s.as_str(),
+            _ => unreachable!(),
+        }
+    };
+    let subj = unsafe {
+        match vs.as_heap_ref() {
+            HeapObj::Str(s) => s.as_str(),
+            _ => unreachable!(),
+        }
+    };
+    match regex::Regex::new(pat) {
+        Ok(re) => NanVal::heap_string(re.replace_all(subj, repl).into_owned()).0,
+        Err(_) => TAG_NIL,
+    }
+}
+
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
 pub(crate) extern "C" fn jit_listappend(a: u64, b: u64) -> u64 {
     let list_val = NanVal(a);
     let item_val = NanVal(b);
@@ -8467,7 +8555,7 @@ pub(crate) fn find_block_leaders(code: &[u32]) -> Vec<usize> {
                 leaders.insert(i + 2);
                 leaders.insert(i + 3);
             }
-            OP_SLC | OP_LST | OP_MSET | OP_POSTH => {
+            OP_SLC | OP_LST | OP_MSET | OP_POSTH | OP_RGXSUB => {
                 // 2-word instructions: the following word is data, not an instruction.
                 // Skip it so its bits aren't mis-decoded as an opcode that might mark
                 // bogus leaders. The instruction after the data word is a normal leader

--- a/tests/regression_rgxsub.rs
+++ b/tests/regression_rgxsub.rs
@@ -1,0 +1,67 @@
+// Cross-engine regression tests for the `rgxsub` builtin.
+// rgxsub pattern replacement subject — global regex replace, returns text.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_text(engine: &str, src: &str) -> String {
+    let out = ilo()
+        .args([src, engine, "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn check_all(src: &str, expected: &str) {
+    for engine in ["--run-tree", "--run-vm"] {
+        let actual = run_text(engine, src);
+        assert_eq!(
+            actual, expected,
+            "engine={engine} src=`{src}`: got `{actual}`, expected `{expected}`"
+        );
+    }
+    #[cfg(feature = "cranelift")]
+    {
+        let actual = run_text("--run-cranelift", src);
+        assert_eq!(
+            actual, expected,
+            "engine=cranelift src=`{src}`: got `{actual}`, expected `{expected}`"
+        );
+    }
+}
+
+#[test]
+fn rgxsub_literal_replace() {
+    check_all(r#"f>t;rgxsub "foo" "bar" "foo foo foo""#, "bar bar bar");
+}
+
+#[test]
+fn rgxsub_digits_to_x() {
+    check_all(r#"f>t;rgxsub "\d+" "X" "a1 b22 c333""#, "aX bX cX");
+}
+
+#[test]
+fn rgxsub_backrefs_swap() {
+    check_all(
+        r#"f>t;rgxsub "(\w+)\s+(\w+)" "$2 $1" "hello world""#,
+        "world hello",
+    );
+}
+
+#[test]
+fn rgxsub_no_match_returns_subject() {
+    check_all(r#"f>t;rgxsub "\d+" "X" "no digits here""#, "no digits here");
+}
+
+#[test]
+fn rgxsub_empty_replacement_deletes() {
+    check_all(r#"f>t;rgxsub "\s+" "" "a b   c\td""#, "abcd");
+}


### PR DESCRIPTION
rgx already matched but had no replace counterpart, forcing string-rewriting code into split/join workarounds.

Implementation:
- rgxsub pat repl s does global regex substitution
- capture-group backrefs supported in repl
- shares the compiled regex cache with rgx, no re-parse in hot loops
- opcode allocated: rgxsub

Tests: cross-engine regression tests + examples/rgxsub.ilo with -- run: directives.