### PR TITLE
builtins: add uniqby keyed dedup (tree-only HOF)

### DIFF
--- a/examples/uniqby.ilo
+++ b/examples/uniqby.ilo
@@ -1,0 +1,16 @@
+-- uniqby fn xs — keep the first element whose key (computed by `fn`) hasn't been seen.
+-- Mirrors `unq` (which dedupes primitives) but lets you dedupe by a derived key.
+
+-- Key function: parity (returns 0 or 1 as text).
+par n:n>t;r=mod n 2;str r
+
+-- Dedup numbers by parity (keep first even, first odd).
+by-parity ns:L n>L n;uniqby par ns
+
+-- vm/jit lack higher-order builtins (no FnRef dispatch)
+-- engine-skip: vm
+-- engine-skip: jit
+-- engine-skip: cranelift
+
+-- run: by-parity [1,3,2,4,5,6]
+-- out: [1, 2]

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -55,6 +55,7 @@ pub enum Builtin {
     Flt,
     Fld,
     Grp,
+    Uniqby,
 
     // Random / time
     Rnd,
@@ -142,6 +143,7 @@ impl Builtin {
             "flt" => Some(Builtin::Flt),
             "fld" => Some(Builtin::Fld),
             "grp" => Some(Builtin::Grp),
+            "uniqby" => Some(Builtin::Uniqby),
             "rnd" => Some(Builtin::Rnd),
             "now" => Some(Builtin::Now),
             "rd" => Some(Builtin::Rd),
@@ -218,6 +220,7 @@ impl Builtin {
             Builtin::Flt => "flt",
             Builtin::Fld => "fld",
             Builtin::Grp => "grp",
+            Builtin::Uniqby => "uniqby",
             Builtin::Rnd => "rnd",
             Builtin::Now => "now",
             Builtin::Rd => "rd",
@@ -263,9 +266,9 @@ mod tests {
             "str", "num", "abs", "flr", "cel", "rou", "min", "max", "mod", "pow", "sqrt", "log",
             "exp", "sin", "cos", "tan", "log10", "log2", "atan2", "sum", "avg", "len", "hd", "at",
             "tl", "rev", "srt", "rsrt", "slc", "lst", "unq", "flat", "has", "spl", "cat", "zip",
-            "map", "flt", "fld", "grp", "rnd", "now", "rd", "rdl", "rdb", "wr", "wrl", "prnt",
-            "env", "trm", "fmt", "fmt2", "rgx", "rgxsub", "jpth", "jdmp", "jpar", "get", "post",
-            "mmap", "mget", "mset", "mhas", "mkeys", "mvals", "mdel", "fft", "ifft",
+            "map", "flt", "fld", "grp", "uniqby", "rnd", "now", "rd", "rdl", "rdb", "wr", "wrl",
+            "prnt", "env", "trm", "fmt", "fmt2", "rgx", "rgxsub", "jpth", "jdmp", "jpar", "get",
+            "post", "mmap", "mget", "mset", "mhas", "mkeys", "mvals", "mdel", "fft", "ifft",
         ];
         for name in &all {
             let b = Builtin::from_name(name).unwrap_or_else(|| panic!("missing builtin: {name}"));

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1642,6 +1642,59 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         return Ok(acc);
     }
 
+    if builtin == Some(Builtin::Uniqby) && args.len() == 2 {
+        let fn_name = resolve_fn_ref(&args[0]).ok_or_else(|| {
+            RuntimeError::new(
+                "ILO-R009",
+                format!(
+                    "uniqby: first arg must be a function reference, got {:?}",
+                    args[0]
+                ),
+            )
+        })?;
+        let items = match &args[1] {
+            Value::List(l) => l.clone(),
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!("uniqby: second arg must be a list, got {:?}", other),
+                ));
+            }
+        };
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut out: Vec<Value> = Vec::new();
+        for item in items {
+            let key = call_function(env, &fn_name, vec![item.clone()])?;
+            // Prefix the hashed key with a type tag so values from distinct
+            // domains never alias each other. Without this, `Number(5)` and
+            // `Text("5")` both stringify to `"5"` and collide.
+            let key_str = match &key {
+                Value::Text(s) => format!("t:{s}"),
+                Value::Number(n) => {
+                    if *n == (*n as i64) as f64 {
+                        format!("n:{}", *n as i64)
+                    } else {
+                        format!("n:{n}")
+                    }
+                }
+                Value::Bool(b) => format!("b:{b}"),
+                other => {
+                    return Err(RuntimeError::new(
+                        "ILO-R009",
+                        format!(
+                            "uniqby: key function must return a string, number, or bool, got {:?}",
+                            other
+                        ),
+                    ));
+                }
+            };
+            if seen.insert(key_str) {
+                out.push(item);
+            }
+        }
+        return Ok(Value::List(out));
+    }
+
     if builtin == Some(Builtin::Grp) && args.len() == 2 {
         let fn_name = resolve_fn_ref(&args[0]).ok_or_else(|| {
             RuntimeError::new(

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2243,6 +2243,7 @@ fn builtin_arity_tables() -> (HashMap<String, usize>, HashMap<String, Vec<bool>>
         ("flt", 2, &[0]),
         ("fld", 3, &[0]),
         ("grp", 2, &[0]),
+        ("uniqby", 2, &[0]),
         // I/O
         ("prnt", 1, &[]),
         ("wr", 2, &[]),

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -307,6 +307,7 @@ const BUILTINS: &[(&str, &[&str], &str)] = &[
     ("flt", &["fn", "list"], "list"),
     ("fld", &["fn", "list", "any"], "any"),
     ("grp", &["fn", "list"], "map"),
+    ("uniqby", &["fn", "list"], "list"),
     ("flat", &["list"], "list"),
     ("sum", &["list"], "n"),
     ("avg", &["list"], "n"),
@@ -1295,6 +1296,26 @@ fn builtin_check_args(
                 Ty::Map(Box::new(key_ty), Box::new(Ty::List(Box::new(elem_ty)))),
                 errors,
             )
+        }
+        "uniqby" => {
+            // uniqby fn:F a t xs:L a → L a — keep first occurrence by key fn
+            if let Some(fn_ty) = arg_types.first()
+                && !matches!(fn_ty, Ty::Fn(_, _) | Ty::Unknown)
+            {
+                errors.push(VerifyError {
+                    code: "ILO-T013",
+                    function: func_ctx.to_string(),
+                    message: format!("'uniqby' first arg must be a function (F ...), got {fn_ty}"),
+                    hint: Some("pass a function name: uniqby key-fn xs".to_string()),
+                    span,
+                    is_warning: false,
+                });
+            }
+            let ret = match arg_types.get(1) {
+                Some(ty @ Ty::List(_)) => ty.clone(),
+                _ => Ty::Unknown,
+            };
+            (ret, errors)
         }
         "flat" => {
             // flat xs:L (L a) → L a — flatten one level
@@ -6444,7 +6465,7 @@ mod tests {
         }
         // IO/HTTP/HOF/polymorphic builtins must NOT promote.
         for n in [
-            "map", "flt", "fld", "grp", "prnt", "get", "post", "hd", "tl",
+            "map", "flt", "fld", "grp", "uniqby", "prnt", "get", "post", "hd", "tl",
         ] {
             assert!(
                 builtin_as_fn_ty(n).is_none(),

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -112,6 +112,7 @@ struct HelperFuncs {
     prt: FuncId,
     trm: FuncId,
     unq: FuncId,
+    uniqby: FuncId,
     // File I/O
     rd: FuncId,
     rdl: FuncId,
@@ -240,6 +241,7 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         prt: declare_helper(module, "jit_prt", 1, 1),
         trm: declare_helper(module, "jit_trm", 1, 1),
         unq: declare_helper(module, "jit_unq", 1, 1),
+        uniqby: declare_helper(module, "jit_uniqby", 2, 1),
         // File I/O
         rd: declare_helper(module, "jit_rd", 1, 1),
         rdl: declare_helper(module, "jit_rdl", 1, 1),
@@ -930,8 +932,8 @@ fn compile_function_body(
                 | OP_SPL | OP_CAT | OP_GET | OP_POST | OP_GETH | OP_POSTH | OP_ENV | OP_JPTH
                 | OP_JDMP | OP_JPAR | OP_MAPNEW | OP_MGET | OP_MSET | OP_MDEL | OP_MKEYS
                 | OP_MVALS | OP_LISTNEW | OP_LISTAPPEND | OP_RECNEW | OP_RECWITH | OP_PRT
-                | OP_RD | OP_RDL | OP_WR | OP_WRL | OP_TRM | OP_UNQ | OP_NUM | OP_RGXSUB
-                | OP_ZIP | OP_FFT | OP_IFFT => {
+                | OP_RD | OP_RDL | OP_WR | OP_WRL | OP_TRM | OP_UNQ | OP_UNIQBY | OP_NUM
+                | OP_RGXSUB | OP_ZIP | OP_FFT | OP_IFFT => {
                     non_num_write[a] = true;
                     non_bool_write[a] = true;
                 }
@@ -2904,6 +2906,15 @@ fn compile_function_body(
                 let bv = builder.use_var(vars[b_idx]);
                 let fref = get_func_ref(&mut builder, module, helpers.unq);
                 let call_inst = builder.ins().call(fref, &[bv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_UNIQBY => {
+                // HOF: B = fn-ref reg, C = list reg. Helper is a stub today.
+                let bv = builder.use_var(vars[b_idx]);
+                let cv = builder.use_var(vars[c_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.uniqby);
+                let call_inst = builder.ins().call(fref, &[bv, cv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -120,6 +120,7 @@ struct HelperFuncs {
     prt: FuncId,
     trm: FuncId,
     unq: FuncId,
+    uniqby: FuncId,
     // File I/O
     rd: FuncId,
     rdl: FuncId,
@@ -238,6 +239,7 @@ fn register_helpers(builder: &mut JITBuilder) {
         ("jit_prt", jit_prt as *const u8),
         ("jit_trm", jit_trm as *const u8),
         ("jit_unq", jit_unq as *const u8),
+        ("jit_uniqby", jit_uniqby as *const u8),
         // File I/O
         ("jit_rd", jit_rd as *const u8),
         ("jit_rdl", jit_rdl as *const u8),
@@ -347,6 +349,7 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         prt: declare_helper(module, "jit_prt", 1, 1),
         trm: declare_helper(module, "jit_trm", 1, 1),
         unq: declare_helper(module, "jit_unq", 1, 1),
+        uniqby: declare_helper(module, "jit_uniqby", 2, 1),
         // File I/O
         rd: declare_helper(module, "jit_rd", 1, 1),
         rdl: declare_helper(module, "jit_rdl", 1, 1),
@@ -921,7 +924,7 @@ fn compile_function_body(
                 | OP_MAPNEW | OP_MGET | OP_MSET | OP_MDEL | OP_MKEYS | OP_MVALS
                 | OP_LISTNEW | OP_LISTAPPEND
                 | OP_RECNEW | OP_RECWITH
-                | OP_PRT | OP_RD | OP_RDL | OP_WR | OP_WRL | OP_TRM | OP_UNQ
+                | OP_PRT | OP_RD | OP_RDL | OP_WR | OP_WRL | OP_TRM | OP_UNQ | OP_UNIQBY
                 | OP_NUM | OP_RGXSUB => {
                     non_num_write[a] = true;
                     non_bool_write[a] = true;
@@ -3415,6 +3418,15 @@ fn compile_function_body(
                 let bv = builder.use_var(vars[b_idx]);
                 let fref = get_func_ref(&mut builder, module, helpers.unq);
                 let call_inst = builder.ins().call(fref, &[bv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_UNIQBY => {
+                // HOF: B = fn-ref reg, C = list reg. Helper is a stub today.
+                let bv = builder.use_var(vars[b_idx]);
+                let cv = builder.use_var(vars[c_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.uniqby);
+                let call_inst = builder.ins().call(fref, &[bv, cv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -205,6 +205,8 @@ pub(crate) const OP_FMT2: u8 = 104; // R[A] = fmt2(R[B], R[C])  (format number t
 // of `[real, imag]` pairs; OP_IFFT takes the same shape and returns `L n`.
 pub(crate) const OP_FFT: u8 = 129; // R[A] = fft(R[B])
 pub(crate) const OP_IFFT: u8 = 130; // R[A] = ifft(R[B])
+// Higher-order: uniqby fn xs — pre-allocated, HOF dispatch not yet wired in VM.
+pub(crate) const OP_UNIQBY: u8 = 116; // R[A] = uniqby(R[B] (fn-ref), R[C] (list))
 
 // ABx mode — register + 16-bit operand
 pub(crate) const OP_LOADK: u8 = 20;
@@ -2529,10 +2531,11 @@ fn chunk_is_all_numeric(chunk: &Chunk) -> bool {
         let op = (inst >> 24) as u8;
         match op {
             OP_RECNEW | OP_LISTNEW | OP_RECWITH | OP_WRAPOK | OP_WRAPERR | OP_STR | OP_CAT
-            | OP_SPL | OP_REV | OP_SRT | OP_SRTDESC | OP_SLC | OP_UNQ | OP_LISTAPPEND | OP_JPAR
-            | OP_JDMP | OP_ENV | OP_GET | OP_GETH | OP_POST | OP_POSTH | OP_RD | OP_RDL | OP_WR
-            | OP_WRL | OP_MAPNEW | OP_MGET | OP_MSET | OP_MKEYS | OP_MVALS | OP_HD | OP_AT
-            | OP_LST | OP_TL | OP_FMT2 | OP_RGXSUB | OP_ZIP | OP_FFT | OP_IFFT => {
+            | OP_SPL | OP_REV | OP_SRT | OP_SRTDESC | OP_SLC | OP_UNQ | OP_UNIQBY
+            | OP_LISTAPPEND | OP_JPAR | OP_JDMP | OP_ENV | OP_GET | OP_GETH | OP_POST
+            | OP_POSTH | OP_RD | OP_RDL | OP_WR | OP_WRL | OP_MAPNEW | OP_MGET | OP_MSET
+            | OP_MKEYS | OP_MVALS | OP_HD | OP_AT | OP_LST | OP_TL | OP_FMT2 | OP_RGXSUB
+            | OP_ZIP | OP_FFT | OP_IFFT => {
                 return false;
             }
             _ => {}
@@ -6123,6 +6126,12 @@ impl<'a> VM<'a> {
                         }
                     }
                 }
+                OP_UNIQBY => {
+                    // HOF dispatch not wired through the VM yet (matches map/flt/fld/grp).
+                    // Emitter currently falls through to OP_CALL → interpreter; this arm
+                    // exists so the opcode is a known dispatch target for future wiring.
+                    vm_err!(VmError::Type("uniqby: VM HOF dispatch not implemented"));
+                }
                 _ => vm_err!(VmError::UnknownOpcode { op }),
             }
         }
@@ -8415,6 +8424,15 @@ pub(crate) extern "C" fn jit_unq(v: u64) -> u64 {
         }
         return NanVal::heap_list(out).0;
     }
+    TAG_NIL
+}
+
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_uniqby(_fn_ref: u64, _list: u64) -> u64 {
+    // HOF dispatch is not wired through the JIT yet (matches map/flt/fld/grp).
+    // Returns nil so callers see a typed failure rather than UB. The emitter
+    // does not produce OP_UNIQBY today; this stub exists for plumbing parity.
     TAG_NIL
 }
 

--- a/tests/regression_uniqby.rs
+++ b/tests/regression_uniqby.rs
@@ -1,0 +1,138 @@
+// Regression tests for the `uniqby fn xs` builtin: keyed dedup that keeps the
+// first occurrence per key. Mirrors `unq` (primitive dedup) but lets agents
+// dedup records or transformed values without pre-mapping.
+//
+// VM and Cranelift JIT don't implement HOF/FnRef dispatch yet (same posture
+// as map/flt/fld/grp), so they are exercised only for verifier-error cases
+// where it makes sense.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn write_src(name: &str, src: &str) -> std::path::PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut path = std::env::temp_dir();
+    path.push(format!("ilo_uniqby_{name}_{}_{n}.ilo", std::process::id()));
+    std::fs::write(&path, src).expect("write src");
+    path
+}
+
+fn run_ok(engine: &str, src: &str, entry: &str, args: &[&str]) -> String {
+    let path = write_src(entry, src);
+    let mut cmd = ilo();
+    cmd.arg(&path).arg(engine).arg(entry);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn run_err(engine: &str, src: &str, entry: &str) -> String {
+    let path = write_src(entry, src);
+    let out = ilo()
+        .arg(&path)
+        .arg(engine)
+        .arg(entry)
+        .output()
+        .expect("failed to run ilo");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        !out.status.success(),
+        "expected failure but ilo {engine} succeeded for `{src}`"
+    );
+    let mut s = String::from_utf8_lossy(&out.stderr).into_owned();
+    s.push_str(&String::from_utf8_lossy(&out.stdout));
+    s
+}
+
+// ── Basic: dedup by computed key (first character) ─────────────────────────
+
+const BASIC_SRC: &str = "fc s:t>t;hd s f xs:L t>L t;uniqby fc xs";
+
+#[test]
+fn uniqby_basic_dedup_by_key_tree() {
+    assert_eq!(
+        run_ok(
+            "--run-tree",
+            BASIC_SRC,
+            "f",
+            &["[\"apple\",\"ant\",\"banana\",\"blueberry\",\"cherry\"]"],
+        ),
+        "[apple, banana, cherry]"
+    );
+}
+
+// ── Empty input list returns empty list ────────────────────────────────────
+
+#[test]
+fn uniqby_empty_list_tree() {
+    assert_eq!(run_ok("--run-tree", BASIC_SRC, "f", &["[]"]), "[]");
+}
+
+// ── All-same-key: keep only the first element ──────────────────────────────
+
+#[test]
+fn uniqby_all_same_key_keeps_first_tree() {
+    assert_eq!(
+        run_ok(
+            "--run-tree",
+            BASIC_SRC,
+            "f",
+            &["[\"alpha\",\"avocado\",\"apricot\"]"],
+        ),
+        "[alpha]"
+    );
+}
+
+// ── Order preservation: first-seen wins, original order preserved ──────────
+
+const PARITY_SRC: &str =
+    "par n:n>t\n==(mod n 2) 0{ret \"even\"}\n\"odd\"\nf xs:L n>L n;uniqby par xs";
+
+#[test]
+fn uniqby_preserves_order_tree() {
+    // Input [1,3,2,4,5,6]:
+    //   1 → odd (kept)
+    //   3 → odd (dropped)
+    //   2 → even (kept)
+    //   rest → dropped
+    // Expected: [1, 2] in original positional order.
+    assert_eq!(
+        run_ok("--run-tree", PARITY_SRC, "f", &["[1,3,2,4,5,6]"]),
+        "[1, 2]"
+    );
+}
+
+// ── Verifier: wrong first arg (not a fn) is rejected on every engine ──────
+
+const BAD_FN_SRC: &str = "f xs:L n>L n;uniqby 42 xs";
+
+#[test]
+fn uniqby_wrong_fn_arg_tree() {
+    let err = run_err("--run-tree", BAD_FN_SRC, "f");
+    assert!(
+        err.contains("uniqby") || err.contains("fn") || err.contains("function"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn uniqby_wrong_fn_arg_vm() {
+    let err = run_err("--run-vm", BAD_FN_SRC, "f");
+    assert!(
+        err.contains("uniqby") || err.contains("fn") || err.contains("function"),
+        "got: {err}"
+    );
+}


### PR DESCRIPTION
uniq did raw equality dedup. uniqby dedupes by a derived key, keeping the first occurrence per key. Critical for record-shaped lists where the equality you care about is on one field.

Implementation:
- tree-only HOF, verifier enforces function literal in fn position
- interpreter evaluates fn per element, tracks seen keys in a hash set
- preserves input order

Tests: cross-engine regression tests + examples/uniqby.ilo with -- run: directives.