### PR TITLE
builtins: add rsrt descending sort for list and text

### DIFF
--- a/examples/rsrt.ilo
+++ b/examples/rsrt.ilo
@@ -1,0 +1,13 @@
+-- rsrt xs: descending sort. Same Ord as srt, just reversed.
+-- One-step alternative to `rev (srt xs)`.
+
+-- Numeric: largest first
+top-nums xs:L n>L n;rsrt xs
+
+-- Text: lexicographic descending
+top-words ws:L t>L t;rsrt ws
+
+-- run: top-nums [3,1,4,1,5,9,2,6]
+-- out: [9, 6, 5, 4, 3, 2, 1, 1]
+-- run: top-words ["banana","apple","cherry"]
+-- out: ["cherry", "banana", "apple"]

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -38,6 +38,7 @@ pub enum Builtin {
     Tl,
     Rev,
     Srt,
+    Rsrt,
     Slc,
     Lst,
     Unq,
@@ -122,6 +123,7 @@ impl Builtin {
             "tl" => Some(Builtin::Tl),
             "rev" => Some(Builtin::Rev),
             "srt" => Some(Builtin::Srt),
+            "rsrt" => Some(Builtin::Rsrt),
             "slc" => Some(Builtin::Slc),
             "lst" => Some(Builtin::Lst),
             "unq" => Some(Builtin::Unq),
@@ -193,6 +195,7 @@ impl Builtin {
             Builtin::Tl => "tl",
             Builtin::Rev => "rev",
             Builtin::Srt => "srt",
+            Builtin::Rsrt => "rsrt",
             Builtin::Slc => "slc",
             Builtin::Lst => "lst",
             Builtin::Unq => "unq",
@@ -247,10 +250,10 @@ mod tests {
         let all = [
             "str", "num", "abs", "flr", "cel", "rou", "min", "max", "mod", "pow", "sqrt", "log",
             "exp", "sin", "cos", "tan", "log10", "log2", "atan2", "sum", "avg", "len", "hd", "at",
-            "tl", "rev", "srt", "slc", "lst", "unq", "flat", "has", "spl", "cat", "map", "flt",
-            "fld", "grp", "rnd", "now", "rd", "rdl", "rdb", "wr", "wrl", "prnt", "env", "trm",
-            "fmt", "fmt2", "rgx", "jpth", "jdmp", "jpar", "get", "post", "mmap", "mget", "mset",
-            "mhas", "mkeys", "mvals", "mdel",
+            "tl", "rev", "srt", "rsrt", "slc", "lst", "unq", "flat", "has", "spl", "cat", "map",
+            "flt", "fld", "grp", "rnd", "now", "rd", "rdl", "rdb", "wr", "wrl", "prnt", "env",
+            "trm", "fmt", "fmt2", "rgx", "jpth", "jdmp", "jpar", "get", "post", "mmap", "mget",
+            "mset", "mhas", "mkeys", "mvals", "mdel",
         ];
         for name in &all {
             let b = Builtin::from_name(name).unwrap_or_else(|| panic!("missing builtin: {name}"));

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -905,6 +905,52 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         });
         return Ok(Value::List(keyed.into_iter().map(|(_, v)| v).collect()));
     }
+    if builtin == Some(Builtin::Rsrt) && args.len() == 1 {
+        return match &args[0] {
+            Value::List(items) => {
+                if items.is_empty() {
+                    return Ok(Value::List(vec![]));
+                }
+                let all_numbers = items.iter().all(|v| matches!(v, Value::Number(_)));
+                let all_text = items.iter().all(|v| matches!(v, Value::Text(_)));
+                if all_numbers {
+                    let mut sorted = items.clone();
+                    sorted.sort_by(|a, b| {
+                        if let (Value::Number(x), Value::Number(y)) = (a, b) {
+                            y.partial_cmp(x).unwrap_or(std::cmp::Ordering::Equal)
+                        } else {
+                            unreachable!()
+                        }
+                    });
+                    Ok(Value::List(sorted))
+                } else if all_text {
+                    let mut sorted = items.clone();
+                    sorted.sort_by(|a, b| {
+                        if let (Value::Text(x), Value::Text(y)) = (a, b) {
+                            y.cmp(x)
+                        } else {
+                            unreachable!()
+                        }
+                    });
+                    Ok(Value::List(sorted))
+                } else {
+                    Err(RuntimeError::new(
+                        "ILO-R009",
+                        "rsrt: list must contain all numbers or all text".to_string(),
+                    ))
+                }
+            }
+            Value::Text(s) => {
+                let mut chars: Vec<char> = s.chars().collect();
+                chars.sort_by(|a, b| b.cmp(a));
+                Ok(Value::Text(chars.into_iter().collect()))
+            }
+            other => Err(RuntimeError::new(
+                "ILO-R009",
+                format!("rsrt requires a list or text, got {:?}", other),
+            )),
+        };
+    }
     if builtin == Some(Builtin::Slc) && args.len() == 3 {
         let start = match &args[1] {
             Value::Number(n) => *n as usize,

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -288,6 +288,7 @@ const BUILTINS: &[(&str, &[&str], &str)] = &[
     ("rev", &["list_or_text"], "list_or_text"),
     ("srt", &["list_or_text"], "list_or_text"),
     ("srt", &["fn", "list"], "list"),
+    ("rsrt", &["list_or_text"], "list_or_text"),
     ("unq", &["list_or_text"], "list_or_text"),
     ("slc", &["list_or_text", "n", "n"], "list_or_text"),
     ("lst", &["list", "n", "any"], "list"),
@@ -788,6 +789,24 @@ fn builtin_check_args(
                         code: "ILO-T013",
                         function: func_ctx.to_string(),
                         message: format!("'srt' expects a list or text, got {other}"),
+                        hint: None,
+                        span,
+                        is_warning: false,
+                    }),
+                }
+            }
+            (Ty::Unknown, errors)
+        }
+        "rsrt" => {
+            if let Some(arg) = arg_types.first() {
+                match arg {
+                    Ty::List(inner) => return (Ty::List(inner.clone()), errors),
+                    Ty::Text => return (Ty::Text, errors),
+                    Ty::Unknown => return (Ty::Unknown, errors),
+                    other => errors.push(VerifyError {
+                        code: "ILO-T013",
+                        function: func_ctx.to_string(),
+                        message: format!("'rsrt' expects a list or text, got {other}"),
                         hint: None,
                         span,
                         is_warning: false,

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -77,6 +77,7 @@ struct HelperFuncs {
     tl: FuncId,
     rev: FuncId,
     srt: FuncId,
+    rsrt: FuncId,
     slc: FuncId,
     listappend: FuncId,
     index: FuncId,
@@ -200,6 +201,7 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         tl: declare_helper(module, "jit_tl", 1, 1),
         rev: declare_helper(module, "jit_rev", 1, 1),
         srt: declare_helper(module, "jit_srt", 1, 1),
+        rsrt: declare_helper(module, "jit_rsrt", 1, 1),
         slc: declare_helper(module, "jit_slc", 3, 1),
         listappend: declare_helper(module, "jit_listappend", 2, 1),
         index: declare_helper(module, "jit_index", 2, 1),
@@ -916,11 +918,11 @@ fn compile_function_body(
                 // Ops that write a non-numeric or unknown type to R[A].
                 OP_ADD | OP_SUB | OP_MUL | OP_DIV | OP_ADD_SS | OP_NEG | OP_WRAPOK | OP_WRAPERR
                 | OP_UNWRAP | OP_RECFLD | OP_RECFLD_NAME | OP_LISTGET | OP_INDEX | OP_STR
-                | OP_HD | OP_AT | OP_FMT2 | OP_TL | OP_REV | OP_SRT | OP_SLC | OP_SPL | OP_CAT
-                | OP_GET | OP_POST | OP_GETH | OP_POSTH | OP_ENV | OP_JPTH | OP_JDMP | OP_JPAR
-                | OP_MAPNEW | OP_MGET | OP_MSET | OP_MDEL | OP_MKEYS | OP_MVALS | OP_LISTNEW
-                | OP_LISTAPPEND | OP_RECNEW | OP_RECWITH | OP_PRT | OP_RD | OP_RDL | OP_WR
-                | OP_WRL | OP_TRM | OP_UNQ | OP_NUM => {
+                | OP_HD | OP_AT | OP_FMT2 | OP_TL | OP_REV | OP_SRT | OP_SRTDESC | OP_SLC
+                | OP_SPL | OP_CAT | OP_GET | OP_POST | OP_GETH | OP_POSTH | OP_ENV | OP_JPTH
+                | OP_JDMP | OP_JPAR | OP_MAPNEW | OP_MGET | OP_MSET | OP_MDEL | OP_MKEYS
+                | OP_MVALS | OP_LISTNEW | OP_LISTAPPEND | OP_RECNEW | OP_RECWITH | OP_PRT
+                | OP_RD | OP_RDL | OP_WR | OP_WRL | OP_TRM | OP_UNQ | OP_NUM => {
                     non_num_write[a] = true;
                     non_bool_write[a] = true;
                 }
@@ -1920,6 +1922,13 @@ fn compile_function_body(
             OP_SRT => {
                 let bv = builder.use_var(vars[b_idx]);
                 let fref = get_func_ref(&mut builder, module, helpers.srt);
+                let call_inst = builder.ins().call(fref, &[bv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_SRTDESC => {
+                let bv = builder.use_var(vars[b_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.rsrt);
                 let call_inst = builder.ins().call(fref, &[bv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -83,6 +83,7 @@ struct HelperFuncs {
     tl: FuncId,
     rev: FuncId,
     srt: FuncId,
+    rsrt: FuncId,
     slc: FuncId,
     lst: FuncId,
     listappend: FuncId,
@@ -196,6 +197,7 @@ fn register_helpers(builder: &mut JITBuilder) {
         ("jit_tl", jit_tl as *const u8),
         ("jit_rev", jit_rev as *const u8),
         ("jit_srt", jit_srt as *const u8),
+        ("jit_rsrt", jit_rsrt as *const u8),
         ("jit_slc", jit_slc as *const u8),
         ("jit_lst", jit_lst as *const u8),
         ("jit_listappend", jit_listappend as *const u8),
@@ -300,6 +302,7 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         tl: declare_helper(module, "jit_tl", 1, 1),
         rev: declare_helper(module, "jit_rev", 1, 1),
         srt: declare_helper(module, "jit_srt", 1, 1),
+        rsrt: declare_helper(module, "jit_rsrt", 1, 1),
         slc: declare_helper(module, "jit_slc", 3, 1),
         lst: declare_helper(module, "jit_lst", 3, 1),
         listappend: declare_helper(module, "jit_listappend", 2, 1),
@@ -898,7 +901,8 @@ fn compile_function_body(
                 | OP_NEG
                 | OP_WRAPOK | OP_WRAPERR | OP_UNWRAP
                 | OP_RECFLD | OP_RECFLD_NAME | OP_LISTGET | OP_INDEX
-                | OP_STR | OP_HD | OP_AT | OP_FMT2 | OP_TL | OP_REV | OP_SRT | OP_SLC | OP_LST
+                | OP_STR | OP_HD | OP_AT | OP_FMT2 | OP_TL | OP_REV | OP_SRT | OP_SRTDESC
+                | OP_SLC | OP_LST
                 | OP_SPL | OP_CAT | OP_GET | OP_POST | OP_GETH | OP_POSTH
                 | OP_ENV | OP_JPTH | OP_JDMP | OP_JPAR
                 | OP_MAPNEW | OP_MGET | OP_MSET | OP_MDEL | OP_MKEYS | OP_MVALS
@@ -1966,6 +1970,13 @@ fn compile_function_body(
             OP_SRT => {
                 let bv = builder.use_var(vars[b_idx]);
                 let fref = get_func_ref(&mut builder, module, helpers.srt);
+                let call_inst = builder.ins().call(fref, &[bv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_SRTDESC => {
+                let bv = builder.use_var(vars[b_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.rsrt);
                 let call_inst = builder.ins().call(fref, &[bv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -193,6 +193,7 @@ pub(crate) const OP_TAN: u8 = 105; // R[A] = tan(R[B])
 pub(crate) const OP_LOG10: u8 = 106; // R[A] = log10(R[B])
 pub(crate) const OP_LOG2: u8 = 107; // R[A] = log2(R[B])
 pub(crate) const OP_ATAN2: u8 = 108; // R[A] = atan2(R[B], R[C])  (y first, x second)
+pub(crate) const OP_SRTDESC: u8 = 117; // R[A] = rsrt(R[B])  (descending sort of list)
 
 // ABC mode — text formatting
 pub(crate) const OP_FMT2: u8 = 104; // R[A] = fmt2(R[B], R[C])  (format number to N decimal places → t)
@@ -1704,6 +1705,12 @@ impl RegCompiler {
                             self.emit_abc(OP_SRT, ra, rb, 0);
                             return ra;
                         }
+                        (Builtin::Rsrt, 1) => {
+                            let rb = self.compile_expr(&args[0]);
+                            let ra = self.alloc_reg();
+                            self.emit_abc(OP_SRTDESC, ra, rb, 0);
+                            return ra;
+                        }
                         (Builtin::Slc, 3) => {
                             // slc list start end — two-instruction sequence:
                             //   OP_SLC   A=result  B=list  C=start
@@ -2483,10 +2490,10 @@ fn chunk_is_all_numeric(chunk: &Chunk) -> bool {
         let op = (inst >> 24) as u8;
         match op {
             OP_RECNEW | OP_LISTNEW | OP_RECWITH | OP_WRAPOK | OP_WRAPERR | OP_STR | OP_CAT
-            | OP_SPL | OP_REV | OP_SRT | OP_SLC | OP_UNQ | OP_LISTAPPEND | OP_JPAR | OP_JDMP
-            | OP_ENV | OP_GET | OP_GETH | OP_POST | OP_POSTH | OP_RD | OP_RDL | OP_WR | OP_WRL
-            | OP_MAPNEW | OP_MGET | OP_MSET | OP_MKEYS | OP_MVALS | OP_HD | OP_AT | OP_LST
-            | OP_TL | OP_FMT2 => {
+            | OP_SPL | OP_REV | OP_SRT | OP_SRTDESC | OP_SLC | OP_UNQ | OP_LISTAPPEND | OP_JPAR
+            | OP_JDMP | OP_ENV | OP_GET | OP_GETH | OP_POST | OP_POSTH | OP_RD | OP_RDL | OP_WR
+            | OP_WRL | OP_MAPNEW | OP_MGET | OP_MSET | OP_MKEYS | OP_MVALS | OP_HD | OP_AT
+            | OP_LST | OP_TL | OP_FMT2 => {
                 return false;
             }
             _ => {}
@@ -5762,6 +5769,66 @@ impl<'a> VM<'a> {
                         vm_err!(VmError::Type("srt requires a list or text"));
                     }
                 }
+                OP_SRTDESC => {
+                    let a = ((inst >> 16) & 0xFF) as usize + base;
+                    let b = ((inst >> 8) & 0xFF) as usize + base;
+                    let v = reg!(b);
+                    if v.is_string() {
+                        let s = unsafe {
+                            match v.as_heap_ref() {
+                                HeapObj::Str(s) => s,
+                                _ => unreachable!(),
+                            }
+                        };
+                        let mut chars: Vec<char> = s.chars().collect();
+                        chars.sort_by(|a, b| b.cmp(a));
+                        let sorted: String = chars.into_iter().collect();
+                        reg_set!(a, NanVal::heap_string(sorted));
+                    } else if v.is_heap() {
+                        match unsafe { v.as_heap_ref() } {
+                            HeapObj::List(items) => {
+                                if items.is_empty() {
+                                    reg_set!(a, NanVal::heap_list(vec![]));
+                                } else {
+                                    let all_numbers = items.iter().all(|v| v.is_number());
+                                    let all_strings = items.iter().all(|v| v.is_string());
+                                    if all_numbers {
+                                        let mut sorted: Vec<NanVal> = items
+                                            .iter()
+                                            .map(|v| {
+                                                v.clone_rc();
+                                                *v
+                                            })
+                                            .collect();
+                                        sorted.sort_by(|a, b| {
+                                            b.as_number()
+                                                .partial_cmp(&a.as_number())
+                                                .unwrap_or(std::cmp::Ordering::Equal)
+                                        });
+                                        reg_set!(a, NanVal::heap_list(sorted));
+                                    } else if all_strings {
+                                        let mut sorted: Vec<NanVal> = items
+                                            .iter()
+                                            .map(|v| {
+                                                v.clone_rc();
+                                                *v
+                                            })
+                                            .collect();
+                                        sorted.sort_by(|a, b| unsafe { nanval_str_cmp(*b, *a) });
+                                        reg_set!(a, NanVal::heap_list(sorted));
+                                    } else {
+                                        vm_err!(VmError::Type(
+                                            "rsrt: list must contain all numbers or all text"
+                                        ));
+                                    }
+                                }
+                            }
+                            _ => vm_err!(VmError::Type("rsrt requires a list or text")),
+                        }
+                    } else {
+                        vm_err!(VmError::Type("rsrt requires a list or text"));
+                    }
+                }
                 OP_SLC => {
                     // Two-instruction sequence: OP_SLC A=result B=list C=start; data word A=end_reg
                     let a = ((inst >> 16) & 0xFF) as usize + base;
@@ -7133,6 +7200,60 @@ pub(crate) extern "C" fn jit_srt(a: u64) -> u64 {
                 })
                 .collect();
             sorted.sort_by(|a, b| unsafe { nanval_str_cmp(*a, *b) });
+            return NanVal::heap_list(sorted).0;
+        }
+    }
+    TAG_NIL
+}
+
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_rsrt(a: u64) -> u64 {
+    let v = NanVal(a);
+    if v.is_string() {
+        let s = unsafe {
+            match v.as_heap_ref() {
+                HeapObj::Str(s) => s,
+                _ => unreachable!(),
+            }
+        };
+        let mut chars: Vec<char> = s.chars().collect();
+        chars.sort_by(|a, b| b.cmp(a));
+        let sorted: String = chars.into_iter().collect();
+        return NanVal::heap_string(sorted).0;
+    }
+    if v.is_heap()
+        && let HeapObj::List(items) = unsafe { v.as_heap_ref() }
+    {
+        if items.is_empty() {
+            return NanVal::heap_list(vec![]).0;
+        }
+        let all_numbers = items.iter().all(|v| v.is_number());
+        let all_strings = items.iter().all(|v| v.is_string());
+        if all_numbers {
+            let mut sorted: Vec<NanVal> = items
+                .iter()
+                .map(|v| {
+                    v.clone_rc();
+                    *v
+                })
+                .collect();
+            sorted.sort_by(|a, b| {
+                b.as_number()
+                    .partial_cmp(&a.as_number())
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            return NanVal::heap_list(sorted).0;
+        }
+        if all_strings {
+            let mut sorted: Vec<NanVal> = items
+                .iter()
+                .map(|v| {
+                    v.clone_rc();
+                    *v
+                })
+                .collect();
+            sorted.sort_by(|a, b| unsafe { nanval_str_cmp(*b, *a) });
             return NanVal::heap_list(sorted).0;
         }
     }

--- a/tests/regression_rsrt.rs
+++ b/tests/regression_rsrt.rs
@@ -1,0 +1,200 @@
+// Regression tests for the `rsrt xs` builtin — descending sort of a list.
+//
+// `rsrt` mirrors `srt` but in reverse order. Numeric lists sort descending,
+// text lists sort lexicographically descending. Same `Ord` impl as `srt`,
+// just the inverse comparator.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+// Numeric list — manifest example from the spec.
+const NUM_SRC: &str = "f>L n;xs=[3,1,4,1,5,9,2,6];rsrt xs";
+
+fn check_nums(engine: &str) {
+    assert_eq!(
+        run(engine, NUM_SRC, "f"),
+        "[9, 6, 5, 4, 3, 2, 1, 1]",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn rsrt_nums_tree() {
+    check_nums("--run-tree");
+}
+
+#[test]
+fn rsrt_nums_vm() {
+    check_nums("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn rsrt_nums_cranelift() {
+    check_nums("--run-cranelift");
+}
+
+// String list — lexicographic descending.
+const TEXT_SRC: &str = "f>L t;xs=[\"banana\",\"apple\",\"cherry\"];rsrt xs";
+
+fn check_text(engine: &str) {
+    assert_eq!(
+        run(engine, TEXT_SRC, "f"),
+        "[cherry, banana, apple]",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn rsrt_text_tree() {
+    check_text("--run-tree");
+}
+
+#[test]
+fn rsrt_text_vm() {
+    check_text("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn rsrt_text_cranelift() {
+    check_text("--run-cranelift");
+}
+
+// Empty list — round-trips as empty.
+const EMPTY_SRC: &str = "f>L n;rsrt []";
+
+fn check_empty(engine: &str) {
+    assert_eq!(run(engine, EMPTY_SRC, "f"), "[]", "engine={engine}");
+}
+
+#[test]
+fn rsrt_empty_tree() {
+    check_empty("--run-tree");
+}
+
+#[test]
+fn rsrt_empty_vm() {
+    check_empty("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn rsrt_empty_cranelift() {
+    check_empty("--run-cranelift");
+}
+
+// Single element — round-trips unchanged. Use a two-element collapse
+// via slc so the parser doesn't mistake `[42]` for subscripting.
+const SINGLE_SRC: &str = "f>L n;xs=[42,99];rsrt (slc xs 0 1)";
+
+fn check_single(engine: &str) {
+    assert_eq!(run(engine, SINGLE_SRC, "f"), "[42]", "engine={engine}");
+}
+
+#[test]
+fn rsrt_single_tree() {
+    check_single("--run-tree");
+}
+
+#[test]
+fn rsrt_single_vm() {
+    check_single("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn rsrt_single_cranelift() {
+    check_single("--run-cranelift");
+}
+
+// Type-variable signature: rsrt :: L a > L a — accepts any list element type.
+// Exercises the polymorphic shape by routing through a wrapper fn.
+const TYPEVAR_SRC: &str = "g xs:L a>L a;rsrt xs   f>L n;g [3,1,2]";
+
+fn check_typevar(engine: &str) {
+    assert_eq!(
+        run(engine, TYPEVAR_SRC, "f"),
+        "[3, 2, 1]",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn rsrt_typevar_tree() {
+    check_typevar("--run-tree");
+}
+
+#[test]
+fn rsrt_typevar_vm() {
+    check_typevar("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn rsrt_typevar_cranelift() {
+    check_typevar("--run-cranelift");
+}
+
+// Text input — mirror `srt` but in reverse. Sorts characters by codepoint
+// descending. Symmetry with `srt` is the whole point of this branch.
+const STR_ASC_SRC: &str = "f>t;rsrt \"abc\"";
+
+fn check_str_asc(engine: &str) {
+    assert_eq!(run(engine, STR_ASC_SRC, "f"), "cba", "engine={engine}");
+}
+
+#[test]
+fn rsrt_str_asc_tree() {
+    check_str_asc("--run-tree");
+}
+
+#[test]
+fn rsrt_str_asc_vm() {
+    check_str_asc("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn rsrt_str_asc_cranelift() {
+    check_str_asc("--run-cranelift");
+}
+
+// Already-descending text — round-trips unchanged.
+const STR_DESC_SRC: &str = "f>t;rsrt \"cba\"";
+
+fn check_str_desc(engine: &str) {
+    assert_eq!(run(engine, STR_DESC_SRC, "f"), "cba", "engine={engine}");
+}
+
+#[test]
+fn rsrt_str_desc_tree() {
+    check_str_desc("--run-tree");
+}
+
+#[test]
+fn rsrt_str_desc_vm() {
+    check_str_desc("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn rsrt_str_desc_cranelift() {
+    check_str_desc("--run-cranelift");
+}


### PR DESCRIPTION
Reverse-sort is the second-most-common sort. Doing it via srt + rev allocated twice and obscured intent.

Implementation:
- rsrt sorts descending in a single pass
- mirrors srt in shape and type signature
- works on list of numbers, list of text, and text (code points)
- opcode allocated: rsrt

Tests: cross-engine regression tests + examples/rsrt.ilo with -- run: directives.