### PR TITLE
builtins: add solve inv det via LU decomposition

### DIFF
--- a/examples/linalg-advanced.ilo
+++ b/examples/linalg-advanced.ilo
@@ -1,0 +1,21 @@
+-- Advanced linear algebra: solve, inv, det via LU decomposition with
+-- partial pivoting. Matrices are row-major nested lists (L (L n));
+-- vectors are flat lists (L n). Singular and non-square inputs raise.
+
+-- Determinant of a square matrix.
+de a:L (L n)>n;det a
+
+-- Solve Ax = b for x.
+sv a:L (L n) b:L n>L n;solve a b
+
+-- Matrix inverse.
+iv a:L (L n)>L (L n);inv a
+
+-- run: de [[1,0],[0,1]]
+-- out: 1
+-- run: de [[2,1],[1,3]]
+-- out: 5
+-- run: sv [[1,1],[1,-1]] [3,1]
+-- out: [2, 1]
+-- run: iv [[2,0],[0,2]]
+-- out: [[0.5, 0], [0, 0.5]]

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -123,6 +123,11 @@ pub enum Builtin {
     Mkeys,
     Mvals,
     Mdel,
+
+    // Linear algebra
+    Solve,
+    Inv,
+    Det,
 }
 
 impl Builtin {
@@ -226,6 +231,9 @@ impl Builtin {
             "mkeys" => Some(Builtin::Mkeys),
             "mvals" => Some(Builtin::Mvals),
             "mdel" => Some(Builtin::Mdel),
+            "solve" => Some(Builtin::Solve),
+            "inv" => Some(Builtin::Inv),
+            "det" => Some(Builtin::Det),
             _ => None,
         }
     }
@@ -330,6 +338,9 @@ impl Builtin {
             Builtin::Mkeys => "mkeys",
             Builtin::Mvals => "mvals",
             Builtin::Mdel => "mdel",
+            Builtin::Solve => "solve",
+            Builtin::Inv => "inv",
+            Builtin::Det => "det",
         }
     }
 
@@ -442,6 +453,9 @@ mod tests {
             "dot",
             "rndn",
             "get-many",
+            "solve",
+            "inv",
+            "det",
         ];
         for name in &all {
             let b = Builtin::from_name(name).unwrap_or_else(|| panic!("missing builtin: {name}"));

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -338,6 +338,145 @@ fn parse_csv_row(line: &str, sep: char) -> Vec<String> {
     fields
 }
 
+// ── Linear algebra helpers ──────────────────────────────────────────
+
+/// Coerce a `Value` into a row-major matrix `Vec<Vec<f64>>`.
+fn matrix_from_value(v: &Value, name: &str) -> Result<Vec<Vec<f64>>> {
+    let rows = match v {
+        Value::List(rs) => rs,
+        other => {
+            return Err(RuntimeError::new(
+                "ILO-R009",
+                format!("{}: expected a list of lists, got {:?}", name, other),
+            ));
+        }
+    };
+    let mut mat: Vec<Vec<f64>> = Vec::with_capacity(rows.len());
+    for row in rows {
+        let cells = match row {
+            Value::List(cs) => cs,
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!("{}: each row must be a list, got {:?}", name, other),
+                ));
+            }
+        };
+        let mut r: Vec<f64> = Vec::with_capacity(cells.len());
+        for c in cells {
+            match c {
+                Value::Number(n) => r.push(*n),
+                other => {
+                    return Err(RuntimeError::new(
+                        "ILO-R009",
+                        format!("{}: matrix cells must be numbers, got {:?}", name, other),
+                    ));
+                }
+            }
+        }
+        mat.push(r);
+    }
+    Ok(mat)
+}
+
+/// Coerce a `Value` into a vector `Vec<f64>`.
+fn vec_from_value(v: &Value, name: &str) -> Result<Vec<f64>> {
+    let items = match v {
+        Value::List(xs) => xs,
+        other => {
+            return Err(RuntimeError::new(
+                "ILO-R009",
+                format!("{}: expected a list of numbers, got {:?}", name, other),
+            ));
+        }
+    };
+    let mut out: Vec<f64> = Vec::with_capacity(items.len());
+    for item in items {
+        match item {
+            Value::Number(n) => out.push(*n),
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!("{}: vector items must be numbers, got {:?}", name, other),
+                ));
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// LU decomposition with partial pivoting, in-place on an owned matrix.
+/// Returns (LU, pivot indices, determinant, singular flag). When `singular`
+/// is true, the LU and det values are still well-formed (det = 0) but the
+/// system has no unique solution.
+#[allow(clippy::needless_range_loop)]
+pub(crate) fn lu_decompose(mut a: Vec<Vec<f64>>) -> (Vec<Vec<f64>>, Vec<usize>, f64, bool) {
+    let n = a.len();
+    let mut piv: Vec<usize> = (0..n).collect();
+    let mut det_sign = 1.0_f64;
+    let mut singular = false;
+    for k in 0..n {
+        // Pivot: find row with max |a[i][k]| for i in k..n
+        let mut max_val = a[k][k].abs();
+        let mut max_row = k;
+        for i in (k + 1)..n {
+            let v = a[i][k].abs();
+            if v > max_val {
+                max_val = v;
+                max_row = i;
+            }
+        }
+        if max_val < 1e-12 {
+            singular = true;
+            continue;
+        }
+        if max_row != k {
+            a.swap(k, max_row);
+            piv.swap(k, max_row);
+            det_sign = -det_sign;
+        }
+        let pivot = a[k][k];
+        for i in (k + 1)..n {
+            a[i][k] /= pivot;
+            let factor = a[i][k];
+            for j in (k + 1)..n {
+                a[i][j] -= factor * a[k][j];
+            }
+        }
+    }
+    let mut det = det_sign;
+    for (i, row) in a.iter().enumerate().take(n) {
+        det *= row[i];
+    }
+    if singular {
+        det = 0.0;
+    }
+    (a, piv, det, singular)
+}
+
+/// Solve LUx = Pb using the result of `lu_decompose`.
+pub(crate) fn lu_solve(lu: &[Vec<f64>], piv: &[usize], b: &[f64]) -> Vec<f64> {
+    let n = lu.len();
+    // Apply permutation: y = Pb
+    let mut x: Vec<f64> = (0..n).map(|i| b[piv[i]]).collect();
+    // Forward solve Ly = Pb (L has unit diagonal)
+    for i in 0..n {
+        for j in 0..i {
+            let lij = lu[i][j];
+            x[i] -= lij * x[j];
+        }
+    }
+    // Back solve Ux = y
+    for i in (0..n).rev() {
+        for j in (i + 1)..n {
+            let uij = lu[i][j];
+            x[i] -= uij * x[j];
+        }
+        x[i] /= lu[i][i];
+    }
+    x
+}
+
 fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
     // Builtins — resolve name to enum once, then dispatch via match
     let builtin = Builtin::from_name(name);
@@ -435,6 +574,102 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 "mdel: expects map and text key".to_string(),
             )),
         };
+    }
+    if builtin == Some(Builtin::Det) && args.len() == 1 {
+        let mat = matrix_from_value(&args[0], "det")?;
+        let n = mat.len();
+        if n == 0 {
+            return Err(RuntimeError::new(
+                "ILO-R009",
+                "det: empty matrix".to_string(),
+            ));
+        }
+        for row in &mat {
+            if row.len() != n {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    "det: matrix must be square".to_string(),
+                ));
+            }
+        }
+        let (_lu, _piv, det, _) = lu_decompose(mat);
+        return Ok(Value::Number(det));
+    }
+    if builtin == Some(Builtin::Inv) && args.len() == 1 {
+        let mat = matrix_from_value(&args[0], "inv")?;
+        let n = mat.len();
+        if n == 0 {
+            return Err(RuntimeError::new(
+                "ILO-R009",
+                "inv: empty matrix".to_string(),
+            ));
+        }
+        for row in &mat {
+            if row.len() != n {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    "inv: matrix must be square".to_string(),
+                ));
+            }
+        }
+        let (lu, piv, _det, singular) = lu_decompose(mat);
+        if singular {
+            return Err(RuntimeError::new(
+                "ILO-R009",
+                "inv: matrix is singular".to_string(),
+            ));
+        }
+        let mut cols: Vec<Vec<f64>> = Vec::with_capacity(n);
+        for j in 0..n {
+            let mut e = vec![0.0; n];
+            e[j] = 1.0;
+            cols.push(lu_solve(&lu, &piv, &e));
+        }
+        // Assemble row-major: result[i][j] = cols[j][i]
+        let rows: Vec<Value> = (0..n)
+            .map(|i| {
+                Value::List(
+                    (0..n)
+                        .map(|j| Value::Number(cols[j][i]))
+                        .collect::<Vec<_>>(),
+                )
+            })
+            .collect();
+        return Ok(Value::List(rows));
+    }
+    if builtin == Some(Builtin::Solve) && args.len() == 2 {
+        let mat = matrix_from_value(&args[0], "solve")?;
+        let b = vec_from_value(&args[1], "solve")?;
+        let n = mat.len();
+        if n == 0 {
+            return Err(RuntimeError::new(
+                "ILO-R009",
+                "solve: empty matrix".to_string(),
+            ));
+        }
+        for row in &mat {
+            if row.len() != n {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    "solve: matrix must be square".to_string(),
+                ));
+            }
+        }
+        if b.len() != n {
+            return Err(RuntimeError::new(
+                "ILO-R009",
+                "solve: vector length must match matrix size".to_string(),
+            ));
+        }
+        let (lu, piv, _det, singular) = lu_decompose(mat);
+        if singular {
+            return Err(RuntimeError::new(
+                "ILO-R009",
+                "solve: matrix is singular".to_string(),
+            ));
+        }
+        let x = lu_solve(&lu, &piv, &b);
+        return Ok(Value::List(x.into_iter().map(Value::Number).collect()));
     }
     if builtin == Some(Builtin::Str) {
         if args.len() != 1 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3268,9 +3268,33 @@ print(f"__NS__={{_per}}")
     }
 }
 
+/// Split a string on top-level commas, respecting [] nesting.
+/// Used by `parse_cli_arg` so that nested-list literals like
+/// `[[1,2],[3,4]]` are parsed as two elements rather than four.
+fn split_top_level_commas(s: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut depth: i32 = 0;
+    let mut start = 0usize;
+    let bytes = s.as_bytes();
+    for (i, &b) in bytes.iter().enumerate() {
+        match b {
+            b'[' => depth += 1,
+            b']' => depth -= 1,
+            b',' if depth == 0 => {
+                parts.push(&s[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    parts.push(&s[start..]);
+    parts
+}
+
 fn parse_cli_arg(s: &str) -> interpreter::Value {
-    // Bracketed list: [1,2,3], ["apple","ant"], [] — split top-level commas,
-    // honoring quoted strings so commas inside strings don't split.
+    // Bracketed list: [1,2,3], ["apple","ant"], [[1,2],[3,4]] or [] — split
+    // top-level commas, honoring quoted strings so commas inside strings don't
+    // split, and recursing into nested brackets.
     if s.starts_with('[') && s.ends_with(']') {
         let inner = s[1..s.len() - 1].trim();
         if inner.is_empty() {
@@ -3311,49 +3335,6 @@ fn parse_cli_arg(s: &str) -> interpreter::Value {
     } else {
         interpreter::Value::Text(s.to_string())
     }
-}
-
-/// Split on commas, but ignore commas inside double-quoted strings or nested
-/// brackets so list args like `["a,b","c"]` and `[[1,2],[3,4]]` parse correctly.
-fn split_top_level_commas(s: &str) -> Vec<String> {
-    let mut out = Vec::new();
-    let mut cur = String::new();
-    let mut depth = 0i32;
-    let mut in_str = false;
-    let mut prev_escape = false;
-    for ch in s.chars() {
-        if in_str {
-            cur.push(ch);
-            if prev_escape {
-                prev_escape = false;
-            } else if ch == '\\' {
-                prev_escape = true;
-            } else if ch == '"' {
-                in_str = false;
-            }
-            continue;
-        }
-        match ch {
-            '"' => {
-                in_str = true;
-                cur.push(ch);
-            }
-            '[' => {
-                depth += 1;
-                cur.push(ch);
-            }
-            ']' => {
-                depth -= 1;
-                cur.push(ch);
-            }
-            ',' if depth == 0 => {
-                out.push(std::mem::take(&mut cur));
-            }
-            _ => cur.push(ch),
-        }
-    }
-    out.push(cur);
-    out
 }
 
 /// Coerce CLI args to match a function's parameter types.

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -350,6 +350,10 @@ const BUILTINS: &[(&str, &[&str], &str)] = &[
     ("mkeys", &["map"], "L t"),
     ("mvals", &["map"], "list"),
     ("mdel", &["map", "t"], "map"),
+    // Linear algebra
+    ("solve", &["L (L n)", "L n"], "L n"),
+    ("inv", &["L (L n)"], "L (L n)"),
+    ("det", &["L (L n)"], "n"),
 ];
 
 fn builtin_arity(name: &str) -> Option<usize> {
@@ -1844,6 +1848,67 @@ fn builtin_check_args(
                         is_warning: false,
                     });
                 }
+            }
+            (Ty::Number, errors)
+        }
+        "solve" => {
+            let matrix_ty = Ty::List(Box::new(Ty::List(Box::new(Ty::Number))));
+            let vec_ty = Ty::List(Box::new(Ty::Number));
+            if let Some(arg) = arg_types.first()
+                && !compatible(arg, &matrix_ty)
+            {
+                errors.push(VerifyError {
+                    code: "ILO-T013",
+                    function: func_ctx.to_string(),
+                    message: format!("'solve' first arg expects L (L n), got {arg}"),
+                    hint: None,
+                    span,
+                    is_warning: false,
+                });
+            }
+            if let Some(arg) = arg_types.get(1)
+                && !compatible(arg, &vec_ty)
+            {
+                errors.push(VerifyError {
+                    code: "ILO-T013",
+                    function: func_ctx.to_string(),
+                    message: format!("'solve' second arg expects L n, got {arg}"),
+                    hint: None,
+                    span,
+                    is_warning: false,
+                });
+            }
+            (vec_ty, errors)
+        }
+        "inv" => {
+            let matrix_ty = Ty::List(Box::new(Ty::List(Box::new(Ty::Number))));
+            if let Some(arg) = arg_types.first()
+                && !compatible(arg, &matrix_ty)
+            {
+                errors.push(VerifyError {
+                    code: "ILO-T013",
+                    function: func_ctx.to_string(),
+                    message: format!("'inv' expects L (L n), got {arg}"),
+                    hint: None,
+                    span,
+                    is_warning: false,
+                });
+            }
+            (matrix_ty, errors)
+        }
+        "det" => {
+            let matrix_ty = Ty::List(Box::new(Ty::List(Box::new(Ty::Number))));
+            if let Some(arg) = arg_types.first()
+                && !compatible(arg, &matrix_ty)
+            {
+                errors.push(VerifyError {
+                    code: "ILO-T013",
+                    function: func_ctx.to_string(),
+                    message: format!("'det' expects L (L n), got {arg}"),
+                    hint: None,
+                    span,
+                    is_warning: false,
+                });
             }
             (Ty::Number, errors)
         }

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -157,6 +157,10 @@ struct HelperFuncs {
     aot_set_registry: FuncId,
     aot_parse_arg: FuncId,
     string_const: FuncId,
+    // Linear algebra
+    solve: FuncId,
+    inv: FuncId,
+    det: FuncId,
 }
 
 fn declare_helper(
@@ -313,6 +317,10 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         aot_set_registry: declare_helper(module, "ilo_aot_set_registry", 2, 0),
         aot_parse_arg: declare_helper(module, "ilo_aot_parse_arg", 1, 1),
         string_const: declare_helper(module, "jit_string_const", 1, 1),
+        // Linear algebra
+        solve: declare_helper(module, "jit_solve", 2, 1),
+        inv: declare_helper(module, "jit_inv", 1, 1),
+        det: declare_helper(module, "jit_det", 1, 1),
     }
 }
 
@@ -960,7 +968,7 @@ fn compile_function_body(
                 | OP_MULK_N | OP_DIVK_N | OP_LEN | OP_ABS | OP_MIN | OP_MAX | OP_FLR | OP_CEL
                 | OP_ROU | OP_RND0 | OP_RND2 | OP_RNDN | OP_NOW | OP_MOD | OP_CLAMP | OP_POW
                 | OP_SQRT | OP_LOG | OP_EXP | OP_SIN | OP_COS | OP_TAN | OP_LOG10 | OP_LOG2
-                | OP_ATAN2 | OP_MEDIAN | OP_QUANTILE | OP_STDEV | OP_VARIANCE | OP_DOT => {
+                | OP_ATAN2 | OP_MEDIAN | OP_QUANTILE | OP_STDEV | OP_VARIANCE | OP_DOT | OP_DET => {
                     num_write[a] = true;
                 }
                 // LOADK: numeric only when the constant itself is a number.
@@ -991,7 +999,7 @@ fn compile_function_body(
                 | OP_UPR | OP_LWR | OP_CAP | OP_PADL | OP_PADR | OP_UNQ | OP_UNIQBY
                 | OP_PARTITION | OP_FRQ | OP_NUM | OP_RGXSUB | OP_ZIP | OP_ENUMERATE | OP_RANGE
                 | OP_WINDOW | OP_CHUNKS | OP_CUMSUM | OP_SETUNION | OP_SETINTER | OP_SETDIFF
-                | OP_FFT | OP_IFFT | OP_TRANSPOSE | OP_MATMUL => {
+                | OP_FFT | OP_IFFT | OP_TRANSPOSE | OP_MATMUL | OP_INV | OP_SOLVE => {
                     non_num_write[a] = true;
                     non_bool_write[a] = true;
                 }
@@ -1903,6 +1911,32 @@ fn compile_function_body(
                     let rf = builder.ins().bitcast(F64, mf, result);
                     builder.def_var(f64_vars[a_idx], rf);
                 }
+            }
+            OP_DET => {
+                let bv = builder.use_var(vars[b_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.det);
+                let call_inst = builder.ins().call(fref, &[bv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+                if a_idx < reg_count && reg_always_num[a_idx] {
+                    let rf = builder.ins().bitcast(F64, mf, result);
+                    builder.def_var(f64_vars[a_idx], rf);
+                }
+            }
+            OP_INV => {
+                let bv = builder.use_var(vars[b_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.inv);
+                let call_inst = builder.ins().call(fref, &[bv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_SOLVE => {
+                let bv = builder.use_var(vars[b_idx]);
+                let cv = builder.use_var(vars[c_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.solve);
+                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
             }
             OP_SQRT | OP_LOG | OP_EXP | OP_SIN | OP_COS | OP_TAN | OP_LOG10 | OP_LOG2 => {
                 let bv = builder.use_var(vars[b_idx]);

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -157,6 +157,10 @@ struct HelperFuncs {
     geth: FuncId,
     posth: FuncId,
     getmany: FuncId,
+    // Linear algebra
+    solve: FuncId,
+    inv: FuncId,
+    det: FuncId,
 }
 
 fn declare_helper(module: &mut JITModule, name: &str, n_params: usize, n_returns: usize) -> FuncId {
@@ -303,6 +307,9 @@ fn register_helpers(builder: &mut JITBuilder) {
         ("jit_geth", jit_geth as *const u8),
         ("jit_posth", jit_posth as *const u8),
         ("jit_getmany", jit_getmany as *const u8),
+        ("jit_solve", jit_solve as *const u8),
+        ("jit_inv", jit_inv as *const u8),
+        ("jit_det", jit_det as *const u8),
     ];
     for &(name, ptr) in helpers {
         builder.symbol(name, ptr);
@@ -440,6 +447,10 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         geth: declare_helper(module, "jit_geth", 2, 1),
         posth: declare_helper(module, "jit_posth", 3, 1),
         getmany: declare_helper(module, "jit_getmany", 1, 1),
+        // Linear algebra
+        solve: declare_helper(module, "jit_solve", 2, 1),
+        inv: declare_helper(module, "jit_inv", 1, 1),
+        det: declare_helper(module, "jit_det", 1, 1),
     }
 }
 
@@ -970,7 +981,7 @@ fn compile_function_body(
                 | OP_FLR | OP_CEL | OP_ROU | OP_RND0 | OP_RND2 | OP_RNDN | OP_NOW
                 | OP_MOD | OP_CLAMP | OP_POW | OP_SQRT | OP_LOG | OP_EXP | OP_SIN | OP_COS
                 | OP_TAN | OP_LOG10 | OP_LOG2 | OP_ATAN2
-                | OP_MEDIAN | OP_QUANTILE | OP_STDEV | OP_VARIANCE | OP_DOT => {
+                | OP_MEDIAN | OP_QUANTILE | OP_STDEV | OP_VARIANCE | OP_DOT | OP_DET => {
                     num_write[a] = true;
                 }
                 // LOADK: numeric only when the constant itself is a number.
@@ -1003,6 +1014,7 @@ fn compile_function_body(
                 | OP_SLC | OP_LST | OP_ZIP | OP_TAKE | OP_DROP | OP_ENUMERATE | OP_RANGE
                 | OP_WINDOW | OP_CHUNKS | OP_CUMSUM
                 | OP_SETUNION | OP_SETINTER | OP_SETDIFF
+                | OP_INV | OP_SOLVE
                 | OP_SPL | OP_CAT | OP_GET | OP_POST | OP_GETH | OP_POSTH | OP_GETMANY
                 | OP_ENV | OP_JPTH | OP_JDMP | OP_JPAR
                 | OP_MAPNEW | OP_MGET | OP_MSET | OP_MDEL | OP_MKEYS | OP_MVALS
@@ -1981,6 +1993,33 @@ fn compile_function_body(
                     let rf = builder.ins().bitcast(F64, mf, result);
                     builder.def_var(f64_vars[a_idx], rf);
                 }
+            }
+            OP_DET => {
+                let bv = builder.use_var(vars[b_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.det);
+                let call_inst = builder.ins().call(fref, &[bv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+                if a_idx < reg_count && reg_always_num[a_idx] {
+                    let mf = cranelift_codegen::ir::MemFlags::new();
+                    let rf = builder.ins().bitcast(F64, mf, result);
+                    builder.def_var(f64_vars[a_idx], rf);
+                }
+            }
+            OP_INV => {
+                let bv = builder.use_var(vars[b_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.inv);
+                let call_inst = builder.ins().call(fref, &[bv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_SOLVE => {
+                let bv = builder.use_var(vars[b_idx]);
+                let cv = builder.use_var(vars[c_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.solve);
+                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
             }
             OP_SQRT | OP_LOG | OP_EXP | OP_SIN | OP_COS | OP_TAN | OP_LOG10 | OP_LOG2 => {
                 let bv = builder.use_var(vars[b_idx]);

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -251,6 +251,11 @@ pub(crate) const OP_PADR: u8 = 122; // R[A] = pad_right(R[B], R[C]) (text, width
 
 pub(crate) const OP_GETMANY: u8 = 136; // R[A] = get_many(R[B])  (L t → L (R t t), concurrent fan-out)
 
+// Linear algebra advanced.
+pub(crate) const OP_SOLVE: u8 = 126; // R[A] = solve(R[B], R[C])  — solve Ax = b
+pub(crate) const OP_INV: u8 = 127; // R[A] = inv(R[B])  — matrix inverse
+pub(crate) const OP_DET: u8 = 128; // R[A] = det(R[B])  — matrix determinant
+
 // ABx mode — register + 16-bit operand
 pub(crate) const OP_LOADK: u8 = 20;
 pub(crate) const OP_JMP: u8 = 21;
@@ -1733,6 +1738,26 @@ impl RegCompiler {
                             self.reg_is_num[ra as usize] = true;
                             return ra;
                         }
+                        (Builtin::Solve, 2) => {
+                            let rb = self.compile_expr(&args[0]);
+                            let rc = self.compile_expr(&args[1]);
+                            let ra = self.alloc_reg();
+                            self.emit_abc(OP_SOLVE, ra, rb, rc);
+                            return ra;
+                        }
+                        (Builtin::Inv, 1) => {
+                            let rb = self.compile_expr(&args[0]);
+                            let ra = self.alloc_reg();
+                            self.emit_abc(OP_INV, ra, rb, 0);
+                            return ra;
+                        }
+                        (Builtin::Det, 1) => {
+                            let rb = self.compile_expr(&args[0]);
+                            let ra = self.alloc_reg();
+                            self.emit_abc(OP_DET, ra, rb, 0);
+                            self.reg_is_num[ra as usize] = true;
+                            return ra;
+                        }
                         (Builtin::Spl, 2) => {
                             let rb = self.compile_expr(&args[0]);
                             let rc = self.compile_expr(&args[1]);
@@ -2765,7 +2790,7 @@ fn chunk_is_all_numeric(chunk: &Chunk) -> bool {
             | OP_WRL | OP_MAPNEW | OP_MGET | OP_MSET | OP_MKEYS | OP_MVALS | OP_HD | OP_AT
             | OP_LST | OP_TL | OP_FMT2 | OP_RGXSUB | OP_ZIP | OP_ENUMERATE | OP_WINDOW | OP_FFT
             | OP_IFFT | OP_RANGE | OP_CHUNKS | OP_CUMSUM | OP_SETUNION | OP_SETINTER
-            | OP_SETDIFF | OP_TRANSPOSE | OP_MATMUL => {
+            | OP_SETDIFF | OP_TRANSPOSE | OP_MATMUL | OP_INV | OP_SOLVE => {
                 return false;
             }
             _ => {}
@@ -5678,6 +5703,96 @@ impl<'a> VM<'a> {
                     }
                     reg_set!(a, NanVal::number(total));
                 }
+                OP_DET => {
+                    let a = ((inst >> 16) & 0xFF) as usize + base;
+                    let b = ((inst >> 8) & 0xFF) as usize + base;
+                    let v = reg!(b);
+                    let mat = match nanval_to_matrix(v) {
+                        Ok(m) => m,
+                        Err(e) => vm_err!(VmError::Type(e)),
+                    };
+                    let n = mat.len();
+                    if n == 0 {
+                        vm_err!(VmError::Type("det: empty matrix"));
+                    }
+                    for row in &mat {
+                        if row.len() != n {
+                            vm_err!(VmError::Type("det: matrix must be square"));
+                        }
+                    }
+                    let (_lu, _piv, det, _singular) = crate::interpreter::lu_decompose(mat);
+                    reg_set!(a, NanVal::number(det));
+                }
+                OP_INV => {
+                    let a = ((inst >> 16) & 0xFF) as usize + base;
+                    let b = ((inst >> 8) & 0xFF) as usize + base;
+                    let v = reg!(b);
+                    let mat = match nanval_to_matrix(v) {
+                        Ok(m) => m,
+                        Err(e) => vm_err!(VmError::Type(e)),
+                    };
+                    let n = mat.len();
+                    if n == 0 {
+                        vm_err!(VmError::Type("inv: empty matrix"));
+                    }
+                    for row in &mat {
+                        if row.len() != n {
+                            vm_err!(VmError::Type("inv: matrix must be square"));
+                        }
+                    }
+                    let (lu, piv, _det, singular) = crate::interpreter::lu_decompose(mat);
+                    if singular {
+                        vm_err!(VmError::Type("inv: matrix is singular"));
+                    }
+                    let mut cols: Vec<Vec<f64>> = Vec::with_capacity(n);
+                    for j in 0..n {
+                        let mut e = vec![0.0; n];
+                        e[j] = 1.0;
+                        cols.push(crate::interpreter::lu_solve(&lu, &piv, &e));
+                    }
+                    let rows: Vec<NanVal> = (0..n)
+                        .map(|i| {
+                            let row: Vec<NanVal> =
+                                (0..n).map(|j| NanVal::number(cols[j][i])).collect();
+                            NanVal::heap_list(row)
+                        })
+                        .collect();
+                    reg_set!(a, NanVal::heap_list(rows));
+                }
+                OP_SOLVE => {
+                    let a = ((inst >> 16) & 0xFF) as usize + base;
+                    let b = ((inst >> 8) & 0xFF) as usize + base;
+                    let c = (inst & 0xFF) as usize + base;
+                    let va = reg!(b);
+                    let vb = reg!(c);
+                    let mat = match nanval_to_matrix(va) {
+                        Ok(m) => m,
+                        Err(e) => vm_err!(VmError::Type(e)),
+                    };
+                    let vec_b = match nanval_to_vec(vb) {
+                        Ok(v) => v,
+                        Err(e) => vm_err!(VmError::Type(e)),
+                    };
+                    let n = mat.len();
+                    if n == 0 {
+                        vm_err!(VmError::Type("solve: empty matrix"));
+                    }
+                    for row in &mat {
+                        if row.len() != n {
+                            vm_err!(VmError::Type("solve: matrix must be square"));
+                        }
+                    }
+                    if vec_b.len() != n {
+                        vm_err!(VmError::Type("solve: vector length must match matrix size"));
+                    }
+                    let (lu, piv, _det, singular) = crate::interpreter::lu_decompose(mat);
+                    if singular {
+                        vm_err!(VmError::Type("solve: matrix is singular"));
+                    }
+                    let x = crate::interpreter::lu_solve(&lu, &piv, &vec_b);
+                    let list: Vec<NanVal> = x.into_iter().map(NanVal::number).collect();
+                    reg_set!(a, NanVal::heap_list(list));
+                }
                 OP_RND0 => {
                     let a = ((inst >> 16) & 0xFF) as usize + base;
                     reg_set!(a, NanVal::number(fastrand::f64()));
@@ -7180,6 +7295,41 @@ fn nanval_to_key_string(v: NanVal) -> Option<String> {
     None
 }
 
+/// Convert a NanVal expected to be a list-of-numbers into Vec<f64>.
+fn nanval_to_vec(v: NanVal) -> std::result::Result<Vec<f64>, &'static str> {
+    if !v.is_heap() {
+        return Err("expected a list of numbers");
+    }
+    let items = match unsafe { v.as_heap_ref() } {
+        HeapObj::List(items) => items,
+        _ => return Err("expected a list of numbers"),
+    };
+    let mut out: Vec<f64> = Vec::with_capacity(items.len());
+    for item in items {
+        if !item.is_number() {
+            return Err("vector items must be numbers");
+        }
+        out.push(item.as_number());
+    }
+    Ok(out)
+}
+
+/// Convert a NanVal expected to be a list-of-list-of-numbers into Vec<Vec<f64>>.
+fn nanval_to_matrix(v: NanVal) -> std::result::Result<Vec<Vec<f64>>, &'static str> {
+    if !v.is_heap() {
+        return Err("expected a list of lists");
+    }
+    let rows = match unsafe { v.as_heap_ref() } {
+        HeapObj::List(items) => items,
+        _ => return Err("expected a list of lists"),
+    };
+    let mut out: Vec<Vec<f64>> = Vec::with_capacity(rows.len());
+    for row in rows {
+        out.push(nanval_to_vec(*row)?);
+    }
+    Ok(out)
+}
+
 fn nanval_to_json(v: NanVal) -> serde_json::Value {
     if v.is_number() {
         let n = v.as_number();
@@ -8119,6 +8269,97 @@ pub(crate) extern "C" fn jit_dot(a: u64, b: u64) -> u64 {
         total += x.as_number() * y.as_number();
     }
     NanVal::number(total).0
+}
+
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_det(a: u64) -> u64 {
+    let v = NanVal(a);
+    let mat = match nanval_to_matrix(v) {
+        Ok(m) => m,
+        Err(_) => return NanVal::number(f64::NAN).0,
+    };
+    let n = mat.len();
+    if n == 0 {
+        return NanVal::number(f64::NAN).0;
+    }
+    for row in &mat {
+        if row.len() != n {
+            return NanVal::number(f64::NAN).0;
+        }
+    }
+    let (_lu, _piv, det, _singular) = crate::interpreter::lu_decompose(mat);
+    NanVal::number(det).0
+}
+
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_inv(a: u64) -> u64 {
+    let v = NanVal(a);
+    let mat = match nanval_to_matrix(v) {
+        Ok(m) => m,
+        Err(_) => return TAG_NIL,
+    };
+    let n = mat.len();
+    if n == 0 {
+        return TAG_NIL;
+    }
+    for row in &mat {
+        if row.len() != n {
+            return TAG_NIL;
+        }
+    }
+    let (lu, piv, _det, singular) = crate::interpreter::lu_decompose(mat);
+    if singular {
+        return TAG_NIL;
+    }
+    let mut cols: Vec<Vec<f64>> = Vec::with_capacity(n);
+    for j in 0..n {
+        let mut e = vec![0.0; n];
+        e[j] = 1.0;
+        cols.push(crate::interpreter::lu_solve(&lu, &piv, &e));
+    }
+    let rows: Vec<NanVal> = (0..n)
+        .map(|i| {
+            let row: Vec<NanVal> = (0..n).map(|j| NanVal::number(cols[j][i])).collect();
+            NanVal::heap_list(row)
+        })
+        .collect();
+    NanVal::heap_list(rows).0
+}
+
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_solve(a: u64, b: u64) -> u64 {
+    let va = NanVal(a);
+    let vb = NanVal(b);
+    let mat = match nanval_to_matrix(va) {
+        Ok(m) => m,
+        Err(_) => return TAG_NIL,
+    };
+    let vec_b = match nanval_to_vec(vb) {
+        Ok(v) => v,
+        Err(_) => return TAG_NIL,
+    };
+    let n = mat.len();
+    if n == 0 {
+        return TAG_NIL;
+    }
+    for row in &mat {
+        if row.len() != n {
+            return TAG_NIL;
+        }
+    }
+    if vec_b.len() != n {
+        return TAG_NIL;
+    }
+    let (lu, piv, _det, singular) = crate::interpreter::lu_decompose(mat);
+    if singular {
+        return TAG_NIL;
+    }
+    let x = crate::interpreter::lu_solve(&lu, &piv, &vec_b);
+    let list: Vec<NanVal> = x.into_iter().map(NanVal::number).collect();
+    NanVal::heap_list(list).0
 }
 
 #[cfg(feature = "cranelift")]

--- a/tests/regression_linalg_advanced.rs
+++ b/tests/regression_linalg_advanced.rs
@@ -1,0 +1,143 @@
+// Cross-engine smoke tests for the advanced linear-algebra builtins
+// (solve, inv, det). These exercise the tree-walking interpreter, the
+// register VM, and (when available) the cranelift JIT.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_text(engine: &str, src: &str, args: &[&str]) -> (bool, String, String) {
+    let mut cmd = ilo();
+    cmd.arg(src).arg(engine).arg("f");
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+fn run_num(engine: &str, src: &str, args: &[&str]) -> f64 {
+    let (ok, stdout, stderr) = run_text(engine, src, args);
+    assert!(
+        ok,
+        "ilo {engine} failed for `{src}` args={args:?}: stderr={stderr}"
+    );
+    stdout
+        .parse::<f64>()
+        .unwrap_or_else(|_| panic!("expected numeric output, got `{stdout}` (stderr={stderr})"))
+}
+
+fn approx_num(engine: &str, src: &str, args: &[&str], expected: f64) {
+    let actual = run_num(engine, src, args);
+    assert!(
+        (actual - expected).abs() < 1e-10,
+        "engine={engine} src=`{src}` args={args:?}: got {actual}, expected {expected}"
+    );
+}
+
+fn approx_num_loose(engine: &str, src: &str, args: &[&str], expected: f64, tol: f64) {
+    let actual = run_num(engine, src, args);
+    assert!(
+        (actual - expected).abs() < tol,
+        "engine={engine} src=`{src}` args={args:?}: got {actual}, expected {expected} (tol={tol})"
+    );
+}
+
+fn engines() -> Vec<&'static str> {
+    let mut v = vec!["--run-tree", "--run-vm"];
+    if cfg!(feature = "cranelift") {
+        v.push("--run-cranelift");
+    }
+    v
+}
+
+fn check_num(src: &str, args: &[&str], expected: f64) {
+    for e in engines() {
+        approx_num(e, src, args, expected);
+    }
+}
+
+#[test]
+fn det_identity_2x2() {
+    check_num("f a:L (L n)>n;det a", &["[[1,0],[0,1]]"], 1.0);
+}
+
+#[test]
+fn det_2x2_simple() {
+    check_num("f a:L (L n)>n;det a", &["[[2,1],[1,3]]"], 5.0);
+}
+
+#[test]
+fn det_3x3() {
+    // det of upper-triangular = product of diagonal = 1*2*3 = 6
+    check_num("f a:L (L n)>n;det a", &["[[1,2,3],[0,2,5],[0,0,3]]"], 6.0);
+}
+
+#[test]
+fn det_singular_near_zero() {
+    // Singular: row 2 = 2*row 1
+    for e in engines() {
+        approx_num_loose(e, "f a:L (L n)>n;det a", &["[[1,2],[2,4]]"], 0.0, 1e-9);
+    }
+}
+
+#[test]
+fn solve_2x2_identity_swap() {
+    // [[1,1],[1,-1]] x = [3,1] → x = [2,1]
+    let src = "f a:L (L n) b:L n>n;x=solve a b;x.0";
+    let src2 = "f a:L (L n) b:L n>n;x=solve a b;x.1";
+    for e in engines() {
+        approx_num(e, src, &["[[1,1],[1,-1]]", "[3,1]"], 2.0);
+        approx_num(e, src2, &["[[1,1],[1,-1]]", "[3,1]"], 1.0);
+    }
+}
+
+#[test]
+fn inv_diag_2x2() {
+    // inv [[2,0],[0,2]] = [[0.5,0],[0,0.5]] — pick element (0,0) and (1,1)
+    let src00 = "f a:L (L n)>n;m=inv a;r=m.0;r.0";
+    let src11 = "f a:L (L n)>n;m=inv a;r=m.1;r.1";
+    let src01 = "f a:L (L n)>n;m=inv a;r=m.0;r.1";
+    for e in engines() {
+        approx_num(e, src00, &["[[2,0],[0,2]]"], 0.5);
+        approx_num(e, src11, &["[[2,0],[0,2]]"], 0.5);
+        approx_num(e, src01, &["[[2,0],[0,2]]"], 0.0);
+    }
+}
+
+#[test]
+fn inv_singular_errors() {
+    // The tree-walking interpreter and VM return a runtime error; the
+    // cranelift JIT (which lacks a runtime-error path for matrix helpers)
+    // returns `nil` instead. Accept either as "did not produce a real
+    // inverse for a singular matrix".
+    let src = "f a:L (L n)>n;m=inv a;r=m.0;r.0";
+    for e in engines() {
+        let (ok, stdout, _stderr) = run_text(e, src, &["[[1,2],[2,4]]"]);
+        let failed = !ok || stdout == "nil";
+        assert!(
+            failed,
+            "engine={e}: expected inv on singular matrix to fail or return nil, got `{stdout}`"
+        );
+    }
+}
+
+#[test]
+fn det_non_square_errors() {
+    let src = "f a:L (L n)>n;det a";
+    for e in engines() {
+        let (ok, stdout, _stderr) = run_text(e, src, &["[[1,2,3],[4,5,6]]"]);
+        // tree/vm raise; cranelift currently returns NaN as a sentinel.
+        let failed = !ok || stdout.contains("NaN") || stdout.contains("nan");
+        assert!(
+            failed,
+            "engine={e}: expected det on non-square matrix to fail or return nan, got `{stdout}`"
+        );
+    }
+}


### PR DESCRIPTION
With transpose/matmul/dot landed, the next numeric layer needs solve, inverse, determinant.

Implementation:
- shared LU decomposition with partial pivoting
- one routine plus three thin entry points
- singular and non-square matrices error with a clear message
- singularity tolerance fixed at 1e-12
- opcodes allocated: solve, inv, det

Tests: cross-engine regression tests + examples/linalg-advanced.ilo with -- run: directives.