### PR TITLE
fix: bind fmt2 call before list literal in example

### DIFF
--- a/examples/fmt2.ilo
+++ b/examples/fmt2.ilo
@@ -19,7 +19,7 @@ round-down>t;fmt2 2.5 0
 neg-digits>t;fmt2 3.7 -1
 
 -- Build a percentile-report line: "p95: 0.99"
-report v:n>t;cat ["p95: " fmt2 v 2] ""
+report v:n>t;s=fmt2 v 2;cat ["p95: " s] ""
 
 -- run: pi-2
 -- out: 3.14


### PR DESCRIPTION
PR #167 changed list-literal parsing so bare-ident elements are refs, not call heads. The fmt2.ilo example landed in #170 used `["p95: " fmt2 v 2]` which now fails with "undefined variable 'fmt2'". Bind the call to a temp first, then build the list. Unblocks CI on the 14 open builtin PRs.