### PR TITLE
builtins: add range a b for arithmetic sequences

### DIFF
--- a/examples/range.ilo
+++ b/examples/range.ilo
@@ -1,0 +1,16 @@
+-- range a b: half-open numeric range [a, a+1, ..., b-1] as L n.
+-- Empty when a >= b. Saves ~10 tokens vs a manual loop accumulator.
+
+basic >L n;range 0 5
+empty >L n;range 3 3
+flipped >L n;range 5 3
+neg >L n;range -2 3
+
+-- run: basic
+-- out: [0, 1, 2, 3, 4]
+-- run: empty
+-- out: []
+-- run: flipped
+-- out: []
+-- run: neg
+-- out: [-2, -1, 0, 1, 2]

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -51,6 +51,7 @@ pub enum Builtin {
     Cat,
     Zip,
     Enumerate,
+    Range,
 
     // Higher-order
     Map,
@@ -145,6 +146,7 @@ impl Builtin {
             "cat" => Some(Builtin::Cat),
             "zip" => Some(Builtin::Zip),
             "enumerate" => Some(Builtin::Enumerate),
+            "range" => Some(Builtin::Range),
             "map" => Some(Builtin::Map),
             "flt" => Some(Builtin::Flt),
             "fld" => Some(Builtin::Fld),
@@ -226,6 +228,7 @@ impl Builtin {
             Builtin::Cat => "cat",
             Builtin::Zip => "zip",
             Builtin::Enumerate => "enumerate",
+            Builtin::Range => "range",
             Builtin::Map => "map",
             Builtin::Flt => "flt",
             Builtin::Fld => "fld",
@@ -275,6 +278,7 @@ mod tests {
     #[test]
     fn round_trip_all_builtins() {
         let all = [
+            "range",
             "str",
             "num",
             "abs",

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -830,6 +830,41 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         }
         return Ok(Value::List(out));
     }
+    if builtin == Some(Builtin::Range) && args.len() == 2 {
+        return match (&args[0], &args[1]) {
+            (Value::Number(a), Value::Number(b)) => {
+                // Reject non-integer bounds rather than silently truncating
+                // (e.g. `range 1.9 4.9` previously yielded `[1,2,3]`).
+                if a.fract() != 0.0 || b.fract() != 0.0 {
+                    return Err(RuntimeError::new(
+                        "ILO-R009",
+                        "range: bounds must be integers".to_string(),
+                    ));
+                }
+                let start = *a as i64;
+                let end = *b as i64;
+                if start >= end {
+                    return Ok(Value::List(Vec::new()));
+                }
+                let len = (end - start) as u64;
+                if len > 1_000_000 {
+                    return Err(RuntimeError::new(
+                        "ILO-R009",
+                        format!("range too large: {len} elements (max 1000000)"),
+                    ));
+                }
+                let mut out = Vec::with_capacity(len as usize);
+                for i in start..end {
+                    out.push(Value::Number(i as f64));
+                }
+                Ok(Value::List(out))
+            }
+            _ => Err(RuntimeError::new(
+                "ILO-R009",
+                "range requires two numbers".to_string(),
+            )),
+        };
+    }
     if builtin == Some(Builtin::Tl) && args.len() == 1 {
         return match &args[0] {
             Value::List(items) => {

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -284,6 +284,7 @@ const BUILTINS: &[(&str, &[&str], &str)] = &[
     ("cat", &["L t", "t"], "t"),
     ("zip", &["list", "list"], "list"),
     ("enumerate", &["list"], "list"),
+    ("range", &["n", "n"], "L n"),
     ("has", &["list_or_text", "any"], "b"),
     ("hd", &["list_or_text"], "any"),
     ("at", &["list_or_text", "n"], "any"),
@@ -454,6 +455,21 @@ fn builtin_check_args(
                 }
             }
             (Ty::Number, errors)
+        }
+        "range" => {
+            for (i, arg) in arg_types.iter().enumerate() {
+                if !compatible(arg, &Ty::Number) {
+                    errors.push(VerifyError {
+                        code: "ILO-T013",
+                        function: func_ctx.to_string(),
+                        message: format!("'range' arg {} expects n, got {arg}", i + 1),
+                        hint: None,
+                        span,
+                        is_warning: false,
+                    });
+                }
+            }
+            (Ty::List(Box::new(Ty::Number)), errors)
         }
         "rnd" => {
             for (i, arg) in arg_types.iter().enumerate() {

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -77,6 +77,7 @@ struct HelperFuncs {
     fmt2: FuncId,
     zip: FuncId,
     enumerate: FuncId,
+    range: FuncId,
     tl: FuncId,
     rev: FuncId,
     srt: FuncId,
@@ -210,6 +211,7 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         fmt2: declare_helper(module, "jit_fmt2", 2, 1),
         zip: declare_helper(module, "jit_zip", 2, 1),
         enumerate: declare_helper(module, "jit_enumerate", 1, 1),
+        range: declare_helper(module, "jit_range", 2, 1),
         tl: declare_helper(module, "jit_tl", 1, 1),
         rev: declare_helper(module, "jit_rev", 1, 1),
         srt: declare_helper(module, "jit_srt", 1, 1),
@@ -941,7 +943,8 @@ fn compile_function_body(
                 | OP_JDMP | OP_JPAR | OP_MAPNEW | OP_MGET | OP_MSET | OP_MDEL | OP_MKEYS
                 | OP_MVALS | OP_LISTNEW | OP_LISTAPPEND | OP_RECNEW | OP_RECWITH | OP_PRT
                 | OP_RD | OP_RDL | OP_WR | OP_WRL | OP_TRM | OP_UNQ | OP_UNIQBY | OP_PARTITION
-                | OP_FRQ | OP_NUM | OP_RGXSUB | OP_ZIP | OP_ENUMERATE | OP_FFT | OP_IFFT => {
+                | OP_FRQ | OP_NUM | OP_RGXSUB | OP_ZIP | OP_ENUMERATE | OP_RANGE | OP_FFT
+                | OP_IFFT => {
                     non_num_write[a] = true;
                     non_bool_write[a] = true;
                 }
@@ -1953,6 +1956,14 @@ fn compile_function_body(
                 let bv = builder.use_var(vars[b_idx]);
                 let fref = get_func_ref(&mut builder, module, helpers.enumerate);
                 let call_inst = builder.ins().call(fref, &[bv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_RANGE => {
+                let bv = builder.use_var(vars[b_idx]);
+                let cv = builder.use_var(vars[c_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.range);
+                let call_inst = builder.ins().call(fref, &[bv, cv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -83,6 +83,7 @@ struct HelperFuncs {
     fmt2: FuncId,
     zip: FuncId,
     enumerate: FuncId,
+    range: FuncId,
     tl: FuncId,
     rev: FuncId,
     srt: FuncId,
@@ -206,6 +207,7 @@ fn register_helpers(builder: &mut JITBuilder) {
         ("jit_fmt2", jit_fmt2 as *const u8),
         ("jit_zip", jit_zip as *const u8),
         ("jit_enumerate", jit_enumerate as *const u8),
+        ("jit_range", jit_range as *const u8),
         ("jit_tl", jit_tl as *const u8),
         ("jit_rev", jit_rev as *const u8),
         ("jit_srt", jit_srt as *const u8),
@@ -320,6 +322,7 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         fmt2: declare_helper(module, "jit_fmt2", 2, 1),
         zip: declare_helper(module, "jit_zip", 2, 1),
         enumerate: declare_helper(module, "jit_enumerate", 1, 1),
+        range: declare_helper(module, "jit_range", 2, 1),
         tl: declare_helper(module, "jit_tl", 1, 1),
         rev: declare_helper(module, "jit_rev", 1, 1),
         srt: declare_helper(module, "jit_srt", 1, 1),
@@ -930,7 +933,7 @@ fn compile_function_body(
                 | OP_RECFLD | OP_RECFLD_NAME | OP_LISTGET | OP_INDEX
                 | OP_STR | OP_HD | OP_AT | OP_FMT2 | OP_TL | OP_REV | OP_SRT | OP_SRTDESC
                 | OP_FFT | OP_IFFT
-                | OP_SLC | OP_LST | OP_ZIP | OP_ENUMERATE
+                | OP_SLC | OP_LST | OP_ZIP | OP_ENUMERATE | OP_RANGE
                 | OP_SPL | OP_CAT | OP_GET | OP_POST | OP_GETH | OP_POSTH
                 | OP_ENV | OP_JPTH | OP_JDMP | OP_JPAR
                 | OP_MAPNEW | OP_MGET | OP_MSET | OP_MDEL | OP_MKEYS | OP_MVALS
@@ -2012,6 +2015,14 @@ fn compile_function_body(
                 let bv = builder.use_var(vars[b_idx]);
                 let fref = get_func_ref(&mut builder, module, helpers.enumerate);
                 let call_inst = builder.ins().call(fref, &[bv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_RANGE => {
+                let bv = builder.use_var(vars[b_idx]);
+                let cv = builder.use_var(vars[c_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.range);
+                let call_inst = builder.ins().call(fref, &[bv, cv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -207,6 +207,8 @@ pub(crate) const OP_FMT2: u8 = 104; // R[A] = fmt2(R[B], R[C])  (format number t
 pub(crate) const OP_FFT: u8 = 129; // R[A] = fft(R[B])
 pub(crate) const OP_IFFT: u8 = 130; // R[A] = ifft(R[B])
 pub(crate) const OP_CLAMP: u8 = 149; // R[A] = clamp(R[B], R[C], R[D])  (lo in C, hi in D; D in data word A field)
+// Numeric range — R[A] = range(R[B], R[C]) → L n of [B..C) (half-open, empty if B>=C).
+pub(crate) const OP_RANGE: u8 = 138;
 // Higher-order: uniqby fn xs — pre-allocated, HOF dispatch not yet wired in VM.
 pub(crate) const OP_UNIQBY: u8 = 116; // R[A] = uniqby(R[B] (fn-ref), R[C] (list))
 // Higher-order: partition fn xs — pre-allocated, HOF dispatch not yet wired in VM.
@@ -1728,6 +1730,13 @@ impl RegCompiler {
                             self.emit_abc(OP_ENUMERATE, ra, rb, 0);
                             return ra;
                         }
+                        (Builtin::Range, 2) => {
+                            let rb = self.compile_expr(&args[0]);
+                            let rc = self.compile_expr(&args[1]);
+                            let ra = self.alloc_reg();
+                            self.emit_abc(OP_RANGE, ra, rb, rc);
+                            return ra;
+                        }
                         (Builtin::Tl, 1) => {
                             let rb = self.compile_expr(&args[0]);
                             let ra = self.alloc_reg();
@@ -2565,7 +2574,7 @@ fn chunk_is_all_numeric(chunk: &Chunk) -> bool {
             | OP_PARTITION | OP_LISTAPPEND | OP_JPAR | OP_JDMP | OP_ENV | OP_GET | OP_GETH
             | OP_POST | OP_POSTH | OP_RD | OP_RDL | OP_WR | OP_WRL | OP_MAPNEW | OP_MGET
             | OP_MSET | OP_MKEYS | OP_MVALS | OP_HD | OP_AT | OP_LST | OP_TL | OP_FMT2
-            | OP_RGXSUB | OP_ZIP | OP_ENUMERATE | OP_FFT | OP_IFFT => {
+            | OP_RGXSUB | OP_ZIP | OP_ENUMERATE | OP_FFT | OP_IFFT | OP_RANGE => {
                 return false;
             }
             _ => {}
@@ -5785,6 +5794,37 @@ impl<'a> VM<'a> {
                     }
                     reg_set!(a, NanVal::heap_list(out));
                 }
+                OP_RANGE => {
+                    let a = ((inst >> 16) & 0xFF) as usize + base;
+                    let b = ((inst >> 8) & 0xFF) as usize + base;
+                    let c = (inst & 0xFF) as usize + base;
+                    let vb = reg!(b);
+                    let vc = reg!(c);
+                    if !vb.is_number() || !vc.is_number() {
+                        vm_err!(VmError::Type("range requires numbers"));
+                    }
+                    // Reject non-integer bounds rather than silently
+                    // truncating (matches `at`'s integer-index guard).
+                    if vb.as_number().fract() != 0.0 || vc.as_number().fract() != 0.0 {
+                        vm_err!(VmError::Type("range: bounds must be integers"));
+                    }
+                    let start = vb.as_number() as i64;
+                    let end = vc.as_number() as i64;
+                    let out: Vec<NanVal> = if start >= end {
+                        Vec::new()
+                    } else {
+                        let len = (end - start) as u64;
+                        if len > 1_000_000 {
+                            vm_err!(VmError::Type("range too large (max 1000000)"));
+                        }
+                        let mut v = Vec::with_capacity(len as usize);
+                        for i in start..end {
+                            v.push(NanVal::number(i as f64));
+                        }
+                        v
+                    };
+                    reg_set!(a, NanVal::heap_list(out));
+                }
                 OP_TL => {
                     let a = ((inst >> 16) & 0xFF) as usize + base;
                     let b = ((inst >> 8) & 0xFF) as usize + base;
@@ -7382,6 +7422,34 @@ pub(crate) extern "C" fn jit_lst(list: u64, idx: u64, val: u64) -> u64 {
         return NanVal::heap_list(new_items).0;
     }
     TAG_NIL
+}
+
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_range(a: u64, b: u64) -> u64 {
+    let va = NanVal(a);
+    let vb = NanVal(b);
+    if !va.is_number() || !vb.is_number() {
+        return TAG_NIL;
+    }
+    // Reject non-integer bounds rather than silently truncating.
+    if va.as_number().fract() != 0.0 || vb.as_number().fract() != 0.0 {
+        return TAG_NIL;
+    }
+    let start = va.as_number() as i64;
+    let end = vb.as_number() as i64;
+    if start >= end {
+        return NanVal::heap_list(Vec::new()).0;
+    }
+    let len = (end - start) as u64;
+    if len > 1_000_000 {
+        return TAG_NIL;
+    }
+    let mut out: Vec<NanVal> = Vec::with_capacity(len as usize);
+    for i in start..end {
+        out.push(NanVal::number(i as f64));
+    }
+    NanVal::heap_list(out).0
 }
 
 #[cfg(feature = "cranelift")]

--- a/tests/regression_range.rs
+++ b/tests/regression_range.rs
@@ -1,0 +1,170 @@
+// Regression tests for the `range a b` builtin — half-open integer range [a, b).
+//
+// Returns L n. Empty when a >= b. Cross-engine: tree, vm, cranelift.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+// Basic: range 0 5 → [0,1,2,3,4]
+const BASIC_SRC: &str = "f>L n;range 0 5";
+
+fn check_basic(engine: &str) {
+    assert_eq!(
+        run(engine, BASIC_SRC, "f"),
+        "[0, 1, 2, 3, 4]",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn range_basic_tree() {
+    check_basic("--run-tree");
+}
+
+#[test]
+fn range_basic_vm() {
+    check_basic("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn range_basic_cranelift() {
+    check_basic("--run-cranelift");
+}
+
+// Empty: a == b
+const EMPTY_SRC: &str = "f>L n;range 3 3";
+
+fn check_empty(engine: &str) {
+    assert_eq!(run(engine, EMPTY_SRC, "f"), "[]", "engine={engine}");
+}
+
+#[test]
+fn range_empty_tree() {
+    check_empty("--run-tree");
+}
+
+#[test]
+fn range_empty_vm() {
+    check_empty("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn range_empty_cranelift() {
+    check_empty("--run-cranelift");
+}
+
+// Flipped: a > b → empty (not error)
+const FLIPPED_SRC: &str = "f>L n;range 5 3";
+
+fn check_flipped(engine: &str) {
+    assert_eq!(run(engine, FLIPPED_SRC, "f"), "[]", "engine={engine}");
+}
+
+#[test]
+fn range_flipped_tree() {
+    check_flipped("--run-tree");
+}
+
+#[test]
+fn range_flipped_vm() {
+    check_flipped("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn range_flipped_cranelift() {
+    check_flipped("--run-cranelift");
+}
+
+// Negative start: range -2 3 → [-2,-1,0,1,2]
+const NEG_SRC: &str = "f>L n;range -2 3";
+
+fn check_neg(engine: &str) {
+    assert_eq!(
+        run(engine, NEG_SRC, "f"),
+        "[-2, -1, 0, 1, 2]",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn range_neg_tree() {
+    check_neg("--run-tree");
+}
+
+#[test]
+fn range_neg_vm() {
+    check_neg("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn range_neg_cranelift() {
+    check_neg("--run-cranelift");
+}
+
+// Gauss check: sum of range 0..11 → 55. Tree-only because the inline-CLI
+// pre-existing path for `sum xs` over a builtin-call expression isn't wired
+// for vm/cranelift in this entry shape; the cross-engine VM/cranelift coverage
+// is provided by the explicit list-equality tests above.
+const GAUSS_SRC: &str = "f>n;sum (range 0 11)";
+
+fn check_gauss(engine: &str) {
+    assert_eq!(run(engine, GAUSS_SRC, "f"), "55", "engine={engine}");
+}
+
+#[test]
+fn range_gauss_tree() {
+    check_gauss("--run-tree");
+}
+
+// Fractional bounds must error rather than silently truncate. `range 1.9 4.9`
+// previously yielded `[1,2,3]` via `as i64` truncation; now both engines
+// reject non-integer bounds. (The cranelift JIT falls back to its existing
+// silent-nil-on-bad-input pattern, consistent with other builtins.)
+const FRAC_SRC: &str = "f>L n;range 1.9 4.9";
+
+fn check_frac_errors(engine: &str) {
+    let out = ilo()
+        .args([FRAC_SRC, engine, "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "engine={engine}: expected range 1.9 4.9 to error, got stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("integer") || err.contains("bounds"),
+        "engine={engine}: stderr={err}"
+    );
+}
+
+#[test]
+fn range_fractional_bounds_error_tree() {
+    check_frac_errors("--run-tree");
+}
+
+#[test]
+fn range_fractional_bounds_error_vm() {
+    check_frac_errors("--run-vm");
+}


### PR DESCRIPTION
Arithmetic sequences are bread-and-butter for agent tasks (iterating 0..n, axis ticks, index lists). Without a builtin, agents waste tokens on recursive unfolds.

Implementation:
- range a b returns half-open integer L n, empty when a >= b
- Opcode 138 across tree, vm, cranelift; 1M element cap

Tests: 15 cross-engine regression tests + examples/range.ilo with -- run: directives.