### PR TITLE
builtins: add enumerate xs for indexed pairs

### DIFF
--- a/examples/enumerate.ilo
+++ b/examples/enumerate.ilo
@@ -1,0 +1,10 @@
+-- enumerate xs: pair each element with its index, returning [[i, v], ...].
+-- "map with index" appears in every program — destructure the pair to use it.
+
+idx xs:L n>L (L _);enumerate xs
+words xs:L t>L (L _);enumerate xs
+
+-- run: idx [10,20,30]
+-- out: [[0, 10], [1, 20], [2, 30]]
+-- run: words ["a","b","c"]
+-- out: [[0, a], [1, b], [2, c]]

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -49,6 +49,7 @@ pub enum Builtin {
     Spl,
     Cat,
     Zip,
+    Enumerate,
 
     // Higher-order
     Map,
@@ -140,6 +141,7 @@ impl Builtin {
             "spl" => Some(Builtin::Spl),
             "cat" => Some(Builtin::Cat),
             "zip" => Some(Builtin::Zip),
+            "enumerate" => Some(Builtin::Enumerate),
             "map" => Some(Builtin::Map),
             "flt" => Some(Builtin::Flt),
             "fld" => Some(Builtin::Fld),
@@ -218,6 +220,7 @@ impl Builtin {
             Builtin::Spl => "spl",
             Builtin::Cat => "cat",
             Builtin::Zip => "zip",
+            Builtin::Enumerate => "enumerate",
             Builtin::Map => "map",
             Builtin::Flt => "flt",
             Builtin::Fld => "fld",
@@ -302,6 +305,7 @@ mod tests {
             "spl",
             "cat",
             "zip",
+            "enumerate",
             "map",
             "flt",
             "fld",

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -801,6 +801,22 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         }
         return Ok(Value::List(out));
     }
+    if builtin == Some(Builtin::Enumerate) && args.len() == 1 {
+        let xs = match &args[0] {
+            Value::List(items) => items,
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!("enumerate requires a list, got {:?}", other),
+                ));
+            }
+        };
+        let mut out = Vec::with_capacity(xs.len());
+        for (i, v) in xs.iter().enumerate() {
+            out.push(Value::List(vec![Value::Number(i as f64), v.clone()]));
+        }
+        return Ok(Value::List(out));
+    }
     if builtin == Some(Builtin::Tl) && args.len() == 1 {
         return match &args[0] {
             Value::List(items) => {

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -282,6 +282,7 @@ const BUILTINS: &[(&str, &[&str], &str)] = &[
     ("spl", &["t", "t"], "L t"),
     ("cat", &["L t", "t"], "t"),
     ("zip", &["list", "list"], "list"),
+    ("enumerate", &["list"], "list"),
     ("has", &["list_or_text", "any"], "b"),
     ("hd", &["list_or_text"], "any"),
     ("at", &["list_or_text", "n"], "any"),
@@ -663,6 +664,25 @@ fn builtin_check_args(
                 _ => Ty::Unknown,
             };
             (Ty::List(Box::new(Ty::List(Box::new(inner)))), errors)
+        }
+        "enumerate" => {
+            // enumerate xs — returns a list of [index, value] pairs.
+            // Inner element type is erased to Unknown because the pair holds
+            // both a number (index) and an `a` (element).
+            if let Some(arg) = arg_types.first() {
+                match arg {
+                    Ty::List(_) | Ty::Unknown => {}
+                    other => errors.push(VerifyError {
+                        code: "ILO-T013",
+                        function: func_ctx.to_string(),
+                        message: format!("'enumerate' expects a list, got {other}"),
+                        hint: None,
+                        span,
+                        is_warning: false,
+                    }),
+                }
+            }
+            (Ty::List(Box::new(Ty::List(Box::new(Ty::Unknown)))), errors)
         }
         "tl" => {
             if let Some(arg) = arg_types.first() {

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -75,6 +75,7 @@ struct HelperFuncs {
     at: FuncId,
     fmt2: FuncId,
     zip: FuncId,
+    enumerate: FuncId,
     tl: FuncId,
     rev: FuncId,
     srt: FuncId,
@@ -205,6 +206,7 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         at: declare_helper(module, "jit_at", 2, 1),
         fmt2: declare_helper(module, "jit_fmt2", 2, 1),
         zip: declare_helper(module, "jit_zip", 2, 1),
+        enumerate: declare_helper(module, "jit_enumerate", 1, 1),
         tl: declare_helper(module, "jit_tl", 1, 1),
         rev: declare_helper(module, "jit_rev", 1, 1),
         srt: declare_helper(module, "jit_srt", 1, 1),
@@ -935,7 +937,7 @@ fn compile_function_body(
                 | OP_JDMP | OP_JPAR | OP_MAPNEW | OP_MGET | OP_MSET | OP_MDEL | OP_MKEYS
                 | OP_MVALS | OP_LISTNEW | OP_LISTAPPEND | OP_RECNEW | OP_RECWITH | OP_PRT
                 | OP_RD | OP_RDL | OP_WR | OP_WRL | OP_TRM | OP_UNQ | OP_UNIQBY | OP_PARTITION
-                | OP_NUM | OP_RGXSUB | OP_ZIP | OP_FFT | OP_IFFT => {
+                | OP_NUM | OP_RGXSUB | OP_ZIP | OP_ENUMERATE | OP_FFT | OP_IFFT => {
                     non_num_write[a] = true;
                     non_bool_write[a] = true;
                 }
@@ -1923,6 +1925,13 @@ fn compile_function_body(
                 let cv = builder.use_var(vars[c_idx]);
                 let fref = get_func_ref(&mut builder, module, helpers.zip);
                 let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_ENUMERATE => {
+                let bv = builder.use_var(vars[b_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.enumerate);
+                let call_inst = builder.ins().call(fref, &[bv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -81,6 +81,7 @@ struct HelperFuncs {
     at: FuncId,
     fmt2: FuncId,
     zip: FuncId,
+    enumerate: FuncId,
     tl: FuncId,
     rev: FuncId,
     srt: FuncId,
@@ -201,6 +202,7 @@ fn register_helpers(builder: &mut JITBuilder) {
         ("jit_at", jit_at as *const u8),
         ("jit_fmt2", jit_fmt2 as *const u8),
         ("jit_zip", jit_zip as *const u8),
+        ("jit_enumerate", jit_enumerate as *const u8),
         ("jit_tl", jit_tl as *const u8),
         ("jit_rev", jit_rev as *const u8),
         ("jit_srt", jit_srt as *const u8),
@@ -312,6 +314,7 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         at: declare_helper(module, "jit_at", 2, 1),
         fmt2: declare_helper(module, "jit_fmt2", 2, 1),
         zip: declare_helper(module, "jit_zip", 2, 1),
+        enumerate: declare_helper(module, "jit_enumerate", 1, 1),
         tl: declare_helper(module, "jit_tl", 1, 1),
         rev: declare_helper(module, "jit_rev", 1, 1),
         srt: declare_helper(module, "jit_srt", 1, 1),
@@ -921,7 +924,7 @@ fn compile_function_body(
                 | OP_RECFLD | OP_RECFLD_NAME | OP_LISTGET | OP_INDEX
                 | OP_STR | OP_HD | OP_AT | OP_FMT2 | OP_TL | OP_REV | OP_SRT | OP_SRTDESC
                 | OP_FFT | OP_IFFT
-                | OP_SLC | OP_LST | OP_ZIP
+                | OP_SLC | OP_LST | OP_ZIP | OP_ENUMERATE
                 | OP_SPL | OP_CAT | OP_GET | OP_POST | OP_GETH | OP_POSTH
                 | OP_ENV | OP_JPTH | OP_JDMP | OP_JPAR
                 | OP_MAPNEW | OP_MGET | OP_MSET | OP_MDEL | OP_MKEYS | OP_MVALS
@@ -1978,6 +1981,13 @@ fn compile_function_body(
                 let cv = builder.use_var(vars[c_idx]);
                 let fref = get_func_ref(&mut builder, module, helpers.zip);
                 let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_ENUMERATE => {
+                let bv = builder.use_var(vars[b_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.enumerate);
+                let call_inst = builder.ins().call(fref, &[bv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -196,6 +196,7 @@ pub(crate) const OP_ATAN2: u8 = 108; // R[A] = atan2(R[B], R[C])  (y first, x se
 pub(crate) const OP_SRTDESC: u8 = 117; // R[A] = rsrt(R[B])  (descending sort of list)
 pub(crate) const OP_RGXSUB: u8 = 115; // R[A] = rgxsub(R[B], R[C], R[D])  (pattern, replacement, subject; D in data word A field)
 pub(crate) const OP_ZIP: u8 = 111; // R[A] = zip(R[B], R[C])  (list of [x,y] pairs, truncated)
+pub(crate) const OP_ENUMERATE: u8 = 139; // R[A] = enumerate(R[B])  (list of [i, v] pairs)
 
 // ABC mode — text formatting
 pub(crate) const OP_FMT2: u8 = 104; // R[A] = fmt2(R[B], R[C])  (format number to N decimal places → t)
@@ -1706,6 +1707,12 @@ impl RegCompiler {
                             self.emit_abc(OP_ZIP, ra, rb, rc);
                             return ra;
                         }
+                        (Builtin::Enumerate, 1) => {
+                            let rb = self.compile_expr(&args[0]);
+                            let ra = self.alloc_reg();
+                            self.emit_abc(OP_ENUMERATE, ra, rb, 0);
+                            return ra;
+                        }
                         (Builtin::Tl, 1) => {
                             let rb = self.compile_expr(&args[0]);
                             let ra = self.alloc_reg();
@@ -2537,7 +2544,7 @@ fn chunk_is_all_numeric(chunk: &Chunk) -> bool {
             | OP_PARTITION | OP_LISTAPPEND | OP_JPAR | OP_JDMP | OP_ENV | OP_GET | OP_GETH
             | OP_POST | OP_POSTH | OP_RD | OP_RDL | OP_WR | OP_WRL | OP_MAPNEW | OP_MGET
             | OP_MSET | OP_MKEYS | OP_MVALS | OP_HD | OP_AT | OP_LST | OP_TL | OP_FMT2
-            | OP_RGXSUB | OP_ZIP | OP_FFT | OP_IFFT => {
+            | OP_RGXSUB | OP_ZIP | OP_ENUMERATE | OP_FFT | OP_IFFT => {
                 return false;
             }
             _ => {}
@@ -5716,6 +5723,26 @@ impl<'a> VM<'a> {
                     }
                     reg_set!(a, NanVal::heap_list(out));
                 }
+                OP_ENUMERATE => {
+                    let a = ((inst >> 16) & 0xFF) as usize + base;
+                    let b = ((inst >> 8) & 0xFF) as usize + base;
+                    let vb = reg!(b);
+                    let xs = if vb.is_heap() {
+                        match unsafe { vb.as_heap_ref() } {
+                            HeapObj::List(items) => items,
+                            _ => vm_err!(VmError::Type("enumerate requires a list")),
+                        }
+                    } else {
+                        vm_err!(VmError::Type("enumerate requires a list"));
+                    };
+                    let mut out: Vec<NanVal> = Vec::with_capacity(xs.len());
+                    for (i, &v) in xs.iter().enumerate() {
+                        v.clone_rc();
+                        let pair = NanVal::heap_list(vec![NanVal::number(i as f64), v]);
+                        out.push(pair);
+                    }
+                    reg_set!(a, NanVal::heap_list(out));
+                }
                 OP_TL => {
                     let a = ((inst >> 16) & 0xFF) as usize + base;
                     let b = ((inst >> 8) & 0xFF) as usize + base;
@@ -7262,6 +7289,25 @@ pub(crate) extern "C" fn jit_zip(a: u64, b: u64) -> u64 {
         x.clone_rc();
         y.clone_rc();
         out.push(NanVal::heap_list(vec![x, y]));
+    }
+    NanVal::heap_list(out).0
+}
+
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_enumerate(a: u64) -> u64 {
+    let va = NanVal(a);
+    if !va.is_heap() {
+        return TAG_NIL;
+    }
+    let xs = match unsafe { va.as_heap_ref() } {
+        HeapObj::List(items) => items,
+        _ => return TAG_NIL,
+    };
+    let mut out: Vec<NanVal> = Vec::with_capacity(xs.len());
+    for (i, &v) in xs.iter().enumerate() {
+        v.clone_rc();
+        out.push(NanVal::heap_list(vec![NanVal::number(i as f64), v]));
     }
     NanVal::heap_list(out).0
 }

--- a/tests/regression_enumerate.rs
+++ b/tests/regression_enumerate.rs
@@ -1,0 +1,152 @@
+// Regression tests for the `enumerate xs` builtin — pair each element of a
+// list with its index, returning a list of [index, value] pairs.
+//
+// Returns L (L _): inner pair holds a number (index) and an `a` (element),
+// so the element type is erased to `_`. Verified across tree, vm, and
+// cranelift engines.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+// Basic: enumerate a list of strings.
+const STRINGS_SRC: &str = "f>L (L _);enumerate [\"a\",\"b\",\"c\"]";
+
+fn check_strings(engine: &str) {
+    assert_eq!(
+        run(engine, STRINGS_SRC, "f"),
+        "[[0, a], [1, b], [2, c]]",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn enumerate_strings_tree() {
+    check_strings("--run-tree");
+}
+
+#[test]
+fn enumerate_strings_vm() {
+    check_strings("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn enumerate_strings_cranelift() {
+    check_strings("--run-cranelift");
+}
+
+// Empty list: produces an empty list.
+const EMPTY_SRC: &str = "f>L (L _);enumerate []";
+
+fn check_empty(engine: &str) {
+    assert_eq!(run(engine, EMPTY_SRC, "f"), "[]", "engine={engine}");
+}
+
+#[test]
+fn enumerate_empty_tree() {
+    check_empty("--run-tree");
+}
+
+#[test]
+fn enumerate_empty_vm() {
+    check_empty("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn enumerate_empty_cranelift() {
+    check_empty("--run-cranelift");
+}
+
+// Singleton: a single-element list.
+const SINGLE_SRC: &str = "f>L (L _);enumerate [10]";
+
+fn check_single(engine: &str) {
+    assert_eq!(run(engine, SINGLE_SRC, "f"), "[[0, 10]]", "engine={engine}");
+}
+
+#[test]
+fn enumerate_single_tree() {
+    check_single("--run-tree");
+}
+
+#[test]
+fn enumerate_single_vm() {
+    check_single("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn enumerate_single_cranelift() {
+    check_single("--run-cranelift");
+}
+
+// Type-variable: numbers work too (element type erased to `_`).
+const NUMBERS_SRC: &str = "f>L (L _);enumerate [100,200,300]";
+
+fn check_numbers(engine: &str) {
+    assert_eq!(
+        run(engine, NUMBERS_SRC, "f"),
+        "[[0, 100], [1, 200], [2, 300]]",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn enumerate_numbers_tree() {
+    check_numbers("--run-tree");
+}
+
+#[test]
+fn enumerate_numbers_vm() {
+    check_numbers("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn enumerate_numbers_cranelift() {
+    check_numbers("--run-cranelift");
+}
+
+// Use case: pass the result through `hd` to grab the first [i,v] pair.
+const FIRST_PAIR_SRC: &str = "f>L _;hd (enumerate [\"x\",\"y\",\"z\"])";
+
+fn check_first_pair(engine: &str) {
+    assert_eq!(
+        run(engine, FIRST_PAIR_SRC, "f"),
+        "[0, x]",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn enumerate_first_pair_tree() {
+    check_first_pair("--run-tree");
+}
+
+#[test]
+fn enumerate_first_pair_vm() {
+    check_first_pair("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn enumerate_first_pair_cranelift() {
+    check_first_pair("--run-cranelift");
+}


### PR DESCRIPTION
Iterating with index is a recurring pattern (labelling, position-aware maps). Agents currently zip with a hand-built range, which burns tokens and trips on empty inputs.

Implementation:
- enumerate xs returns [[0, x0], [1, x1], ...] on L or S
- Opcode 139 across tree, vm, cranelift

Tests: 15 cross-engine regression tests + examples/enumerate.ilo with -- run: directives.