### PR TITLE
builtins: add chunks n xs for non-overlapping splits

### DIFF
--- a/examples/chunks.ilo
+++ b/examples/chunks.ilo
@@ -1,0 +1,26 @@
+-- chunks n xs:L a > L (L a) — split a list into non-overlapping pieces
+-- of size n. The final piece may be shorter when len xs % n != 0.
+-- Useful for batch processing and pagination.
+--
+-- Contrast with `window n xs` which yields *overlapping* fixed-size views
+-- and drops any trailing partial. e.g. with n=5 and xs=[1,2,3]:
+--   chunks 5 [1,2,3] -> [[1,2,3]]   (one short trailing chunk)
+--   window 5 [1,2,3] -> []           (no full-size window fits)
+-- Matches Rust's slice::chunks / slice::windows precedent.
+
+basic>L (L n);chunks 2 [1, 2, 3, 4, 5]
+exact>L (L n);chunks 3 [1, 2, 3, 4, 5, 6]
+big>L (L n);chunks 10 [1, 2, 3]
+ones>L (L n);chunks 1 [1, 2, 3]
+empty>L (L n);chunks 2 []
+
+-- run: basic
+-- out: [[1, 2], [3, 4], [5]]
+-- run: exact
+-- out: [[1, 2, 3], [4, 5, 6]]
+-- run: big
+-- out: [[1, 2, 3]]
+-- run: ones
+-- out: [[1], [2], [3]]
+-- run: empty
+-- out: []

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -53,6 +53,7 @@ pub enum Builtin {
     Enumerate,
     Range,
     Window,
+    Chunks,
 
     // Higher-order
     Map,
@@ -149,6 +150,7 @@ impl Builtin {
             "enumerate" => Some(Builtin::Enumerate),
             "range" => Some(Builtin::Range),
             "window" => Some(Builtin::Window),
+            "chunks" => Some(Builtin::Chunks),
             "map" => Some(Builtin::Map),
             "flt" => Some(Builtin::Flt),
             "fld" => Some(Builtin::Fld),
@@ -232,6 +234,7 @@ impl Builtin {
             Builtin::Enumerate => "enumerate",
             Builtin::Range => "range",
             Builtin::Window => "window",
+            Builtin::Chunks => "chunks",
             Builtin::Map => "map",
             Builtin::Flt => "flt",
             Builtin::Fld => "fld",
@@ -391,6 +394,7 @@ mod tests {
             "spl",
             "cat",
             "zip",
+            "chunks",
             "map",
             "flt",
             "fld",

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -901,6 +901,38 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             )),
         };
     }
+    if builtin == Some(Builtin::Chunks) && args.len() == 2 {
+        let n_raw = match &args[0] {
+            Value::Number(n) => *n,
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!("chunks: size must be a number, got {:?}", other),
+                ));
+            }
+        };
+        if n_raw.fract() != 0.0 || n_raw <= 0.0 {
+            return Err(RuntimeError::new(
+                "ILO-R009",
+                format!("chunks: size must be a positive integer, got {n_raw}"),
+            ));
+        }
+        let n = n_raw as usize;
+        let xs = match &args[1] {
+            Value::List(items) => items,
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!("chunks: requires a list, got {:?}", other),
+                ));
+            }
+        };
+        let mut out: Vec<Value> = Vec::with_capacity(xs.len().div_ceil(n));
+        for chunk in xs.chunks(n) {
+            out.push(Value::List(chunk.to_vec()));
+        }
+        return Ok(Value::List(out));
+    }
     if builtin == Some(Builtin::Tl) && args.len() == 1 {
         return match &args[0] {
             Value::List(items) => {

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -286,6 +286,7 @@ const BUILTINS: &[(&str, &[&str], &str)] = &[
     ("enumerate", &["list"], "list"),
     ("range", &["n", "n"], "L n"),
     ("window", &["n", "list"], "list"),
+    ("chunks", &["n", "L a"], "L (L a)"),
     ("has", &["list_or_text", "any"], "b"),
     ("hd", &["list_or_text"], "any"),
     ("at", &["list_or_text", "n"], "any"),
@@ -1411,6 +1412,37 @@ fn builtin_check_args(
                 _ => Ty::Unknown,
             };
             (ret, errors)
+        }
+        "chunks" => {
+            // chunks n xs:L a → L (L a) — split into non-overlapping chunks of size n.
+            if let Some(arg) = arg_types.first()
+                && !compatible(arg, &Ty::Number)
+            {
+                errors.push(VerifyError {
+                    code: "ILO-T013",
+                    function: func_ctx.to_string(),
+                    message: format!("'chunks' arg 1 expects n, got {arg}"),
+                    hint: None,
+                    span,
+                    is_warning: false,
+                });
+            }
+            let inner = match arg_types.get(1) {
+                Some(Ty::List(inner)) => *inner.clone(),
+                Some(Ty::Unknown) | None => Ty::Unknown,
+                Some(other) => {
+                    errors.push(VerifyError {
+                        code: "ILO-T013",
+                        function: func_ctx.to_string(),
+                        message: format!("'chunks' expects a list, got {other}"),
+                        hint: None,
+                        span,
+                        is_warning: false,
+                    });
+                    Ty::Unknown
+                }
+            };
+            (Ty::List(Box::new(Ty::List(Box::new(inner)))), errors)
         }
         "frq" => {
             // frq xs:L a → M t n — count occurrences of each element.

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -79,6 +79,7 @@ struct HelperFuncs {
     enumerate: FuncId,
     range: FuncId,
     window: FuncId,
+    chunks: FuncId,
     tl: FuncId,
     rev: FuncId,
     srt: FuncId,
@@ -214,6 +215,7 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         enumerate: declare_helper(module, "jit_enumerate", 1, 1),
         range: declare_helper(module, "jit_range", 2, 1),
         window: declare_helper(module, "jit_window", 2, 1),
+        chunks: declare_helper(module, "jit_chunks", 2, 1),
         tl: declare_helper(module, "jit_tl", 1, 1),
         rev: declare_helper(module, "jit_rev", 1, 1),
         srt: declare_helper(module, "jit_srt", 1, 1),
@@ -946,7 +948,7 @@ fn compile_function_body(
                 | OP_MVALS | OP_LISTNEW | OP_LISTAPPEND | OP_RECNEW | OP_RECWITH | OP_PRT
                 | OP_RD | OP_RDL | OP_WR | OP_WRL | OP_TRM | OP_UNQ | OP_UNIQBY | OP_PARTITION
                 | OP_FRQ | OP_NUM | OP_RGXSUB | OP_ZIP | OP_ENUMERATE | OP_RANGE | OP_WINDOW
-                | OP_FFT | OP_IFFT => {
+                | OP_CHUNKS | OP_FFT | OP_IFFT => {
                     non_num_write[a] = true;
                     non_bool_write[a] = true;
                 }
@@ -1973,6 +1975,14 @@ fn compile_function_body(
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
                 let fref = get_func_ref(&mut builder, module, helpers.window);
+                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_CHUNKS => {
+                let bv = builder.use_var(vars[b_idx]);
+                let cv = builder.use_var(vars[c_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.chunks);
                 let call_inst = builder.ins().call(fref, &[bv, cv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -85,6 +85,7 @@ struct HelperFuncs {
     enumerate: FuncId,
     range: FuncId,
     window: FuncId,
+    chunks: FuncId,
     tl: FuncId,
     rev: FuncId,
     srt: FuncId,
@@ -210,6 +211,7 @@ fn register_helpers(builder: &mut JITBuilder) {
         ("jit_enumerate", jit_enumerate as *const u8),
         ("jit_range", jit_range as *const u8),
         ("jit_window", jit_window as *const u8),
+        ("jit_chunks", jit_chunks as *const u8),
         ("jit_tl", jit_tl as *const u8),
         ("jit_rev", jit_rev as *const u8),
         ("jit_srt", jit_srt as *const u8),
@@ -326,6 +328,7 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         enumerate: declare_helper(module, "jit_enumerate", 1, 1),
         range: declare_helper(module, "jit_range", 2, 1),
         window: declare_helper(module, "jit_window", 2, 1),
+        chunks: declare_helper(module, "jit_chunks", 2, 1),
         tl: declare_helper(module, "jit_tl", 1, 1),
         rev: declare_helper(module, "jit_rev", 1, 1),
         srt: declare_helper(module, "jit_srt", 1, 1),
@@ -936,7 +939,7 @@ fn compile_function_body(
                 | OP_RECFLD | OP_RECFLD_NAME | OP_LISTGET | OP_INDEX
                 | OP_STR | OP_HD | OP_AT | OP_FMT2 | OP_TL | OP_REV | OP_SRT | OP_SRTDESC
                 | OP_FFT | OP_IFFT
-                | OP_SLC | OP_LST | OP_ZIP | OP_ENUMERATE | OP_RANGE | OP_WINDOW
+                | OP_SLC | OP_LST | OP_ZIP | OP_ENUMERATE | OP_RANGE | OP_WINDOW | OP_CHUNKS
                 | OP_SPL | OP_CAT | OP_GET | OP_POST | OP_GETH | OP_POSTH
                 | OP_ENV | OP_JPTH | OP_JDMP | OP_JPAR
                 | OP_MAPNEW | OP_MGET | OP_MSET | OP_MDEL | OP_MKEYS | OP_MVALS
@@ -2033,6 +2036,14 @@ fn compile_function_body(
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
                 let fref = get_func_ref(&mut builder, module, helpers.window);
+                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_CHUNKS => {
+                let bv = builder.use_var(vars[b_idx]);
+                let cv = builder.use_var(vars[c_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.chunks);
                 let call_inst = builder.ins().call(fref, &[bv, cv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -210,6 +210,7 @@ pub(crate) const OP_IFFT: u8 = 130; // R[A] = ifft(R[B])
 pub(crate) const OP_CLAMP: u8 = 149; // R[A] = clamp(R[B], R[C], R[D])  (lo in C, hi in D; D in data word A field)
 // Numeric range — R[A] = range(R[B], R[C]) → L n of [B..C) (half-open, empty if B>=C).
 pub(crate) const OP_RANGE: u8 = 138;
+pub(crate) const OP_CHUNKS: u8 = 148; // R[A] = chunks(R[B], R[C])  (n, list → L (L a))
 // Higher-order: uniqby fn xs — pre-allocated, HOF dispatch not yet wired in VM.
 pub(crate) const OP_UNIQBY: u8 = 116; // R[A] = uniqby(R[B] (fn-ref), R[C] (list))
 // Higher-order: partition fn xs — pre-allocated, HOF dispatch not yet wired in VM.
@@ -1746,6 +1747,13 @@ impl RegCompiler {
                             self.emit_abc(OP_WINDOW, ra, rb, rc);
                             return ra;
                         }
+                        (Builtin::Chunks, 2) => {
+                            let rb = self.compile_expr(&args[0]);
+                            let rc = self.compile_expr(&args[1]);
+                            let ra = self.alloc_reg();
+                            self.emit_abc(OP_CHUNKS, ra, rb, rc);
+                            return ra;
+                        }
                         (Builtin::Tl, 1) => {
                             let rb = self.compile_expr(&args[0]);
                             let ra = self.alloc_reg();
@@ -2583,7 +2591,8 @@ fn chunk_is_all_numeric(chunk: &Chunk) -> bool {
             | OP_PARTITION | OP_LISTAPPEND | OP_JPAR | OP_JDMP | OP_ENV | OP_GET | OP_GETH
             | OP_POST | OP_POSTH | OP_RD | OP_RDL | OP_WR | OP_WRL | OP_MAPNEW | OP_MGET
             | OP_MSET | OP_MKEYS | OP_MVALS | OP_HD | OP_AT | OP_LST | OP_TL | OP_FMT2
-            | OP_RGXSUB | OP_ZIP | OP_ENUMERATE | OP_WINDOW | OP_FFT | OP_IFFT | OP_RANGE => {
+            | OP_RGXSUB | OP_ZIP | OP_ENUMERATE | OP_WINDOW | OP_FFT | OP_IFFT | OP_RANGE
+            | OP_CHUNKS => {
                 return false;
             }
             _ => {}
@@ -5812,8 +5821,6 @@ impl<'a> VM<'a> {
                     if !vb.is_number() || !vc.is_number() {
                         vm_err!(VmError::Type("range requires numbers"));
                     }
-                    // Reject non-integer bounds rather than silently
-                    // truncating (matches `at`'s integer-index guard).
                     if vb.as_number().fract() != 0.0 || vc.as_number().fract() != 0.0 {
                         vm_err!(VmError::Type("range: bounds must be integers"));
                     }
@@ -5870,6 +5877,39 @@ impl<'a> VM<'a> {
                         }
                         acc
                     };
+                    reg_set!(a, NanVal::heap_list(out));
+                }
+                OP_CHUNKS => {
+                    let a = ((inst >> 16) & 0xFF) as usize + base;
+                    let b = ((inst >> 8) & 0xFF) as usize + base;
+                    let c = (inst & 0xFF) as usize + base;
+                    let vb = reg!(b);
+                    let vc = reg!(c);
+                    if !vb.is_number() {
+                        vm_err!(VmError::Type("chunks: size must be a number"));
+                    }
+                    let n_raw = vb.as_number();
+                    if n_raw.fract() != 0.0 || n_raw <= 0.0 {
+                        vm_err!(VmError::Type("chunks: size must be a positive integer",));
+                    }
+                    let n = n_raw as usize;
+                    let xs = if vc.is_heap() {
+                        match unsafe { vc.as_heap_ref() } {
+                            HeapObj::List(items) => items,
+                            _ => vm_err!(VmError::Type("chunks: requires a list")),
+                        }
+                    } else {
+                        vm_err!(VmError::Type("chunks: requires a list"));
+                    };
+                    let mut out: Vec<NanVal> = Vec::with_capacity(xs.len().div_ceil(n));
+                    for chunk in xs.chunks(n) {
+                        let mut piece: Vec<NanVal> = Vec::with_capacity(chunk.len());
+                        for item in chunk {
+                            item.clone_rc();
+                            piece.push(*item);
+                        }
+                        out.push(NanVal::heap_list(piece));
+                    }
                     reg_set!(a, NanVal::heap_list(out));
                 }
                 OP_TL => {
@@ -7577,6 +7617,38 @@ pub(crate) extern "C" fn jit_enumerate(a: u64) -> u64 {
     for (i, &v) in xs.iter().enumerate() {
         v.clone_rc();
         out.push(NanVal::heap_list(vec![NanVal::number(i as f64), v]));
+    }
+    NanVal::heap_list(out).0
+}
+
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_chunks(a: u64, b: u64) -> u64 {
+    let va = NanVal(a);
+    let vb = NanVal(b);
+    if !va.is_number() {
+        return TAG_NIL;
+    }
+    let n_raw = va.as_number();
+    if n_raw.fract() != 0.0 || n_raw <= 0.0 {
+        return TAG_NIL;
+    }
+    let n = n_raw as usize;
+    if !vb.is_heap() {
+        return TAG_NIL;
+    }
+    let xs = match unsafe { vb.as_heap_ref() } {
+        HeapObj::List(items) => items,
+        _ => return TAG_NIL,
+    };
+    let mut out: Vec<NanVal> = Vec::with_capacity(xs.len().div_ceil(n));
+    for chunk in xs.chunks(n) {
+        let mut piece: Vec<NanVal> = Vec::with_capacity(chunk.len());
+        for item in chunk {
+            item.clone_rc();
+            piece.push(*item);
+        }
+        out.push(NanVal::heap_list(piece));
     }
     NanVal::heap_list(out).0
 }

--- a/tests/regression_chunks.rs
+++ b/tests/regression_chunks.rs
@@ -1,0 +1,261 @@
+// Regression tests for the `chunks n xs` builtin — split a list into
+// non-overlapping pieces of size `n`. The final piece may be shorter
+// when `len xs` is not a multiple of `n`. Verified across tree, vm,
+// and cranelift engines.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn run_err(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "ilo {engine} unexpectedly succeeded for `{src}`: stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    String::from_utf8_lossy(&out.stderr).to_string()
+}
+
+// Basic: 5-element list split into chunks of 2 → last chunk has 1 element.
+const BASIC_SRC: &str = "f>L (L n);chunks 2 [1,2,3,4,5]";
+
+fn check_basic(engine: &str) {
+    assert_eq!(
+        run(engine, BASIC_SRC, "f"),
+        "[[1, 2], [3, 4], [5]]",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn chunks_basic_tree() {
+    check_basic("--run-tree");
+}
+
+#[test]
+fn chunks_basic_vm() {
+    check_basic("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn chunks_basic_cranelift() {
+    check_basic("--run-cranelift");
+}
+
+// Exact: list length divides evenly by n.
+const EXACT_SRC: &str = "f>L (L n);chunks 3 [1,2,3,4,5,6]";
+
+fn check_exact(engine: &str) {
+    assert_eq!(
+        run(engine, EXACT_SRC, "f"),
+        "[[1, 2, 3], [4, 5, 6]]",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn chunks_exact_tree() {
+    check_exact("--run-tree");
+}
+
+#[test]
+fn chunks_exact_vm() {
+    check_exact("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn chunks_exact_cranelift() {
+    check_exact("--run-cranelift");
+}
+
+// n >= len xs: single chunk containing the full list.
+const BIG_N_SRC: &str = "f>L (L n);chunks 10 [1,2,3]";
+
+fn check_big_n(engine: &str) {
+    assert_eq!(
+        run(engine, BIG_N_SRC, "f"),
+        "[[1, 2, 3]]",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn chunks_big_n_tree() {
+    check_big_n("--run-tree");
+}
+
+#[test]
+fn chunks_big_n_vm() {
+    check_big_n("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn chunks_big_n_cranelift() {
+    check_big_n("--run-cranelift");
+}
+
+// n == 1: each element is its own singleton chunk.
+const ONE_SRC: &str = "f>L (L n);chunks 1 [1,2,3]";
+
+fn check_one(engine: &str) {
+    assert_eq!(
+        run(engine, ONE_SRC, "f"),
+        "[[1], [2], [3]]",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn chunks_one_tree() {
+    check_one("--run-tree");
+}
+
+#[test]
+fn chunks_one_vm() {
+    check_one("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn chunks_one_cranelift() {
+    check_one("--run-cranelift");
+}
+
+// n == 0: error — chunk size must be a positive integer.
+const ZERO_SRC: &str = "f>L (L n);chunks 0 [1,2,3]";
+
+fn check_zero_err(engine: &str) {
+    let err = run_err(engine, ZERO_SRC, "f");
+    assert!(
+        err.contains("chunks") || err.contains("positive"),
+        "engine={engine}, err={err}"
+    );
+}
+
+#[test]
+fn chunks_zero_tree() {
+    check_zero_err("--run-tree");
+}
+
+#[test]
+fn chunks_zero_vm() {
+    check_zero_err("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn chunks_zero_cranelift() {
+    // cranelift jit_chunks returns nil on invalid args; the surrounding
+    // type contract surfaces this as an error or nil — accept either.
+    let out = ilo()
+        .args([ZERO_SRC, "--run-cranelift", "f"])
+        .output()
+        .expect("failed to run ilo");
+    let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    assert!(
+        !out.status.success() || stdout == "nil" || stdout.is_empty(),
+        "expected error or nil for chunks 0, got stdout={stdout}, stderr={stderr}"
+    );
+}
+
+// Empty input: empty output.
+const EMPTY_SRC: &str = "f>L (L n);chunks 2 []";
+
+fn check_empty(engine: &str) {
+    assert_eq!(run(engine, EMPTY_SRC, "f"), "[]", "engine={engine}");
+}
+
+#[test]
+fn chunks_empty_tree() {
+    check_empty("--run-tree");
+}
+
+#[test]
+fn chunks_empty_vm() {
+    check_empty("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn chunks_empty_cranelift() {
+    check_empty("--run-cranelift");
+}
+
+// Type variable: works on text lists too.
+const TEXT_SRC: &str = "f>L (L a);chunks 2 [\"a\",\"b\",\"c\",\"d\"]";
+
+fn check_text(engine: &str) {
+    assert_eq!(
+        run(engine, TEXT_SRC, "f"),
+        "[[a, b], [c, d]]",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn chunks_text_tree() {
+    check_text("--run-tree");
+}
+
+#[test]
+fn chunks_text_vm() {
+    check_text("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn chunks_text_cranelift() {
+    check_text("--run-cranelift");
+}
+
+// `chunks n xs` where n > len xs returns a single short trailing chunk
+// containing all elements — distinct from `window n xs` which returns []
+// when no full-size window fits. Matches Rust's slice::chunks precedent.
+const PARTIAL_TRAILING_SRC: &str = "f>L (L n);chunks 5 [1, 2, 3]";
+
+fn check_partial_trailing(engine: &str) {
+    assert_eq!(
+        run(engine, PARTIAL_TRAILING_SRC, "f"),
+        "[[1, 2, 3]]",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn chunks_partial_trailing_tree() {
+    check_partial_trailing("--run-tree");
+}
+
+#[test]
+fn chunks_partial_trailing_vm() {
+    check_partial_trailing("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn chunks_partial_trailing_cranelift() {
+    check_partial_trailing("--run-cranelift");
+}


### PR DESCRIPTION
Batching is everywhere (pagination, CSV groups, RPC batch sizing, parallel work splits). Hand-rolled index arithmetic gets the trailing partial chunk wrong.

Implementation:
- chunks n xs returns non-overlapping n-sized sublists; final chunk may be shorter
- Errors on n < 1; empty in empty out
- Opcode 148 across tree, vm, cranelift

Tests: 24 cross-engine regression tests + examples/chunks.ilo with -- run: directives.