### PR TITLE
lexer: accept camelCase at post-dot field access

### DIFF
--- a/examples/camel-fields.ilo
+++ b/examples/camel-fields.ilo
@@ -1,0 +1,13 @@
+-- camelCase dot-access on records parsed from real-world JSON (NVD, AWS, Stripe, GitHub).
+sev j:t>R n t;r=jpar! j;r.baseSeverity
+url j:t>R n t;r=jpar! j;r.gitURL
+chained j:t>R n t;r=jpar! j;r.baseSeverity.label
+
+-- run: sev {"baseSeverity":"HIGH"}
+-- out: HIGH
+
+-- run: url {"gitURL":"https://x"}
+-- out: https://x
+
+-- run: chained {"baseSeverity":{"label":"low"}}
+-- out: low

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -235,16 +235,37 @@ pub fn lex(source: &str) -> Result<Vec<(Token, std::ops::Range<usize>)>, LexErro
                 // Detect uppercase mid-identifier: a single uppercase type sigil
                 // (L/R/F/O/M/S) sitting flush against a preceding ident.
                 if is_type_sigil(&token) {
-                    if let Some((Token::Ident(prev), prev_span)) = tokens.last() {
-                        if prev_span.end == span.start {
-                            let sigil_char = normalized[span.clone()].chars().next().unwrap();
-                            return Err(uppercase_mid_ident_error(
-                                prev,
-                                sigil_char,
-                                &normalized[span.end..],
-                                prev_span.start,
-                            ));
+                    let prev_info = tokens.last().and_then(|(t, s)| match t {
+                        Token::Ident(name) if s.end == span.start => {
+                            Some((name.clone(), s.clone()))
                         }
+                        _ => None,
+                    });
+                    if let Some((prev_name, prev_span)) = prev_info {
+                        // At a post-dot field-access position, real-world
+                        // JSON (NVD, AWS, Stripe, GitHub) is overwhelmingly
+                        // camelCase. Absorb the rest of the camelCase run
+                        // into a single Ident token rather than erroring.
+                        // The strict lowercase rule still applies to
+                        // bindings (no preceding Dot/DotQuestion).
+                        if prev_ident_is_post_dot(&tokens) {
+                            if let Some(_consumed) = absorb_camel_tail(
+                                &normalized,
+                                span.start,
+                                span.end,
+                                &mut lexer,
+                                &mut tokens,
+                            ) {
+                                continue;
+                            }
+                        }
+                        let sigil_char = normalized[span.clone()].chars().next().unwrap();
+                        return Err(uppercase_mid_ident_error(
+                            &prev_name,
+                            sigil_char,
+                            &normalized[span.end..],
+                            prev_span.start,
+                        ));
                     }
                 }
                 tokens.push((token, span));
@@ -254,18 +275,36 @@ pub fn lex(source: &str) -> Result<Vec<(Token, std::ops::Range<usize>)>, LexErro
                 let bad = &normalized[span.clone()];
                 // Single uppercase ASCII letter directly after an ident is a
                 // mid-identifier capital (e.g. `isAgg` → `is` + bad `A`).
-                if bad.len() == 1
-                    && bad.chars().next().unwrap().is_ascii_uppercase()
-                    && let Some((Token::Ident(prev), prev_span)) = tokens.last()
-                    && prev_span.end == span.start
-                {
-                    let c = bad.chars().next().unwrap();
-                    return Err(uppercase_mid_ident_error(
-                        prev,
-                        c,
-                        &normalized[span.end..],
-                        prev_span.start,
-                    ));
+                if bad.len() == 1 && bad.chars().next().unwrap().is_ascii_uppercase() {
+                    let prev_info = tokens.last().and_then(|(t, s)| match t {
+                        Token::Ident(name) if s.end == span.start => {
+                            Some((name.clone(), s.clone()))
+                        }
+                        _ => None,
+                    });
+                    if let Some((prev_name, prev_span)) = prev_info {
+                        // Post-dot field access: merge the camelCase tail into
+                        // the preceding Ident (mirrors the snake_case post-pass
+                        // below). Bindings still error normally.
+                        if prev_ident_is_post_dot(&tokens) {
+                            if let Some(_consumed) = absorb_camel_tail(
+                                &normalized,
+                                span.start,
+                                span.end,
+                                &mut lexer,
+                                &mut tokens,
+                            ) {
+                                continue;
+                            }
+                        }
+                        let c = bad.chars().next().unwrap();
+                        return Err(uppercase_mid_ident_error(
+                            &prev_name,
+                            c,
+                            &normalized[span.end..],
+                            prev_span.start,
+                        ));
+                    }
                 }
                 let (code, suggestion) = lex_error_kind(bad);
                 return Err(LexError {
@@ -446,6 +485,74 @@ pub fn lex(source: &str) -> Result<Vec<(Token, std::ops::Range<usize>)>, LexErro
     }
 
     Ok(tokens)
+}
+
+/// True when the last token is an `Ident` and the token before it is a
+/// `Dot`/`DotQuestion` sitting flush against it — i.e. the Ident is in
+/// post-dot field-access position (`record.<ident>` or `record.?<ident>`).
+fn prev_ident_is_post_dot(tokens: &[(Token, std::ops::Range<usize>)]) -> bool {
+    let n = tokens.len();
+    if n < 2 {
+        return false;
+    }
+    let (last_tok, last_span) = &tokens[n - 1];
+    let (prev_tok, prev_span) = &tokens[n - 2];
+    matches!(last_tok, Token::Ident(_))
+        && matches!(prev_tok, Token::Dot | Token::DotQuestion)
+        && prev_span.end == last_span.start
+}
+
+/// Absorb a camelCase JSON-key tail into the preceding `Ident` token.
+///
+/// Called from the main lex loop when an uppercase character appears flush
+/// against a post-dot `Ident` (e.g. the `S` in `record.baseSeverity`). Scans
+/// `normalized` from `from` consuming `[A-Za-z0-9]` characters, replaces the
+/// last token with a merged `Ident` spanning `prev_span.start..end`, and
+/// advances the logos lexer past the absorbed bytes. Returns `Some(end)` on
+/// success, `None` if nothing was absorbed (defensive — caller falls through
+/// to the existing error path).
+///
+/// Underscores are deliberately excluded here: snake_case stitching is handled
+/// by the dedicated post-lex pass below so that mixed `gitURL_count` still
+/// works (camelCase merges first, then the snake pass picks up the `_count`).
+fn absorb_camel_tail(
+    normalized: &str,
+    span_start: usize,
+    span_end: usize,
+    lexer: &mut logos::Lexer<'_, Token>,
+    tokens: &mut Vec<(Token, std::ops::Range<usize>)>,
+) -> Option<usize> {
+    let bytes = normalized.as_bytes();
+    let mut end = span_start;
+    while end < bytes.len() {
+        let b = bytes[end];
+        if b.is_ascii_alphanumeric() {
+            end += 1;
+        } else {
+            break;
+        }
+    }
+    if end == span_start {
+        return None;
+    }
+    let (prev_tok, prev_span) = tokens.pop()?;
+    let Token::Ident(_) = prev_tok else {
+        // Defensive: caller already checked, but restore on mismatch.
+        tokens.push((prev_tok, prev_span));
+        return None;
+    };
+    let merged_span = prev_span.start..end;
+    let merged = normalized[merged_span.clone()].to_string();
+    tokens.push((Token::Ident(merged), merged_span));
+    // Advance the logos lexer past the bytes we just absorbed. Logos has
+    // already consumed up to `span_end` (the end of the offending token —
+    // either the type sigil's 1 byte or the rejected uppercase byte), so
+    // bump by the remaining extent.
+    let bump = end.saturating_sub(span_end);
+    if bump > 0 {
+        lexer.bump(bump);
+    }
+    Some(end)
 }
 
 fn is_type_sigil(t: &Token) -> bool {

--- a/tests/regression_camelcase_dot.rs
+++ b/tests/regression_camelcase_dot.rs
@@ -1,0 +1,233 @@
+// Regression tests for camelCase field access on records.
+//
+// Real-world JSON from NVD, AWS, Stripe, GitHub is overwhelmingly camelCase
+// (`baseSeverity`, `stargazersCount`, `paymentMethod`). The strict identifier
+// rule (lowercase + hyphens) made `r.baseSeverity` trip ILO-L003 at the lexer
+// because uppercase mid-ident is rejected. The fix mirrors the snake_case
+// post-pass: when an uppercase character appears flush against an `Ident` that
+// is itself flush against a preceding `Dot`/`DotQuestion`, the lexer absorbs
+// the camelCase tail (`[A-Za-z0-9]+`) into a single `Ident` token.
+//
+// Bindings (`fooBar=5`) still emit ILO-L003.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str, args: &[&str]) -> String {
+    let mut cmd = ilo();
+    cmd.arg(src).arg(engine).arg(entry);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn run_err(src: &str) -> String {
+    let out = ilo()
+        .args([src, "--run-tree", "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(!out.status.success(), "expected failure for `{src}`");
+    String::from_utf8_lossy(&out.stderr).to_string()
+}
+
+// `r.baseSeverity` (capital is a type sigil `S`) returns "HIGH" across engines.
+const SIGIL: &str = "f j:t>R n t;r=jpar! j;r.baseSeverity";
+
+fn check_sigil(engine: &str) {
+    assert_eq!(
+        run(engine, SIGIL, "f", &[r#"{"baseSeverity":"HIGH"}"#]),
+        "HIGH",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn camel_field_sigil_tree() {
+    check_sigil("--run-tree");
+}
+
+#[test]
+fn camel_field_sigil_vm() {
+    check_sigil("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn camel_field_sigil_cranelift() {
+    check_sigil("--run-cranelift");
+}
+
+// `r.gitURL` (capital is a non-sigil `U`) — exercises the second lex path.
+const NON_SIGIL: &str = "f j:t>R n t;r=jpar! j;r.gitURL";
+
+fn check_non_sigil(engine: &str) {
+    assert_eq!(
+        run(engine, NON_SIGIL, "f", &[r#"{"gitURL":"x"}"#]),
+        "x",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn camel_field_non_sigil_tree() {
+    check_non_sigil("--run-tree");
+}
+
+#[test]
+fn camel_field_non_sigil_vm() {
+    check_non_sigil("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn camel_field_non_sigil_cranelift() {
+    check_non_sigil("--run-cranelift");
+}
+
+// Chained camelCase access: `r.baseSeverity.label`.
+const CHAINED: &str = "f j:t>R n t;r=jpar! j;r.baseSeverity.label";
+
+fn check_chained(engine: &str) {
+    assert_eq!(
+        run(engine, CHAINED, "f", &[r#"{"baseSeverity":{"label":"x"}}"#]),
+        "x",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn camel_field_chained_tree() {
+    check_chained("--run-tree");
+}
+
+#[test]
+fn camel_field_chained_vm() {
+    check_chained("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn camel_field_chained_cranelift() {
+    check_chained("--run-cranelift");
+}
+
+// camelCase + trailing digit: `r.field2Name`.
+const DIGIT: &str = "f j:t>R n t;r=jpar! j;r.field2Name";
+
+fn check_digit(engine: &str) {
+    assert_eq!(
+        run(engine, DIGIT, "f", &[r#"{"field2Name":42}"#]),
+        "42",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn camel_field_digit_tree() {
+    check_digit("--run-tree");
+}
+
+#[test]
+fn camel_field_digit_vm() {
+    check_digit("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn camel_field_digit_cranelift() {
+    check_digit("--run-cranelift");
+}
+
+// Safe access on a camelCase field: `r.?baseSeverity`.
+#[test]
+fn camel_field_safe_access_tree() {
+    let out = run(
+        "--run-tree",
+        "f j:t>R n t;r=jpar! j;r.?baseSeverity",
+        "f",
+        &[r#"{"baseSeverity":"HIGH"}"#],
+    );
+    assert_eq!(out, "HIGH");
+}
+
+// Mixed camelCase + snake_case: `r.gitURL_count`. The camelCase pass runs
+// first inside the main lex loop, producing `Ident("gitURL")`; then the
+// post-lex snake_case pass stitches `_count` onto the end.
+const MIXED: &str = "f j:t>R n t;r=jpar! j;r.gitURL_count";
+
+fn check_mixed(engine: &str) {
+    assert_eq!(
+        run(engine, MIXED, "f", &[r#"{"gitURL_count":7}"#]),
+        "7",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn camel_field_mixed_snake_tree() {
+    check_mixed("--run-tree");
+}
+
+#[test]
+fn camel_field_mixed_snake_vm() {
+    check_mixed("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn camel_field_mixed_snake_cranelift() {
+    check_mixed("--run-cranelift");
+}
+
+// ---- Negative regressions: strict lowercase rule preserved for bindings ----
+
+#[test]
+fn camel_binding_still_errors_sigil() {
+    // `fooSet=5` (S is a type sigil) in a binding position must still emit
+    // ILO-L003 with the lowercase-suggestion friendly message.
+    let err = run_err("f>n;fooSet=5;fooSet");
+    assert!(err.contains("ILO-L003"), "stderr: {err}");
+    assert!(err.contains("fooSet"), "stderr: {err}");
+}
+
+#[test]
+fn camel_binding_still_errors_non_sigil() {
+    // `fooBar=5` (B is not a sigil) — same expectation.
+    let err = run_err("f>n;fooBar=5;fooBar");
+    assert!(err.contains("ILO-L003"), "stderr: {err}");
+    assert!(err.contains("fooBar"), "stderr: {err}");
+}
+
+#[test]
+fn dot_then_plain_ident_unchanged() {
+    // `r.foo` (no uppercase) must still parse as a plain field access.
+    let out = run(
+        "--run-tree",
+        "f j:t>R n t;r=jpar! j;r.foo",
+        "f",
+        &[r#"{"foo":3}"#],
+    );
+    assert_eq!(out, "3");
+}
+
+#[test]
+fn dot_then_camel_space_ident_keeps_tokens_separate() {
+    // `r.fooBar baz` must absorb `fooBar` as the field name but leave `baz` as
+    // a separate token. `baz` is unbound so the program should fail rather
+    // than silently treat it as part of the field name.
+    let err = run_err("f j:t>R n t;r=jpar! j;r.fooBar baz");
+    assert!(!err.is_empty(), "expected an error, got empty stderr");
+    // The error should NOT be the L003 uppercase-rejection — the camelCase
+    // tail merged correctly. It should be a downstream parse/resolve error.
+    assert!(!err.contains("baseSeverity"), "stderr: {err}");
+}


### PR DESCRIPTION
## Summary

Real-world JSON from NVD, AWS, Stripe, and GitHub is overwhelmingly camelCase. `record.baseSeverity` used to trip `ILO-L003: unexpected character` at the lexer because any uppercase mid-ident was a hard error. The workaround (`jpth! record "baseSeverity"`) is verbose and burns tokens on every field read, which fights the manifesto: agents reading JSON shouldn't pay a token tax for the fact that the source happens to capitalise.

This mirrors the snake_case post-pass that landed earlier: at post-dot field-access position (and only there), the lexer absorbs the camelCase tail into a single `Ident` token. Bindings still emit `ILO-L003` unchanged.

## Repro

Before:

```
$ ilo 'f j:t>R n t;r=jpar! j;r.baseSeverity' f '{"baseSeverity":"HIGH"}'
ILO-L003: unexpected token 'baseSeverity'
```

After:

```
$ ilo 'f j:t>R n t;r=jpar! j;r.baseSeverity' f '{"baseSeverity":"HIGH"}'
HIGH
```

Bindings still reject (unchanged):

```
$ ilo 'fooBar=5;fooBar'
ILO-L003: unexpected token 'fooBar'
```

## What's in the diff

- `lexer: accept camelCase at post-dot field access` - the fix itself. Two lex paths needed updating: the type-sigil branch (`L/R/F/O/M/S` tokens, e.g. the `S` in `baseSeverity`) and the single-uppercase-error branch (non-sigil capitals, e.g. the `U` in `gitURL`). New `prev_ident_is_post_dot` helper detects the position; new `absorb_camel_tail` does the merge and advances the logos cursor.
- `test: cross-engine regression coverage for camelCase dot-access` - 20 tests across tree, VM, and Cranelift covering sigil capitals, non-sigil capitals, chained access, trailing digits, safe access, mixed camel + snake (`gitURL_count`), and negative regressions on bindings.
- `example: camelCase dot-access on real-world JSON shapes` - picked up by `tests/examples_engines.rs` so every engine exercises the path through the example harness too.

## Test plan

- [x] `cargo build --release --features cranelift`
- [x] `cargo test --release --features cranelift` (4101 passed, 0 failed, up from 4081 with 20 new)
- [x] `cargo fmt`
- [x] `cargo clippy --release --features cranelift -- -D warnings` (clean)
- [x] Manual repro of `baseSeverity`, `gitURL`, chained, safe, mixed, and binding-still-errors cases

## Follow-ups

- Leading-uppercase keys like `record.URL` and `record.ID` still fail at the lexer (no preceding `Ident` to merge into). Worth a separate fix that treats `Dot`+uppercase-run as a field-name Ident directly. Out of scope here to keep the change tight.