### PR TITLE
Accept reserved keywords as field names at dot-access

### DIFF
--- a/examples/dot-keywords.ilo
+++ b/examples/dot-keywords.ilo
@@ -1,0 +1,26 @@
+-- Reserved keywords as field names at dot-access. Real-world JSON keys are
+-- often named after keywords (`type`, `if`, `use`); dot-access should just work.
+ftype j:t>R n t;r=jpar! j;r.type
+fif j:t>R n t;r=jpar! j;r.if
+fuse j:t>R n t;r=jpar! j;r.use
+ftrue j:t>R n t;r=jpar! j;r.true
+fnil j:t>R n t;r=jpar! j;r.nil
+ftypeid j:t>R n t;r=jpar! j;r.type_id
+
+-- run: ftype {"type":42}
+-- out: 42
+
+-- run: fif {"if":7}
+-- out: 7
+
+-- run: fuse {"use":1}
+-- out: 1
+
+-- run: ftrue {"true":99}
+-- out: 99
+
+-- run: fnil {"nil":13}
+-- out: 13
+
+-- run: ftypeid {"type_id":1234}
+-- out: 1234

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -338,6 +338,59 @@ pub fn lex(source: &str) -> Result<Vec<(Token, std::ops::Range<usize>)>, LexErro
         }
     }
 
+    // Post-lex: after `.` or `.?` (field access), accept reserved keywords
+    // (`type`, `if`, `let`, `fn`, `var`, `use`, `with`, type sigils `R`/`L`/`F`/`O`/`M`/`S`,
+    // `true`, `false`, `nil`, ...) as plain field names by rewriting the keyword
+    // token back into a `Token::Ident` using the original source slice. Real-world
+    // JSON keys are frequently named after keywords (`type`, `if`, `use`), and
+    // dot-access on those should "just work" — the workaround was the verbose
+    // `jpth! resp "type"` per field. Only fires when the keyword token sits flush
+    // against a preceding `Dot`/`DotQuestion` (no whitespace), so reserved words
+    // in binding position still emit their friendly ILO-P011 error.
+    //
+    // This runs before the snake_case pass below so `record.type_id` correctly
+    // stitches: after this pass the token sequence becomes
+    // `Dot Ident("type") Underscore Ident("id")`, then the snake_case loop merges
+    // it into `Dot Ident("type_id")`.
+    {
+        let mut i = 0;
+        while i < tokens.len() {
+            if i == 0 {
+                i += 1;
+                continue;
+            }
+            let prev_is_dot = matches!(tokens[i - 1].0, Token::Dot | Token::DotQuestion)
+                && tokens[i - 1].1.end == tokens[i].1.start;
+            if !prev_is_dot {
+                i += 1;
+                continue;
+            }
+            if matches!(tokens[i].0, Token::Ident(_) | Token::Number(_)) {
+                i += 1;
+                continue;
+            }
+            let span = tokens[i].1.clone();
+            let slice = &normalized[span.clone()];
+            // Only rewrite tokens whose source slice is a valid bare field name —
+            // identifier-shaped (`[A-Za-z][A-Za-z0-9_]*`). This catches keyword
+            // tokens (`type`, `if`, `use`, ...) and type sigils (`R`, `L`, `F`,
+            // `O`, `M`, `S`), but skips punctuation like `..` or `.?` that the
+            // lexer happens to emit as non-Ident tokens.
+            let mut chars = slice.chars();
+            let first_ok = chars
+                .next()
+                .map(|c| c.is_ascii_alphabetic())
+                .unwrap_or(false);
+            let rest_ok = chars.all(|c| c.is_ascii_alphanumeric() || c == '_');
+            if !first_ok || !rest_ok {
+                i += 1;
+                continue;
+            }
+            tokens[i] = (Token::Ident(slice.to_string()), span);
+            i += 1;
+        }
+    }
+
     // Post-lex: after `.` or `.?` (field access), accept JSON-style snake_case
     // field names by merging contiguous `Ident (Underscore (Ident|Number))*`
     // runs back into a single `Ident` token. Real-world JSON (which agents

--- a/tests/regression_dot_keywords.rs
+++ b/tests/regression_dot_keywords.rs
@@ -1,0 +1,203 @@
+// Regression tests for reserved-keyword field names at dot-access.
+//
+// Real-world JSON keys are frequently named after keywords (`type`, `if`,
+// `use`, `with`, `true`, `false`, `nil`, ...). The strict identifier rule
+// makes `parsed.type` trip ILO-P005 (`expected identifier, got Type`) at the
+// parser, forcing the verbose `jpth! resp "type"` workaround.
+//
+// The fix: a lexer post-pass rewrites any keyword token sitting flush
+// against a preceding `Dot`/`DotQuestion` into a `Token::Ident` using its
+// original source slice. Bindings still emit their friendly ILO-P011 error.
+// The pass runs before the snake_case merge so `.type_id` stitches.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str, args: &[&str]) -> String {
+    let mut cmd = ilo();
+    cmd.arg(src).arg(engine).arg(entry);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn run_err(src: &str) -> String {
+    let out = ilo()
+        .args([src, "--run-tree", "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(!out.status.success(), "expected failure for `{src}`");
+    String::from_utf8_lossy(&out.stderr).to_string()
+}
+
+// Build a one-shot `f j:t>R n t;r=jpar! j;r.<field>` program for the given
+// reserved-keyword field name.
+fn prog(field: &str) -> String {
+    format!("f j:t>R n t;r=jpar! j;r.{field}")
+}
+
+fn check_keyword(engine: &str, field: &str, value: i32) {
+    let src = prog(field);
+    let json = format!("{{\"{field}\":{value}}}");
+    assert_eq!(
+        run(engine, &src, "f", &[&json]),
+        value.to_string(),
+        "engine={engine} field={field}"
+    );
+}
+
+// Every reserved keyword that the lexer emits as a non-Ident token, and that
+// could plausibly appear as a JSON field name. Type sigils (R/L/F/O/M/S) are
+// included because real-world JSON keys can be a single uppercase letter.
+const KEYWORDS: &[&str] = &[
+    "type", "tool", "use", "with", "timeout", "retry", "if", "return", "let", "fn", "def", "var",
+    "const", "true", "false", "nil", "R", "L", "F", "O", "M", "S",
+];
+
+fn check_all_keywords(engine: &str) {
+    for (i, kw) in KEYWORDS.iter().enumerate() {
+        check_keyword(engine, kw, i as i32 + 1);
+    }
+}
+
+#[test]
+fn dot_keywords_all_tree() {
+    check_all_keywords("--run-tree");
+}
+
+#[test]
+fn dot_keywords_all_vm() {
+    check_all_keywords("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn dot_keywords_all_cranelift() {
+    check_all_keywords("--run-cranelift");
+}
+
+// `.?keyword` (safe field access) still parses. We only assert the parse
+// succeeds; runtime semantics on missing keys are unchanged by this fix.
+const SAFE: &str = "f j:t>R n t;r=jpar! j;r.?type";
+
+fn check_safe(engine: &str) {
+    assert_eq!(run(engine, SAFE, "f", &[r#"{"type":17}"#]), "17");
+}
+
+#[test]
+fn dot_keywords_safe_tree() {
+    check_safe("--run-tree");
+}
+
+#[test]
+fn dot_keywords_safe_vm() {
+    check_safe("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn dot_keywords_safe_cranelift() {
+    check_safe("--run-cranelift");
+}
+
+// `record.type_id` — keyword followed by snake_case suffix. The
+// keyword-rewrite pass must run before the snake_case stitch so the
+// trailing `_id` segment gets merged into the same Ident.
+const SNAKE_AFTER_KW: &str = "f j:t>R n t;r=jpar! j;r.type_id";
+
+fn check_snake_after_kw(engine: &str) {
+    assert_eq!(
+        run(engine, SNAKE_AFTER_KW, "f", &[r#"{"type_id":1234}"#]),
+        "1234",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn dot_keywords_snake_after_kw_tree() {
+    check_snake_after_kw("--run-tree");
+}
+
+#[test]
+fn dot_keywords_snake_after_kw_vm() {
+    check_snake_after_kw("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn dot_keywords_snake_after_kw_cranelift() {
+    check_snake_after_kw("--run-cranelift");
+}
+
+// `record.type_kind_id` — alternating keyword + snake segments.
+const SNAKE_LONG: &str = "f j:t>R n t;r=jpar! j;r.type_kind_id";
+
+fn check_snake_long(engine: &str) {
+    assert_eq!(
+        run(engine, SNAKE_LONG, "f", &[r#"{"type_kind_id":42}"#]),
+        "42",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn dot_keywords_snake_long_tree() {
+    check_snake_long("--run-tree");
+}
+
+#[test]
+fn dot_keywords_snake_long_vm() {
+    check_snake_long("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn dot_keywords_snake_long_cranelift() {
+    check_snake_long("--run-cranelift");
+}
+
+// --- Negative regressions: reserved words in binding position still error. ---
+//
+// The lexer rewrite is gated on `Dot`/`DotQuestion` being the immediately
+// preceding token with no whitespace, so plain `type=5` still hits the
+// existing ILO-P011 friendly-error path via `reserved_keyword_message`.
+
+#[test]
+fn type_as_binding_still_errors() {
+    let err = run_err("f j:t>n;type=5;type");
+    assert!(
+        err.contains("reserved") || err.contains("Type") || err.contains("got Type"),
+        "expected reserved-word error, got: {err}"
+    );
+}
+
+#[test]
+fn if_as_binding_still_errors() {
+    let err = run_err("f j:t>n;if=5;if");
+    assert!(
+        err.contains("reserved") || err.contains("KwIf") || err.contains("got KwIf"),
+        "expected reserved-word error, got: {err}"
+    );
+}
+
+// `.<space>type` (whitespace between dot and keyword) still errors — the
+// rewrite requires span-contiguity so it doesn't accidentally swallow
+// keywords that aren't actually in field-access position.
+#[test]
+fn dot_with_whitespace_still_errors() {
+    let err = run_err("f j:t>R n t;r=jpar! j;r. type");
+    assert!(
+        err.contains("ILO-P") || err.contains("expected"),
+        "expected parse error, got: {err}"
+    );
+}


### PR DESCRIPTION
## Summary

Real-world JSON keys are frequently named after keywords (`type`, `if`, `use`, `with`, `true`, `false`, `nil`, ...), but `parsed.type` crashed with `ILO-P005: expected identifier, got Type`. Personas in the assessment runs hit this repeatedly and fell back to the verbose `jpth! resp "type"` per-field workaround, costing tokens on every JSON field.

Pattern-matched to the snake_case dot-access fix (PR #160): a lexer post-pass that rewrites the keyword token back into a `Token::Ident` using its original source slice, but only when it sits flush against a preceding `Dot`/`DotQuestion`. Binding position is untouched, so `type=5` still emits the friendly ILO-P011 error.

## Repro

Before:

```
$ echo 'f j:t>R n t;r=jpar! j;r.type' > /tmp/t.ilo
$ ilo /tmp/t.ilo --run-tree f '{"type":42}'
ILO-P005: expected identifier, got Type
```

After:

```
$ ilo /tmp/t.ilo --run-tree f '{"type":42}'
42
```

Same on `--run-vm` and `--run-cranelift`.

## What's in the diff

- **`lexer: rewrite reserved keywords as Ident in dot-access position`** — new post-lex pass between the dot-number splitter and the snake_case stitch. After a `Dot`/`DotQuestion`, any non-Ident, non-Number token whose source slice is identifier-shaped (`[A-Za-z][A-Za-z0-9_]*`) gets rewritten into `Token::Ident(slice)`. Strict span-contiguity guards against whitespace. Runs before the snake_case pass so `.type_id` stitches cleanly.

- **`tests + example: pin reserved-keyword dot-access across engines`** — 15 cross-engine regression tests covering every keyword token (`type`, `tool`, `use`, `with`, `timeout`, `retry`, `if`, `return`, `let`, `fn`, `def`, `var`, `const`, `true`, `false`, `nil`, plus type sigils `R`/`L`/`F`/`O`/`M`/`S`), safe-access `.?type`, keyword-plus-snake `record.type_id`, alternating `record.type_kind_id`, and three negatives confirming `type=5`, `if=5`, and `r. type` still error. `examples/dot-keywords.ilo` exercises six shapes via `examples_engines.rs`.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --release --features cranelift` full suite green (2861 + others)
- [x] New `regression_dot_keywords` test: 15/15 pass tree + vm + cranelift
- [x] `regression_snake_field_access` and `regression_dot_list_index` unchanged (adjacent dot-access tests)
- [x] Bindings `type=5`, `if=5` still emit reserved-word errors (covered by new negative tests)
- [x] `examples/dot-keywords.ilo` runs across every engine via `examples_engines.rs`

## Follow-ups

- Hyphen-containing JSON keys (`change-1d`, etc.) still need `jpth!`. Out of scope here; would need a different lexer strategy.