### PR TITLE
cli: run single-fn files, list multi-fn files, gate AST dump behind --ast

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -125,6 +125,10 @@ pub struct RunArgs {
     #[arg(long, short = 'e', aliases = ["fmt-expanded"])]
     pub expanded: bool,
 
+    /// Dump the parsed AST as JSON instead of running.
+    #[arg(long = "ast")]
+    pub ast: bool,
+
     /// HTTP tool provider config (JSON).
     #[arg(long = "tools")]
     pub tools_path: Option<String>,
@@ -659,6 +663,7 @@ mod tests {
             explain: false,
             dense: false,
             expanded: false,
+            ast: false,
             tools_path: None,
             mcp_path: None,
             rest: vec![],

--- a/src/main.rs
+++ b/src/main.rs
@@ -1913,6 +1913,23 @@ fn dispatch_bare_args(raw_args: Vec<String>, global: &cli::Global) -> i32 {
         }
     };
 
+    // Extract --ast flag from anywhere in the arg list so it can sit before
+    // the source, after the source, or after positional args. The flag
+    // forces the AST-dump path; without it `ilo file.ilo` auto-runs a
+    // single-function file or prints a friendly function listing.
+    let (pre_ast, args) = {
+        let mut found = false;
+        let mut filtered: Vec<String> = Vec::with_capacity(args.len());
+        for a in args.into_iter() {
+            if a == "--ast" {
+                found = true;
+            } else {
+                filtered.push(a);
+            }
+        }
+        (found, filtered)
+    };
+
     // Override with clap-parsed global flags if they were set
     let mode = if global.ansi {
         OutputMode::Ansi
@@ -2073,6 +2090,7 @@ fn dispatch_bare_args(raw_args: Vec<String>, global: &cli::Global) -> i32 {
                     explain: false,
                     dense: false,
                     expanded: false,
+                    ast: false,
                     tools_path: tools_config_path,
                     mcp_path: mcp_config_path,
                     rest: args[m + 1..].to_vec(),
@@ -2093,6 +2111,7 @@ fn dispatch_bare_args(raw_args: Vec<String>, global: &cli::Global) -> i32 {
                     explain: true,
                     dense: false,
                     expanded: false,
+                    ast: false,
                     tools_path: tools_config_path,
                     mcp_path: mcp_config_path,
                     rest: vec![],
@@ -2118,6 +2137,7 @@ fn dispatch_bare_args(raw_args: Vec<String>, global: &cli::Global) -> i32 {
                     explain: false,
                     dense: false,
                     expanded: false,
+                    ast: false,
                     tools_path: tools_config_path,
                     mcp_path: mcp_config_path,
                     rest: vec![],
@@ -2138,6 +2158,7 @@ fn dispatch_bare_args(raw_args: Vec<String>, global: &cli::Global) -> i32 {
                     explain: false,
                     dense: true,
                     expanded: false,
+                    ast: false,
                     tools_path: tools_config_path,
                     mcp_path: mcp_config_path,
                     rest: vec![],
@@ -2158,9 +2179,31 @@ fn dispatch_bare_args(raw_args: Vec<String>, global: &cli::Global) -> i32 {
                     explain: false,
                     dense: false,
                     expanded: true,
+                    ast: false,
                     tools_path: tools_config_path,
                     mcp_path: mcp_config_path,
                     rest: vec![],
+                };
+                return dispatch_run(run_args, mode, explicit_json, no_hints);
+            }
+            "--ast" if engine_flag.is_none() => {
+                let run_args = cli::RunArgs {
+                    source,
+                    engine: cli::Engine::Default,
+                    run_tree: false,
+                    run: false,
+                    run_vm: false,
+                    run_cranelift: false,
+                    run_llvm: false,
+                    bench: false,
+                    emit: None,
+                    explain: false,
+                    dense: false,
+                    expanded: false,
+                    ast: true,
+                    tools_path: tools_config_path,
+                    mcp_path: mcp_config_path,
+                    rest: args[m + 1..].to_vec(),
                 };
                 return dispatch_run(run_args, mode, explicit_json, no_hints);
             }
@@ -2190,6 +2233,7 @@ fn dispatch_bare_args(raw_args: Vec<String>, global: &cli::Global) -> i32 {
         explain: false,
         dense: false,
         expanded: false,
+        ast: pre_ast,
         tools_path: tools_config_path,
         mcp_path: mcp_config_path,
         rest,
@@ -2329,21 +2373,22 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
         had_errors = true;
     }
 
-    // Inline-no-func AST-dump mode: when running `ilo '<code>'` with no entry
-    // point and no other mode flag, the binary prints the AST and exits. This
-    // is an inspection path, not an execution path, so verify (which exists to
-    // gate execution) shouldn't gate it. Skipping verify here also avoids
+    // AST-dump mode: explicit (`--ast`) OR the legacy inline-no-func default
+    // (`ilo '<code>'` with no entry point and no other mode flag). This is an
+    // inspection path, not an execution path, so verify (which exists to gate
+    // execution) shouldn't gate it. Skipping verify here also avoids
     // false-positive errors on builtins or partial snippets that users want to
     // explore via the AST dump. Parse errors still gate (we can't dump an AST
     // we couldn't parse).
-    let ast_dump_mode = !is_file
-        && r.rest.is_empty()
-        && !r.bench
-        && !r.explain
-        && r.emit.is_none()
-        && !r.dense
-        && !r.expanded
-        && matches!(r.effective_engine(), cli::Engine::Default);
+    let ast_dump_mode = r.ast
+        || (!is_file
+            && r.rest.is_empty()
+            && !r.bench
+            && !r.explain
+            && r.emit.is_none()
+            && !r.dense
+            && !r.expanded
+            && matches!(r.effective_engine(), cli::Engine::Default));
 
     if !ast_dump_mode {
         let verify_result = verify::verify(&program);
@@ -2471,6 +2516,11 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
                     })
                     .collect();
 
+                // Explicit AST dump (`--ast`) takes precedence over everything.
+                if r.ast {
+                    return dump_ast_json(&program);
+                }
+
                 let (func_name, run_args) = if let Some(first) = rest.first() {
                     if func_names.contains(&first.as_str()) {
                         let args: Vec<_> = rest[1..].iter().map(|a| parse_cli_arg(a)).collect();
@@ -2481,18 +2531,37 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
                     } else {
                         (None, rest.iter().map(|a| parse_cli_arg(a)).collect())
                     }
-                } else {
-                    // No args at all: AST JSON
-                    match serde_json::to_string_pretty(&program) {
-                        Ok(json) => {
-                            println!("{}", json);
-                            return 0;
-                        }
-                        Err(e) => {
-                            eprintln!("Serialization error: {}", e);
+                } else if is_file {
+                    // File with no func arg: auto-run if there's exactly one
+                    // function, list available functions if there are
+                    // several, AST-dump if there are none (declarations-only
+                    // file — useful for inspecting type/alias-only modules).
+                    match func_names.len() {
+                        0 => return dump_ast_json(&program),
+                        1 => (None, vec![]),
+                        _ => {
+                            eprintln!(
+                                "error: {} defines multiple functions, please specify one.",
+                                source_arg
+                            );
+                            eprintln!("available functions:");
+                            for n in &func_names {
+                                eprintln!("  {}", n);
+                            }
+                            eprintln!();
+                            eprintln!("  ilo {} <func> [args...]   run a function", source_arg);
+                            eprintln!(
+                                "  ilo --ast {}              dump the parsed AST as JSON",
+                                source_arg
+                            );
                             return 1;
                         }
                     }
+                } else {
+                    // Inline code with no func arg and no other mode flag:
+                    // legacy AST-dump path. Preserved for tooling and for
+                    // `ilo '<snippet>'` inspection. Documented since 0.x.
+                    return dump_ast_json(&program);
                 };
 
                 run_default(&program, func_name, run_args, &source, mode, explicit_json)
@@ -2646,7 +2715,7 @@ fn print_help() {
     println!("  ilo <code> --explain / -x            Annotate each statement with its role");
     println!("  ilo <code> --dense / -d             Reformat (dense wire format)");
     println!("  ilo <code> --expanded / -e          Reformat (expanded human format)");
-    println!("  ilo <code>                        Print AST as JSON (no args)");
+    println!("  ilo --ast <code-or-file>          Print AST as JSON");
     println!("  ilo <code> --bench func [args...] Benchmark a function");
     println!("  ilo repl                          Interactive REPL");
     println!("  ilo graph <file> [flags]          Dependency graph (JSON or DOT)");
@@ -2848,6 +2917,21 @@ fn run_interp_with_provider(
         }
         Err(e) => {
             report_diagnostic(&Diagnostic::from(&e).with_source(source.to_string()), mode);
+            1
+        }
+    }
+}
+
+/// Serialize the program as pretty JSON to stdout. Used by the explicit
+/// `--ast` flag and by the legacy inline-no-func default path.
+fn dump_ast_json(program: &ast::Program) -> i32 {
+    match serde_json::to_string_pretty(program) {
+        Ok(json) => {
+            println!("{}", json);
+            0
+        }
+        Err(e) => {
+            eprintln!("Serialization error: {}", e);
             1
         }
     }
@@ -6439,6 +6523,7 @@ mod tests {
             explain: false,
             dense: false,
             expanded: false,
+            ast: false,
             tools_path: None,
             mcp_path: None,
             rest: vec![],
@@ -6464,6 +6549,7 @@ mod tests {
             explain: false,
             dense: false,
             expanded: false,
+            ast: false,
             tools_path: Some("/tmp/t.json".to_string()),
             mcp_path: Some("/tmp/m.json".to_string()),
             rest: vec![],
@@ -6490,6 +6576,7 @@ mod tests {
             explain: false,
             dense: false,
             expanded: false,
+            ast: false,
             tools_path: None,
             mcp_path: None,
             rest: vec![],
@@ -6516,6 +6603,7 @@ mod tests {
             explain: false,
             dense: false,
             expanded: false,
+            ast: false,
             tools_path: None,
             mcp_path: None,
             rest: vec!["f".to_string(), "1".to_string()],
@@ -6540,6 +6628,7 @@ mod tests {
             explain: false,
             dense: false,
             expanded: false,
+            ast: false,
             tools_path: None,
             mcp_path: None,
             rest: vec!["f".to_string(), "1".to_string()],
@@ -6566,6 +6655,7 @@ mod tests {
             explain: false,
             dense: false,
             expanded: false,
+            ast: false,
             tools_path: None,
             mcp_path: None,
             rest: vec![],
@@ -6592,6 +6682,7 @@ mod tests {
             explain: false,
             dense: false,
             expanded: false,
+            ast: false,
             tools_path: None,
             mcp_path: None,
             rest: vec!["f".to_string(), "1".to_string()],

--- a/src/main.rs
+++ b/src/main.rs
@@ -2186,27 +2186,6 @@ fn dispatch_bare_args(raw_args: Vec<String>, global: &cli::Global) -> i32 {
                 };
                 return dispatch_run(run_args, mode, explicit_json, no_hints);
             }
-            "--ast" if engine_flag.is_none() => {
-                let run_args = cli::RunArgs {
-                    source,
-                    engine: cli::Engine::Default,
-                    run_tree: false,
-                    run: false,
-                    run_vm: false,
-                    run_cranelift: false,
-                    run_llvm: false,
-                    bench: false,
-                    emit: None,
-                    explain: false,
-                    dense: false,
-                    expanded: false,
-                    ast: true,
-                    tools_path: tools_config_path,
-                    mcp_path: mcp_config_path,
-                    rest: args[m + 1..].to_vec(),
-                };
-                return dispatch_run(run_args, mode, explicit_json, no_hints);
-            }
             _ => {}
         }
     }

--- a/tests/eval_inline.rs
+++ b/tests/eval_inline.rs
@@ -222,9 +222,14 @@ fn file_bare_args_runs_first_func() {
 }
 
 #[test]
-fn file_no_args_outputs_ast() {
+fn file_with_ast_flag_dumps_ast() {
+    // Previously `ilo file.ilo` with no func arg dumped raw AST JSON,
+    // which was a long-standing first-touch surprise: users expected
+    // it to run. The AST dump is now gated behind an explicit `--ast`
+    // flag (the auto-run / friendly-listing behaviour is pinned in
+    // tests/regression_cli_default.rs).
     let out = ilo()
-        .args(["examples/01-simple-function.ilo"])
+        .args(["--ast", "examples/01-simple-function.ilo"])
         .output()
         .expect("failed to run ilo");
     assert!(out.status.success());

--- a/tests/regression_cli_default.rs
+++ b/tests/regression_cli_default.rs
@@ -1,0 +1,182 @@
+// Regression: `ilo file.ilo` with no func name used to dump raw AST JSON,
+// which was a long-running first-touch surprise documented repeatedly in
+// the assessment log (entries at lines 527, 623, 816, 839, 936, 1045).
+//
+// New behaviour:
+//   * `ilo file.ilo`           with exactly one fn → runs that fn
+//   * `ilo file.ilo`           with multiple fns   → prints a friendly
+//                                                    listing and exits 1
+//   * `ilo file.ilo func args` keeps working unchanged
+//   * `ilo --ast file.ilo`     dumps the AST as JSON (explicit flag,
+//                              works before or after the source)
+//   * `ilo '<code>'`           inline with no func arg still AST-dumps
+//                              (legacy contract from PR #178 preserved)
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(args: &[&str]) -> (bool, String, String) {
+    let out = ilo()
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn ilo: {e}"));
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+fn write_temp(content: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("prog.ilo");
+    std::fs::write(&path, content).expect("write temp ilo");
+    (dir, path)
+}
+
+// ── single-fn file: auto-run ───────────────────────────────────────────────────
+
+#[test]
+fn single_fn_file_runs_with_no_func_arg() {
+    let (_dir, path) = write_temp("f>n;42\n");
+    let (ok, stdout, stderr) = run(&[path.to_str().unwrap()]);
+    assert!(ok, "expected success; stderr: {stderr}");
+    assert_eq!(stdout.trim(), "42");
+    assert!(
+        !stdout.contains("\"declarations\""),
+        "no AST dump expected; got: {stdout}"
+    );
+}
+
+#[test]
+fn single_fn_file_runs_with_positional_args() {
+    let (_dir, path) = write_temp("double x:n>n;*x 2\n");
+    let (ok, stdout, stderr) = run(&[path.to_str().unwrap(), "7"]);
+    assert!(ok, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "14");
+}
+
+// ── multi-fn file: friendly listing, non-zero exit ────────────────────────────
+
+#[test]
+fn multi_fn_file_with_no_func_arg_lists_and_exits_nonzero() {
+    let (_dir, path) = write_temp("foo>n;1\nbar>n;2\nbaz>n;3\n");
+    let (ok, stdout, stderr) = run(&[path.to_str().unwrap()]);
+    assert!(!ok, "expected non-zero exit; stdout: {stdout}");
+    assert!(
+        stderr.contains("defines multiple functions"),
+        "expected listing header; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("foo"),
+        "expected foo listed; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("bar"),
+        "expected bar listed; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("baz"),
+        "expected baz listed; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("--ast"),
+        "expected --ast hint; stderr: {stderr}"
+    );
+    assert!(
+        !stdout.contains("\"declarations\""),
+        "no AST dump expected; got: {stdout}"
+    );
+}
+
+#[test]
+fn multi_fn_file_with_func_name_runs_unchanged() {
+    let (_dir, path) = write_temp("foo>n;1\nbar>n;2\nbaz>n;3\n");
+    let (ok, stdout, stderr) = run(&[path.to_str().unwrap(), "bar"]);
+    assert!(ok, "expected success; stderr: {stderr}");
+    assert_eq!(stdout.trim(), "2");
+}
+
+#[test]
+fn multi_fn_file_with_func_name_and_args() {
+    let (_dir, path) = write_temp("add a:n b:n>n;+a b\nmul a:n b:n>n;*a b\n");
+    let (ok, stdout, stderr) = run(&[path.to_str().unwrap(), "mul", "6", "7"]);
+    assert!(ok, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "42");
+}
+
+// ── --ast flag: explicit AST dump ─────────────────────────────────────────────
+
+#[test]
+fn ast_flag_dumps_single_fn_file() {
+    let (_dir, path) = write_temp("f>n;42\n");
+    let (ok, stdout, _stderr) = run(&["--ast", path.to_str().unwrap()]);
+    assert!(ok);
+    assert!(
+        stdout.contains("\"declarations\""),
+        "expected JSON AST; got: {stdout}"
+    );
+    // Crucially does NOT execute the fn.
+    assert!(
+        !stdout.trim().starts_with("42"),
+        "AST dump must not execute; got: {stdout}"
+    );
+}
+
+#[test]
+fn ast_flag_dumps_multi_fn_file() {
+    let (_dir, path) = write_temp("foo>n;1\nbar>n;2\n");
+    let (ok, stdout, stderr) = run(&["--ast", path.to_str().unwrap()]);
+    assert!(ok, "stderr: {stderr}");
+    assert!(
+        stdout.contains("\"declarations\""),
+        "expected JSON AST; got: {stdout}"
+    );
+    assert!(
+        !stderr.contains("defines multiple functions"),
+        "no listing should fire when --ast is explicit; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn ast_flag_trailing_position() {
+    let (_dir, path) = write_temp("foo>n;1\nbar>n;2\n");
+    let (ok, stdout, _stderr) = run(&[path.to_str().unwrap(), "--ast"]);
+    assert!(ok);
+    assert!(stdout.contains("\"declarations\""));
+}
+
+#[test]
+fn ast_flag_on_inline_code() {
+    let (ok, stdout, _stderr) = run(&["--ast", "f>n;5"]);
+    assert!(ok);
+    assert!(stdout.contains("\"declarations\""));
+}
+
+// ── legacy inline-no-func AST dump preserved ──────────────────────────────────
+
+#[test]
+fn inline_no_func_still_dumps_ast() {
+    let (ok, stdout, _stderr) = run(&["f>n;5"]);
+    assert!(ok);
+    assert!(
+        stdout.contains("\"declarations\""),
+        "inline-no-func default AST dump should be preserved; got: {stdout}"
+    );
+}
+
+// ── no-fn file: AST dump (nothing to run) ─────────────────────────────────────
+
+#[test]
+fn empty_file_dumps_ast() {
+    // A file with zero functions has nothing to run, so the AST-dump
+    // path is still the right fallback. Empty file is the cleanest
+    // example we can write portably.
+    let (_dir, path) = write_temp("");
+    let (ok, stdout, stderr) = run(&[path.to_str().unwrap()]);
+    assert!(ok, "stderr: {stderr}");
+    assert!(stdout.contains("\"declarations\""));
+}


### PR DESCRIPTION
## Summary

\`ilo file.ilo\` with no function name has dumped raw AST JSON since the early days, which is a first-touch surprise the assessment doc has caught at least six times (lines 527, 623, 816, 839, 936, 1045). It looks like silent success: the program ran, here is some output, except none of it is the program's output. Personas burn 1-3 retries before they figure out they need to pass a function name.

New behaviour:

| Invocation | Before | After |
|---|---|---|
| \`ilo file.ilo\` with 1 fn | AST JSON | runs the fn |
| \`ilo file.ilo\` with N fns | AST JSON | friendly listing, exit 1 |
| \`ilo file.ilo func args\` | runs fn | runs fn (unchanged) |
| \`ilo --ast file.ilo\` | (n/a) | AST JSON |
| \`ilo '<code>'\` inline-no-func | AST JSON | AST JSON (preserved, PR #178) |

The \`--ast\` flag works in leading, trailing, or any-position - it is extracted in a pre-scan like the engine flags from PR #175. AST dump still skips verify so partial/exploratory snippets work.

Manifesto framing: every retry costs tokens. The current behaviour costs tokens on first contact and disproportionately hits agents that lean on natural-language intuitions about \"how to run a file\". This change makes the most common case Just Work and reserves the inspection path for an explicit flag.

## Repro

Before:

\`\`\`
$ ilo file.ilo
{ \"declarations\": [ ... ] }    # looks like success, no fn was run
\`\`\`

After:

\`\`\`
$ ilo single-fn.ilo
42                                # runs

$ ilo multi-fn.ilo
error: multi-fn.ilo defines multiple functions, please specify one.
available functions:
  foo
  bar
  baz

  ilo multi-fn.ilo <func> [args...]   run a function
  ilo --ast multi-fn.ilo              dump the parsed AST as JSON

$ ilo --ast file.ilo
{ \"declarations\": [ ... ] }
\`\`\`

## What's in the diff

- **c7a50e2 cli: run single-fn files, list multi-fn files, gate AST dump behind --ast** - adds \`pub ast: bool\` to \`RunArgs\`, threads \`ast: false\` through every construction site, pre-scans \`--ast\` from anywhere in argv, replaces the file-AST-dump path with auto-run / friendly listing / declarations-only fallback. Extends the verify-skip predicate so \`--ast\` skips verify the same way the legacy inline-no-func path does. Updates \`print_help\`.
- **52e9f37 tests: cover new ilo file.ilo dispatch and --ast flag** - eleven cross-cutting regressions in \`tests/regression_cli_default.rs\` plus a retarget of the one existing test that asserted the old AST-on-no-args contract.

## Test plan

- [x] \`cargo test --release --features cranelift\` green (full suite)
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --release --features cranelift --all-targets\` clean
- [x] New regressions cover: single-fn auto-run, single-fn auto-run with positional args, multi-fn listing exit code and listed names, multi-fn explicit-fn unchanged, multi-fn explicit-fn with args, \`--ast\` in leading position, \`--ast\` in trailing position, \`--ast\` on inline code, \`--ast\` does NOT execute the fn, inline-no-func legacy AST dump preserved, empty-file AST dump
- [x] Existing inline-no-func tests in \`tests/eval_inline.rs\` still pass (PR #178 contract preserved)
- [x] Existing CLI flag-placement tests in \`tests/cli_run_flag_placement.rs\` still pass

## Follow-ups

- The friendly listing currently includes both user functions and any \`tool\` decls? It only iterates \`ast::Decl::Function\` so tool-only files still hit the declarations-only AST-dump fallback. Probably fine, could revisit if it surprises users.
- An \`examples/*.ilo\` regression of this scenario doesn't fit naturally (the harness invokes engines, not the bare-args CLI dispatcher we changed), so the coverage lives entirely in the new Rust regression test.