### PR TITLE
rgxall: multi-match capture-group extraction for HTML scraping

### DIFF
--- a/examples/rgxall.ilo
+++ b/examples/rgxall.ilo
@@ -1,0 +1,33 @@
+-- rgxall pattern text: every match as a list of capture groups.
+-- Shape is always L (L t): no-group patterns wrap the whole match in
+-- a single-element inner list, so the outer shape stays predictable.
+-- `rgx` returns only the first match when the pattern has a capture group,
+-- so `rgxall` is the right tool for HTML scraping and bulk extraction.
+
+-- No-group case: each match wrapped in a single-element list.
+all-digits>L (L t);rgxall "\d+" "a1 b22 c333"
+
+-- One capture group: pull the inner text of every <h2>.
+-- This is the case where `rgx` fails (first match only).
+inner-h2>L (L t);rgxall "<h2>([^<]+)</h2>" "<h2>One</h2> <h2>Two</h2> <h2>Three</h2>"
+
+-- Two capture groups: each inner list has length 2.
+kv-pairs>L (L t);rgxall "(\w+)=(\d+)" "x=1 y=22 z=333"
+
+-- No matches: empty outer list.
+no-match>L (L t);rgxall "\d+" "no digits here"
+
+-- run: all-digits
+-- out: [[1], [22], [333]]
+-- run: inner-h2
+-- out: [[One], [Two], [Three]]
+-- run: kv-pairs
+-- out: [[x, 1], [y, 22], [z, 333]]
+-- run: no-match
+-- out: []
+
+-- VM and cranelift compilers don't yet wire builtin calls through to the
+-- interpreter for rgx/rgxall (only --run-tree does). When that gap closes,
+-- drop these skips.
+-- engine-skip: vm
+-- engine-skip: cranelift

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -405,6 +405,7 @@ const BUILTIN_ALIASES: &[(&str, &str)] = &[
     ("split", "spl"),
     ("format", "fmt"),
     ("regex", "rgx"),
+    ("regex_all", "rgxall"),
     ("regex_sub", "rgxsub"),
     ("read", "rd"),
     ("readlines", "rdl"),

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -106,6 +106,7 @@ pub enum Builtin {
     Fmt,
     Fmt2,
     Rgx,
+    Rgxall,
     Rgxsub,
 
     // JSON
@@ -224,6 +225,7 @@ impl Builtin {
             "fmt" => Some(Builtin::Fmt),
             "fmt2" => Some(Builtin::Fmt2),
             "rgx" => Some(Builtin::Rgx),
+            "rgxall" => Some(Builtin::Rgxall),
             "rgxsub" => Some(Builtin::Rgxsub),
             "jpth" => Some(Builtin::Jpth),
             "jdmp" => Some(Builtin::Jdmp),
@@ -335,6 +337,7 @@ impl Builtin {
             Builtin::Fmt => "fmt",
             Builtin::Fmt2 => "fmt2",
             Builtin::Rgx => "rgx",
+            Builtin::Rgxall => "rgxall",
             Builtin::Rgxsub => "rgxsub",
             Builtin::Jpth => "jpth",
             Builtin::Jdmp => "jdmp",
@@ -444,6 +447,7 @@ mod tests {
             "fmt",
             "fmt2",
             "rgx",
+            "rgxall",
             "rgxsub",
             "jpth",
             "jdmp",

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -3234,6 +3234,50 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         };
         return Ok(Value::List(result));
     }
+    if builtin == Some(Builtin::Rgxall) && args.len() == 2 {
+        let pattern = match &args[0] {
+            Value::Text(s) => s.as_str(),
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!(
+                        "rgxall: first arg must be a string pattern, got {:?}",
+                        other
+                    ),
+                ));
+            }
+        };
+        let input = match &args[1] {
+            Value::Text(s) => s.as_str(),
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!("rgxall: second arg must be a string, got {:?}", other),
+                ));
+            }
+        };
+        let re = regex::Regex::new(pattern).map_err(|e| {
+            RuntimeError::new("ILO-R009", format!("rgxall: invalid regex pattern: {e}"))
+        })?;
+        // Uniform shape: L (L t). Each match is a list of capture-group strings.
+        // No-group patterns wrap the whole match in a single-element inner list,
+        // so the outer shape stays predictable regardless of group count.
+        let result: Vec<Value> = if re.captures_len() > 1 {
+            re.captures_iter(input)
+                .map(|caps| {
+                    let groups: Vec<Value> = (1..caps.len())
+                        .filter_map(|i| caps.get(i).map(|m| Value::Text(m.as_str().to_string())))
+                        .collect();
+                    Value::List(groups)
+                })
+                .collect()
+        } else {
+            re.find_iter(input)
+                .map(|m| Value::List(vec![Value::Text(m.as_str().to_string())]))
+                .collect()
+        };
+        return Ok(Value::List(result));
+    }
     if builtin == Some(Builtin::Rgxsub) && args.len() == 3 {
         let pattern = match &args[0] {
             Value::Text(s) => s.as_str(),

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -3259,9 +3259,18 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         let re = regex::Regex::new(pattern).map_err(|e| {
             RuntimeError::new("ILO-R009", format!("rgxall: invalid regex pattern: {e}"))
         })?;
-        // Uniform shape: L (L t). Each match is a list of capture-group strings.
-        // No-group patterns wrap the whole match in a single-element inner list,
-        // so the outer shape stays predictable regardless of group count.
+        // Outer shape is always L (L t). Inner-list contents depend on the
+        // pattern:
+        // - No capture groups: inner list is [whole_match] (length 1).
+        // - With capture groups: inner list holds only the groups that
+        //   *participated* in this particular match, in declaration order.
+        //   For straight patterns like `(\w+)=(\d+)` that means N declared
+        //   groups = N inner-list entries on every match. For alternation
+        //   patterns like `(a)|(b)`, only the branch that fired contributes,
+        //   so the inner list can be shorter than the declared group count.
+        //   This matches the `rgx` family's existing filter_map semantics
+        //   and avoids the empty-string-sentinel ambiguity of an alternative
+        //   "always emit N slots" design.
         let result: Vec<Value> = if re.captures_len() > 1 {
             re.captures_iter(input)
                 .map(|caps| {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2262,6 +2262,7 @@ fn builtin_arity_tables() -> (HashMap<String, usize>, HashMap<String, Vec<bool>>
         ("jpth", 2, &[]),
         // Regex
         ("rgx", 2, &[]),
+        ("rgxall", 2, &[]),
         ("rgxsub", 3, &[]),
         // Map (associative)
         ("mget", 2, &[]),

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -345,6 +345,7 @@ const BUILTINS: &[(&str, &[&str], &str)] = &[
     ("matmul", &["L (L n)", "L (L n)"], "L (L n)"),
     ("dot", &["L n", "L n"], "n"),
     ("rgx", &["t", "t"], "L t"),
+    ("rgxall", &["t", "t"], "L (L t)"),
     ("rgxsub", &["t", "t", "t"], "t"),
     // Map builtins (M k v type)
     ("mmap", &[], "map"),

--- a/tests/regression_rgxall.rs
+++ b/tests/regression_rgxall.rs
@@ -1,0 +1,105 @@
+// Regression tests for the `rgxall` builtin.
+// rgxall pattern text -> L (L t): every match as a list of capture groups.
+// No-group patterns wrap the whole match in a single-element inner list,
+// so the outer shape stays predictable regardless of group count.
+//
+// Engine coverage: tree-only.
+//
+// The sibling builtin `rgx` is also tree-only today (both --run-vm and
+// --run-cranelift report `Compile error: undefined function: rgx` on main).
+// The VM compiler's "falls through to OP_CALL → interpreter" comment at
+// src/vm/mod.rs:2394-2397 is aspirational, not current — there is no
+// builtin bridge in OP_CALL's dispatcher today. Wiring rgx/rgxall through
+// the VM and cranelift is a separate, larger fix (touches verify, VM
+// compile, JIT compile) and out of scope for this PR. Keeping rgxall
+// tree-only matches rgx's actual reality; when the VM bridge lands, both
+// will switch on together and these tests should grow to check all three
+// engines.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_text(src: &str) -> String {
+    let out = ilo()
+        .args([src, "--run-tree", "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo --run-tree failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn check(src: &str, expected: &str) {
+    let actual = run_text(src);
+    assert_eq!(
+        actual, expected,
+        "src=`{src}`: got `{actual}`, expected `{expected}`"
+    );
+}
+
+#[test]
+fn rgxall_no_match_returns_empty_list() {
+    check(r#"f>L (L t);rgxall "\d+" "no digits here""#, "[]");
+}
+
+#[test]
+fn rgxall_single_match_no_groups() {
+    check(r#"f>L (L t);rgxall "\d+" "abc 42 def""#, "[[42]]");
+}
+
+#[test]
+fn rgxall_multiple_matches_no_groups() {
+    // No-group case wraps each whole match in a single-element inner list,
+    // preserving the uniform L (L t) shape.
+    check(
+        r#"f>L (L t);rgxall "\d+" "a1 b22 c333""#,
+        "[[1], [22], [333]]",
+    );
+}
+
+#[test]
+fn rgxall_multiple_matches_one_group() {
+    // The real-world HTML-scrape case: pull the inner text of every <h2>.
+    // `rgx` silently returns only the first match here; `rgxall` returns
+    // all of them.
+    check(
+        r#"f>L (L t);rgxall "<h2>([^<]+)</h2>" "<h2>One</h2> <h2>Two</h2> <h2>Three</h2>""#,
+        "[[One], [Two], [Three]]",
+    );
+}
+
+#[test]
+fn rgxall_multiple_matches_multiple_groups() {
+    // Two groups per match: every inner list has length 2.
+    check(
+        r#"f>L (L t);rgxall "(\w+)=(\d+)" "x=1 y=22 z=333""#,
+        "[[x, 1], [y, 22], [z, 333]]",
+    );
+}
+
+#[test]
+fn rgxall_unicode_input() {
+    check(
+        r#"f>L (L t);rgxall "\w+" "café résumé naïve""#,
+        "[[café], [résumé], [naïve]]",
+    );
+}
+
+#[test]
+fn rgxall_invalid_pattern_errors() {
+    // Unclosed group is a regex compile error; must surface as a runtime error.
+    let out = ilo()
+        .args([r#"f>L (L t);rgxall "(unclosed" "input""#, "--run-tree", "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "expected failure on invalid regex pattern"
+    );
+}

--- a/tests/regression_rgxall.rs
+++ b/tests/regression_rgxall.rs
@@ -92,6 +92,15 @@ fn rgxall_unicode_input() {
 }
 
 #[test]
+fn rgxall_alternation_absent_groups_filtered() {
+    // `(a)|(b)` against "a b": the matching branch contributes its group,
+    // the absent branch is filtered out (via captures.get(i).map). Inner
+    // list length tracks *participating* groups, not declared groups. This
+    // matches rgx's existing semantics and is the documented behaviour.
+    check(r#"f>L (L t);rgxall "(a)|(b)" "a b""#, "[[a], [b]]");
+}
+
+#[test]
 fn rgxall_invalid_pattern_errors() {
     // Unclosed group is a regex compile error; must surface as a runtime error.
     let out = ilo()


### PR DESCRIPTION
## Summary

`rgx pattern text` has an asymmetric semantics that bites the moment you reach for it on real-world text. Without a capture group it returns every match (good); with a capture group it silently returns only the first match (bad). The HTML-scrape case where you want `<h2>([^<]+)</h2>` to pull every title gets stuck on title number one, and the workaround is either dropping the group and post-stripping or chunking the input by hand. Both are token-heavy and the kind of thing a model has to rediscover every session.

`rgxall pattern text -> L (L t)` is the additive fix. Every match is wrapped as a list of capture-group strings; no-group patterns wrap the whole match in a single-element inner list so the outer shape stays uniform regardless of group count. The verifier table sees a predictable nested type and the agent doesn't have to branch on group count to figure out the shape.

I picked the uniform shape over saving a level of nesting for the no-group case because variadic output is a verifier nightmare and the friction of one `flat` call is far cheaper than every consumer guessing the shape from context. The manifesto cares about deterministic behaviour; that won.

I also looked at changing `rgx` to always return all matches with groups, but that would silently reshape the output of every program that currently relies on first-match semantics. Additive only.

## Repro on main (before)

```
ilo 'f>L t;rgx "<h2>([^<]+)</h2>" "<h2>One</h2> <h2>Two</h2> <h2>Three</h2>"' --run-tree f
[One]
```

With `rgxall` (after):

```
ilo 'f>L (L t);rgxall "<h2>([^<]+)</h2>" "<h2>One</h2> <h2>Two</h2> <h2>Three</h2>"' --run-tree f
[[One], [Two], [Three]]
```

## What's in the diff

- `builtins: add rgxall pattern text in name table and type sigs` (4e43e41) — `Builtin::Rgxall` variant, `from_name`/`name()` round-trip, ast alias `("regex_all", "rgxall")`, parser arity `("rgxall", 2, &[])`, verifier signature `("rgxall", &["t", "t"], "L (L t)")`. No explicit verify handler needed, matches `rgx`'s pattern of signature-table-only.
- `interpreter: dispatch rgxall over captures_iter for all matches` (9bee71a) — `re.captures_iter` walks every non-overlapping match. `re.captures_len() > 1` branches to capture-group mode; otherwise wraps each whole match in `[whole]`. `ILO-R009` error family matches `rgx`/`rgxsub`.
- `tests + example: pin rgxall multi-match capture extraction` (17bed89) — seven regression tests + `examples/rgxall.ilo` with `-- run:` / `-- out:` assertions.

## Engine coverage

Tree-only at the engine level, with `-- engine-skip: vm` and `-- engine-skip: cranelift` on the example.

Reason: `rgx` itself is currently a compile error under `--run-vm` and `--run-cranelift` on main. The `// Builtins that fall through to OP_CALL` comment at `src/vm/mod.rs:2394-2397` is aspirational, not current. The OP_CALL dispatcher only routes user functions via `func_names`; there's no builtin bridge yet. `rgxall` inherits the same limitation. Wiring it through (touches verify, VM compile, JIT compile, plus a uniform builtin-call lowering pass) is a separate, larger fix and out of scope here. Logged in the assessment doc as a parked adjacent finding.

When that bridge lands, both `rgx` and `rgxall` should switch on together and the test file's tree-only restriction can lift in the same PR.

## Test plan

- [x] `cargo test --release --features cranelift` clean (2861 + 199 + ...; all suites green)
- [x] `tests/regression_rgxall.rs` 7/7 passing
- [x] `examples/rgxall.ilo` runs through `tests/examples.rs` and `tests/examples_engines.rs` with tree engine
- [x] `cargo fmt --check` clean after format pass
- [x] `cargo clippy --release --features cranelift --all-targets -- -D warnings` clean
- [x] Manual smoke test on the HTML-scrape repro confirms `[One, Two, Three]` instead of `[One]`

## Follow-ups

- The VM/cranelift bridge for the `rgx` family (and `fmt` variadic, `rd path fmt`, `rdb`, ...) is logged in `ilo_assessment_feedback.md` for a future PR. Once it lands, lift the tree-only restriction in `tests/regression_rgxall.rs` and the engine-skip lines in `examples/rgxall.ilo`.