### PR TITLE
parser: friendly error for fld used as binding name

### DIFF
--- a/examples/fld-reserved-rename.ilo
+++ b/examples/fld-reserved-rename.ilo
@@ -1,0 +1,12 @@
+-- fld is reserved as the fold builtin. Using it as a variable name
+-- triggers ILO-P011 with a rename suggestion, not a misleading
+-- arity-mismatch cascade from the builtin call site.
+--
+-- Correct shape: pick a different name like field or folder.
+
+countup n:n>n;field=0;@i 0..n{field=+field 1};field
+
+-- run: countup 5
+-- out: 5
+-- run: countup 10
+-- out: 10

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -315,6 +315,19 @@ impl Parser {
                 format!("pick a different name like `{alt}` or `{}`", &word[..1]),
             ));
         }
+        // Builtin `fld` (fold) used as binding name: `fld=5`. Personas reach
+        // for `fld` as a natural variable (field/fold/folder); the builtin
+        // collision otherwise surfaces as a misleading ILO-T006 arity error.
+        if let Some(Token::Ident(name)) = self.peek()
+            && name == "fld"
+            && self.token_at(self.pos + 1) == Some(&Token::Eq)
+        {
+            return Err(self.error_hint(
+                "ILO-P011",
+                "`fld` is reserved for the fold builtin and cannot be used as an identifier".into(),
+                "pick a different name like `field` or `folder`".into(),
+            ));
+        }
         match self.peek() {
             Some(Token::Type) => self.parse_type_decl(),
             Some(Token::Tool) => self.parse_tool_decl(),
@@ -800,6 +813,16 @@ impl Parser {
                 }
                 self.advance(); // consume "cnt"
                 Ok(Stmt::Continue)
+            }
+            Some(Token::Ident(name))
+                if name == "fld" && self.token_at(self.pos + 1) == Some(&Token::Eq) =>
+            {
+                Err(self.error_hint(
+                    "ILO-P011",
+                    "`fld` is reserved for the fold builtin and cannot be used as an identifier"
+                        .into(),
+                    "pick a different name like `field` or `folder`".into(),
+                ))
             }
             Some(Token::Ident(name)) if name == "wh" => {
                 self.advance(); // consume "wh"

--- a/tests/regression_fld_reserved.rs
+++ b/tests/regression_fld_reserved.rs
@@ -1,0 +1,128 @@
+// Regression: `fld` used as a binding name must surface the friendly
+// ILO-P011 reserved-word error, not a misleading ILO-T006 arity mismatch
+// from the fold builtin. Mirrors the `cnt`/`brk` handling from commit
+// 8928635. Personas reach for `fld` as a natural variable name (field /
+// fold / folder) and previously paid the retry tax on a cryptic error.
+//
+// The fix lives in the parser, so all engines surface the same error.
+// Tests confirm each engine's CLI path emits ILO-P011 with the right
+// wording.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str) -> (bool, String) {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+// `fld=5` at top level inside a function body.
+const FLD_BINDING_IN_BODY: &str = "f>n;fld=5;fld";
+
+fn check_fld_binding(engine: &str) {
+    let (ok, stderr) = run(engine, FLD_BINDING_IN_BODY, "f");
+    assert!(!ok, "engine={engine}: expected parse failure");
+    assert!(
+        stderr.contains("ILO-P011"),
+        "engine={engine}: missing ILO-P011, stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("`fld` is reserved for the fold builtin"),
+        "engine={engine}: missing friendly message, stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("field") || stderr.contains("folder"),
+        "engine={engine}: hint should suggest field/folder, stderr={stderr}"
+    );
+    // Should not cascade into the verifier's misleading arity error.
+    assert!(
+        !stderr.contains("ILO-T006"),
+        "engine={engine}: arity cascade leaked, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("arity mismatch"),
+        "engine={engine}: arity cascade leaked, stderr={stderr}"
+    );
+}
+
+#[test]
+fn fld_binding_in_body_tree() {
+    check_fld_binding("--run-tree");
+}
+
+#[test]
+fn fld_binding_in_body_vm() {
+    check_fld_binding("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn fld_binding_in_body_cranelift() {
+    check_fld_binding("--run-cranelift");
+}
+
+// `fld=5` inside a loop body, the natural shape a persona writes when
+// accumulating a fold-style value across iterations.
+const FLD_BINDING_IN_LOOP: &str = "f a:n>n;@i 0..a{fld=i};1";
+
+fn check_fld_binding_loop(engine: &str) {
+    let (ok, stderr) = run(engine, FLD_BINDING_IN_LOOP, "f");
+    assert!(!ok, "engine={engine}: expected parse failure");
+    assert!(
+        stderr.contains("ILO-P011"),
+        "engine={engine}: missing ILO-P011, stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("`fld` is reserved for the fold builtin"),
+        "engine={engine}: missing friendly message, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("ILO-T006"),
+        "engine={engine}: arity cascade leaked, stderr={stderr}"
+    );
+}
+
+#[test]
+fn fld_binding_in_loop_tree() {
+    check_fld_binding_loop("--run-tree");
+}
+
+#[test]
+fn fld_binding_in_loop_vm() {
+    check_fld_binding_loop("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn fld_binding_in_loop_cranelift() {
+    check_fld_binding_loop("--run-cranelift");
+}
+
+// Sanity: `fld` as the fold builtin still works after the fix.
+#[test]
+fn fld_as_builtin_still_works() {
+    let out = ilo()
+        .args([
+            "add x:n y:n>n;+x y;f>n;fld add [1 2 3 4] 0",
+            "--run-tree",
+            "f",
+        ])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "fld builtin broken: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("10"), "expected 10, got: {stdout}");
+}

--- a/tests/regression_friendly_errors.rs
+++ b/tests/regression_friendly_errors.rs
@@ -88,6 +88,23 @@ fn friendly_brk_binding() {
     assert!(!err.contains("ILO-T028"), "cascade leaked: {err}");
 }
 
+#[test]
+fn friendly_fld_binding() {
+    let err = run_err("fld=5");
+    assert!(err.contains("ILO-P011"), "stderr: {err}");
+    assert!(
+        err.contains("`fld` is reserved for the fold builtin"),
+        "stderr: {err}"
+    );
+    assert!(err.contains("field"), "hint should suggest `field`: {err}");
+    // Should not cascade through to the verifier's misleading arity error.
+    assert!(!err.contains("ILO-T006"), "arity cascade leaked: {err}");
+    assert!(
+        !err.contains("arity mismatch"),
+        "arity cascade leaked: {err}"
+    );
+}
+
 // ---- Underscore mid-identifier ----
 
 #[test]


### PR DESCRIPTION
## Summary

`fld=5` used to silently parse as a 0-arg call to the fold builtin and surface as `ILO-T006 arity mismatch: 'fld' expects 3 or 4 args, got 0`. Personas reach for `fld` as a natural variable (field/fold/folder) and pay the retry tax on a misleading error.

This adds `fld` to the existing reserved-word friendly-error path that already covers `cnt`/`brk`/`var`/`let`/`if`/etc. (the work from 8928635). Same family, same shape, same ILO-P011 code.

## Repro

Before:

```
$ ilo run -e 'f>n;fld=5;p fld'
ILO-T006 arity mismatch: 'fld' expects 3 or 4 args, got 0
ILO-T005 undefined function 'p' (called with 1 args)
```

After:

```
$ ilo run -e 'f>n;fld=5;p fld'
ILO-P011 `fld` is reserved for the fold builtin and cannot be used as an identifier
hint: pick a different name like `field` or `folder`
```

## What's in the diff

- **parser: friendly error for `fld` used as binding name** — adds the guard in `parse_decl` and `parse_stmt`, mirroring the existing `cnt`/`brk` shape so the friendly error fires uniformly at top level and inside function bodies.
- **tests: regression coverage** — `tests/regression_fld_reserved.rs` pins the ILO-P011 path under tree/vm/cranelift for both body-level and inside-loop bindings, plus a sanity test that the `fld` builtin itself still works. A parallel one-liner added to `regression_friendly_errors.rs` keeps the friendly-error suite the canonical reserved-word audit. `examples/fld-reserved-rename.ilo` shows the renamed-variable shape an agent should reach for after hitting the error.

## Test plan

- [x] `cargo test --release --features cranelift` green (all suites)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --release --features cranelift --tests` clean
- [x] Manual repro confirmed before/after across tree/vm/cranelift

## Follow-ups

None.