### PR TITLE
match arms: accept brace-block bodies

### DIFF
--- a/examples/match-block.ilo
+++ b/examples/match-block.ilo
@@ -1,0 +1,26 @@
+-- Match arms accept brace-block bodies: ~v:{stmt;stmt;final-expr}.
+-- Final statement of the block is the arm value; mirrors =cond{block}.
+-- Inline ;-separated bodies still work; brace form just disambiguates.
+
+-- Brace block with a local binding inside an Ok arm
+parse-ok>n;r=num "10";?r{~v:{d=*v 2;+d 1};^e:0}
+
+-- Brace block on the Err arm
+parse-bad>t;r=num "oops";?r{~v:str v;^e:{tag="err: ";+tag e}}
+
+-- Nested match inside a brace-block arm
+classify>t;r=num "0";?r{~v:{?v{0:"zero";_:"nonzero"}};^e:"bad"}
+
+-- Multi-line bool match with brace blocks (each branch does setup work)
+report b:b>t;?b{true:{tag="OK: ";+tag "all good"};false:{tag="FAIL: ";+tag "see logs"}}
+
+-- run: parse-ok
+-- out: 21
+-- run: parse-bad
+-- out: err: oops
+-- run: classify
+-- out: zero
+-- run: report true
+-- out: OK: all good
+-- run: report false
+-- out: FAIL: see logs

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -964,8 +964,20 @@ impl Parser {
         Ok(MatchArm { pattern, body })
     }
 
-    /// Parse body of a match arm — multiple statements until next arm pattern or `}`
+    /// Parse body of a match arm — multiple statements until next arm pattern or `}`.
+    ///
+    /// Two body shapes are accepted:
+    /// - Brace block: `~v:{stmt1;stmt2;final-expr}` — mirrors `=cond{block}` grammar,
+    ///   makes the arm boundary unambiguous when the body contains call-shapes that
+    ///   could look like patterns. Final stmt is the arm value.
+    /// - Inline `;`-separated: `~v:stmt1;stmt2;final-expr` — existing form. `;` followed
+    ///   by a pattern-shaped token sequence starts a new arm (see `semi_starts_new_arm`).
     fn parse_arm_body(&mut self) -> Result<Vec<Spanned<Stmt>>> {
+        // Brace-block form: only when the `{...}` is not a destructure pattern start
+        // (e.g. `{a, b}=v` is a destructure assignment, kept on the inline path).
+        if self.peek() == Some(&Token::LBrace) && !self.is_destructure_pattern() {
+            return self.parse_brace_body();
+        }
         let mut stmts = Vec::new();
         if !self.at_arm_end() {
             let span_start = self.peek_span();

--- a/tests/regression_match_block.rs
+++ b/tests/regression_match_block.rs
@@ -1,0 +1,119 @@
+// Regression tests for match arm brace-block bodies:
+//
+//   ?expr{~v:{stmt;stmt;final-expr} ^e:body}
+//
+// Before the fix, the parser rejected `{` immediately after the arm `:` with
+// `ILO-P009: expected expression, got LBrace`. Personas paid a helper-function
+// tax on every Result-handling site because the only way to put multi-step
+// logic inside an arm was to factor it out into a separate function. The
+// `;`-inline form (`~v:stmt1;stmt2;final-expr`) was already accepted by the
+// parser but is visually noisy and ambiguous to a tired model when the body
+// contains call-shapes that resemble patterns. Brace-block form mirrors the
+// existing `=cond{block}` grammar and makes the arm boundary unambiguous.
+//
+// These tests pin cross-engine behaviour across tree / VM / Cranelift so the
+// shape can't silently regress.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+#[cfg(feature = "cranelift")]
+const ENGINES_ALL: &[&str] = &["--run-tree", "--run-vm", "--run-cranelift"];
+#[cfg(not(feature = "cranelift"))]
+const ENGINES_ALL: &[&str] = &["--run-tree", "--run-vm"];
+
+// Single-expression arms (existing behaviour) must keep working unchanged.
+const SINGLE_EXPR: &str = r#"f>n;?2{0:0;1:1;2:42;_:99}"#;
+
+#[test]
+fn single_expr_arm_preserved_cross_engine() {
+    for engine in ENGINES_ALL {
+        let out = run(engine, SINGLE_EXPR, "f");
+        assert_eq!(out.trim(), "42", "{engine}: {out:?}");
+    }
+}
+
+// Brace-block arm with a local binding and a final expression.
+const BLOCK_WITH_LOCAL: &str = r#"f>n;r=num "10";?r{~v:{d=*v 2;+d 1};^e:0}"#;
+
+#[test]
+fn brace_block_with_local_cross_engine() {
+    for engine in ENGINES_ALL {
+        let out = run(engine, BLOCK_WITH_LOCAL, "f");
+        assert_eq!(out.trim(), "21", "{engine}: {out:?}");
+    }
+}
+
+// Brace-block on the Err arm too.
+const BLOCK_ON_ERR: &str = r#"f>t;r=num "oops";?r{~v:str v;^e:{tag="err: ";+tag e}}"#;
+
+#[test]
+fn brace_block_on_err_cross_engine() {
+    for engine in ENGINES_ALL {
+        let out = run(engine, BLOCK_ON_ERR, "f");
+        assert_eq!(out.trim(), "err: oops", "{engine}: {out:?}");
+    }
+}
+
+// Nested match: brace-block body contains another match expression.
+const NESTED_MATCH: &str = r#"f>t;r=num "0";?r{~v:{?v{0:"zero";_:"nonzero"}};^e:"bad"}"#;
+
+#[test]
+fn nested_match_in_block_cross_engine() {
+    for engine in ENGINES_ALL {
+        let out = run(engine, NESTED_MATCH, "f");
+        assert_eq!(out.trim(), "zero", "{engine}: {out:?}");
+    }
+}
+
+// Multiple brace-block arms on a bool match: each branch does setup work
+// before producing its value.
+const BOOL_BLOCKS: &str =
+    r#"f>t;?true{true:{tag="OK: ";+tag "all good"};false:{tag="FAIL: ";+tag "see logs"}}"#;
+
+#[test]
+fn bool_match_brace_blocks_cross_engine() {
+    for engine in ENGINES_ALL {
+        let out = run(engine, BOOL_BLOCKS, "f");
+        assert_eq!(out.trim(), "OK: all good", "{engine}: {out:?}");
+    }
+}
+
+// Existing inline `;`-separated arm body must keep working — the brace-block
+// path is purely additive.
+const INLINE_SEMI: &str = r#"f>n;r=num "10";?r{~v:d=*v 2;+d 1;^e:0}"#;
+
+#[test]
+fn inline_semi_arm_body_preserved_cross_engine() {
+    for engine in ENGINES_ALL {
+        let out = run(engine, INLINE_SEMI, "f");
+        assert_eq!(out.trim(), "21", "{engine}: {out:?}");
+    }
+}
+
+// Match-as-expression in RHS of a binding, with a brace-block arm body.
+const MATCH_EXPR_BLOCK: &str = r#"f>n;r=num "5";x=?r{~v:{d=*v 3;+d 1};^e:0};+x 0"#;
+
+#[test]
+fn match_expr_brace_block_cross_engine() {
+    for engine in ENGINES_ALL {
+        let out = run(engine, MATCH_EXPR_BLOCK, "f");
+        assert_eq!(out.trim(), "16", "{engine}: {out:?}");
+    }
+}


### PR DESCRIPTION
## Summary

`~v:{stmt1;stmt2;final-expr}` is now a valid match arm body, alongside the existing inline `~v:stmt1;stmt2;final-expr` form. Mirrors the existing `=cond{block}` grammar so the arm boundary is unambiguous when the body contains call-shapes that resemble patterns.

The manifesto framing: every Result-handling site that wants more than a single expression in an arm currently either uses the inline `;` form (which works but is visually noisy and easy for a tired model to mis-segment) or extracts a helper function. Personas reported the helper tax repeatedly (`ilo_assessment_feedback.md` lines 830, 851, 928). Brace blocks give a visually clear, unambiguous shape that matches what the agent already knows about `=cond{block}`.

## Repro

Before:

```ilo
go>n;r=num "10";?r{~v:{d=*v 2;+d 1};^e:0}
```

```
{"code":"ILO-P009","labels":[...],"message":"expected expression, got LBrace",...}
```

After:

```
21
```

## What's in the diff

- **parser: accept brace-block bodies in match arms** — in `parse_arm_body`, when the post-colon token is `LBrace` and it is not a destructure-pattern start, delegate to `parse_brace_body`. AST shape unchanged: `MatchArm.body` stays `Vec<Spanned<Stmt>>`, last stmt is the arm value. Every backend already iterates that way, so no verifier / interpreter / VM / Cranelift change needed.
- **tests: cross-engine coverage** — `tests/regression_match_block.rs` with seven tests across tree / VM / Cranelift: single-expr (existing), brace block with local in Ok arm, brace block on Err arm, nested match in block, bool match with blocks on both branches, inline `;`-separated still works, match-as-expression with brace-block arm.
- **examples: `examples/match-block.ilo`** — engine-asserted example picked up by `tests/examples_engines.rs` so the shape is exercised on every backend.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --release --features cranelift --all-targets -- -D warnings`
- [x] `cargo test --release --features cranelift` — full suite green
- [x] New `regression_match_block` tests all pass on tree, VM, and Cranelift
- [x] Existing single-expr and inline-`;` arm bodies still work (anchored by the first and sixth tests)

## Follow-ups

None for this PR. The inline-`;` form remains valid and is the more token-minimal shape for short arm bodies; brace blocks are the readable escape hatch when you need locals or want the boundary to be unmistakable.