### PR TITLE
parser: accept prefix-op operands in @ range bounds

### DIFF
--- a/examples/range-expr.ilo
+++ b/examples/range-expr.ilo
@@ -1,0 +1,30 @@
+-- Range bounds in @ loops accept prefix-op expressions, not just atoms.
+-- Saves the intermediate-binding tax for `start = current + offset` patterns.
+
+-- Skip the first two: @j +i 2..n iterates 5..10 = [5,6,7,8,9]
+skip-first-two i:n n:n>L n;xs=[];@j +i 2..n{xs=+=xs j};xs
+
+-- Double-end: @j 0..*n 2 iterates 0..(n*2) = 0..6 = [0,1,2,3,4,5]
+double-end n:n>L n;xs=[];@j 0..*n 2{xs=+=xs j};xs
+
+-- Trim both ends: @j -a 1..-b 1 iterates 1..5 = [1,2,3,4]
+trim-both a:n b:n>L n;xs=[];@j -a 1..-b 1{xs=+=xs j};xs
+
+-- Skip the last one: @j 0..-n 1 iterates 0..(n-1) = [0,1,2,3]
+drop-last n:n>L n;xs=[];@j 0..-n 1{xs=+=xs j};xs
+
+-- Call-style bounds still need a binding (`n=len xs` first).
+-- This is the documented workaround; the parser does not call-parse
+-- inside range bounds.
+sum-via-len xs:L n>n;n=len xs;s=0;@j 0..n{s=+s j};+s 0
+
+-- run: skip-first-two 3 10
+-- out: [5, 6, 7, 8, 9]
+-- run: double-end 3
+-- out: [0, 1, 2, 3, 4, 5]
+-- run: trim-both 2 6
+-- out: [1, 2, 3, 4]
+-- run: drop-last 5
+-- out: [0, 1, 2, 3]
+-- run: sum-via-len [1,2,3]
+-- out: 3

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1144,11 +1144,16 @@ impl Parser {
     fn parse_foreach(&mut self) -> Result<Stmt> {
         self.expect(&Token::At)?;
         let binding = self.expect_ident()?;
-        let start_expr = self.parse_atom()?;
+        // Range bounds accept any operand, not just atoms: this lets personas
+        // write `@j +i 2..n` and `@j 0..-n 1` directly instead of binding an
+        // intermediate (`jst=+i 2;@j jst..n`). Call-style bounds like
+        // `@j 0..len xs` still need a binding; see tests/regression_range_expr.rs
+        // for the negative anchor.
+        let start_expr = self.parse_operand()?;
         // Check for range syntax: start..end
         if self.peek() == Some(&Token::DotDot) {
             self.advance(); // consume ..
-            let end_expr = self.parse_atom()?;
+            let end_expr = self.parse_operand()?;
             let body = self.parse_brace_body()?;
             return Ok(Stmt::ForRange {
                 binding,

--- a/tests/regression_range_expr.rs
+++ b/tests/regression_range_expr.rs
@@ -1,0 +1,141 @@
+// Cross-engine regression tests for range bounds in `@` loops.
+//
+// Until this fix, `parse_foreach` used `parse_atom` for both range bounds,
+// so `@j +i 2..n` (prefix-binop start) and `@j 0..*n 2` (prefix-binop end)
+// were rejected with ILO-P009. Personas had to bind an intermediate
+// (`jst=+i 2;@j jst..n`) for every compound bound. Now both sides accept
+// any operand: literals, idents, prefix-binop forms (`+a b`, `-a b`,
+// `*a b`, `/a b`), and unary forms (`-x` literal negation).
+//
+// Call-style bounds (`@j 0..len xs`) explicitly still require an
+// intermediate binding; the `call_style_bound_still_requires_binding`
+// test below anchors that contract so a future change extending range
+// bounds to `parse_call_or_atom` is a deliberate decision.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_text(engine: &str, src: &str) -> String {
+    let out = ilo()
+        .args([src, engine, "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn check_all(src: &str, expected: &str) {
+    for engine in ["--run-tree", "--run-vm"] {
+        let actual = run_text(engine, src);
+        assert_eq!(
+            actual, expected,
+            "engine={engine} src=`{src}`: got `{actual}`, expected `{expected}`"
+        );
+    }
+    #[cfg(feature = "cranelift")]
+    {
+        let engine = "--run-cranelift";
+        let actual = run_text(engine, src);
+        assert_eq!(
+            actual, expected,
+            "engine={engine} src=`{src}`: got `{actual}`, expected `{expected}`"
+        );
+    }
+}
+
+#[test]
+fn plus_op_start_bound() {
+    // @j +i 2..n collects 5..10 = [5,6,7,8,9]
+    check_all(
+        "f>L n;i=3;n=10;xs=[];@j +i 2..n{xs=+=xs j};xs",
+        "[5, 6, 7, 8, 9]",
+    );
+}
+
+#[test]
+fn star_op_end_bound() {
+    // @j 0..*n 2 collects 0..6 = [0,1,2,3,4,5]
+    check_all(
+        "f>L n;n=3;xs=[];@j 0..*n 2{xs=+=xs j};xs",
+        "[0, 1, 2, 3, 4, 5]",
+    );
+}
+
+#[test]
+fn minus_op_both_bounds() {
+    // @j -a 1..-b 1 with a=2,b=6 → 1..5 = [1,2,3,4]
+    check_all(
+        "f>L n;a=2;b=6;xs=[];@j -a 1..-b 1{xs=+=xs j};xs",
+        "[1, 2, 3, 4]",
+    );
+}
+
+#[test]
+fn div_op_start_bound() {
+    // @j /n 2..n with n=8 → 4..8 = [4,5,6,7]
+    check_all("f>L n;n=8;xs=[];@j /n 2..n{xs=+=xs j};xs", "[4, 5, 6, 7]");
+}
+
+#[test]
+fn nested_range_with_op_bounds() {
+    // Outer @i 0..2, inner @j +i 1..3 collects pairs i*10+j.
+    // i=0 -> j in 1..3 -> [1,2]; i=1 -> j in 2..3 -> [2]
+    // Total: [1, 2, 12]
+    check_all(
+        "f>L n;xs=[];@i 0..2{@j +i 1..3{xs=+=xs +*i 10 j}};xs",
+        "[1, 2, 12]",
+    );
+}
+
+#[test]
+fn plus_bounds_negative_result_empty() {
+    // When start >= end the loop body never runs.
+    check_all("f>L n;i=5;n=4;xs=[];@j +i 0..n{xs=+=xs j};xs", "[]");
+}
+
+#[test]
+fn atom_only_bounds_still_work() {
+    // Regression: the existing atom-only forms must keep working.
+    check_all("f>n;s=0;@j 0..5{s=+s j};+s 0", "10");
+}
+
+#[test]
+fn ident_to_ident_bounds_still_work() {
+    // Two-ident range, the most common existing form.
+    check_all("f>n;a=1;b=4;s=0;@j a..b{s=+s j};+s 0", "6");
+}
+
+#[test]
+fn call_style_bound_still_requires_binding() {
+    // Anchor: bare function-call bounds remain unsupported. If this test
+    // starts failing because the call form now parses, that's a deliberate
+    // extension and the test should be updated (and the assessment-doc
+    // entry reopened to consider the call-form follow-up).
+    let out = ilo()
+        .args([
+            "f>n;xs=[1,2,3];s=0;@j 0..len xs{s=+s j};+s 0",
+            "--run-tree",
+            "f",
+        ])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "expected call-style range bound to fail; stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn call_style_bound_works_with_binding() {
+    // The documented workaround: bind first, then range over the binding.
+    check_all("f>n;xs=[1,2,3];n=len xs;s=0;@j 0..n{s=+s j};+s 0", "3");
+}


### PR DESCRIPTION
## Summary

`@j +i 2..n` was rejected with `ILO-P009: expected expression, got Plus`. Personas had to bind an intermediate (`jst=+i 2;@j jst..n`) every time the start or end of a range needed a compound expression. The bound parser was using `parse_atom` instead of `parse_operand`.

This is a small parser fix with cross-engine regression coverage. Saves the intermediate-binding tax for the common "start = current + offset" / "end = n - 1" / "end = n * 2" patterns. Manifesto framing: ~9 chars and one binding name eliminated per occurrence, with the matching reduction in token cost for any agent reading the code afterwards.

## Repro

Before:
```
$ ilo run -e 'go>n;n=10;i=3;@j +i 2..n{prnt j};+n 0' go
{"code":"ILO-P009","message":"expected expression, got Plus",...}
```

After (tree, VM, Cranelift all agree):
```
$ ilo run -e 'go>n;n=10;i=3;@j +i 2..n{prnt j};+n 0' go
5
6
7
8
9
```

## What's in the diff

- **`parser: accept prefix-op operands in @ range bounds`** — single-function change in `parse_foreach`, swaps `parse_atom` to `parse_operand` for both bound positions. `parse_operand` is a strict superset (its `_ => parse_atom()` arm preserves every previously-accepted form), and it stops at non-operand-starters, so `..`, `{`, and other delimiters are not over-consumed.
- **`test: cross-engine regression for prefix-op range bounds`** — `tests/regression_range_expr.rs`, 10 tests across tree, VM, Cranelift covering `+`/`-`/`*`/`/` on either side, nested ranges, empty-range, atom-only preservation, and a negative anchor for call-style bounds (`@j 0..len xs` still requires a binding).
- **`example: prefix-op range bounds`** — `examples/range-expr.ilo` for in-context persona learning. Picked up by `tests/examples_engines.rs` as an extra cross-engine regression layer.

## Scope limit

Call-style bounds (`@j 0..len xs`) explicitly remain unsupported. There's a negative test anchoring that. If persona demand emerges, extending range bounds to `parse_call_or_atom` is a separate, deliberate change with its own greedy-call-parsing analysis.

## Test plan

- [x] `cargo fmt`
- [x] `cargo test --release --features cranelift --test regression_range_expr` — 10/10 pass
- [x] `cargo test --release --features cranelift --test examples_engines` — passes (covers new example across all engines)
- [x] `cargo test --release --features cranelift` — full suite passes (the four AOT-cross-compile tests in `vm::compile_cranelift::tests` are pre-existing parallel-execution flakiness on shared `/tmp` paths; reproducible on `main`, pass in isolation, unrelated to this fix)
- [ ] CI green

## Follow-ups

None required. Optional future extension: bare call bounds (`0..len xs`), gated by demand.