### PR TITLE
fix: suppress top-level auto-print when entry body ends in a loop

### DIFF
--- a/examples/lists.ilo
+++ b/examples/lists.ilo
@@ -7,8 +7,11 @@ fst xs:L n>n;xs.0
 -- Third element (safe — index expression)
 thr xs:L n>n;xs.2
 
--- Square each element, return last squared value (safe — foreach ends with })
-sq-last xs:L n>n;@x xs{*x x}
+-- Square each element, return last squared value. Bind the loop's value to
+-- `r` so the function's syntactic tail is an expression — top-level
+-- auto-print only fires when the tail is a value expression, never when
+-- the function body ends with a bare loop.
+sq-last xs:L n>n;r=0;@x xs{r=*x x};+r 0
 
 -- Length of list (last function — bare call safe at EOF)
 sz xs:L n>n;len xs

--- a/examples/print-loop.ilo
+++ b/examples/print-loop.ilo
@@ -1,0 +1,31 @@
+-- Print-loop: `@x xs{prnt x}` at the function tail no longer double-prints.
+-- Previously the loop's last-body-value (the last printed item) was auto-
+-- printed again at top level, forcing a trailing `+0 0` sentinel idiom.
+-- Now: when the entry function's body ends with a loop AND has no early-
+-- return path, the top-level auto-print is suppressed. Loop-as-expression
+-- value inside functions is unchanged (callers still see the loop's last
+-- body value). Explicit `nil` returns from non-loop tails still print as
+-- "nil" — suppression is syntactic loop-tail only, not blanket Nil.
+-- `tests/regression_loop_print.rs` covers nested-caller, brk/while, and
+-- explicit-nil cases. The annotations below pin the single-line scenarios
+-- so `tests/examples_engines.rs` exercises them too.
+
+-- Single-item print-loop at top level: prints "42" once. Pre-fix this
+-- printed "42\n42\n".
+print-one>n;xs=[42];@x xs{prnt x}
+
+-- Empty-list loop: function returns nil, suppressed at top level
+-- (no "nil" line). Stdout is empty.
+empty-loop>n;xs=[];@x xs{prnt x}
+
+-- Trailing-expression sentinel: when the syntactic tail is an expression
+-- (not a loop), suppression does NOT apply — the value still auto-prints.
+-- Stdout: "99".
+with-sentinel>n;xs=[];@x xs{prnt x};+99 0
+
+-- run: print-one
+-- out: 42
+-- run: empty-loop
+-- out:
+-- run: with-sentinel
+-- out: 99

--- a/src/main.rs
+++ b/src/main.rs
@@ -2424,6 +2424,7 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
                         return 1;
                     }
                 };
+                let suppress = program_result_should_suppress(&program, func_name);
                 run_vm_with_provider(
                     &compiled,
                     func_name,
@@ -2436,6 +2437,7 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
                     &source,
                     mode,
                     explicit_json,
+                    suppress,
                 )
             }
             cli::Engine::Tree => {
@@ -2518,6 +2520,7 @@ fn run_cranelift_engine(program: &ast::Program, rest: &[String], explicit_json: 
         vec![]
     };
     let run_args = coerce_cli_args(program, func_name, run_args);
+    let suppress = program_result_should_suppress(program, func_name);
 
     #[cfg(feature = "cranelift")]
     {
@@ -2551,7 +2554,7 @@ fn run_cranelift_engine(program: &ast::Program, rest: &[String], explicit_json: 
         match vm::jit_cranelift::compile_and_call(chunk, nan_consts, &nan_args, &compiled) {
             Some(result_bits) => {
                 let result = vm::NanVal(result_bits).to_value();
-                print_value(&result, explicit_json);
+                print_value(&result, explicit_json, suppress);
                 0
             }
             None => {
@@ -2562,7 +2565,7 @@ fn run_cranelift_engine(program: &ast::Program, rest: &[String], explicit_json: 
     }
     #[cfg(not(feature = "cranelift"))]
     {
-        let _ = (func_name, run_args, explicit_json);
+        let _ = (func_name, run_args, explicit_json, suppress);
         eprintln!("Cranelift JIT not enabled. Build with: cargo build --features cranelift");
         1
     }
@@ -2710,13 +2713,14 @@ fn run_vm_with_provider(
     source: &str,
     mode: OutputMode,
     explicit_json: bool,
+    suppress_loop_tail: bool,
 ) -> i32 {
     #[cfg(feature = "tools")]
     if let Some(provider) = mcp_provider {
         let rt = mcp_rt.expect("runtime present with mcp_provider");
         match vm::run_with_tools(compiled, func_name, args, provider, rt) {
             Ok(val) => {
-                print_value(&val, explicit_json);
+                print_value(&val, explicit_json, suppress_loop_tail);
                 return 0;
             }
             Err(e) => {
@@ -2749,7 +2753,7 @@ fn run_vm_with_provider(
             &runtime,
         ) {
             Ok(val) => {
-                print_value(&val, explicit_json);
+                print_value(&val, explicit_json, suppress_loop_tail);
                 0
             }
             Err(e) => {
@@ -2761,7 +2765,7 @@ fn run_vm_with_provider(
 
     match vm::run(compiled, func_name, args) {
         Ok(val) => {
-            print_value(&val, explicit_json);
+            print_value(&val, explicit_json, suppress_loop_tail);
             0
         }
         Err(e) => {
@@ -2785,6 +2789,7 @@ fn run_interp_with_provider(
     mode: OutputMode,
     explicit_json: bool,
 ) -> i32 {
+    let suppress = program_result_should_suppress(program, func_name);
     #[cfg(feature = "tools")]
     if let Some(provider) = mcp_provider {
         let rt = std::sync::Arc::new(mcp_rt.expect("runtime present with mcp_provider"));
@@ -2796,7 +2801,7 @@ fn run_interp_with_provider(
             rt,
         ) {
             Ok(val) => {
-                print_value(&val, explicit_json);
+                print_value(&val, explicit_json, suppress);
                 return 0;
             }
             Err(e) => {
@@ -2831,7 +2836,7 @@ fn run_interp_with_provider(
             runtime,
         ) {
             Ok(val) => {
-                print_value(&val, explicit_json);
+                print_value(&val, explicit_json, suppress);
                 0
             }
             Err(e) => {
@@ -2843,7 +2848,7 @@ fn run_interp_with_provider(
 
     match interpreter::run(program, func_name, args) {
         Ok(val) => {
-            print_value(&val, explicit_json);
+            print_value(&val, explicit_json, suppress);
             0
         }
         Err(e) => {
@@ -2861,6 +2866,7 @@ fn run_default(
     mode: OutputMode,
     explicit_json: bool,
 ) -> i32 {
+    let suppress = program_result_should_suppress(program, func_name);
     // Try Cranelift JIT first — all functions are now eligible
     #[cfg(feature = "cranelift")]
     {
@@ -2880,7 +2886,7 @@ fn run_default(
                     vm::jit_cranelift::compile_and_call(chunk, nan_consts, &nan_args, &compiled)
                 {
                     let result = vm::NanVal(result_bits).to_value();
-                    print_value(&result, explicit_json);
+                    print_value(&result, explicit_json, suppress);
                     return 0;
                 }
             }
@@ -2890,7 +2896,7 @@ fn run_default(
     // Fall back to interpreter
     match interpreter::run(program, func_name, args) {
         Ok(val) => {
-            print_value(&val, explicit_json);
+            print_value(&val, explicit_json, suppress);
             0
         }
         Err(e) => {
@@ -2900,10 +2906,92 @@ fn run_default(
     }
 }
 
+/// Walk a body looking for any `ret` or braceless guard — these short-circuit the
+/// function and mean the program's return value did not come from the body-tail.
+fn body_has_early_return(body: &[ast::Spanned<ast::Stmt>]) -> bool {
+    for s in body {
+        if stmt_has_early_return(&s.node) {
+            return true;
+        }
+    }
+    false
+}
+
+fn stmt_has_early_return(stmt: &ast::Stmt) -> bool {
+    match stmt {
+        ast::Stmt::Return(_) => true,
+        // Braceless guards (`cond expr`) early-return from the function.
+        ast::Stmt::Guard {
+            braceless: true, ..
+        } => true,
+        // Braced guards do NOT early-return, but their bodies might contain `ret`.
+        ast::Stmt::Guard {
+            body, else_body, ..
+        } => {
+            body_has_early_return(body)
+                || else_body.as_ref().is_some_and(|b| body_has_early_return(b))
+        }
+        ast::Stmt::Match { arms, .. } => arms.iter().any(|a| body_has_early_return(&a.body)),
+        ast::Stmt::ForEach { body, .. }
+        | ast::Stmt::ForRange { body, .. }
+        | ast::Stmt::While { body, .. } => body_has_early_return(body),
+        _ => false,
+    }
+}
+
+/// Top-level auto-print suppression rule for the program's final value.
+///
+/// Returns true when the program's syntactic entry-function body ends with a
+/// `@`/`wh` loop AND has no early-return path. In that case the loop's
+/// last-body-value bubbles up as the program result, and re-printing it on top
+/// of whatever the loop body already printed (e.g. via `prnt`) just duplicates
+/// the last item. Functions are still free to use loop-as-expression value
+/// internally; this is purely about the final stdout line at the top level.
+fn program_result_should_suppress(program: &ast::Program, func_name: Option<&str>) -> bool {
+    let entry_body: Option<&Vec<ast::Spanned<ast::Stmt>>> = match func_name {
+        Some(name) => program.declarations.iter().find_map(|d| match d {
+            ast::Decl::Function { name: n, body, .. } if n == name => Some(body),
+            _ => None,
+        }),
+        None => program.declarations.iter().find_map(|d| match d {
+            ast::Decl::Function { body, .. } => Some(body),
+            _ => None,
+        }),
+    };
+    let Some(body) = entry_body else {
+        return false;
+    };
+    let Some(last) = body.last() else {
+        return false;
+    };
+    let ends_with_loop = matches!(
+        last.node,
+        ast::Stmt::ForEach { .. } | ast::Stmt::ForRange { .. } | ast::Stmt::While { .. }
+    );
+    if !ends_with_loop {
+        return false;
+    }
+    // Only suppress when the entry body has no early-return path. With an
+    // early-return present (`ret`, braceless guard) we can't tell at print
+    // time whether the value came from the loop tail or from an explicit
+    // return, so we err on the side of printing.
+    !body_has_early_return(body)
+}
+
 /// Print a program result value. When `as_json` is true (explicit -j/--json), wraps it as
 /// `{"ok": ...}` or `{"error": ...}`. Auto-detected JSON mode does not affect result format.
-fn print_value(val: &interpreter::Value, as_json: bool) {
+///
+/// In plain (non-JSON) mode, suppresses the line entirely when
+/// `suppress_loop_tail` is true — see [`program_result_should_suppress`] for
+/// the rule. A bare Nil that came from an *explicit* return (e.g. a function
+/// declared `>O n` returning `nil`) is still printed, because the user asked
+/// for it. JSON mode is unchanged so machine-readable consumers always get a
+/// structured result.
+fn print_value(val: &interpreter::Value, as_json: bool, suppress_loop_tail: bool) {
     if !as_json {
+        if suppress_loop_tail {
+            return;
+        }
         println!("{}", val);
         return;
     }
@@ -4109,6 +4197,7 @@ mod tests {
             "f x:n>n;*x 2",
             OutputMode::Text,
             false,
+            false,
         );
     }
 
@@ -4127,6 +4216,7 @@ mod tests {
             "f x:n>n;*x 3",
             OutputMode::Json,
             true,
+            false,
         );
     }
 
@@ -4269,40 +4359,40 @@ mod tests {
 
     #[test]
     fn print_value_plain_number_no_json() {
-        print_value(&interpreter::Value::Number(42.0), false);
+        print_value(&interpreter::Value::Number(42.0), false, false);
     }
 
     #[test]
     fn print_value_ok_as_json() {
         let val = interpreter::Value::Ok(Box::new(interpreter::Value::Number(42.0)));
-        print_value(&val, true);
+        print_value(&val, true, false);
     }
 
     #[test]
     fn print_value_err_as_json() {
         let val = interpreter::Value::Err(Box::new(interpreter::Value::Text("oops".into())));
-        print_value(&val, true);
+        print_value(&val, true, false);
     }
 
     #[test]
     fn print_value_err_no_json() {
         let val = interpreter::Value::Err(Box::new(interpreter::Value::Text("fail".into())));
-        print_value(&val, false);
+        print_value(&val, false, false);
     }
 
     #[test]
     fn print_value_text_as_json() {
-        print_value(&interpreter::Value::Text("hello".into()), true);
+        print_value(&interpreter::Value::Text("hello".into()), true, false);
     }
 
     #[test]
     fn print_value_bool_as_json() {
-        print_value(&interpreter::Value::Bool(true), true);
+        print_value(&interpreter::Value::Bool(true), true, false);
     }
 
     #[test]
     fn print_value_nil_as_json() {
-        print_value(&interpreter::Value::Nil, true);
+        print_value(&interpreter::Value::Nil, true, false);
     }
 
     #[test]
@@ -4311,7 +4401,7 @@ mod tests {
             interpreter::Value::Number(1.0),
             interpreter::Value::Number(2.0),
         ]);
-        print_value(&val, true);
+        print_value(&val, true, false);
     }
 
     // ── warn_cross_language_syntax: Json mode ─────────────────────────────────
@@ -4770,7 +4860,7 @@ mod tests {
             interpreter::Value::Number(1.0),
             interpreter::Value::Text("x".into()),
         ]);
-        print_value(&val, false);
+        print_value(&val, false, false);
     }
 
     #[test]
@@ -4778,7 +4868,7 @@ mod tests {
         let mut m = std::collections::HashMap::new();
         m.insert("k".to_string(), interpreter::Value::Number(7.0));
         let val = interpreter::Value::Map(m);
-        print_value(&val, true);
+        print_value(&val, true, false);
     }
 
     #[test]
@@ -4786,7 +4876,7 @@ mod tests {
         let mut m = std::collections::HashMap::new();
         m.insert("key".to_string(), interpreter::Value::Bool(true));
         let val = interpreter::Value::Map(m);
-        print_value(&val, false);
+        print_value(&val, false, false);
     }
 
     // ── subprocess helpers ────────────────────────────────────────────────────
@@ -6830,6 +6920,7 @@ mod tests {
             None,
             "f>n;/1 0",
             OutputMode::Text,
+            false,
             false,
         );
         assert_eq!(code, 1);

--- a/tests/eval_inline.rs
+++ b/tests/eval_inline.rs
@@ -1886,8 +1886,13 @@ fn braceless_guard_early_return_vs_braced_conditional() {
 
 #[test]
 fn range_basic() {
+    // Loop's last body value (2) is captured into `r` and returned as the
+    // function's trailing expression so the top-level auto-print fires.
+    // Pre-loop-suppression this was `f>n;@i 0..3{i}` and relied on the loop
+    // being the function tail; that shape now (correctly) suppresses the
+    // top-level print to avoid double-output in print-loops.
     let out = ilo()
-        .args(["f>n;@i 0..3{i}", "--run", "f"])
+        .args(["f>n;r=0;@i 0..3{r=i};+r 0", "--run", "f"])
         .output()
         .expect("failed to run ilo");
     assert!(
@@ -1901,7 +1906,7 @@ fn range_basic() {
 #[test]
 fn range_with_arg() {
     let out = ilo()
-        .args(["f n:n>n;@i 0..n{*i i}", "4"])
+        .args(["f n:n>n;r=0;@i 0..n{r=*i i};+r 0", "4"])
         .output()
         .expect("failed to run ilo");
     assert!(
@@ -1909,7 +1914,7 @@ fn range_with_arg() {
         "stderr: {}",
         String::from_utf8_lossy(&out.stderr)
     );
-    // i goes 0,1,2,3 → last body value is 3*3 = 9
+    // i goes 0,1,2,3 → last body value bound into r is 3*3 = 9
     assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "9");
 }
 

--- a/tests/regression_loop_print.rs
+++ b/tests/regression_loop_print.rs
@@ -1,0 +1,238 @@
+// Top-level auto-print suppression for loop-tail function results.
+//
+// Background: `prnt v` prints v and returns v (passthrough). A function body
+// whose last statement is a loop returns the loop's last body value. So a
+// "print every item" loop like `@x xs{prnt x}` used to double-print: each item
+// inside the loop, and then the loop's final body value (the last printed
+// item) again from the top-level auto-print. Personas worked around this with
+// trailing `+0 0` sentinels.
+//
+// Fix (print-layer only, `src/main.rs`): when the program's entry function
+// body ends with `@`/`wh` AND has no early-return path, the plain-text top-
+// level auto-print is suppressed. The check is *syntactic* — it looks at the
+// AST tail, not at the runtime value — so a function that explicitly returns
+// `nil` from a non-loop tail (e.g. `nothing>O n;nil`) still prints "nil".
+// Function-internal loop-as-expression semantics are unchanged: a caller that
+// consumes such a function's return value still sees the loop's last body
+// value. JSON mode is untouched.
+//
+// This test suite pins:
+//   1. Top-level print-loop: only the loop body's prints reach stdout (no
+//      trailing duplicate).
+//   2. Nested print-loop: caller observes the loop's last-body-value as the
+//      callee's return — semantics inside functions are unchanged.
+//   3. Empty-list loop at top level: nothing prints (loop tail catches the
+//      Nil and suppresses; previously this leaked a `nil` line).
+//   4. Loop with `brk` at top level: still suppressed.
+//   5. While loop at top level: suppressed.
+//   6. Trailing-expression sentinel still prints normally (the `+0 0` /
+//      explicit-expression idiom must keep working — non-regression).
+//   7. Early-return present + loop tail: top-level value still prints (we
+//      can't tell at print time whether the value came from the loop or the
+//      `ret`, so we err on the side of printing).
+//   8. Explicit nil return from a non-loop tail still prints "nil" (the rule
+//      is syntactic loop-tail, never blanket Nil).
+//   9. JSON mode is unaffected: `--json` always emits a structured line.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn write_src(src: &str, tag: &str) -> std::path::PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let seq = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let path = std::env::temp_dir().join(format!(
+        "ilo_loop_print_{}_{}_{}.ilo",
+        std::process::id(),
+        seq,
+        tag,
+    ));
+    std::fs::write(&path, src).unwrap();
+    path
+}
+
+fn run_file(engine: &str, src: &str, fn_name: &str, args: &[&str]) -> String {
+    let path = write_src(
+        src,
+        &format!("{}_{}", fn_name, engine.trim_start_matches("--")),
+    );
+    let mut cmd = ilo();
+    cmd.arg(path.to_str().unwrap()).arg(engine).arg(fn_name);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for fn={fn_name} src=`{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // Don't trim — leading/trailing newlines matter for "did it auto-print?"
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn run_file_json(engine: &str, src: &str, fn_name: &str) -> String {
+    let path = write_src(
+        src,
+        &format!("{}_{}_json", fn_name, engine.trim_start_matches("--")),
+    );
+    let out = ilo()
+        .arg(path.to_str().unwrap())
+        .arg(engine)
+        .arg("--json")
+        .arg(fn_name)
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} --json failed for fn={fn_name}: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+// ── Sources ───────────────────────────────────────────────────────────────
+
+// 1. Print-loop at top level. Used to print "1\n2\n3\n3\n".
+const PRINT_LOOP: &str = "f>n;xs=[1 2 3];@x xs{prnt x}";
+
+// 2. Print-loop nested in a caller. Outer function consumes the loop's
+//    return value. `inner` must still return 3 so `+v 0` evaluates to 3.
+const NESTED_PRINT_LOOP: &str = "inner>n;xs=[1 2 3];@x xs{prnt x}\nouter>n;v=inner();+v 0";
+
+// 3. Empty-list loop at top level. Loop never runs, last_value stays Nil,
+//    function returns Nil. Used to print "nil\n".
+const EMPTY_LOOP: &str = "f>n;xs=[];@x xs{prnt x}";
+
+// 4. brk-loop at top level. Loop prints the running sum, breaks when i>=3.
+//    Function ends with the loop so the loop tail bubbles up. Suppressed.
+//    Body ends with `prnt s` so the loop's value type is `n` (typechecker
+//    requires the tail to resolve to the declared return type).
+const BRK_LOOP: &str = "f>n;s=0;@i 0..10{>=i 3{brk};s=+s i;prnt s}";
+
+// 5. While loop at top level. Body ends with `prnt i` for the same type
+//    reason as BRK_LOOP — the loop's value must type-check as `n`.
+const WHILE_LOOP: &str = "f>n;i=0;wh <i 3{i=+i 1;prnt i}";
+
+// 6. Trailing-expression sentinel (e.g. function returns 42). Loop is NOT
+//    the syntactic tail — there's a final `+42 0`. Must still print "42".
+const TRAILING_SENTINEL: &str = "f>n;xs=[1 2 3];@x xs{prnt x};+42 0";
+
+// 7. Early-return + loop tail. Guard early-returns 99 when n>0, otherwise
+//    the loop tail runs. Suppression must NOT apply (body has a `ret`-like
+//    path), so the value is printed for both branches.
+const EARLY_RETURN_THEN_LOOP: &str = "f n:n>n;>n 0{ret 99};xs=[1 2 3];@x xs{prnt x}";
+
+// 8. Explicit nil return. Pin that a function whose body-tail is a bare
+//    `nil` (NOT a loop) still auto-prints "nil". Suppression must be
+//    syntactic loop-tail only — never blanket-Nil — so legitimate
+//    Optional-returning functions like `nothing>O n;nil` keep working.
+const EXPLICIT_NIL: &str = "f>O n;nil";
+
+// ── Engine-coverage harness ───────────────────────────────────────────────
+
+fn check_all(engine: &str) {
+    // 1. Top-level print-loop: only "1\n2\n3\n" — no trailing duplicate.
+    let out = run_file(engine, PRINT_LOOP, "f", &[]);
+    assert_eq!(
+        out, "1\n2\n3\n",
+        "print-loop double-output regression engine={engine}: got `{out}`"
+    );
+
+    // 2. Nested: outer consumes inner. Loop body prints 1,2,3; outer returns
+    //    inner-return-value + 0 = 3, which DOES print because outer's tail is
+    //    `+v 0`, not a loop.
+    let out = run_file(engine, NESTED_PRINT_LOOP, "outer", &[]);
+    assert_eq!(
+        out, "1\n2\n3\n3\n",
+        "nested print-loop must still propagate inner's return engine={engine}: got `{out}`"
+    );
+
+    // 3. Empty loop: no body prints, Nil suppressed → empty stdout.
+    let out = run_file(engine, EMPTY_LOOP, "f", &[]);
+    assert_eq!(
+        out, "",
+        "empty-loop nil should be suppressed engine={engine}: got `{out}`"
+    );
+
+    // 4. brk-loop: body prints running sum (0,1,3) then brk before i=3 in the
+    //    next iteration. Loop tail value (3 from the last prnt) is suppressed.
+    let out = run_file(engine, BRK_LOOP, "f", &[]);
+    assert_eq!(
+        out, "0\n1\n3\n",
+        "brk-loop tail suppressed engine={engine}: got `{out}`"
+    );
+
+    // 5. while-loop: body increments and prints, prints 1,2,3. No trailing dupe.
+    let out = run_file(engine, WHILE_LOOP, "f", &[]);
+    assert_eq!(
+        out, "1\n2\n3\n",
+        "while-loop double-output engine={engine}: got `{out}`"
+    );
+
+    // 6. Trailing sentinel: must still auto-print 42.
+    let out = run_file(engine, TRAILING_SENTINEL, "f", &[]);
+    assert_eq!(
+        out, "1\n2\n3\n42\n",
+        "trailing-expression sentinel auto-print engine={engine}: got `{out}`"
+    );
+
+    // 7a. Early-return fires (n=1 > 0 → ret 99). Loop never runs. 99 prints
+    //     because the body has an early-return path so suppression is off.
+    let out = run_file(engine, EARLY_RETURN_THEN_LOOP, "f", &["1"]);
+    assert_eq!(
+        out, "99\n",
+        "early-return value must still print engine={engine}: got `{out}`"
+    );
+
+    // 7b. Early-return doesn't fire (n=0). Loop runs and prints 1,2,3, then
+    //     because the body has an early-return path the loop tail (3) also
+    //     prints — preserves the conservative rule.
+    let out = run_file(engine, EARLY_RETURN_THEN_LOOP, "f", &["0"]);
+    assert_eq!(
+        out, "1\n2\n3\n3\n",
+        "early-return + loop-tail conservative rule engine={engine}: got `{out}`"
+    );
+
+    // 7c. Explicit nil return: must still print "nil". The fix is loop-tail-
+    //     scoped, not blanket Nil suppression, so legitimate `>O n;nil`
+    //     functions are unaffected.
+    let out = run_file(engine, EXPLICIT_NIL, "f", &[]);
+    assert_eq!(
+        out, "nil\n",
+        "explicit nil return must auto-print engine={engine}: got `{out}`"
+    );
+
+    // 8. JSON mode unaffected: print-loop tail emits "{\"ok\":3}".
+    let out = run_file_json(engine, PRINT_LOOP, "f");
+    assert!(
+        out.contains("\"ok\":3") || out.contains("\"ok\": 3"),
+        "JSON mode must still emit structured result engine={engine}: got `{out}`"
+    );
+
+    // 8b. JSON mode for empty-loop: must still emit `{"ok":null}` (Nil).
+    let out = run_file_json(engine, EMPTY_LOOP, "f");
+    assert!(
+        out.contains("\"ok\":null") || out.contains("\"ok\": null"),
+        "JSON mode must still emit nil engine={engine}: got `{out}`"
+    );
+}
+
+#[test]
+fn loop_print_tree() {
+    check_all("--run-tree");
+}
+
+#[test]
+fn loop_print_vm() {
+    check_all("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn loop_print_cranelift() {
+    check_all("--run-cranelift");
+}


### PR DESCRIPTION
## Summary

Print-loops like `@x xs{prnt x}` at the function tail used to double-print at the top level: each item from the loop body via `prnt`, then the loop's last-body-value bubbled up as the program result and got auto-printed again. The well-known persona workaround was a trailing `+0 0` sentinel after every print-loop, called out as a "consistent irritant across all 5 programs" in the assessment doc (line 834) and as one of the top friction items at line 854.

Print-layer-only fix, scoped to `src/main.rs`. When the program's syntactic entry-function body ends with `@`/`wh` AND has no early-return path, the plain-text top-level auto-print is suppressed. Loop-as-expression semantics inside functions are completely unchanged - a caller that consumes such a function's return value still sees the loop's last body value. JSON mode is untouched so machine-readable consumers always get a structured result.

The check is syntactic, not value-based: a function that explicitly returns `nil` from a non-loop tail (e.g. `nothing>O n;nil`) still prints "nil" because the user asked for it.

## Repro

Before:
```
$ cat /tmp/p.ilo
print-each>n;xs=[1 2 3];@x xs{prnt x}
$ ilo /tmp/p.ilo print-each
1
2
3
3       <-- the loop's last-body-value, auto-printed again
```

After:
```
$ ilo /tmp/p.ilo print-each
1
2
3
```

Cross-engine: tree, VM, and Cranelift all agree.

## What's in the diff

Three commits, each one logical step:

1. **`suppress top-level auto-print when entry body ends in a loop`** - the helper (`program_result_should_suppress`) walks the entry function's AST tail and decides whether to suppress; `print_value` gains a `suppress_loop_tail` flag, plain mode honours it, JSON mode ignores it. All four engine runners (`run_default`, `run_cranelift_engine`, `run_vm_with_provider`, `run_interp_with_provider`) compute the flag once at dispatch and thread it to `print_value`. A separate `body_has_early_return` walker is the conservative safety valve: if the body contains any `ret` or braceless guard anywhere (including inside nested guards/match/loops), suppression is off, because we can't tell at print time whether the program's value came from the loop tail or from an explicit return.

2. **`update bare-loop-tail tests and example to use sentinel form`** - three pre-existing tests asserted the previous "function ends with a bare loop, auto-print the loop value" shape. They're updated to bind the loop value and end with a trailing expression, the same pattern `examples/loops.ilo` uses for every existing loop example. Inline comments explain the convention so future readers don't think the rewrite was cosmetic.

3. **`cross-engine regression test and example for print-loop suppression`** - `tests/regression_loop_print.rs` runs nine scenarios across tree/VM/Cranelift: top-level print-loop, nested print-loop (must still return the value), empty-loop, brk-loop, while-loop, trailing-sentinel non-regression, early-return + loop tail (conservative rule), explicit-nil return (non-regression), and JSON mode (non-regression). `examples/print-loop.ilo` documents the same scenarios with `-- run:`/`-- out:` annotations so `tests/examples_engines.rs` exercises them as higher-level engine-parity checks.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --release --features cranelift` - full suite passes
- [x] New `tests/regression_loop_print.rs` passes on all three engines
- [x] `tests/examples_engines.rs` picks up the new `examples/print-loop.ilo` and runs it on tree + VM
- [x] Manual repro confirmed: `1\n2\n3\n` instead of `1\n2\n3\n3\n` across all three engines
- [x] JSON mode unchanged: `--json` still emits `{"ok":3}` for the print-loop case and `{"ok":null}` for empty-loop
- [x] Nested case verified: `outer>n;v=inner();+v 0` where `inner` ends in a print-loop still returns 3 to `outer`

## Follow-ups

None blocking. If we ever want to revisit the early-return-present-plus-loop-tail edge case, the right place is runtime-flagging "did this value come from the loop tail?" inside the interpreter/VM/Cranelift - significant cross-backend plumbing, deferred unless a persona report surfaces the pain.