### PR TITLE
fix chained nil-coalesce mis-parse on arity-aware calls

### DIFF
--- a/examples/chained-nilcoalesce.ilo
+++ b/examples/chained-nilcoalesce.ilo
@@ -1,0 +1,14 @@
+-- Chained `??`: bare `f a ?? g b ?? d` parses as `(f a) ?? (g b) ?? d`.
+-- The arity-aware call parser stops each call at its arg count, then
+-- `??` falls out as left-associative infix. First non-nil wins.
+
+lookup k1:t k2:t>n;m=mset (mset mmap "a" 1) "b" 2;mget m k1 ?? mget m k2 ?? 99
+
+-- run: lookup "a" "b"
+-- out: 1
+
+-- run: lookup "x" "b"
+-- out: 2
+
+-- run: lookup "x" "y"
+-- out: 99

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1870,10 +1870,16 @@ impl Parser {
                     let arg_idx = args.len();
                     let in_fn_pos = self.is_fn_ref_position(&name, arg_idx);
                     args.push(self.parse_call_arg(in_fn_pos)?);
-                    // After each arg, if next is infix, stop
+                    // After each arg, if next is infix, stop. `??` is always
+                    // infix once we've already collected at least one arg —
+                    // `f a ?? b` means `(f a) ?? b`, never `f a (??b ...)`.
+                    // Without this, chained `f a ?? g b ?? d` mis-parses as
+                    // `f a (?? g b) (?? d)` because the prefix-binary scanner
+                    // sees `?? g b` as a valid prefix nil-coalesce form.
                     if let Some(tok) = self.peek()
                         && Self::is_infix_or_suffix_op(tok)
-                        && !self.looks_like_prefix_binary(self.pos)
+                        && (matches!(tok, Token::NilCoalesce)
+                            || !self.looks_like_prefix_binary(self.pos))
                     {
                         break;
                     }

--- a/tests/regression_mget_default.rs
+++ b/tests/regression_mget_default.rs
@@ -61,11 +61,29 @@ const PATHKEY_HIT: &str = r#"f>n;m=mset mmap "k" 5;ks=["k"];mget m ks.0 ?? 0"#;
 const CALLKEY_HIT: &str = r#"f>n;m=mset mmap "5" 7;mget m str 5 ?? 0"#;
 // Parenthesised key — defensive lower bound on the precedence.
 const PARENKEY_HIT: &str = r#"f>n;m=mset mmap "5" 7;mget m (str 5) ?? 0"#;
-// Note: bare-chained `mget m "a" ?? mget m "b" ?? 99` does NOT parse
-// today — the arity-aware call parser doesn't extend through a `??`
-// boundary, so the second `mget` slurps `m "b" ?? 99` as three args.
-// Bind each lookup into a temp first (`a=mget m "a";b=mget m "b";a??b??99`)
-// or parenthesise. Logged as a separate adjacent finding.
+
+// --- chained `mget m k ?? mget m k2 ?? d` ---
+//
+// Earlier, the post-arg break in `parse_call_or_atom` let `??` through
+// when followed by 2+ atoms (the prefix-binary lookahead matched), so
+// `mget m "a" ?? mget m "b" ?? 99` parsed as `mget m "a" (?? mget m) (?? "b" ...)`
+// and failed with ILO-T006 "expects 2 args, got 3". Now `??` is always
+// infix once at least one call arg has been collected.
+
+// First lookup hits — short-circuits before second `mget` runs.
+const CHAIN_FIRST_HIT: &str = r#"f>n;m=mset mmap "a" 1;mget m "a" ?? mget m "b" ?? 99"#;
+// First miss, second hits.
+const CHAIN_SECOND_HIT: &str = r#"f>n;m=mset mmap "b" 2;mget m "a" ?? mget m "b" ?? 99"#;
+// Both miss — default wins.
+const CHAIN_BOTH_MISS: &str = r#"f>n;m=mmap;mget m "a" ?? mget m "b" ?? 99"#;
+// Two-element chain with no trailing default.
+const CHAIN_NO_DEFAULT_HIT: &str = r#"f>O n;m=mset mmap "a" 1;mget m "a" ?? mget m "b""#;
+const CHAIN_NO_DEFAULT_MISS: &str = r#"f>O n;m=mset mmap "b" 2;mget m "a" ?? mget m "b""#;
+// `at` is another arity-2 builtin — confirm the fix isn't `mget`-specific.
+// (Skip the out-of-bounds case: engines disagree on whether `at` returns nil
+// or raises ILO-R004/ILO-R009, which is orthogonal to the parser fix.)
+const CHAIN_AT_FIRST_HIT: &str = r#"f>n;xs=[10 20 30];at xs 0 ?? at xs 1 ?? 0"#;
+const CHAIN_AT_SECOND_HIT: &str = r#"f>n;xs=[10 20 30];at xs 1 ?? at xs 2 ?? 0"#;
 
 fn check_all(engine: &str) {
     assert_eq!(
@@ -112,6 +130,41 @@ fn check_all(engine: &str) {
         run_file(engine, PARENKEY_HIT, "f"),
         "7",
         "parenkey hit engine={engine}"
+    );
+    assert_eq!(
+        run_file(engine, CHAIN_FIRST_HIT, "f"),
+        "1",
+        "chain first hit engine={engine}"
+    );
+    assert_eq!(
+        run_file(engine, CHAIN_SECOND_HIT, "f"),
+        "2",
+        "chain second hit engine={engine}"
+    );
+    assert_eq!(
+        run_file(engine, CHAIN_BOTH_MISS, "f"),
+        "99",
+        "chain both miss engine={engine}"
+    );
+    assert_eq!(
+        run_file(engine, CHAIN_NO_DEFAULT_HIT, "f"),
+        "1",
+        "chain no-default hit engine={engine}"
+    );
+    assert_eq!(
+        run_file(engine, CHAIN_NO_DEFAULT_MISS, "f"),
+        "2",
+        "chain no-default miss engine={engine}"
+    );
+    assert_eq!(
+        run_file(engine, CHAIN_AT_FIRST_HIT, "f"),
+        "10",
+        "chain at first hit engine={engine}"
+    );
+    assert_eq!(
+        run_file(engine, CHAIN_AT_SECOND_HIT, "f"),
+        "20",
+        "chain at second hit engine={engine}"
     );
 }
 


### PR DESCRIPTION
## Summary

Chained `mget m "a" ?? mget m "b" ?? 99` failed at the verifier with `ILO-T006 arity mismatch: 'mget' expects 2 args, got 3`. Single `mget m k ?? d` was fine; only chains broke.

Root cause is in `parse_call_or_atom`'s post-arg break. After each collected argument, the loop checks for an infix operator to stop on, but allows the prefix-binary lookahead (`looks_like_prefix_binary`) to override that break. `??` is registered as a prefix-binary candidate (so `g ??c 7` can pass a prefix-`??` sub-expression to `g`), and `?? mget m "b"` has 3 tail atoms which the scanner happily reads as a prefix nil-coalesce. So the first `mget` kept absorbing `?? mget m` as its third arg, then `"b" ?? 99` as its fourth, producing the bogus 3-arg verifier error.

Fix: once at least one argument has been collected for a call, `??` is unambiguously the infix nil-coalesce on the call result. Don't let the prefix-binary scanner pull it back into call-arg territory. The first-token case is left alone so prefix `??c 7` in a call-arg position still works.

## Repro

```
f>n;m=mset (mmap) "a" 1;mget m "a" ?? mget m "b" ?? 99
```

Before:
```
ILO-T006 arity mismatch: 'mget' expects 2 args, got 3
```

After:
```
1
```

## What's in the diff

- `src/parser/mod.rs`: in the post-arg infix check in `parse_call_or_atom`, treat `Token::NilCoalesce` as always-infix. One condition, one comment block explaining why.
- `tests/regression_mget_default.rs`: extend the existing cross-engine harness with chained `mget m k1 ?? mget m k2 ?? d` in first-hit, second-hit, both-miss and no-default shapes. Add an `at`-based pair to confirm the fix isn't `mget`-specific. Drop the stale comment that said chained `??` didn't parse.
- `examples/chained-nilcoalesce.ilo`: in-context learning example exercised across every engine by `tests/examples_engines.rs`.

## Test plan

- [x] Repro program returns the expected value across `--run-tree`, `--run-vm`, `--run-cranelift`.
- [x] Existing `regression_prefix_nil_coalesce` (covers `g ??c 7`) still passes — prefix-`??` in call-arg position is unaffected.
- [x] Existing `regression_mget_default` single-`mget` cases still pass.
- [x] `examples/chained-nilcoalesce.ilo` runs clean under the examples harness.
- [x] Full suite green: `cargo test --release --features cranelift`.
- [x] `cargo fmt --check`, `cargo clippy --all-targets --release --features cranelift` clean.

## Follow-ups

None. The post-arg infix check was the only place this leaked.