### PR TITLE
wire rgx/rgxall/fmt/rd/rdb through vm + cranelift via tree bridge

### DIFF
--- a/examples/builtin-bridge.ilo
+++ b/examples/builtin-bridge.ilo
@@ -1,0 +1,33 @@
+-- Generic tree-bridge: tree-only builtins now work on every engine.
+--
+-- Pre-fix, `rgx`, `rgxall`, `fmt` variadic, 2-arg `rd`, and `rdb` errored
+-- under `--run-vm` and `--run-cranelift` with
+-- `Compile error: undefined function: <name>`. The fix routes them through
+-- `OP_CALL_BUILTIN_TREE`, a single opcode that hands the call to the same
+-- interpreter dispatcher `--run-tree` uses. Tree, VM, and Cranelift now
+-- produce identical output, which is what the engine harness asserts when
+-- it replays this example across all three.
+
+-- rgx: every match of a no-group pattern.
+digits>L t;rgx "\d+" "a1 b22 c333"
+
+-- rgxall: every match with capture groups, uniform L (L t) shape.
+pairs>L (L t);rgxall "(\w+)=(\d+)" "x=1 y=22 z=333"
+
+-- fmt: variadic; bridge handles arbitrary argc by spilling regs to a
+-- contiguous slot before the call.
+sentence>t;fmt "{} hits across {} files" 3 1
+
+-- rdb: in-memory CSV parse. Result-returning, so the function returns
+-- R (L (L t)) t and the engine asserts on the wrapped form.
+parsed>R (L (L t)) t;rdb "a,1
+b,2" "csv"
+
+-- run: digits
+-- out: [1, 22, 333]
+-- run: pairs
+-- out: [[x, 1], [y, 22], [z, 333]]
+-- run: sentence
+-- out: 3 hits across 1 files
+-- run: parsed
+-- out: ~[[a, 1], [b, 2]]

--- a/examples/rgxall.ilo
+++ b/examples/rgxall.ilo
@@ -25,9 +25,3 @@ no-match>L (L t);rgxall "\d+" "no digits here"
 -- out: [[x, 1], [y, 22], [z, 333]]
 -- run: no-match
 -- out: []
-
--- VM and cranelift compilers don't yet wire builtin calls through to the
--- interpreter for rgx/rgxall (only --run-tree does). When that gap closes,
--- drop these skips.
--- engine-skip: vm
--- engine-skip: cranelift

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -369,6 +369,137 @@ impl Builtin {
     pub fn is_builtin(name: &str) -> bool {
         Self::from_name(name).is_some()
     }
+
+    /// Stable list of every `Builtin` variant, in canonical order.
+    ///
+    /// The position of each variant in this slice is its on-wire tag
+    /// for `OP_CALL_BUILTIN_TREE`. Stability matters: appending is fine,
+    /// reordering or removing entries breaks any persisted bytecode.
+    pub const ALL: &'static [Builtin] = &[
+        Builtin::Str,
+        Builtin::Num,
+        Builtin::Abs,
+        Builtin::Flr,
+        Builtin::Cel,
+        Builtin::Rou,
+        Builtin::Min,
+        Builtin::Max,
+        Builtin::Mod,
+        Builtin::Clamp,
+        Builtin::Pow,
+        Builtin::Sqrt,
+        Builtin::Log,
+        Builtin::Exp,
+        Builtin::Sin,
+        Builtin::Cos,
+        Builtin::Tan,
+        Builtin::Log10,
+        Builtin::Log2,
+        Builtin::Atan2,
+        Builtin::Sum,
+        Builtin::Cumsum,
+        Builtin::Avg,
+        Builtin::Median,
+        Builtin::Quantile,
+        Builtin::Stdev,
+        Builtin::Variance,
+        Builtin::Fft,
+        Builtin::Ifft,
+        Builtin::Transpose,
+        Builtin::Matmul,
+        Builtin::Dot,
+        Builtin::Len,
+        Builtin::Hd,
+        Builtin::At,
+        Builtin::Tl,
+        Builtin::Rev,
+        Builtin::Srt,
+        Builtin::Rsrt,
+        Builtin::Slc,
+        Builtin::Lst,
+        Builtin::Take,
+        Builtin::Drop,
+        Builtin::Unq,
+        Builtin::Flat,
+        Builtin::Has,
+        Builtin::Spl,
+        Builtin::Cat,
+        Builtin::Zip,
+        Builtin::Enumerate,
+        Builtin::Range,
+        Builtin::Window,
+        Builtin::Chunks,
+        Builtin::Setunion,
+        Builtin::Setinter,
+        Builtin::Setdiff,
+        Builtin::Map,
+        Builtin::Flt,
+        Builtin::Fld,
+        Builtin::Grp,
+        Builtin::Uniqby,
+        Builtin::Partition,
+        Builtin::Frq,
+        Builtin::Flatmap,
+        Builtin::Rnd,
+        Builtin::Rndn,
+        Builtin::Now,
+        Builtin::Dtfmt,
+        Builtin::Dtparse,
+        Builtin::Rd,
+        Builtin::Rdl,
+        Builtin::Rdb,
+        Builtin::Wr,
+        Builtin::Wrl,
+        Builtin::Prnt,
+        Builtin::Env,
+        Builtin::Trm,
+        Builtin::Upr,
+        Builtin::Lwr,
+        Builtin::Cap,
+        Builtin::Padl,
+        Builtin::Padr,
+        Builtin::Ord,
+        Builtin::Chr,
+        Builtin::Fmt,
+        Builtin::Fmt2,
+        Builtin::Rgx,
+        Builtin::Rgxall,
+        Builtin::Rgxsub,
+        Builtin::Jpth,
+        Builtin::Jdmp,
+        Builtin::Jpar,
+        Builtin::Rdjl,
+        Builtin::Get,
+        Builtin::Post,
+        Builtin::GetMany,
+        Builtin::Mmap,
+        Builtin::Mget,
+        Builtin::Mset,
+        Builtin::Mhas,
+        Builtin::Mkeys,
+        Builtin::Mvals,
+        Builtin::Mdel,
+        Builtin::Solve,
+        Builtin::Inv,
+        Builtin::Det,
+    ];
+
+    /// On-wire 8-bit tag for cross-engine builtin dispatch. See `ALL`.
+    pub fn tag(self) -> u8 {
+        // Linear search over a small dense table; this is only called
+        // at compile time by the bytecode emitter, not on the hot path.
+        Self::ALL
+            .iter()
+            .position(|b| *b == self)
+            .expect("Builtin::ALL must include every variant") as u8
+    }
+
+    /// Inverse of `tag`. Returns `None` for unknown tags so the VM/JIT
+    /// can surface a clean runtime error rather than panicking on a
+    /// malformed instruction.
+    pub fn from_tag(tag: u8) -> Option<Builtin> {
+        Self::ALL.get(tag as usize).copied()
+    }
 }
 
 /// Result of a char-by-signed-index lookup on a `&str`.
@@ -541,6 +672,132 @@ mod tests {
     fn non_builtin_returns_none() {
         assert_eq!(Builtin::from_name("foo"), None);
         assert_eq!(Builtin::from_name(""), None);
+    }
+
+    #[test]
+    fn tag_round_trips_for_every_builtin() {
+        // Anchor for the OP_CALL_BUILTIN_TREE bridge: every builtin must
+        // tag↔from_tag cleanly, and Builtin::ALL must list every variant
+        // covered by from_name (no silent drift).
+        for name in &[
+            "str",
+            "num",
+            "abs",
+            "flr",
+            "cel",
+            "rou",
+            "min",
+            "max",
+            "mod",
+            "clamp",
+            "pow",
+            "sqrt",
+            "log",
+            "exp",
+            "sin",
+            "cos",
+            "tan",
+            "log10",
+            "log2",
+            "atan2",
+            "sum",
+            "cumsum",
+            "avg",
+            "median",
+            "quantile",
+            "stdev",
+            "variance",
+            "fft",
+            "ifft",
+            "transpose",
+            "matmul",
+            "dot",
+            "len",
+            "hd",
+            "at",
+            "tl",
+            "rev",
+            "srt",
+            "rsrt",
+            "slc",
+            "lst",
+            "take",
+            "drop",
+            "unq",
+            "flat",
+            "has",
+            "spl",
+            "cat",
+            "zip",
+            "enumerate",
+            "range",
+            "window",
+            "chunks",
+            "setunion",
+            "setinter",
+            "setdiff",
+            "map",
+            "flt",
+            "fld",
+            "grp",
+            "uniqby",
+            "partition",
+            "frq",
+            "flatmap",
+            "rnd",
+            "rndn",
+            "now",
+            "dtfmt",
+            "dtparse",
+            "rd",
+            "rdl",
+            "rdb",
+            "wr",
+            "wrl",
+            "prnt",
+            "env",
+            "trm",
+            "upr",
+            "lwr",
+            "cap",
+            "padl",
+            "padr",
+            "ord",
+            "chr",
+            "fmt",
+            "fmt2",
+            "rgx",
+            "rgxall",
+            "rgxsub",
+            "jpth",
+            "jdmp",
+            "jpar",
+            "rdjl",
+            "get",
+            "post",
+            "get-many",
+            "mmap",
+            "mget",
+            "mset",
+            "mhas",
+            "mkeys",
+            "mvals",
+            "mdel",
+            "solve",
+            "inv",
+            "det",
+        ] {
+            let b = Builtin::from_name(name).unwrap_or_else(|| panic!("no builtin: {name}"));
+            let t = b.tag();
+            let round = Builtin::from_tag(t).unwrap_or_else(|| panic!("no from_tag for {name}"));
+            assert_eq!(b, round, "tag round-trip failed for {name}");
+        }
+        // No tag collisions.
+        let tags: Vec<u8> = Builtin::ALL.iter().map(|b| b.tag()).collect();
+        let mut sorted = tags.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(sorted.len(), tags.len(), "tag collision in Builtin::ALL");
     }
 
     fn unwrap_found(r: CharAtResult) -> char {

--- a/src/diagnostic/mod.rs
+++ b/src/diagnostic/mod.rs
@@ -178,6 +178,10 @@ impl From<&crate::vm::VmError> for Diagnostic {
             VmError::FieldNotFound { .. } => "ILO-R005",
             VmError::UnknownOpcode { .. } => "ILO-R013",
             VmError::Type(_) => "ILO-R004",
+            // Tree-bridge surfaces the interpreter's RuntimeError verbatim;
+            // R009 mirrors what the tree interpreter would produce for the
+            // same call, keeping diagnostic codes consistent across engines.
+            VmError::Runtime(_) => "ILO-R009",
         };
         Diagnostic::error(e.to_string()).with_code(code)
     }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -213,6 +213,23 @@ pub fn run(program: &Program, func_name: Option<&str>, args: Vec<Value>) -> Resu
     run_with_env(program, func_name, args, Env::new())
 }
 
+/// Dispatch a builtin call from the VM/Cranelift tree-bridge (`OP_CALL_BUILTIN_TREE`).
+///
+/// Used by `--run-vm` and `--run-cranelift` to delegate tree-only builtins
+/// (`rgx`, `rgxall`, `fmt` variadic, 2-arg `rd`, `rdb`) to the same code path
+/// the tree interpreter uses. Caller has already converted NanVal arg
+/// registers to owned `Value`s; we return an owned `Value` for the caller
+/// to NaN-box back into a result register.
+///
+/// Scope is deliberately limited to builtins that need no `Env`: no FnRef
+/// args, no user-function callbacks, no tool dispatch. The call_function
+/// dispatcher tolerates an empty Env for this subset because none of these
+/// builtins look up user bindings or invoke other functions.
+pub fn call_builtin_for_bridge(name: &str, args: Vec<Value>) -> Result<Value> {
+    let mut env = Env::new();
+    call_function(&mut env, name, args)
+}
+
 pub fn run_with_tools(
     program: &Program,
     func_name: Option<&str>,

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -155,6 +155,8 @@ struct HelperFuncs {
     // Datetime
     dtfmt: FuncId,
     dtparse: FuncId,
+    // Tree-bridge for tree-only builtins
+    call_builtin_tree: FuncId,
     // AOT-specific helpers
     get_arena_ptr: FuncId,
     get_registry_ptr: FuncId,
@@ -320,6 +322,7 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         getmany: declare_helper(module, "jit_getmany", 1, 1),
         dtfmt: declare_helper(module, "jit_dtfmt", 2, 1),
         dtparse: declare_helper(module, "jit_dtparse", 2, 1),
+        call_builtin_tree: declare_helper(module, "jit_call_builtin_tree", 3, 1),
         // AOT-specific helpers
         get_arena_ptr: declare_helper(module, "jit_get_arena_ptr", 0, 1),
         get_registry_ptr: declare_helper(module, "jit_get_registry_ptr", 0, 1),
@@ -1012,7 +1015,7 @@ fn compile_function_body(
                 | OP_UNQ | OP_UNIQBY | OP_PARTITION | OP_FRQ | OP_NUM | OP_RGXSUB | OP_ZIP
                 | OP_ENUMERATE | OP_RANGE | OP_WINDOW | OP_CHUNKS | OP_CUMSUM | OP_SETUNION
                 | OP_SETINTER | OP_SETDIFF | OP_FFT | OP_IFFT | OP_TRANSPOSE | OP_MATMUL
-                | OP_INV | OP_SOLVE | OP_DTFMT | OP_DTPARSE => {
+                | OP_INV | OP_SOLVE | OP_DTFMT | OP_DTPARSE | OP_CALL_BUILTIN_TREE => {
                     non_num_write[a] = true;
                     non_bool_write[a] = true;
                 }
@@ -2241,6 +2244,35 @@ fn compile_function_body(
                 let dv = builder.use_var(vars[d_idx]);
                 let fref = get_func_ref(&mut builder, module, helpers.rgxsub);
                 let call_inst = builder.ins().call(fref, &[bv, cv, dv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_CALL_BUILTIN_TREE => {
+                // Generic tree-bridge: A=result, B=Builtin::tag, C=argc;
+                // args contiguous in R[A+1..=A+argc]. Mirrors jit_cranelift.
+                let tag = b_idx as i64;
+                let argc = c_idx;
+                let tag_val = builder.ins().iconst(I64, tag);
+                let argc_val = builder.ins().iconst(I64, argc as i64);
+
+                let regs_ptr = if argc == 0 {
+                    builder.ins().iconst(I64, 0)
+                } else {
+                    let slot =
+                        builder.create_sized_stack_slot(cranelift_codegen::ir::StackSlotData::new(
+                            cranelift_codegen::ir::StackSlotKind::ExplicitSlot,
+                            (argc * 8) as u32,
+                            0,
+                        ));
+                    for i in 0..argc {
+                        let src = builder.use_var(vars[a_idx + 1 + i]);
+                        builder.ins().stack_store(src, slot, (i * 8) as i32);
+                    }
+                    builder.ins().stack_addr(I64, slot, 0)
+                };
+
+                let fref = get_func_ref(&mut builder, module, helpers.call_builtin_tree);
+                let call_inst = builder.ins().call(fref, &[tag_val, argc_val, regs_ptr]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -167,6 +167,8 @@ struct HelperFuncs {
     // Datetime
     dtfmt: FuncId,
     dtparse: FuncId,
+    // Tree-bridge for tree-only builtins (rgx, rgxall, fmt-variadic, etc.)
+    call_builtin_tree: FuncId,
 }
 
 fn declare_helper(module: &mut JITModule, name: &str, n_params: usize, n_returns: usize) -> FuncId {
@@ -321,6 +323,7 @@ fn register_helpers(builder: &mut JITBuilder) {
         ("jit_det", jit_det as *const u8),
         ("jit_dtfmt", jit_dtfmt as *const u8),
         ("jit_dtparse", jit_dtparse as *const u8),
+        ("jit_call_builtin_tree", jit_call_builtin_tree as *const u8),
     ];
     for &(name, ptr) in helpers {
         builder.symbol(name, ptr);
@@ -467,6 +470,7 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         det: declare_helper(module, "jit_det", 1, 1),
         dtfmt: declare_helper(module, "jit_dtfmt", 2, 1),
         dtparse: declare_helper(module, "jit_dtparse", 2, 1),
+        call_builtin_tree: declare_helper(module, "jit_call_builtin_tree", 3, 1),
     }
 }
 
@@ -1039,7 +1043,8 @@ fn compile_function_body(
                 | OP_RECNEW | OP_RECWITH
                 | OP_PRT | OP_RD | OP_RDL | OP_WR | OP_WRL | OP_TRM | OP_UPR | OP_LWR | OP_CAP
                 | OP_PADL | OP_PADR | OP_CHR | OP_UNQ | OP_UNIQBY | OP_PARTITION | OP_FRQ | OP_NUM
-                | OP_RGXSUB | OP_TRANSPOSE | OP_MATMUL | OP_DTFMT | OP_DTPARSE => {
+                | OP_RGXSUB | OP_TRANSPOSE | OP_MATMUL | OP_DTFMT | OP_DTPARSE
+                | OP_CALL_BUILTIN_TREE => {
                     non_num_write[a] = true;
                     non_bool_write[a] = true;
                 }
@@ -2346,6 +2351,40 @@ fn compile_function_body(
                 let dv = builder.use_var(vars[d_idx]);
                 let fref = get_func_ref(&mut builder, module, helpers.rgxsub);
                 let call_inst = builder.ins().call(fref, &[bv, cv, dv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_CALL_BUILTIN_TREE => {
+                // Generic bridge for tree-only builtins.
+                //   A = result_reg, B = Builtin::tag, C = argc
+                //   args live in R[A+1..=A+argc]
+                // Spill args to a stack slot, then call
+                // `jit_call_builtin_tree(tag, argc, regs_ptr)`.
+                let tag = b_idx as i64; // B field already extracted as u8 into b_idx
+                let argc = c_idx; // C field is argc
+                let tag_val = builder.ins().iconst(I64, tag);
+                let argc_val = builder.ins().iconst(I64, argc as i64);
+
+                let regs_ptr = if argc == 0 {
+                    // No args: pass a null pointer; the helper's slice
+                    // construction handles argc=0 without dereferencing.
+                    builder.ins().iconst(I64, 0)
+                } else {
+                    let slot =
+                        builder.create_sized_stack_slot(cranelift_codegen::ir::StackSlotData::new(
+                            cranelift_codegen::ir::StackSlotKind::ExplicitSlot,
+                            (argc * 8) as u32,
+                            0,
+                        ));
+                    for i in 0..argc {
+                        let src = builder.use_var(vars[a_idx + 1 + i]);
+                        builder.ins().stack_store(src, slot, (i * 8) as i32);
+                    }
+                    builder.ins().stack_addr(I64, slot, 0)
+                };
+
+                let fref = get_func_ref(&mut builder, module, helpers.call_builtin_tree);
+                let call_inst = builder.ins().call(fref, &[tag_val, argc_val, regs_ptr]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -18,6 +18,10 @@ pub enum VmError {
     UnknownOpcode { op: u8 },
     #[error("{0}")]
     Type(&'static str),
+    /// Dynamic runtime message produced by helpers (used by the tree-bridge
+    /// dispatcher to surface interpreter errors with their original wording).
+    #[error("{0}")]
+    Runtime(String),
 }
 
 type VmResult<T> = Result<T, VmError>;
@@ -265,6 +269,54 @@ pub(crate) const OP_PADR: u8 = 122; // R[A] = pad_right(R[B], R[C]) (text, width
 // Per-char codepoint round-trip — t->n and n->t (Unicode scalar, 1-arg each).
 pub(crate) const OP_ORD: u8 = 153; // R[A] = first-char codepoint of R[B]
 pub(crate) const OP_CHR: u8 = 154; // R[A] = single-char string for codepoint R[B]
+
+// Generic bridge for tree-only builtins (rgx, rgxall, fmt-variadic, rd 2-arg,
+// rdb, plus any future builtin that the VM/JIT hasn't natively lowered yet).
+//
+// Encoding (ABC):
+//   A = result_reg
+//   B = Builtin::tag()  (8-bit on-wire builtin id; see src/builtins.rs)
+//   C = argc            (number of args)
+//
+// The compiler guarantees args live contiguously in R[A+1..=A+argc], mirroring
+// OP_CALL's calling convention. The dispatcher copies them out, converts each
+// NanVal to an owned `Value`, calls the interpreter's `call_function` helper
+// (the same routine `--run-tree` already uses), then converts the result back
+// to a NanVal. RC: input NanVals are read by reference (no clone_rc); the
+// returned NanVal carries fresh RC=1 like every other heap-producing op.
+//
+// This is deliberately a runtime fallback, not a native lowering. Any builtin
+// that gets a dedicated opcode (`OP_RGXSUB`, `OP_FMT2`, etc.) is preferred by
+// the emitter — this op only fires when no specialised arm matches.
+pub(crate) const OP_CALL_BUILTIN_TREE: u8 = 155;
+
+/// Builtins eligible for tree-bridge dispatch when no specialised VM opcode
+/// matches the call shape. The list is deliberately narrow: it covers the
+/// regex/format/file-format family that has no FnRef args, so NanVal↔Value
+/// round-tripping is lossless. Adding a new entry here makes the builtin
+/// callable from `--run-vm` and `--run-cranelift` for free.
+///
+/// HOFs (`map`, `flt`, `fld`, `grp`, `flatmap`, `uniqby`, `partition`,
+/// 2-arg `srt`, dynamic-fmt `wr`) are NOT eligible: their function-reference
+/// argument can't survive the round-trip until FnRef nan-tagging lands.
+pub(crate) fn is_tree_bridge_eligible(b: crate::builtins::Builtin, argc: usize) -> bool {
+    use crate::builtins::Builtin;
+    match (b, argc) {
+        (Builtin::Rgx, 2) => true,
+        (Builtin::Rgxall, 2) => true,
+        (Builtin::Fmt, _) if argc >= 1 => true,
+        (Builtin::Rd, 2) => true,
+        (Builtin::Rdb, 2) => true,
+        _ => false,
+    }
+}
+
+/// Builtins that return a Result (`R _ t`) and therefore participate in
+/// the auto-unwrap (`!`) protocol when called via the tree bridge.
+pub(crate) fn tree_bridge_returns_result(b: crate::builtins::Builtin) -> bool {
+    use crate::builtins::Builtin;
+    matches!(b, Builtin::Rd | Builtin::Rdb)
+}
 
 pub(crate) const OP_GETMANY: u8 = 136; // R[A] = get_many(R[B])  (L t → L (R t t), concurrent fan-out)
 pub(crate) const OP_RDJL: u8 = 135; // R[A] = rdjl(R[B])  (read JSONL file → L (R _ t))
@@ -547,6 +599,72 @@ impl RegCompiler {
             "jump offset {offset_i32} exceeds i16 range — function body too large (max ~32K instructions)"
         );
         self.emit_abx(OP_JMP, 0, offset_i32 as i16 as u16);
+    }
+
+    /// Emit the OP_CALL_BUILTIN_TREE bridge for a tree-only builtin call.
+    ///
+    /// Layout matches OP_CALL: result lands in `R[A]` and args are placed
+    /// contiguously in `R[A+1..=A+argc]`. The dispatcher (VM + Cranelift)
+    /// reads from that slice, builds owned `Value`s, calls the interpreter's
+    /// `call_function` helper, and stores the result back into `R[A]`.
+    ///
+    /// Auto-unwrap (`!`) is supported for Result-returning builtins (`rd`,
+    /// `rdb`); other builtins assume non-Result returns. Verify already
+    /// rejects `!` on non-Result builtins.
+    fn emit_call_builtin_tree(
+        &mut self,
+        builtin: crate::builtins::Builtin,
+        args: &[Expr],
+        unwrap: bool,
+    ) -> u8 {
+        // Compile args first to whatever registers the expr compiler picks.
+        let arg_regs: Vec<u8> = args.iter().map(|a| self.compile_expr(a)).collect();
+
+        // Allocate the result register, then `argc` contiguous slots right
+        // after it. The VM/JIT dispatcher reads R[a+1..=a+argc] as the
+        // arg slice.
+        let a = self.alloc_reg();
+        assert!(
+            (self.next_reg as usize) + args.len() <= 255,
+            "register overflow: tree-bridge call requires too many slots"
+        );
+        let args_base = self.next_reg;
+        self.next_reg += args.len() as u8;
+        if self.next_reg > self.max_reg {
+            self.max_reg = self.next_reg;
+        }
+        for (i, &src) in arg_regs.iter().enumerate() {
+            let dst = args_base + i as u8;
+            if src != dst {
+                self.emit_abc(OP_MOVE, dst, src, 0);
+            }
+        }
+
+        assert!(args.len() <= 255, "tree-bridge call: too many args");
+        self.emit_abc(OP_CALL_BUILTIN_TREE, a, builtin.tag(), args.len() as u8);
+
+        // Only the result register stays live across the call.
+        self.next_reg = a + 1;
+        // The bridge returns a fully boxed value of unknown shape.
+        self.current_all_regs_numeric = false;
+
+        if unwrap {
+            // Result-returning builtins only; verify will have rejected `!`
+            // on a non-Result builtin before reaching here.
+            debug_assert!(
+                tree_bridge_returns_result(builtin),
+                "auto-unwrap on a non-Result tree-bridge builtin slipped past verify"
+            );
+            let check_reg = self.alloc_reg();
+            self.emit_abc(OP_ISOK, check_reg, a, 0);
+            let skip_ret = self.emit_jmpt(check_reg);
+            self.emit_abx(OP_RET, a, 0); // propagate Err
+            self.current.patch_jump(skip_ret);
+            self.emit_abc(OP_UNWRAP, a, a, 0); // extract Ok inner
+            self.next_reg = a + 1;
+        }
+
+        a
     }
 
     /// Try to emit a fused CMPK guard for a non-negated guard whose condition is
@@ -2407,11 +2525,28 @@ impl RegCompiler {
                             self.emit_abc(OP_MDEL, ra, rb, rc);
                             return ra;
                         }
-                        // Builtins that fall through to OP_CALL (interpreter handles them):
-                        // fmt (variadic), map/flt/fld/grp/flatmap (higher-order),
-                        // sum/avg/rgx/flat, rd 2-arg, rdb, wr 3-arg, srt 2-arg, etc.
+                        // Builtins that fall through:
+                        //   - tree-bridge eligible (rgx, rgxall, fmt-variadic, rd 2-arg, rdb)
+                        //     → routed to OP_CALL_BUILTIN_TREE below
+                        //   - HOFs (map/flt/fld/grp/flatmap/uniqby/partition/srt 2-arg/wr 3-arg
+                        //     with dynamic fmt) → still error; FnRef args can't round-trip
+                        //     through the bridge until FnRef NaN-tagging lands
                         _ => {}
                     }
+                }
+
+                // Tree-bridge: any builtin without a native VM opcode that
+                // takes no FnRef args. This is the interpreter-fallback path
+                // promised by the older "fall through to OP_CALL → interpreter"
+                // comments — those were aspirational; OP_CALL only routes user
+                // functions. The bridge converts NanVals to owned `Value`s,
+                // calls the same `call_function` the tree interpreter uses,
+                // then converts back. Slower than a native opcode but correct,
+                // and lets every tree-only builtin work on every engine.
+                if let Some(builtin) = Builtin::from_name(function)
+                    && is_tree_bridge_eligible(builtin, args.len())
+                {
+                    return self.emit_call_builtin_tree(builtin, args, *unwrap);
                 }
 
                 let arg_regs: Vec<u8> = args.iter().map(|a| self.compile_expr(a)).collect();
@@ -2863,7 +2998,7 @@ fn chunk_is_all_numeric(chunk: &Chunk) -> bool {
             | OP_HD | OP_AT | OP_LST | OP_TL | OP_FMT2 | OP_RGXSUB | OP_ZIP | OP_ENUMERATE
             | OP_WINDOW | OP_FFT | OP_IFFT | OP_RANGE | OP_CHUNKS | OP_CUMSUM | OP_SETUNION
             | OP_SETINTER | OP_SETDIFF | OP_TRANSPOSE | OP_MATMUL | OP_INV | OP_SOLVE
-            | OP_DTFMT | OP_DTPARSE => {
+            | OP_DTFMT | OP_DTPARSE | OP_CALL_BUILTIN_TREE => {
                 return false;
             }
             _ => {}
@@ -7181,6 +7316,48 @@ impl<'a> VM<'a> {
                         Err(_) => vm_err!(VmError::Type("rgxsub: invalid regex pattern")),
                     }
                 }
+                OP_CALL_BUILTIN_TREE => {
+                    // Generic bridge for tree-only builtins. Layout:
+                    //   A = result_reg, B = Builtin::tag, C = argc
+                    //   args live in R[A+1..=A+argc]
+                    let a = ((inst >> 16) & 0xFF) as usize + base;
+                    let tag = ((inst >> 8) & 0xFF) as u8;
+                    let argc = (inst & 0xFF) as usize;
+                    let builtin = match crate::builtins::Builtin::from_tag(tag) {
+                        Some(b) => b,
+                        None => {
+                            vm_err!(VmError::Type(
+                                "call-builtin-tree: unknown builtin tag (bytecode mismatch)"
+                            ));
+                        }
+                    };
+
+                    // Collect args as owned Values. We deliberately do not
+                    // mutate the source registers — the bridge owns its copies
+                    // and drops them when the temporary Vec falls out of scope.
+                    let mut value_args: Vec<Value> = Vec::with_capacity(argc);
+                    for i in 0..argc {
+                        let v = reg!(a + 1 + i);
+                        value_args.push(v.to_value());
+                    }
+
+                    // Run the same dispatcher the tree interpreter uses.
+                    // No env is needed for the bridge-eligible set (no FnRef
+                    // args, no user-function callbacks), so we hand it an
+                    // empty `Program` shell.
+                    let result = match crate::interpreter::call_builtin_for_bridge(
+                        builtin.name(),
+                        value_args,
+                    ) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            vm_err!(VmError::Runtime(e.message));
+                        }
+                    };
+
+                    let nv = NanVal::from_value(&result);
+                    reg_set!(a, nv);
+                }
                 OP_TAKE => {
                     let a = ((inst >> 16) & 0xFF) as usize + base;
                     let b = ((inst >> 8) & 0xFF) as usize + base;
@@ -9714,6 +9891,50 @@ pub(crate) extern "C" fn jit_slc(a: u64, start: u64, end: u64) -> u64 {
         return NanVal::heap_list(sliced).0;
     }
     TAG_NIL
+}
+
+/// Cranelift bridge for tree-only builtins (rgx, rgxall, fmt-variadic, 2-arg
+/// rd, rdb, and any future entry added to `is_tree_bridge_eligible`).
+///
+/// Signature: `(tag, argc, regs_ptr) -> u64`. The caller stack-spills the
+/// arg registers into a contiguous `argc`-element NanVal buffer and passes
+/// the address as `regs_ptr`. We re-box each arg as a `Value`, dispatch via
+/// the interpreter's `call_function`, and return the NanVal of the result.
+///
+/// Errors return `TAG_NIL` (matching the existing JIT helper convention; see
+/// `jit_rgxsub` and `jit_rd` for precedent). A future native opcode for a
+/// specific builtin can supersede this bridge without changing callers.
+///
+/// SAFETY: `regs_ptr` must point to at least `argc` valid `NanVal`s in
+/// readable memory for the duration of the call. The compiler guarantees
+/// this by spilling registers into a sized stack slot of `argc * 8` bytes
+/// immediately before the call instruction.
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_call_builtin_tree(tag: u64, argc: u64, regs_ptr: u64) -> u64 {
+    let tag = tag as u8;
+    let argc = argc as usize;
+    let builtin = match crate::builtins::Builtin::from_tag(tag) {
+        Some(b) => b,
+        None => return TAG_NIL,
+    };
+    // SAFETY: caller guarantees `regs_ptr` points to `argc` valid NanVals.
+    // NanVal is Copy (u64); reading by value never aliases.
+    let regs: &[NanVal] = unsafe {
+        if argc == 0 {
+            &[]
+        } else {
+            std::slice::from_raw_parts(regs_ptr as *const NanVal, argc)
+        }
+    };
+    let mut value_args: Vec<Value> = Vec::with_capacity(argc);
+    for nv in regs {
+        value_args.push(nv.to_value());
+    }
+    match crate::interpreter::call_builtin_for_bridge(builtin.name(), value_args) {
+        Ok(v) => NanVal::from_value(&v).0,
+        Err(_) => TAG_NIL,
+    }
 }
 
 #[cfg(feature = "cranelift")]

--- a/tests/regression_builtin_bridge.rs
+++ b/tests/regression_builtin_bridge.rs
@@ -1,0 +1,172 @@
+// Regression coverage for the generic `OP_CALL_BUILTIN_TREE` bridge that
+// lets tree-only builtins (rgx, rgxall, fmt variadic, 2-arg rd, rdb) run
+// under `--run-vm` and `--run-cranelift` via interpreter fallback.
+//
+// Pre-fix, these all failed at VM compile time with
+// `Compile error: undefined function: <name>` because the VM emitter fell
+// through to OP_CALL's user-function lookup. The bridge routes them through
+// the same `interpreter::call_function` the tree engine uses, so every
+// engine produces identical output for the same source.
+//
+// Every test runs on tree, VM, and Cranelift, asserting all three engines
+// agree on the result. That is the contract: future native lowerings can
+// graduate any specific builtin off the bridge without changing user-visible
+// behaviour.
+
+use std::process::Command;
+
+const ENGINES: &[&str] = &["--run-tree", "--run-vm", "--run-cranelift"];
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_engine(src: &str, engine: &str) -> String {
+    let out = ilo()
+        .args([src, engine, "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Asserts the same source produces `expected` on every engine.
+fn check(src: &str, expected: &str) {
+    for engine in ENGINES {
+        let actual = run_engine(src, engine);
+        assert_eq!(
+            actual, expected,
+            "engine={engine}, src=`{src}`: got `{actual}`, expected `{expected}`"
+        );
+    }
+}
+
+// ── rgx ────────────────────────────────────────────────────────────────
+
+#[test]
+fn rgx_no_group_returns_all_matches() {
+    // Pre-fix: tree returned `[1, 2, 3]`; VM/Cranelift errored with
+    // `Compile error: undefined function: rgx`.
+    check(r#"f>L t;rgx "\d+" "a1 b2 c3""#, "[1, 2, 3]");
+}
+
+#[test]
+fn rgx_with_group_returns_first_match_groups() {
+    // With a capture group, `rgx` returns the groups from the first match
+    // only (`rgxall` is the bulk variant). Same semantics on every engine.
+    check(r#"f>L t;rgx "(\w+)=(\d+)" "x=1 y=22 z=333""#, "[x, 1]");
+}
+
+#[test]
+fn rgx_no_match_returns_empty_list() {
+    check(r#"f>L t;rgx "\d+" "no digits""#, "[]");
+}
+
+// ── rgxall ─────────────────────────────────────────────────────────────
+
+#[test]
+fn rgxall_html_extraction_cross_engine() {
+    // The real-world HTML-scrape case that motivated `rgxall`. Cranelift
+    // and VM must agree with tree byte-for-byte.
+    check(
+        r#"f>L (L t);rgxall "<h2>([^<]+)</h2>" "<h2>a</h2> <h2>b</h2> <h2>c</h2>""#,
+        "[[a], [b], [c]]",
+    );
+}
+
+#[test]
+fn rgxall_two_groups_cross_engine() {
+    check(
+        r#"f>L (L t);rgxall "(\w+)=(\d+)" "x=1 y=22 z=333""#,
+        "[[x, 1], [y, 22], [z, 333]]",
+    );
+}
+
+// ── fmt (variadic) ─────────────────────────────────────────────────────
+
+#[test]
+fn fmt_zero_holes() {
+    check(r#"f>t;fmt "literal""#, "literal");
+}
+
+#[test]
+fn fmt_one_hole() {
+    check(r#"f>t;fmt "x={}" 42"#, "x=42");
+}
+
+#[test]
+fn fmt_three_holes_mixed_types() {
+    // Variadic with a mix of number and text args — the case that
+    // motivated the variadic shape over a fixed-arity opcode.
+    check(r#"f>t;fmt "{} {} {}" 1 "two" 3"#, "1 two 3");
+}
+
+#[test]
+fn fmt_extra_holes_left_as_literal() {
+    // When the template has more `{}`s than args, the extra placeholders
+    // pass through unchanged. Documented behaviour that the bridge must
+    // preserve across engines.
+    check(r#"f>t;fmt "{} {}" 1"#, "1 {}");
+}
+
+// ── rd (2-arg) ─────────────────────────────────────────────────────────
+
+#[test]
+fn rd_csv_two_arg_in_block_function() {
+    // 2-arg `rd path fmt` returns `R (L (L t)) t`; auto-unwrap with `!`
+    // requires the enclosing function to also return a Result.
+    use std::io::Write;
+    let mut path = std::env::temp_dir();
+    path.push(format!("ilo-bridge-rd-{}.csv", std::process::id()));
+    {
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "a,1").unwrap();
+        writeln!(f, "b,2").unwrap();
+    }
+    let src = format!(r#"f>R (L (L t)) t;rd "{}" "csv""#, path.to_str().unwrap());
+    check(&src, "~[[a, 1], [b, 2]]");
+    let _ = std::fs::remove_file(&path);
+}
+
+// ── rdb ────────────────────────────────────────────────────────────────
+
+#[test]
+fn rdb_csv_cross_engine() {
+    // `rdb` parses an in-memory buffer in the given format; same dispatcher
+    // as `rd`, so the bridge plumbing must handle both. Newline escapes
+    // resolve at the string literal level.
+    check(
+        r#"f>R (L (L t)) t;rdb "a,1
+b,2" "csv""#,
+        "~[[a, 1], [b, 2]]",
+    );
+}
+
+#[test]
+fn rdb_csv_with_bang_unwrap() {
+    // Auto-unwrap `!` on a Result-returning bridge call: enclosing fn must
+    // return Result, and `!` extracts the Ok inner. The wrap markers vanish
+    // from the printed form because what's left is the inner list.
+    check(
+        r#"f>R (L (L t)) t;rdb! "a,1
+b,2" "csv""#,
+        "[[a, 1], [b, 2]]",
+    );
+}
+
+// ── Cross-engine determinism guard ────────────────────────────────────
+
+#[test]
+fn engines_agree_on_chained_bridge_calls() {
+    // Two bridge calls feeding each other: rgx output piped into fmt.
+    // Catches state-leak bugs where a stale RC or NanVal tag survives
+    // across consecutive bridge invocations.
+    check(
+        r#"f>t;hits=rgx "\d+" "a1 b2 c3";fmt "{} hits" len hits"#,
+        "3 hits",
+    );
+}

--- a/tests/regression_rgxall.rs
+++ b/tests/regression_rgxall.rs
@@ -3,44 +3,41 @@
 // No-group patterns wrap the whole match in a single-element inner list,
 // so the outer shape stays predictable regardless of group count.
 //
-// Engine coverage: tree-only.
-//
-// The sibling builtin `rgx` is also tree-only today (both --run-vm and
-// --run-cranelift report `Compile error: undefined function: rgx` on main).
-// The VM compiler's "falls through to OP_CALL → interpreter" comment at
-// src/vm/mod.rs:2394-2397 is aspirational, not current — there is no
-// builtin bridge in OP_CALL's dispatcher today. Wiring rgx/rgxall through
-// the VM and cranelift is a separate, larger fix (touches verify, VM
-// compile, JIT compile) and out of scope for this PR. Keeping rgxall
-// tree-only matches rgx's actual reality; when the VM bridge lands, both
-// will switch on together and these tests should grow to check all three
-// engines.
+// Engine coverage: tree, VM, Cranelift JIT. The tree-only restriction
+// noted in the original landing PR is gone — `rgxall` (and its siblings
+// `rgx`, `fmt` variadic, 2-arg `rd`, `rdb`) now route through the generic
+// `OP_CALL_BUILTIN_TREE` bridge in the VM and Cranelift JIT, so every
+// engine produces identical output.
 
 use std::process::Command;
+
+const ENGINES: &[&str] = &["--run-tree", "--run-vm", "--run-cranelift"];
 
 fn ilo() -> Command {
     Command::new(env!("CARGO_BIN_EXE_ilo"))
 }
 
-fn run_text(src: &str) -> String {
+fn run_text_engine(src: &str, engine: &str) -> String {
     let out = ilo()
-        .args([src, "--run-tree", "f"])
+        .args([src, engine, "f"])
         .output()
         .expect("failed to run ilo");
     assert!(
         out.status.success(),
-        "ilo --run-tree failed for `{src}`: stderr={}",
+        "ilo {engine} failed for `{src}`: stderr={}",
         String::from_utf8_lossy(&out.stderr)
     );
     String::from_utf8_lossy(&out.stdout).trim().to_string()
 }
 
 fn check(src: &str, expected: &str) {
-    let actual = run_text(src);
-    assert_eq!(
-        actual, expected,
-        "src=`{src}`: got `{actual}`, expected `{expected}`"
-    );
+    for engine in ENGINES {
+        let actual = run_text_engine(src, engine);
+        assert_eq!(
+            actual, expected,
+            "engine={engine}, src=`{src}`: got `{actual}`, expected `{expected}`"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Tree-only builtins (`rgx`, `rgxall`, variadic `fmt`, 2-arg `rd path fmt`, `rdb`) errored under `--run-vm` and `--run-cranelift` with `Compile error: undefined function: <name>`. The "falls through to OP_CALL -> interpreter" comments in the VM compiler were aspirational, never real: OP_CALL only routes user-defined functions via `func_names`.

This adds `OP_CALL_BUILTIN_TREE`, a single generic opcode that hands the call to the same `interpreter::call_function` the tree engine already uses. Every bridge-eligible builtin now runs identically across tree, VM, and Cranelift JIT/AOT, and the manifesto win is permanent: every future tree-only builtin we add gets cross-engine coverage for free by appending one line to the eligibility allowlist. No more agent retry tax for picking the "wrong" engine on regex- or format-heavy work.

## Repro

Before:
```
$ ilo 'f>L t;rgx "\d+" "a1 b2"' --run-vm f
Compile error: undefined function: rgx

$ ilo 'f>t;fmt "x={} y={}" 1 2' --run-cranelift f
Compile error: undefined function: fmt
```

After:
```
$ ilo 'f>L t;rgx "\d+" "a1 b2"' --run-vm f
[1, 2]

$ ilo 'f>t;fmt "x={} y={}" 1 2' --run-cranelift f
x=1 y=2
```

Every test in `tests/regression_builtin_bridge.rs` asserts tree/VM/Cranelift agreement byte-for-byte.

## What's in the diff

Six commits, each one coherent change:

1. **`add Builtin::ALL stable table and tag/from_tag round-trip`** - Wire format for cross-engine dispatch: an append-only slice of every `Builtin` variant, plus `tag()`/`from_tag()` helpers. Documented as stability-critical (appending fine, reordering breaks bytecode). Unit test asserts round-trip across every builtin.

2. **`add interpreter::call_builtin_for_bridge entry point`** - Thin wrapper around `call_function` so the VM/JIT can dispatch without threading an `Env`. Scope limited to builtins that don't need FnRef resolution or user-function lookup.

3. **`wire OP_CALL_BUILTIN_TREE through vm compile and dispatch`** - New opcode 155, encoded ABC: A=result, B=tag, C=argc; args live contiguously in `R[A+1..=A+argc]` (mirrors OP_CALL). Compiler-side allowlist (`is_tree_bridge_eligible`) gates which builtins route through the bridge — currently `rgx`/`rgxall`/`fmt`/`rd 2-arg`/`rdb`. Auto-unwrap (`!`) honoured for `rd`/`rdb`. VM dispatcher converts NanVals to owned `Value`s, calls the bridge, NaN-boxes back; runtime errors surface through a new `VmError::Runtime(String)` variant mapped to `ILO-R009` so error wording matches the tree engine.

4. **`wire OP_CALL_BUILTIN_TREE through cranelift jit and aot backends`** - Both backends spill `argc` register variables into a sized stack slot, call `jit_call_builtin_tree(tag, argc, regs_ptr)`, and assign the return value back to the result register. `argc=0` passes null without dereferencing. JIT helper returns `TAG_NIL` on error to match the existing `jit_rgxsub`/`jit_rd` contract.

5. **`test: cross-engine regression coverage for rgx/fmt/rd/rdb bridge`** - 13 tests in `tests/regression_builtin_bridge.rs`, each running tree/VM/Cranelift and asserting identical output. Covers rgx (no-group, group, no-match), rgxall (HTML extraction, two-group), fmt (zero/one/three holes, extra-holes literal), 2-arg rd (real tempfile), rdb (with and without `!`), and a chained-call determinism guard. New `examples/builtin-bridge.ilo` is exercised by the example harness across every engine.

6. **`lift tree-only restriction on rgxall regression and example`** - `regression_rgxall.rs` now iterates all three engines per test; the tree-only framing is gone. `examples/rgxall.ilo` drops its vm/cranelift engine-skip pragmas.

## Test plan

- [x] `cargo build --release --features cranelift`
- [x] `cargo test --release --features cranelift` (full suite green; new `regression_builtin_bridge` + cross-engine `regression_rgxall` + `examples_all_engines` all pass)
- [x] `cargo fmt`
- [x] `cargo clippy --release --features cranelift --all-targets -- -D warnings`
- [x] Manual cross-engine repro for every bridge-eligible call shape

## Follow-ups (not in this PR)

- HOFs (`map`/`flt`/`fld`/`grp`/`flatmap`/`uniqby`/`partition`/2-arg `srt`/dynamic-fmt 3-arg `wr`) still fall through to the user-function OP_CALL path because their FnRef args can't survive the NanVal round-trip yet. Out of scope; tracked separately under the `ilo-fix-builtins-hof` worktree.
- The JIT helper returns `TAG_NIL` on regex compile or arg-type errors rather than propagating a proper runtime error, matching the existing JIT helper contract (`jit_rgxsub`, `jit_rd`, etc.). A general JIT-error-propagation pass is its own piece of work.
- Any specific bridge-eligible builtin can be graduated to a native opcode later without touching the bridge; the emitter just picks the native arm when one matches.