### PR TITLE
fix: comments above bound-call lines no longer corrupt parsing

### DIFF
--- a/examples/comment-above-call.ilo
+++ b/examples/comment-above-call.ilo
@@ -1,0 +1,37 @@
+-- Comments above a paren-bound call must not corrupt parsing.
+-- Previously a comment immediately above `m=(fmt "k={}" 1)` made the
+-- function body empty and reported a misleading error inside the
+-- format string. Comments are free per the manifesto; this example
+-- pins the contract across every engine.
+
+fmt-with-leading-comment>t
+  -- format a key-value pair
+  m=(fmt "k={}" 1)
+  m
+
+stacked-comments>n
+  -- one
+  -- two
+  -- three
+  x=42
+  x
+
+comment-between-bindings>n
+  a=1
+  -- mid-body note
+  b=2
+  +a b
+
+dashes-in-string>t
+  -- the `--` inside the string is not a comment
+  m="hello -- world"
+  m
+
+-- run: fmt-with-leading-comment
+-- out: k=1
+-- run: stacked-comments
+-- out: 42
+-- run: comment-between-bindings
+-- out: 3
+-- run: dashes-in-string
+-- out: hello -- world

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -187,13 +187,50 @@ pub fn normalize_newlines(source: &str) -> String {
     let mut last_significant: Option<char> = None;
 
     while let Some(c) = chars.next() {
-        if c == '\n' {
+        if c == '"' {
+            // Pass through string literal content verbatim so `--` inside a
+            // string isn't mistaken for a comment, and so `\n` (if ever present
+            // inside a string) isn't rewritten to `;`. Mirrors logos's string
+            // regex: closing quote terminates unless escaped.
+            out.push(c);
+            last_significant = Some(c);
+            while let Some(sc) = chars.next() {
+                out.push(sc);
+                if sc == '\\' {
+                    if let Some(esc) = chars.next() {
+                        out.push(esc);
+                    }
+                } else if sc == '"' {
+                    last_significant = Some(sc);
+                    break;
+                }
+            }
+        } else if c == '-' && chars.peek() == Some(&'-') {
+            // `--` starts a line comment. Drop the comment content (including
+            // both dashes) up to but not including the next `\n`, so the
+            // following `\n` is handled normally by the loop. This matches the
+            // logos `--[^\n]*` skip rule but runs BEFORE newline normalization,
+            // so an indented comment line doesn't bleed `;` separators into
+            // the comment body where the logos regex would then swallow them.
+            chars.next(); // consume second '-'
+            while let Some(&nc) = chars.peek() {
+                if nc == '\n' {
+                    break;
+                }
+                chars.next();
+            }
+            // Do not push anything; do not update last_significant. The
+            // surrounding `\n` handling on the next loop iteration emits the
+            // appropriate `;` or newline based on the line that follows.
+        } else if c == '\n' {
             // Check if next line is indented (starts with space or tab)
             if matches!(chars.peek(), Some(' ') | Some('\t')) {
                 // Indented continuation → emit `;` and skip the whitespace
                 // But first check if the last non-whitespace char was `{` — if so, skip the `;`
-                if last_significant == Some('{') {
-                    // Don't emit `;` after `{`, just skip whitespace
+                // Also skip if `out` already ends in `;` (e.g. previous line
+                // was a comment that produced no significant output).
+                if last_significant == Some('{') || out.ends_with(';') {
+                    // Don't emit `;` after `{` or an existing `;`, just skip whitespace
                 } else {
                     out.push(';');
                 }
@@ -202,7 +239,8 @@ pub fn normalize_newlines(source: &str) -> String {
                     chars.next();
                 }
                 // If the continuation line starts with `}`, don't add `;` before it
-                if chars.peek() == Some(&'}') && last_significant != Some('{') {
+                if chars.peek() == Some(&'}') && last_significant != Some('{') && out.ends_with(';')
+                {
                     out.pop(); // remove the `;` we just pushed
                 }
             } else if chars.peek() == Some(&'}') {

--- a/tests/regression_comment_parse_corrupt.rs
+++ b/tests/regression_comment_parse_corrupt.rs
@@ -1,0 +1,191 @@
+// Regression: an indented `--` comment line above a paren-bound call
+// silently corrupted parsing. `normalize_newlines` (src/lexer/mod.rs)
+// rewrites `\n`+indent to `;` before the logos lexer's `--[^\n]*`
+// comment-skip runs. On an indented comment line, the trailing `\n`
+// also became `;`, so the comment-skip regex (which stops at `\n`)
+// greedily ate the comment text plus every following statement up to
+// the next non-indented newline. The function body ended up empty and
+// the diagnostic pointed many lines past the actual cause (typically
+// inside a format-string `{}` placeholder), costing ~15 minutes of
+// bisection per occurrence.
+//
+// The fix detects `--` directly inside `normalize_newlines` and skips
+// past comment content without emitting `;`, leaving the trailing `\n`
+// intact for the loop's existing newline handling. Strings are passed
+// through verbatim so `--` inside a string literal is not mistaken for
+// a comment.
+//
+// Tests run the same repro across every engine to anchor the
+// invariant that comments are free at every layer.
+
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_file(engine: &str, src: &str, entry: &str) -> (bool, String, String) {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let seq = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let path = std::env::temp_dir().join(format!(
+        "ilo_comment_parse_{}_{}.ilo",
+        std::process::id(),
+        seq
+    ));
+    std::fs::write(&path, src).unwrap();
+    let out = ilo()
+        .args([path.to_str().unwrap(), engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+// The original repro from the assessment doc: indented `--` comment
+// immediately above a paren-bound `fmt` call.
+const PAREN_BOUND_FMT: &str = "main>t\n  -- build the thing\n  m=(fmt \"k={}\" 1)\n  m\n";
+
+// Comment between two bindings (no paren-bound RHS) — also broke the
+// same way before the fix because the comment text was swallowed
+// across the synthesised `;`.
+const COMMENT_BETWEEN_BINDINGS: &str = "main>n\n  a=1\n  -- midline note\n  b=2\n  +a b\n";
+
+// Multiple comment lines in a row.
+const STACKED_COMMENTS: &str = "main>n\n  -- one\n  -- two\n  -- three\n  x=42\n  x\n";
+
+// Comment containing characters that look like operators / punctuation
+// (`{}`, `;`, `()`) — the comment-skip path must not be confused.
+const COMMENT_WITH_PUNCT: &str = "main>n\n  -- format is {} ; (yes)\n  x=7\n  x\n";
+
+// `--` appearing inside a string literal must NOT be treated as a
+// comment by normalize_newlines.
+const DASHES_IN_STRING: &str = "main>t\n  m=\"hello -- world\"\n  m\n";
+
+fn check_paren_bound_fmt(engine: &str) {
+    let (ok, stdout, stderr) = run_file(engine, PAREN_BOUND_FMT, "main");
+    assert!(
+        ok,
+        "engine={engine}: paren-bound fmt with leading comment failed: stderr={stderr}"
+    );
+    assert_eq!(stdout, "k=1", "engine={engine}: wrong output");
+}
+
+fn check_comment_between_bindings(engine: &str) {
+    let (ok, stdout, stderr) = run_file(engine, COMMENT_BETWEEN_BINDINGS, "main");
+    assert!(
+        ok,
+        "engine={engine}: midline comment broke parsing: stderr={stderr}"
+    );
+    assert_eq!(stdout, "3", "engine={engine}: wrong output");
+}
+
+fn check_stacked_comments(engine: &str) {
+    let (ok, stdout, stderr) = run_file(engine, STACKED_COMMENTS, "main");
+    assert!(
+        ok,
+        "engine={engine}: stacked comments broke parsing: stderr={stderr}"
+    );
+    assert_eq!(stdout, "42", "engine={engine}: wrong output");
+}
+
+fn check_comment_with_punct(engine: &str) {
+    let (ok, stdout, stderr) = run_file(engine, COMMENT_WITH_PUNCT, "main");
+    assert!(
+        ok,
+        "engine={engine}: comment with punctuation broke parsing: stderr={stderr}"
+    );
+    assert_eq!(stdout, "7", "engine={engine}: wrong output");
+}
+
+fn check_dashes_in_string(engine: &str) {
+    let (ok, stdout, stderr) = run_file(engine, DASHES_IN_STRING, "main");
+    assert!(
+        ok,
+        "engine={engine}: dashes-in-string broke parsing: stderr={stderr}"
+    );
+    assert_eq!(stdout, "hello -- world", "engine={engine}: wrong output");
+}
+
+#[test]
+fn paren_bound_fmt_tree() {
+    check_paren_bound_fmt("--run-tree");
+}
+
+#[test]
+fn paren_bound_fmt_vm() {
+    check_paren_bound_fmt("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn paren_bound_fmt_cranelift() {
+    check_paren_bound_fmt("--run-cranelift");
+}
+
+#[test]
+fn comment_between_bindings_tree() {
+    check_comment_between_bindings("--run-tree");
+}
+
+#[test]
+fn comment_between_bindings_vm() {
+    check_comment_between_bindings("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn comment_between_bindings_cranelift() {
+    check_comment_between_bindings("--run-cranelift");
+}
+
+#[test]
+fn stacked_comments_tree() {
+    check_stacked_comments("--run-tree");
+}
+
+#[test]
+fn stacked_comments_vm() {
+    check_stacked_comments("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn stacked_comments_cranelift() {
+    check_stacked_comments("--run-cranelift");
+}
+
+#[test]
+fn comment_with_punct_tree() {
+    check_comment_with_punct("--run-tree");
+}
+
+#[test]
+fn comment_with_punct_vm() {
+    check_comment_with_punct("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn comment_with_punct_cranelift() {
+    check_comment_with_punct("--run-cranelift");
+}
+
+#[test]
+fn dashes_in_string_tree() {
+    check_dashes_in_string("--run-tree");
+}
+
+#[test]
+fn dashes_in_string_vm() {
+    check_dashes_in_string("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn dashes_in_string_cranelift() {
+    check_dashes_in_string("--run-cranelift");
+}


### PR DESCRIPTION
## Summary

An indented `--` comment immediately above a paren-bound call silently corrupted parsing. The function body ended up empty and the diagnostic pointed many lines past the actual cause, typically inside a format-string `{}` placeholder. Manifesto-wise, comments are supposed to be free; this regression made them a 15-minute-per-occurrence tax.

## Repro

Before:

```
$ cat repro.ilo
main>t
  -- build the thing
  m=(fmt "k={}" 1)
  m

$ ilo repro.ilo --run-tree main
{"code":"ILO-T008","message":"return type mismatch: expected t, got _", ...}
```

After:

```
$ ilo repro.ilo --run-tree main
k=1
```

## Root cause

`normalize_newlines` in `src/lexer/mod.rs` rewrites `\n`+indent to `;` BEFORE the logos lexer's `--[^\n]*` comment-skip runs. On an indented comment line, the trailing `\n` is also rewritten to `;`, so the logos regex (which stops at `\n`) greedily eats the comment text plus every following statement up to the next non-indented newline. The body vanishes, the verifier reports a type mismatch with no useful position, and the `ILO-P009 expected expression, got Semi` cascade points at a `{` inside the format string several lines later.

## What's in the diff

- **Commit 1** moves comment-handling into `normalize_newlines` itself. When it sees `--`, it advances past the comment content without emitting anything and leaves the trailing `\n` intact for the loop's existing newline handling. It also passes through `"..."` string literals verbatim so `--` inside a string isn't mistaken for a comment, and suppresses duplicate `;` emission when a comment-only line precedes an indented continuation.
- **Commit 2** adds `tests/regression_comment_parse_corrupt.rs`. 15 tests across tree / VM / cranelift covering: paren-bound `fmt` with leading comment, mid-body comment between bindings, stacked comments, comment containing `{}`/`;`/`()`, and dashes inside a string literal.
- **Commit 3** adds `examples/comment-above-call.ilo` with `-- run:` / `-- out:` assertions so `tests/examples_engines.rs` exercises the same cases at the higher integration layer across every engine.

## Test plan

- [x] Original repro from `ilo_assessment_feedback.md` L1790 returns `k=1` instead of `ILO-T008`
- [x] `cargo test --release --features cranelift` full suite passes (2866 lib tests, plus all integration tests, including the new 15-test `regression_comment_parse_corrupt`)
- [x] `tests/examples_engines.rs` passes with the new example
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --release --features cranelift --all-targets -- -D warnings` clean
- [x] `--` inside a string literal (`"hello -- world"`) still round-trips correctly

## Follow-ups

None. The fix is local to `normalize_newlines` and matches the logos `--[^\n]*` rule it's now running ahead of.