### PR TITLE
frq: drop type-prefix from output keys, match grp convention

### DIFF
--- a/examples/frq.ilo
+++ b/examples/frq.ilo
@@ -1,17 +1,23 @@
 -- frq xs:L a > M t n — frequency map: count occurrences of each element.
--- Keys are stringified element values prefixed by type tag (`t:` for text,
--- `n:` for number, `b:` for bool) so distinct domains never alias. Values
--- are counts. Replaces the recurring `inc m k` pattern (mget + ?? 0 + +1 +
--- mset) with one call.
+-- Keys are bare stringified element values (e.g. "the", "s", "1"), matching
+-- `grp`'s convention for user-visible map keys. No type prefix is added,
+-- so `mkeys (frq xs)` and `mget (frq xs) k` work with the natural string
+-- form. Replaces the recurring `inc m k` pattern (mget + ?? 0 + +1 + mset)
+-- with one call.
+--
+-- Heterogeneous-type collisions: distinct-typed values that share a print
+-- form collide on the shared key (e.g. `frq [1, "1"]` produces one key "1"
+-- with count 2). Same collision policy as `grp idt xs`. If you need to
+-- disambiguate, group with a key function that includes a tag.
 
 -- Word frequency in a sentence.
-words>n;m=frq ["the","cat","sat","on","the","mat","the","cat"];r=mget m "t:the";?r{n v:v;_:0}
+words>n;m=frq ["the","cat","sat","on","the","mat","the","cat"];r=mget m "the";?r{n v:v;_:0}
 
 -- Character frequency (split a string into chars, then count).
-chars>n;m=frq (spl "mississippi" "");r=mget m "t:s";?r{n v:v;_:0}
+chars>n;m=frq (spl "mississippi" "");r=mget m "s";?r{n v:v;_:0}
 
--- Number frequency: keys are prefixed `n:<num>` ("n:1","n:2",...).
-nums>n;m=frq [1,2,1,3,1,2];r=mget m "n:1";?r{n v:v;_:0}
+-- Number frequency: keys are bare stringified numbers ("1","2",...).
+nums>n;m=frq [1,2,1,3,1,2];r=mget m "1";?r{n v:v;_:0}
 
 -- run: words
 -- out: 3

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -2721,19 +2721,21 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         };
         let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
         for item in items {
-            // Prefix keys with a type tag so distinct domains never alias each
-            // other. Without this, `Number(1)` and `Text("1")` would both
-            // stringify to `"1"` and collide. Matches uniqby/setops precedent.
+            // Stringify elements without a type tag, matching `grp`'s convention
+            // for user-visible map keys. Heterogeneous lists where distinct-typed
+            // values share a print form (e.g. `Number(1)` and `Text("1")`) will
+            // collide on the shared string; this is the same collision policy as
+            // `grp idt xs` and is documented in `examples/frq.ilo`.
             let key_str = match item {
-                Value::Text(s) => format!("t:{s}"),
+                Value::Text(s) => s.clone(),
                 Value::Number(n) => {
                     if *n == (*n as i64) as f64 {
-                        format!("n:{}", *n as i64)
+                        format!("{}", *n as i64)
                     } else {
-                        format!("n:{n}")
+                        format!("{n}")
                     }
                 }
-                Value::Bool(b) => format!("b:{b}"),
+                Value::Bool(b) => format!("{b}"),
                 other => {
                     return Err(RuntimeError::new(
                         "ILO-R009",

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -7688,28 +7688,31 @@ unsafe fn nanval_str_cmp(a: NanVal, b: NanVal) -> std::cmp::Ordering {
 /// Stringify a NanVal element value for use as a map key in `frq`.
 /// Returns None if the value is not a text, number, or bool.
 ///
-/// Keys are prefixed with a type tag (`n:` / `t:` / `b:`) so that values
-/// from distinct domains never alias one another (e.g. `Number(1)` and
-/// `Text("1")` would otherwise both stringify to `"1"`). Matches the
-/// uniqby/setops precedent.
+/// Keys are bare stringifications of the element value, matching `grp`'s
+/// convention for user-visible map keys. Heterogeneous lists where
+/// distinct-typed values share a print form (e.g. `Number(1)` and
+/// `Text("1")`) will collide on the shared string; same collision policy
+/// as `grp idt xs`. The earlier type-prefixed shape (`n:` / `t:` / `b:`)
+/// leaked an internal disambiguation convention into the API surface and
+/// has been removed.
 fn nanval_to_key_string(v: NanVal) -> Option<String> {
     if v.is_number() {
         let n = v.as_number();
         if n.fract() == 0.0 && n.abs() < 1e15 {
-            return Some(format!("n:{}", n as i64));
+            return Some(format!("{}", n as i64));
         }
-        return Some(format!("n:{n}"));
+        return Some(format!("{n}"));
     }
     match v.0 {
-        TAG_TRUE => return Some("b:true".to_string()),
-        TAG_FALSE => return Some("b:false".to_string()),
+        TAG_TRUE => return Some("true".to_string()),
+        TAG_FALSE => return Some("false".to_string()),
         _ => {}
     }
     if v.is_string() {
         // SAFETY: is_string() confirmed.
         unsafe {
             return match v.as_heap_ref() {
-                HeapObj::Str(s) => Some(format!("t:{s}")),
+                HeapObj::Str(s) => Some(s.as_str().to_owned()),
                 _ => None,
             };
         }

--- a/tests/regression_frq.rs
+++ b/tests/regression_frq.rs
@@ -22,13 +22,15 @@ fn run(engine: &str, src: &str, entry: &str) -> String {
     String::from_utf8_lossy(&out.stdout).trim().to_string()
 }
 
-// ── Strings: frq ["a","b","a","c","b","a"] → {t:a:3, t:b:2, t:c:1} ────────
+// ── Strings: frq ["a","b","a","c","b","a"] → {"a":3, "b":2, "c":1} ────────
 // Map iteration order is non-deterministic, so probe via mget on each key.
-// Keys are type-prefixed (`t:` for text) to prevent cross-type collisions.
+// Keys are bare stringified element values (no type prefix), matching the
+// `grp` convention. Heterogeneous-type collisions are covered separately
+// below as a documented behaviour.
 
-const STRING_A_SRC: &str = r#"f>n;m=frq ["a","b","a","c","b","a"];r=mget m "t:a";?r{n v:v;_:-1}"#;
-const STRING_B_SRC: &str = r#"f>n;m=frq ["a","b","a","c","b","a"];r=mget m "t:b";?r{n v:v;_:-1}"#;
-const STRING_C_SRC: &str = r#"f>n;m=frq ["a","b","a","c","b","a"];r=mget m "t:c";?r{n v:v;_:-1}"#;
+const STRING_A_SRC: &str = r#"f>n;m=frq ["a","b","a","c","b","a"];r=mget m "a";?r{n v:v;_:-1}"#;
+const STRING_B_SRC: &str = r#"f>n;m=frq ["a","b","a","c","b","a"];r=mget m "b";?r{n v:v;_:-1}"#;
+const STRING_C_SRC: &str = r#"f>n;m=frq ["a","b","a","c","b","a"];r=mget m "c";?r{n v:v;_:-1}"#;
 
 fn check_string_freq(engine: &str) {
     assert_eq!(run(engine, STRING_A_SRC, "f"), "3", "engine={engine} key=a");
@@ -52,11 +54,11 @@ fn frq_strings_cranelift() {
     check_string_freq("--run-cranelift");
 }
 
-// ── Numbers: frq [1,2,1,3,2,1] — keys are prefixed `n:<num>` ──────────────
+// ── Numbers: frq [1,2,1,3,2,1] — keys are bare stringified numbers ────────
 
-const NUM_1_SRC: &str = r#"f>n;m=frq [1,2,1,3,2,1];r=mget m "n:1";?r{n v:v;_:-1}"#;
-const NUM_2_SRC: &str = r#"f>n;m=frq [1,2,1,3,2,1];r=mget m "n:2";?r{n v:v;_:-1}"#;
-const NUM_3_SRC: &str = r#"f>n;m=frq [1,2,1,3,2,1];r=mget m "n:3";?r{n v:v;_:-1}"#;
+const NUM_1_SRC: &str = r#"f>n;m=frq [1,2,1,3,2,1];r=mget m "1";?r{n v:v;_:-1}"#;
+const NUM_2_SRC: &str = r#"f>n;m=frq [1,2,1,3,2,1];r=mget m "2";?r{n v:v;_:-1}"#;
+const NUM_3_SRC: &str = r#"f>n;m=frq [1,2,1,3,2,1];r=mget m "3";?r{n v:v;_:-1}"#;
 
 fn check_num_freq(engine: &str) {
     assert_eq!(run(engine, NUM_1_SRC, "f"), "3", "engine={engine} key=1");
@@ -106,9 +108,9 @@ fn frq_empty_cranelift() {
     check_empty("--run-cranelift");
 }
 
-// ── Singleton: frq ["x"] → {t:x:1} ────────────────────────────────────────
+// ── Singleton: frq ["x"] → {"x":1} ────────────────────────────────────────
 
-const SINGLE_SRC: &str = r#"f>n;m=frq ["x"];r=mget m "t:x";?r{n v:v;_:-1}"#;
+const SINGLE_SRC: &str = r#"f>n;m=frq ["x"];r=mget m "x";?r{n v:v;_:-1}"#;
 
 fn check_single(engine: &str) {
     assert_eq!(run(engine, SINGLE_SRC, "f"), "1", "engine={engine}");
@@ -130,22 +132,64 @@ fn frq_single_cranelift() {
     check_single("--run-cranelift");
 }
 
-// ── Cross-type: frq [1, "1", true] — keys must NOT collide ────────────────
-// Without type prefixes, `Number(1)` and `Text("1")` would both stringify to
-// `"1"` and the resulting count would be 2 instead of 1 for each. Verify the
-// prefixed shape: `{n:1: 1, t:1: 1, b:true: 1}`.
+// ── Bare keys round-trip through mkeys: the regression that motivated the
+//    fix. Persona devops-sre flagged that `mkeys (frq xs)` returned
+//    `["t:a","t:b",...]` which broke downstream `fmt`/`cat` of the key. Lock
+//    the bare-key surface: sort the keys and read the first one back, which
+//    proves the prefix is gone end-to-end (not just on the mget probe path).
 
-const CROSS_NUM_SRC: &str = r#"f>n;m=frq [1, "1", true];r=mget m "n:1";?r{n v:v;_:-1}"#;
-const CROSS_TXT_SRC: &str = r#"f>n;m=frq [1, "1", true];r=mget m "t:1";?r{n v:v;_:-1}"#;
-const CROSS_BOOL_SRC: &str = r#"f>n;m=frq [1, "1", true];r=mget m "b:true";?r{n v:v;_:-1}"#;
+const MKEYS_SRC: &str = r#"f>t;m=frq ["b","a","a"];ks=srt (mkeys m);hd ks"#;
+
+fn check_mkeys(engine: &str) {
+    assert_eq!(run(engine, MKEYS_SRC, "f"), "a", "engine={engine}");
+}
+
+#[test]
+fn frq_mkeys_bare_tree() {
+    check_mkeys("--run-tree");
+}
+
+#[test]
+fn frq_mkeys_bare_vm() {
+    check_mkeys("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn frq_mkeys_bare_cranelift() {
+    check_mkeys("--run-cranelift");
+}
+
+// ── Cross-type collision: frq [1, "1", true] — the documented tradeoff.
+// With bare keys, distinct-typed values that share a print form collide on
+// the shared string. `1` and `"1"` both become key `"1"`; their counts sum.
+// `true` keeps its own key `"true"`. This matches `grp idt`'s collision
+// policy and is the deliberate price of dropping the leaky `n:`/`t:`/`b:`
+// prefix from the user-visible API surface.
+
+const CROSS_SHARED_SRC: &str = r#"f>n;m=frq [1, "1", true];r=mget m "1";?r{n v:v;_:-1}"#;
+const CROSS_BOOL_SRC: &str = r#"f>n;m=frq [1, "1", true];r=mget m "true";?r{n v:v;_:-1}"#;
+const CROSS_NOPREFIX_SRC: &str = r#"f>n;m=frq [1, "1", true];r=mget m "t:1";?r{n v:v;_:0}"#;
 
 fn check_cross_type(engine: &str) {
-    assert_eq!(run(engine, CROSS_NUM_SRC, "f"), "1", "engine={engine} n:1");
-    assert_eq!(run(engine, CROSS_TXT_SRC, "f"), "1", "engine={engine} t:1");
+    // Number(1) and Text("1") collide on bare key "1"; combined count is 2.
+    assert_eq!(
+        run(engine, CROSS_SHARED_SRC, "f"),
+        "2",
+        "engine={engine} shared key '1'"
+    );
+    // Bool keeps its own bare key.
     assert_eq!(
         run(engine, CROSS_BOOL_SRC, "f"),
         "1",
-        "engine={engine} b:true"
+        "engine={engine} key 'true'"
+    );
+    // The old prefixed form must no longer hit — guard against regression
+    // back to leaked type tags.
+    assert_eq!(
+        run(engine, CROSS_NOPREFIX_SRC, "f"),
+        "0",
+        "engine={engine} legacy 't:1' must not exist"
     );
 }
 


### PR DESCRIPTION
## Summary

`frq xs` was returning maps with type-tagged keys (`{"t:a":2,"t:b":1}` for `frq ["a","b","a"]`). The PR #210 framing called this a mirror of the uniqby/setops precedent, but it is not actually a precedent: in those builtins the prefix is internal-only, used as a HashMap dedup key while the output is a `List` of original `Value`s. The prefix never reaches the user. `frq`'s output is a `Map`, so the prefix becomes API surface.

devops-sre persona on v0.11.1 flagged this end-to-end: `mkeys (frq xs)` returned `["t:a","t:b",...]`, breaking downstream `fmt`/`cat` of the key and forcing a `grp idt` workaround on every frequency pass. From the assessment doc:

> Workaround: use `grp idt xs` with a named identity helper. Costs one extra declaration but produces clean string keys. Worth investigating, this looks like a regression in `frq`'s key handling vs `grp`.

`grp` already stringifies map keys without a type tag (interpreter/mod.rs:2684-2703) and accepts the print-form collision tradeoff. The fix is to make `frq` match that policy, dropping the leaky prefix at the API boundary.

Token-cost framing: with prefixed keys, every `frq` caller pays a per-access tax (typing `"t:foo"`, stripping prefixes on display, learning the convention). With bare keys, the natural `mget m "foo"` works first time and `mkeys (frq xs)` returns clean strings. The heterogeneous-collision case (`frq [1,"1"]`) is rare in practice and matches `grp idt`'s existing behaviour.

## Repro

Before (main at 4ef85d4):

```
xs=["a","b","a"]
fr=frq xs
jdmp fr
# {"t:a":2,"t:b":1}

mkeys fr
# ["t:a","t:b"]
```

After:

```
xs=["a","b","a"]
fr=frq xs
jdmp fr
# {"a":2,"b":1}

mkeys fr
# ["a","b"]
```

Heterogeneous lists now follow `grp idt`'s collision policy:

```
frq [1, "1", true]
# {"1": 2, "true": 1}  (Number(1) and Text("1") collide on bare key "1")
```

If disambiguation is needed, callers can `grp` with an explicit tagging key function.

## What's in the diff

Two commits:

- **`frq: drop type-prefix from output keys, match grp convention`** — interpreter and VM/Cranelift bridge. `nanval_to_key_string` in `src/vm/mod.rs` is shared by `OP_FRQ` and `jit_frq`, and is only used by frq, so the helper change covers both backends without touching setops/uniqby. Interpreter path in `src/interpreter/mod.rs` mirrors the same stringification logic that `grp` already uses (integer-vs-float check, bare bool format).

- **`test: cover bare-key surface for frq across all engines`** — `tests/regression_frq.rs` and `examples/frq.ilo`. Three additions on top of the rewritten string/number/singleton cases:
  - `frq_mkeys_bare_*` round-trips `srt (mkeys (frq xs))` to prove the prefix is gone end-to-end, not just on the `mget` probe path. This is the exact pipeline that broke for the persona.
  - Cross-type collision test locks in the new collision policy (`frq [1,"1",true]` produces shared key `"1"` with count 2 plus `"true"` with count 1).
  - Anti-regression guard `CROSS_NOPREFIX_SRC` asserts `mget m "t:1"` misses, so any future drift back to leaky tags fails loudly.

The example file is exercised by `tests/examples_engines.rs` on every engine, giving in-context AI agents an example of the now-correct shape.

## Test plan

- [x] `cargo test --release --features cranelift --test regression_frq` (tree + vm + cranelift, 18 tests)
- [x] Full suite: `cargo test --release --features cranelift` (lib 2866 passed, all integration suites passed, 0 failed across the run; the 7 cranelift AOT tests pass once `target/release/libilo.a` is in the canonical path, which CI provides)
- [x] Example `examples/frq.ilo` runs through `tests/examples_engines.rs` on every engine with the new `-- run` / `-- out` assertions
- [x] Anti-regression: `mget m "t:1"` on a `frq [1, "1", true]` result returns nil
- [x] Persona repro pipeline: `mkeys (frq xs)` returns bare strings, no `t:`/`n:`/`b:` prefix

## Follow-ups

None. setops/uniqby keep their internal type-prefixed dedup keys (correct, those aren't user-visible). `grp` continues to be the documented escape hatch for cases that need explicit type-tag disambiguation.