### PR TITLE
fix: preserve raw text for t-typed CLI args

### DIFF
--- a/examples/cli-text-arg.ilo
+++ b/examples/cli-text-arg.ilo
@@ -1,0 +1,40 @@
+-- CLI args declared as `t` (text) are passed through verbatim from the
+-- command line, even when the raw input looks numeric, boolean, or
+-- list-like.
+--
+-- Before this fix, `ilo file.ilo f 2` with `f arg:t` silently coerced
+-- `"2"` to `Number(2.0)` because the CLI parser was type-blind. That
+-- broke any function branching off the declared text type, notably
+-- `num arg`, which returned nil because arg was already a number,
+-- which in turn collapsed the surrounding `?r{~i:.. ;^e:..}` match
+-- (no `nil` arm) into a silent `nil` return.
+--
+-- The fix is in `src/main.rs`: CLI parsing now consults the declared
+-- param type. `t` params skip the greedy numeric/bool/list parse and
+-- keep the raw input as `Text`.
+
+-- Round-trip: take a text param back through `num` and unwrap the
+-- result. Pre-fix this returned nil for any digit-shaped input; now
+-- it returns the parsed number for digits and -1 for non-numerics.
+parse-or-default arg:t>n;r=num arg;?r{~i:i;^e:0 - 1}
+
+-- Identity on the text param. The point is the type of the value
+-- crossing the function boundary: pre-fix `id-text 2` returned a
+-- Number that happened to print as `2`; post-fix it returns Text.
+-- The behavioural difference shows up under `num`, so we test that
+-- above and just use this case to confirm bool-shaped and nil-shaped
+-- inputs are preserved verbatim too.
+id-text arg:t>t;arg
+
+-- run: parse-or-default 2
+-- out: 2
+-- run: parse-or-default 42
+-- out: 42
+-- run: parse-or-default abc
+-- out: -1
+-- run: id-text true
+-- out: true
+-- run: id-text nil
+-- out: nil
+-- run: id-text 99
+-- out: 99

--- a/src/main.rs
+++ b/src/main.rs
@@ -650,8 +650,7 @@ fn process_serv_request(
 
     // Run
     let func_name = req.func.as_deref();
-    let run_args: Vec<interpreter::Value> = req.args.iter().map(|a| parse_cli_arg(a)).collect();
-    let run_args = coerce_cli_args(&program, func_name, run_args);
+    let run_args = parse_cli_args_typed(&program, func_name, &req.args);
 
     #[cfg(feature = "tools")]
     let result = if let Some(p) = provider {
@@ -2389,12 +2388,12 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
     // Dispatch based on mode flags
     let exit_code = if r.bench {
         let func_name = r.rest.first().map(|s| s.as_str());
-        let run_args: Vec<interpreter::Value> = if r.rest.len() > 1 {
-            r.rest[1..].iter().map(|a| parse_cli_arg(a)).collect()
+        let raw = if r.rest.len() > 1 {
+            &r.rest[1..]
         } else {
-            vec![]
+            &[][..]
         };
-        let run_args = coerce_cli_args(&program, func_name, run_args);
+        let run_args = parse_cli_args_typed(&program, func_name, raw);
         run_bench(&program, func_name, &run_args);
         0
     } else if r.explain {
@@ -2435,12 +2434,8 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
             cli::Engine::Llvm => run_llvm_engine(&program, rest),
             cli::Engine::Vm => {
                 let func_name = rest.first().map(|s| s.as_str());
-                let run_args: Vec<interpreter::Value> = if rest.len() > 1 {
-                    rest[1..].iter().map(|a| parse_cli_arg(a)).collect()
-                } else {
-                    vec![]
-                };
-                let run_args = coerce_cli_args(&program, func_name, run_args);
+                let raw = if rest.len() > 1 { &rest[1..] } else { &[][..] };
+                let run_args = parse_cli_args_typed(&program, func_name, raw);
                 let compiled = match vm::compile(&program) {
                     Ok(c) => c,
                     Err(e) => {
@@ -2466,12 +2461,8 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
             }
             cli::Engine::Tree => {
                 let func_name = rest.first().map(|s| s.as_str());
-                let run_args: Vec<interpreter::Value> = if rest.len() > 1 {
-                    rest[1..].iter().map(|a| parse_cli_arg(a)).collect()
-                } else {
-                    vec![]
-                };
-                let run_args = coerce_cli_args(&program, func_name, run_args);
+                let raw = if rest.len() > 1 { &rest[1..] } else { &[][..] };
+                let run_args = parse_cli_args_typed(&program, func_name, raw);
                 run_interp_with_provider(
                     &program,
                     func_name,
@@ -2504,11 +2495,8 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
 
                 let (func_name, run_args) = if let Some(first) = rest.first() {
                     if func_names.contains(&first.as_str()) {
-                        let args: Vec<_> = rest[1..].iter().map(|a| parse_cli_arg(a)).collect();
-                        (
-                            Some(first.as_str()),
-                            coerce_cli_args(&program, Some(first.as_str()), args),
-                        )
+                        let fn_ref = Some(first.as_str());
+                        (fn_ref, parse_cli_args_typed(&program, fn_ref, &rest[1..]))
                     } else {
                         (None, rest.iter().map(|a| parse_cli_arg(a)).collect())
                     }
@@ -2562,12 +2550,8 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
 /// Cranelift JIT engine dispatch. Returns exit code.
 fn run_cranelift_engine(program: &ast::Program, rest: &[String], explicit_json: bool) -> i32 {
     let func_name = rest.first().map(|s| s.as_str());
-    let run_args: Vec<interpreter::Value> = if rest.len() > 1 {
-        rest[1..].iter().map(|a| parse_cli_arg(a)).collect()
-    } else {
-        vec![]
-    };
-    let run_args = coerce_cli_args(program, func_name, run_args);
+    let raw = if rest.len() > 1 { &rest[1..] } else { &[][..] };
+    let run_args = parse_cli_args_typed(program, func_name, raw);
     let suppress = program_result_should_suppress(program, func_name);
 
     #[cfg(feature = "cranelift")]
@@ -3488,23 +3472,94 @@ fn parse_cli_arg(s: &str) -> interpreter::Value {
     }
 }
 
+/// Parse a single CLI arg, taking the declared param type into account.
+///
+/// For `Type::Text` params, the raw CLI string is kept verbatim as `Text`,
+/// bypassing the greedy number/bool/list/nil parsing that `parse_cli_arg`
+/// would otherwise perform. This prevents silent type drift where a function
+/// declared as `arg:t` receives a `Number` at runtime because the CLI value
+/// happened to look numeric (e.g. `"2"`), which then breaks `num arg` /
+/// pattern-matches that key off the declared text type.
+///
+/// For every other declared type (or when no type is known), behaviour is
+/// identical to `parse_cli_arg`.
+fn parse_cli_arg_for_param(s: &str, expected: Option<&ast::Type>) -> interpreter::Value {
+    if matches!(expected, Some(ast::Type::Text)) {
+        // Preserve the raw CLI string verbatim. We still honor the surrounding
+        // double-quote convention `parse_cli_arg` uses (callers sometimes pass
+        // `"hello"` to force the text branch when no type info was available);
+        // stripping them keeps quoted callers backward-compatible. Everything
+        // else, *including* digits, `true`/`false`, `nil`, `[...]`, is kept
+        // as-is and becomes `Text`.
+        let stripped = if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
+            &s[1..s.len() - 1]
+        } else {
+            s
+        };
+        return interpreter::Value::Text(stripped.to_string());
+    }
+    parse_cli_arg(s)
+}
+
+/// Look up a function's declared parameter types in the program.
+/// Returns `None` if the function isn't declared (e.g. inline-snippet entry).
+fn lookup_param_types<'a>(
+    program: &'a ast::Program,
+    func_name: Option<&str>,
+) -> Option<&'a [ast::Param]> {
+    let name = func_name?;
+    program.declarations.iter().find_map(|d| match d {
+        ast::Decl::Function {
+            name: n, params, ..
+        } if n == name => Some(params.as_slice()),
+        _ => None,
+    })
+}
+
+/// Parse and coerce CLI args against a function's declared parameter types.
+///
+/// - For `Type::Text` params, the raw CLI string is preserved as `Text`
+///   without any numeric/bool/list/nil coercion. This is the canonical fix
+///   for the silent `t`-param coercion bug (a CLI input of `"2"` against
+///   `arg:t` used to produce `Number(2.0)`).
+/// - For `Type::List(_)` params, a non-list value is wrapped as `[value]`.
+/// - All other params parse via `parse_cli_arg`'s standard rules.
+fn parse_cli_args_typed(
+    program: &ast::Program,
+    func_name: Option<&str>,
+    raw: &[String],
+) -> Vec<interpreter::Value> {
+    let params = lookup_param_types(program, func_name);
+    raw.iter()
+        .enumerate()
+        .map(|(i, s)| {
+            let expected = params.and_then(|ps| ps.get(i)).map(|p| &p.ty);
+            let mut v = parse_cli_arg_for_param(s, expected);
+            if matches!(expected, Some(ast::Type::List(_)))
+                && !matches!(&v, interpreter::Value::List(_))
+            {
+                v = interpreter::Value::List(vec![v]);
+            }
+            v
+        })
+        .collect()
+}
+
 /// Coerce CLI args to match a function's parameter types.
 /// - Wraps a non-list value in `[value]` when the param type is `L _`
+///
+/// Superseded in production by `parse_cli_args_typed`, which combines parsing
+/// and coercion in one type-aware pass. Kept under `#[cfg(test)]` because the
+/// existing test cases still pin the list-wrap behaviour cleanly when starting
+/// from pre-parsed `Value`s; the typed counterparts cover the new from-raw
+/// path. New non-test callers should use `parse_cli_args_typed`.
+#[cfg(test)]
 fn coerce_cli_args(
     program: &ast::Program,
     func_name: Option<&str>,
     mut args: Vec<interpreter::Value>,
 ) -> Vec<interpreter::Value> {
-    let Some(name) = func_name else {
-        return args;
-    };
-    let params: Option<&[ast::Param]> = program.declarations.iter().find_map(|d| match d {
-        ast::Decl::Function {
-            name: n, params, ..
-        } if n == name => Some(params.as_slice()),
-        _ => None,
-    });
-    let Some(params) = params else {
+    let Some(params) = lookup_param_types(program, func_name) else {
         return args;
     };
     for (i, param) in params.iter().enumerate() {
@@ -4768,6 +4823,94 @@ mod tests {
                 interpreter::Value::Number(3.0),
             ]
         );
+    }
+
+    // ── parse_cli_args_typed: text params bypass numeric coercion ────────────
+
+    /// Regression: a CLI arg of `"2"` against a `t`-typed param used to land
+    /// at runtime as `Number(2.0)`, breaking `num arg` and any branch that
+    /// keyed off the declared text type. The fix wires param types into CLI
+    /// parsing so the raw string is preserved verbatim as `Text`.
+    #[test]
+    fn typed_text_param_preserves_numeric_looking_input() {
+        let program = make_program("f arg:t>t;arg");
+        let raw = vec!["2".to_string()];
+        let parsed = parse_cli_args_typed(&program, Some("f"), &raw);
+        assert_eq!(parsed, vec![interpreter::Value::Text("2".into())]);
+    }
+
+    #[test]
+    fn typed_text_param_preserves_bool_looking_input() {
+        let program = make_program("f arg:t>t;arg");
+        let raw = vec!["true".to_string()];
+        let parsed = parse_cli_args_typed(&program, Some("f"), &raw);
+        assert_eq!(parsed, vec![interpreter::Value::Text("true".into())]);
+    }
+
+    #[test]
+    fn typed_text_param_preserves_nil_looking_input() {
+        let program = make_program("f arg:t>t;arg");
+        let raw = vec!["nil".to_string()];
+        let parsed = parse_cli_args_typed(&program, Some("f"), &raw);
+        assert_eq!(parsed, vec![interpreter::Value::Text("nil".into())]);
+    }
+
+    #[test]
+    fn typed_text_param_preserves_list_looking_input() {
+        // `t` param + `[1,2]` should remain the literal string, not become a list.
+        let program = make_program("f arg:t>t;arg");
+        let raw = vec!["[1,2]".to_string()];
+        let parsed = parse_cli_args_typed(&program, Some("f"), &raw);
+        assert_eq!(parsed, vec![interpreter::Value::Text("[1,2]".into())]);
+    }
+
+    #[test]
+    fn typed_number_param_still_parses_as_number() {
+        // Non-text params keep today's parsing semantics.
+        let program = make_program("f x:n>n;x");
+        let raw = vec!["42".to_string()];
+        let parsed = parse_cli_args_typed(&program, Some("f"), &raw);
+        assert_eq!(parsed, vec![interpreter::Value::Number(42.0)]);
+    }
+
+    #[test]
+    fn typed_list_param_still_wraps_scalar() {
+        // List coercion is preserved alongside the new text-preservation logic.
+        let program = make_program("f xs:L n>n;sum xs");
+        let raw = vec!["10".to_string()];
+        let parsed = parse_cli_args_typed(&program, Some("f"), &raw);
+        assert_eq!(
+            parsed,
+            vec![interpreter::Value::List(vec![interpreter::Value::Number(
+                10.0
+            )])]
+        );
+    }
+
+    #[test]
+    fn typed_mixed_params_route_correctly() {
+        // Mixed signature: `t` first, `n` second. The `"2"` for `t` must stay
+        // as Text, the `"3"` for `n` must become Number.
+        let program = make_program("f a:t b:n>t;a");
+        let raw = vec!["2".to_string(), "3".to_string()];
+        let parsed = parse_cli_args_typed(&program, Some("f"), &raw);
+        assert_eq!(
+            parsed,
+            vec![
+                interpreter::Value::Text("2".into()),
+                interpreter::Value::Number(3.0),
+            ]
+        );
+    }
+
+    #[test]
+    fn typed_no_func_name_falls_back_to_legacy_parsing() {
+        // Without a function name, no types to consult: behave like the
+        // pre-fix code path (greedy numeric parse).
+        let program = make_program("f arg:t>t;arg");
+        let raw = vec!["2".to_string()];
+        let parsed = parse_cli_args_typed(&program, None, &raw);
+        assert_eq!(parsed, vec![interpreter::Value::Number(2.0)]);
     }
 
     #[test]

--- a/tests/regression_cli_text_arg.rs
+++ b/tests/regression_cli_text_arg.rs
@@ -1,0 +1,152 @@
+// Regression: CLI args declared as `t` (text) used to be silently coerced
+// to `Number` when the raw string parsed as a finite float. The fix wires
+// declared param types into the CLI parser, so `t` params keep their raw
+// string verbatim as `Text`.
+//
+// Originating assessment entry (ilo_assessment_feedback.md, 2026-05-13):
+//   "🔴 CLI string-to-number coercion silently corrupts t-typed params.
+//    When a function declares arg:t and the CLI receives "2", the value
+//    passed in is a number at runtime, not text. num "2" then returns nil
+//    (which then breaks the ?r{~i:..;^e:..} match because there's no nil
+//    arm)."
+//
+// This test exercises every engine (default JIT, --run-tree, --run-vm,
+// --run-cranelift). Pre-fix all four returned `nil`; post-fix all four
+// return the parsed number.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn write_temp(content: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("prog.ilo");
+    std::fs::write(&path, content).expect("write temp ilo");
+    (dir, path)
+}
+
+fn run_engine(path: &str, func: &str, arg: &str, engine_flag: Option<&str>) -> String {
+    let mut cmd = ilo();
+    cmd.arg(path).arg(func).arg(arg);
+    if let Some(flag) = engine_flag {
+        cmd.arg(flag);
+    }
+    let out = cmd
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn ilo: {e}"));
+    assert!(
+        out.status.success(),
+        "engine {:?}: exit={:?}, stderr={}",
+        engine_flag,
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+// ── num round-trip through a `t` param ────────────────────────────────────────
+
+/// `f arg:t>n; r=num arg; ?r{~i:i;^e:0-1}` with CLI input `"2"` must
+/// return `2` (not `-1`, not `nil`) on every engine.
+#[test]
+fn text_param_with_digit_input_num_unwraps_across_engines() {
+    let src = "f arg:t>n;r=num arg;?r{~i:i;^e:0 - 1}\n";
+    let (_dir, path) = write_temp(src);
+    let p = path.to_str().unwrap();
+
+    for engine in [
+        None,
+        Some("--run-tree"),
+        Some("--run-vm"),
+        Some("--run-cranelift"),
+    ] {
+        let out = run_engine(p, "f", "2", engine);
+        assert_eq!(
+            out, "2",
+            "engine {engine:?}: expected `2`, got `{out}` (pre-fix bug: arg arrived as Number, num returned nil, match collapsed)"
+        );
+    }
+}
+
+/// A non-numeric input must still take the error arm. Sanity check that
+/// the fix doesn't make `num` accept everything.
+#[test]
+fn text_param_with_non_numeric_input_hits_err_arm_across_engines() {
+    let src = "f arg:t>n;r=num arg;?r{~i:i;^e:0 - 1}\n";
+    let (_dir, path) = write_temp(src);
+    let p = path.to_str().unwrap();
+
+    for engine in [
+        None,
+        Some("--run-tree"),
+        Some("--run-vm"),
+        Some("--run-cranelift"),
+    ] {
+        let out = run_engine(p, "f", "abc", engine);
+        assert_eq!(out, "-1", "engine {engine:?}: expected `-1`, got `{out}`");
+    }
+}
+
+// ── identity preserves bool/nil/list-shaped text inputs ───────────────────────
+
+/// `id-text arg:t>t; arg` with input `"true"` must return the literal
+/// string `true`, not silently coerce to `Value::Bool(true)`.
+#[test]
+fn text_param_preserves_bool_shaped_input_across_engines() {
+    let src = "id arg:t>t;arg\n";
+    let (_dir, path) = write_temp(src);
+    let p = path.to_str().unwrap();
+
+    for engine in [
+        None,
+        Some("--run-tree"),
+        Some("--run-vm"),
+        Some("--run-cranelift"),
+    ] {
+        let out = run_engine(p, "id", "true", engine);
+        assert_eq!(out, "true", "engine {engine:?}: got `{out}`");
+    }
+}
+
+/// `id arg:t>t; arg` with input `"nil"` must return the literal text
+/// `nil`, not `Value::Nil` (which would print as the special nil token
+/// and break any caller that branches on the declared text type).
+#[test]
+fn text_param_preserves_nil_shaped_input_across_engines() {
+    let src = "id arg:t>t;arg\n";
+    let (_dir, path) = write_temp(src);
+    let p = path.to_str().unwrap();
+
+    for engine in [
+        None,
+        Some("--run-tree"),
+        Some("--run-vm"),
+        Some("--run-cranelift"),
+    ] {
+        let out = run_engine(p, "id", "nil", engine);
+        assert_eq!(out, "nil", "engine {engine:?}: got `{out}`");
+    }
+}
+
+// ── number params still parse as numbers (no regression on `n`) ───────────────
+
+/// Cross-check: a `n`-typed param with the same `"2"` input must still
+/// arrive as a Number, so existing call sites don't regress.
+#[test]
+fn number_param_still_parses_as_number_across_engines() {
+    let src = "double x:n>n;*x 2\n";
+    let (_dir, path) = write_temp(src);
+    let p = path.to_str().unwrap();
+
+    for engine in [
+        None,
+        Some("--run-tree"),
+        Some("--run-vm"),
+        Some("--run-cranelift"),
+    ] {
+        let out = run_engine(p, "double", "21", engine);
+        assert_eq!(out, "42", "engine {engine:?}: got `{out}`");
+    }
+}


### PR DESCRIPTION
## Summary

CLI args declared as `t` used to be silently coerced to `Number` when the raw input parsed as a finite float. `f arg:t` with input `2` arrived at runtime as `Number(2.0)`, so `num arg` returned nil, which then collapsed the surrounding `?r{~i:..;^e:..}` match into a silent nil return because there is no nil arm. Static types were fine, so the verifier never caught it.

This was the longstanding 🔴 friction documented in `ilo_assessment_feedback.md` since v0.10, and the same friction surfaced again in the v0.11.1 interactive-CLI rerun. Highest-leverage manifesto win here: zero retries for any agent that declares `arg:t` and passes digit-shaped input. Pre-fix the agent had to invent a workaround (a separate `i:n` param threaded through the dispatcher purely to keep the type honest). Post-fix the declared type does what it says.

## Repro

```
f arg:t>n;r=num arg;?r{~i:i;^e:0 - 1}
```

Before:
```
$ ilo prog.ilo f 2
nil
```

After:
```
$ ilo prog.ilo f 2
2
$ ilo prog.ilo f abc
-1
```

Same result on `--run-tree`, `--run-vm`, `--run-cranelift`.

## What's in the diff

- **`fix: preserve raw text for t-typed CLI args`** — adds `parse_cli_args_typed` which consults declared param types during CLI parsing. `t` params keep the raw string verbatim as `Text` (the existing quoted-string strip is preserved for back-compat); `L _` params still wrap a scalar; everything else parses by the same rules as before. Switches the six production callsites that used to do parse-then-coerce-by-type to the new typed parser. The legacy `coerce_cli_args` is kept under `#[cfg(test)]` so its list-wrap tests keep pinning that behaviour from pre-parsed values, but has no remaining production callers. Unit tests cover text-preservation across numeric, bool, nil, and list-shaped inputs, plus number passthrough, list wrap, mixed signatures, and the no-func-name fallback.
- **`test: cross-engine regression for t-typed CLI args`** — `tests/regression_cli_text_arg.rs` exercises all four engines for the num round-trip (both digit and non-digit input), identity on bool-shaped and nil-shaped inputs, and a sanity check that `n`-typed params still parse as numbers.
- **`examples: t-typed CLI args preserve raw input`** — `examples/cli-text-arg.ilo` documents the now-correct behaviour and is picked up by `tests/examples_engines.rs` for a third regression layer across every engine.

## Test plan

- [x] `cargo test --release --features cranelift` — full suite green (2866 lib tests + integration crates)
- [x] `cargo clippy --release --features cranelift --all-targets -- -W clippy::all` — clean
- [x] `cargo fmt --check` — clean
- [x] Manual repro across all four engines (default, `--run-tree`, `--run-vm`, `--run-cranelift`) — all return `2` for `f arg:t` with input `2`

## Follow-ups

None. The fix is surgical: type-aware parsing for `t` only, every other declared type's behaviour is byte-for-byte unchanged.