### PR TITLE
fix: split `-N v` into subtract at fresh-expression positions

### DIFF
--- a/examples/neg-literal-papercut.ilo
+++ b/examples/neg-literal-papercut.ilo
@@ -1,0 +1,41 @@
+-- `-0 v` (no space) used to lex as `Number(-0)` + stray `Ref(v)` and silently
+-- produced wrong results. Six+ personas hit this writing numerical formulas
+-- where "0 minus x" is the natural unary-negation idiom. Now `-0` glued to a
+-- following expression at a fresh-expression position splits into `Minus` +
+-- `Number(0)` so the parser reads it as binary subtract.
+--
+-- The fix is gated on the *preceding* token so call-arg negative literals
+-- (`at xs -1`, `+a -3`, `into -3 0 10`) keep their meaning. See
+-- `examples/negative-after-op.ilo` for the keep-literal pairings.
+
+-- The canonical bug: unary-negate-by-subtract-from-zero at statement position.
+ab x:n>n;-0 x
+
+-- Same shape inside a function body after a `;` separator.
+absp p:L _>n;v=p.1;-0 v
+
+-- Same shape on the rhs of an assignment.
+diff a:n b:n>n;r=-a b;r
+
+-- Same shape inside a braced block (function body / conditional arm).
+zarm c:n>n;<c 0{-0 c}{c}
+
+-- Same shape inside a parenthesised expression (safe-ending wrap).
+neg n:n>n;(-0 n)
+
+-- run: ab -7
+-- out: 7
+-- run: ab 7
+-- out: -7
+-- run: absp [10,3]
+-- out: -3
+-- run: diff 5 2
+-- out: 3
+-- run: zarm -4
+-- out: 4
+-- run: zarm 6
+-- out: 6
+-- run: neg 9
+-- out: -9
+-- run: neg -2
+-- out: 2

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -415,6 +415,80 @@ pub fn lex(source: &str) -> Result<Vec<(Token, std::ops::Range<usize>)>, LexErro
         }
     }
 
+    // Post-lex: split a glued negative-literal `Number(-N)` back into
+    // `Minus` + `Number(N)` when the preceding token is one that introduces
+    // a fresh expression position. Six personas hit this in the assessment
+    // log: writing `-0 v` (intending `0 - v`) silently produces wrong results
+    // because Logos's `-?[0-9]+...` regex greedily consumes the leading `-`,
+    // so the parser sees `Number(-0)` followed by a stray `Ref(v)`. Same trap
+    // for `-1 cv`, `r1=-1 t2`, `v=p.1;-0 v`, etc. The canonical workaround is
+    // adding a space (`- 0 v`) but it's an easy-to-forget tax on numerical
+    // formulas.
+    //
+    // The split is gated on the *preceding* token rather than blanket-applied
+    // so that legitimate negative-literal-as-call-arg cases are preserved:
+    // `at xs -1`, `+a -3`, `into -3 0 10`, `<r -0.05`, `[1 -2 3]` all keep
+    // their `Number(-N)` token because the preceding token is value-producing
+    // (Ident/Number/etc). `LBracket` is *also* excluded so that
+    // `[-2 1 3]` (a comma-free list literal whose first element is negative)
+    // continues to lex as four tokens — splitting it would make the parser
+    // greedy-subtract `-2 1` into `Subtract(2, 1)` and silently produce a
+    // 2-element list.
+    //
+    // Contexts that *do* split:
+    //   - start of input (no previous token)
+    //   - `;` (statement boundary)
+    //   - `\n` (declaration boundary, after normalize_newlines)
+    //   - `=` (rhs of an assignment)
+    //   - `{` (start of a block - function body, conditional arm)
+    //   - `(` (start of a parenthesised expression)
+    //
+    // After splitting, the parser's existing `parse_minus` handles both
+    // `Negate(N)` (no following operand) and `Subtract(N, M)` (operand
+    // follows), so the unary-negation case at expression start (`a=-3`)
+    // still produces the same `-3` value via `Negate(3)`.
+    {
+        let mut i = 0;
+        while i < tokens.len() {
+            let Token::Number(_) = tokens[i].0 else {
+                i += 1;
+                continue;
+            };
+            let span = tokens[i].1.clone();
+            let slice = &normalized[span.clone()];
+            if !slice.starts_with('-') {
+                i += 1;
+                continue;
+            }
+            let prev_splits = i == 0
+                || matches!(
+                    tokens[i - 1].0,
+                    Token::Semi | Token::Newline | Token::Eq | Token::LBrace | Token::LParen
+                );
+            if !prev_splits {
+                i += 1;
+                continue;
+            }
+            // Re-parse the positive tail (skip the leading `-`) so the new
+            // Number carries the correct value. The slice is guaranteed by
+            // the lexer regex to be a valid f64 literal.
+            let positive_slice = &slice[1..];
+            let Ok(n) = positive_slice.parse::<f64>() else {
+                i += 1;
+                continue;
+            };
+            let minus_span = span.start..span.start + 1;
+            let number_span = span.start + 1..span.end;
+            tokens.splice(
+                i..i + 1,
+                [(Token::Minus, minus_span), (Token::Number(n), number_span)],
+            );
+            // Step past both new tokens - the new Number is not itself a
+            // candidate for re-splitting (its slice doesn't start with `-`).
+            i += 2;
+        }
+    }
+
     // Post-lex: after `.` or `.?` (field access), accept reserved keywords
     // (`type`, `if`, `let`, `fn`, `var`, `use`, `with`, type sigils `R`/`L`/`F`/`O`/`M`/`S`,
     // `true`, `false`, `nil`, ...) as plain field names by rewriting the keyword
@@ -847,7 +921,157 @@ mod tests {
         let tokens = lex(source).unwrap();
         assert_eq!(tokens[0].0, Token::Number(42.0));
         assert_eq!(tokens[1].0, Token::Number(3.14));
+        // After a value-producing token (Number), `-7` stays a negative
+        // literal so call-arg patterns like `f 1 -7` keep their meaning.
         assert_eq!(tokens[2].0, Token::Number(-7.0));
+    }
+
+    /// Negative-literal-vs-subtract: `-0 v` at fresh-expression position
+    /// must lex as three tokens (Minus, 0, v) so the parser sees prefix
+    /// subtract. Documented papercut hit by six+ personas in the
+    /// assessment log; previously `Number(-0)` + stray `Ident(v)` silently
+    /// produced wrong results.
+    #[test]
+    fn lex_neg_zero_at_start_splits_into_minus_number() {
+        let source = "-0 v";
+        let tokens: Vec<_> = lex(source).unwrap().into_iter().map(|(t, _)| t).collect();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Minus,
+                Token::Number(0.0),
+                Token::Ident("v".to_string()),
+            ]
+        );
+    }
+
+    /// Same split fires after `;` (statement boundary).
+    #[test]
+    fn lex_neg_literal_after_semi_splits() {
+        let source = "v=p;-0 v";
+        let tokens: Vec<_> = lex(source).unwrap().into_iter().map(|(t, _)| t).collect();
+        // ... ; - 0 v
+        assert_eq!(tokens[3], Token::Semi);
+        assert_eq!(tokens[4], Token::Minus);
+        assert_eq!(tokens[5], Token::Number(0.0));
+        assert_eq!(tokens[6], Token::Ident("v".to_string()));
+    }
+
+    /// Split fires after `=` (rhs of assignment): `r1=-1 t2`.
+    #[test]
+    fn lex_neg_literal_after_eq_splits() {
+        let source = "r1=-1 t2";
+        let tokens: Vec<_> = lex(source).unwrap().into_iter().map(|(t, _)| t).collect();
+        assert_eq!(tokens[0], Token::Ident("r1".to_string()));
+        assert_eq!(tokens[1], Token::Eq);
+        assert_eq!(tokens[2], Token::Minus);
+        assert_eq!(tokens[3], Token::Number(1.0));
+        assert_eq!(tokens[4], Token::Ident("t2".to_string()));
+    }
+
+    /// Split fires after `{` (block start): `{-0 v}`.
+    #[test]
+    fn lex_neg_literal_after_lbrace_splits() {
+        let source = "{-0 v}";
+        let tokens: Vec<_> = lex(source).unwrap().into_iter().map(|(t, _)| t).collect();
+        assert_eq!(tokens[0], Token::LBrace);
+        assert_eq!(tokens[1], Token::Minus);
+        assert_eq!(tokens[2], Token::Number(0.0));
+        assert_eq!(tokens[3], Token::Ident("v".to_string()));
+        assert_eq!(tokens[4], Token::RBrace);
+    }
+
+    /// Split fires after `(` so `(-0 v)` is `Subtract(0, v)`.
+    #[test]
+    fn lex_neg_literal_after_lparen_splits() {
+        let source = "(-0 v)";
+        let tokens: Vec<_> = lex(source).unwrap().into_iter().map(|(t, _)| t).collect();
+        assert_eq!(tokens[0], Token::LParen);
+        assert_eq!(tokens[1], Token::Minus);
+        assert_eq!(tokens[2], Token::Number(0.0));
+        assert_eq!(tokens[3], Token::Ident("v".to_string()));
+        assert_eq!(tokens[4], Token::RParen);
+    }
+
+    /// Negative literal as call arg after an ident must NOT split:
+    /// `at xs -1` calls `at` with three args, `-1` stays a literal.
+    #[test]
+    fn lex_neg_literal_after_ident_stays_literal() {
+        let source = "at xs -1";
+        let tokens: Vec<_> = lex(source).unwrap().into_iter().map(|(t, _)| t).collect();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Ident("at".to_string()),
+                Token::Ident("xs".to_string()),
+                Token::Number(-1.0),
+            ]
+        );
+    }
+
+    /// Negative literal mid-list (after a Number) stays literal:
+    /// `[1 -2 3]` is a 3-element list `[1, -2, 3]`.
+    #[test]
+    fn lex_neg_literal_mid_list_stays_literal() {
+        let source = "[1 -2 3]";
+        let tokens: Vec<_> = lex(source).unwrap().into_iter().map(|(t, _)| t).collect();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::LBracket,
+                Token::Number(1.0),
+                Token::Number(-2.0),
+                Token::Number(3.0),
+                Token::RBracket,
+            ]
+        );
+    }
+
+    /// Negative literal at the *start* of a comma-free list must also
+    /// stay a literal — otherwise `[-2 1 3]` would split into
+    /// `[ - 2 1 3 ]` and parse-greedy `Subtract(2, 1)` into a 2-element
+    /// list. `LBracket` is deliberately excluded from the split contexts.
+    #[test]
+    fn lex_neg_literal_after_lbracket_stays_literal() {
+        let source = "[-2 1 3]";
+        let tokens: Vec<_> = lex(source).unwrap().into_iter().map(|(t, _)| t).collect();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::LBracket,
+                Token::Number(-2.0),
+                Token::Number(1.0),
+                Token::Number(3.0),
+                Token::RBracket,
+            ]
+        );
+    }
+
+    /// Float negative literal at fresh-expression position also splits.
+    #[test]
+    fn lex_neg_float_at_start_splits() {
+        let source = "-0.05 r";
+        let tokens: Vec<_> = lex(source).unwrap().into_iter().map(|(t, _)| t).collect();
+        assert_eq!(tokens[0], Token::Minus);
+        assert_eq!(tokens[1], Token::Number(0.05));
+        assert_eq!(tokens[2], Token::Ident("r".to_string()));
+    }
+
+    /// Prefix subtract via `+a -3` (negate-3 as second operand to `+`):
+    /// the `-3` after an ident must STAY a literal so `+a -3` means
+    /// `a + (-3)`. Pinned by PR #172.
+    #[test]
+    fn lex_neg_literal_after_prefix_binop_operand_stays() {
+        let source = "+a -3";
+        let tokens: Vec<_> = lex(source).unwrap().into_iter().map(|(t, _)| t).collect();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Plus,
+                Token::Ident("a".to_string()),
+                Token::Number(-3.0),
+            ]
+        );
     }
 
     #[test]

--- a/tests/regression_neg_literal_papercut.rs
+++ b/tests/regression_neg_literal_papercut.rs
@@ -1,0 +1,172 @@
+// Regression tests for the `-0 v` papercut: a glued negative-literal token
+// at a fresh-expression position (start of input, after `;`, after `=`, after
+// `{`, after `(`) silently produced wrong results because Logos's
+// `-?[0-9]+...` regex consumed the leading `-`. So `ab x:n>n;-0 x` lexed as
+// `Number(-0)` followed by a stray `Ref(x)` rather than the user's intended
+// `Subtract(0, x)`. Six+ personas hit this in the assessment log writing
+// numerical formulas where "0 minus v" is the natural unary-negation idiom.
+//
+// The lexer now splits `Number(-N)` into `Minus, Number(N)` when the
+// preceding token is one that introduces a fresh expression position. Call-
+// arg negative literals (`at xs -1`, `+a -3`, `into -3 0 10`, `[1 -2 3]`,
+// `[-2 1 3]`) are deliberately preserved by *excluding* value-producing
+// tokens and `LBracket` from the split contexts.
+//
+// These tests pin the fixed behaviour across all three engines.
+
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, args: &[&str]) -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let seq = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let path = std::env::temp_dir().join(format!(
+        "ilo_neg_papercut_{}_{}_{}.ilo",
+        std::process::id(),
+        seq,
+        engine.trim_start_matches("--"),
+    ));
+    std::fs::write(&path, src).unwrap();
+    let mut cmd = ilo();
+    cmd.arg(path.to_str().unwrap()).arg(engine);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for src=`{src}` args={args:?}: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+// Unary-negate-by-subtract-from-zero at statement position. This is the
+// dominant form of the papercut.
+const AB_AT_START: &str = "ab x:n>n;-0 x\n";
+
+// Same shape inside a function body after a `;` separator (`v=...;-0 v`).
+const ABSP_AFTER_SEMI: &str = "absp p:L _>n;v=p.1;-0 v\n";
+
+// Negative-literal subtract on the rhs of an assignment (`r=-1 t2`).
+const DIFF_AFTER_EQ: &str = "diff a:n b:n>n;r=-a b;r\n";
+
+// `-0 c` inside a braced block (function body / conditional arm).
+const ZARM_INSIDE_BRACE: &str = "zarm c:n>n;<c 0{-0 c}{c}\n";
+
+// `-0 n` inside a parenthesised expression (safe-ending wrap).
+const NEG_INSIDE_PAREN: &str = "neg n:n>n;(-0 n)\n";
+
+// Pin keep-literal cases that MUST NOT split, even after the fix:
+//
+//   - `[1 -2 3]`: middle element follows a Number, stays negative literal.
+//   - `[-2 1 3]`: first element follows `LBracket` (deliberately excluded
+//     from the split contexts), stays negative literal. If LBracket *did*
+//     split, the parser would greedy-subtract `-2 1` and silently produce
+//     a 2-element list `[1, 3]`.
+const MID_LIST: &str = "mid>n;l=[1 -2 3];hd tl l\n";
+const FIRST_NEG: &str = "first>n;l=[-2 1 3];hd l\n";
+const LIST_LEN: &str = "ln>n;l=[-2 1 3];len l\n";
+
+fn check_engine(engine: &str) {
+    // -0 x at fresh-expression position correctly negates.
+    assert_eq!(
+        run(engine, AB_AT_START, &["ab", "7"]),
+        "-7",
+        "ab(7) engine={engine}"
+    );
+    assert_eq!(
+        run(engine, AB_AT_START, &["ab", "-7"]),
+        "7",
+        "ab(-7) engine={engine}"
+    );
+    assert_eq!(
+        run(engine, AB_AT_START, &["ab", "0"]),
+        "0",
+        "ab(0) engine={engine}"
+    );
+
+    // -0 v after a `;` (mid-function-body) reads the list element through
+    // a prior binding and negates it.
+    assert_eq!(
+        run(engine, ABSP_AFTER_SEMI, &["absp", "[10,3]"]),
+        "-3",
+        "absp engine={engine}"
+    );
+
+    // r=-a b on the rhs of an assignment is `Subtract(a, b)`.
+    assert_eq!(
+        run(engine, DIFF_AFTER_EQ, &["diff", "5", "2"]),
+        "3",
+        "diff(5,2) engine={engine}"
+    );
+    assert_eq!(
+        run(engine, DIFF_AFTER_EQ, &["diff", "2", "5"]),
+        "-3",
+        "diff(2,5) engine={engine}"
+    );
+
+    // {-0 c} inside the then-arm of a guard returns the absolute value.
+    assert_eq!(
+        run(engine, ZARM_INSIDE_BRACE, &["zarm", "-4"]),
+        "4",
+        "zarm(-4) engine={engine}"
+    );
+    assert_eq!(
+        run(engine, ZARM_INSIDE_BRACE, &["zarm", "6"]),
+        "6",
+        "zarm(6) engine={engine}"
+    );
+
+    // (-0 n) inside parens negates.
+    assert_eq!(
+        run(engine, NEG_INSIDE_PAREN, &["neg", "9"]),
+        "-9",
+        "neg(9) engine={engine}"
+    );
+    assert_eq!(
+        run(engine, NEG_INSIDE_PAREN, &["neg", "-2"]),
+        "2",
+        "neg(-2) engine={engine}"
+    );
+
+    // Keep-literal: `[1 -2 3]` is a 3-element list; `hd tl l` returns the
+    // second element (-2).
+    assert_eq!(
+        run(engine, MID_LIST, &["mid"]),
+        "-2",
+        "mid list `[1 -2 3]` engine={engine}"
+    );
+
+    // Keep-literal: `[-2 1 3]` is a 3-element list starting with -2.
+    assert_eq!(
+        run(engine, FIRST_NEG, &["first"]),
+        "-2",
+        "first of `[-2 1 3]` engine={engine}"
+    );
+    assert_eq!(
+        run(engine, LIST_LEN, &["ln"]),
+        "3",
+        "len of `[-2 1 3]` engine={engine}"
+    );
+}
+
+#[test]
+fn neg_literal_papercut_tree() {
+    check_engine("--run-tree");
+}
+
+#[test]
+fn neg_literal_papercut_vm() {
+    check_engine("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn neg_literal_papercut_cranelift() {
+    check_engine("--run-cranelift");
+}


### PR DESCRIPTION
## Summary

Manifesto framing: this is a token-cost fix. Six personas in the assessment log (L705, L1252, L1465, L1503, L1545, L1650, L1809) hit the same papercut three or more times each writing numerical formulas. The natural unary-negation idiom `-0 v` (meaning `0 - v`) silently produced wrong results because Logos's `-?[0-9]+...` regex greedily consumed the leading `-`, so `-0 v` lexed as `Number(-0)` + stray `Ref(v)`. The canonical workaround `- 0 v` (with space) works but is easy to forget when transcribing maths, and the failure mode is silent. Every retry costs tokens for everyone downstream.

## Repro

Before:

```
$ ilo "ab x:n>n;-0 x" ab 7
{"code":"ILO-P001","message":"unexpected token Ref(\"x\")...","severity":"error"}
```

After:

```
$ ilo "ab x:n>n;-0 x" ab 7
-7
$ ilo "ab x:n>n;-0 x" ab -7
7
```

## What's in the diff

Three commits:

1. **`lexer: split glued negative literal back into Minus + Number`** - new post-lex pass in `src/lexer/mod.rs` that rewrites `Number(-N)` into `Minus, Number(N)` only when the preceding token is one that introduces a fresh expression position: start of input, `;`, `\n`, `=`, `{`, or `(`. The parser's existing `parse_minus` resolves the rest. Call-arg negatives (`at xs -1`, `+a -3`, `into -3 0 10`, `<r -0.05`, `[1 -2 3]`) keep their `Number(-N)` token. `LBracket` is deliberately excluded so `[-2 1 3]` stays a 3-element list. 10 new lexer unit tests pin every split context and every keep-literal case.

2. **`test: cross-engine regression coverage for neg-literal papercut`** - new `tests/regression_neg_literal_papercut.rs` exercises five fixed-shape programs (one per split context) plus three keep-literal pins, each across tree, VM, and Cranelift.

3. **`examples: neg-literal-papercut.ilo for the now-correct behaviour`** - five small functions (`ab`, `absp`, `diff`, `zarm`, `neg`) with `-- run:` / `-- out:` annotations. Doubles as a cross-engine regression via the `examples_engines` harness and as in-context learning material for future agents.

## Test plan

- [x] `cargo test --release --features cranelift` clean across tree/VM/Cranelift
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --release --features cranelift --all-targets -- -D warnings` clean
- [x] 10 new lexer unit tests pin all split + keep contexts
- [x] 3 new cross-engine regression tests in `regression_neg_literal_papercut.rs`
- [x] `examples_engines` exercises the new `neg-literal-papercut.ilo` across all engines
- [x] Existing `regression_negative_literal_after_op` still green (call-arg literals preserved)

## Follow-ups

None. The split rule is narrow by design - any expansion (e.g. also splitting after `Comma` for function calls that use comma separators, or after prefix-binop tokens) would need its own design pass and cross-engine coverage. If a persona hits a different fresh-expression context that I missed, adding it to the `matches!` arm in `src/lexer/mod.rs:415` is a one-line change with a corresponding unit test.