### PR TITLE
inline lambdas: phase 1 (parenthesised fn literals, lift to synthetic decls)

### DIFF
--- a/examples/inline-lambda.ilo
+++ b/examples/inline-lambda.ilo
@@ -1,0 +1,31 @@
+-- Phase 1 inline lambdas: pass a `(params>ret;body)` literal to a HOF
+-- instead of defining a one-off top-level helper.
+--
+-- Phase 1 does NOT capture enclosing scope. The body's free variables must
+-- all be params, locals, or known fns. To thread external state in, use the
+-- HOF's ctx-arg form (`srt fn ctx xs`) which already works for named fns.
+-- Closure capture is the Phase 2 follow-up — ILO-P017 spells out the path.
+
+-- Sort numbers by distance from zero (would have needed a `dist` helper).
+by-dist xs:L n>L n;srt (x:n>n;abs x) xs
+
+-- Sort words by length (would have needed a `wlen` helper).
+by-len ws:L t>L t;srt (s:t>n;len s) ws
+
+-- Filter to non-empty strings (would have needed an `nempty` predicate).
+-- Note the parens around `len s`: prefix-binops take atoms, so the inner
+-- call needs grouping. Same rule as anywhere else in ilo.
+nonempty ws:L t>L t;flt (s:t>b;>(len s) 0) ws
+
+-- Sum of squares via inline accumulator (would have needed a `sqacc` helper).
+sumsq xs:L n>n;fld (a:n x:n>n;+a *x x) xs 0
+
+-- engine-skip: vm
+-- run: by-dist [-3,1,-5,2]
+-- out: [1, 2, -3, -5]
+-- run: by-len ["banana","fig","apple","kiwi"]
+-- out: [fig, kiwi, apple, banana]
+-- run: nonempty ["a","","b","","c"]
+-- out: [a, b, c]
+-- run: sumsq [1,2,3,4]
+-- out: 30

--- a/src/diagnostic/registry.rs
+++ b/src/diagnostic/registry.rs
@@ -240,6 +240,39 @@ do not need braces:
     cls sp:n>t;>=sp 1000 "gold";>=sp 500 "silver";"bronze"
 "#,
     },
+    ErrorEntry {
+        code: "ILO-P017",
+        short: "inline lambda captures outer scope",
+        long: r#"## ILO-P017: inline lambda captures outer scope
+
+Phase 1 inline lambdas — `(p:t>r;body)` passed to a HOF like `srt`, `map`,
+`flt`, `fld`, `grp` — cannot close over variables from the enclosing function.
+Every name referenced in the body must be a parameter of the lambda, a name
+bound locally inside the lambda body, or a known top-level function/builtin.
+
+**Wrong:**
+
+    rank xs:L n threshold:n>L n
+      srt (x:n>n;-x threshold) xs
+
+The lambda references `threshold` from the enclosing scope.
+
+**Fix A: use the HOF's ctx-arg form.** Every closure-aware HOF accepts an
+optional context value that is threaded through every call:
+
+    rank xs:L n threshold:n>L n
+      srt (x:n c:n>n;-x c) threshold xs
+
+**Fix B: define a top-level helper** that takes the value as a param and use
+`srt fn ctx xs`:
+
+    diff x:n c:n>n;-x c
+    rank xs:L n threshold:n>L n;srt diff threshold xs
+
+Closure capture is tracked as a Phase 2 follow-up; once it lands, free
+variables will be captured by value automatically.
+"#,
+    },
     // ── Type / Verifier ──────────────────────────────────────────────────────
     ErrorEntry {
         code: "ILO-T001",

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -15,6 +15,14 @@ pub struct Parser {
     /// parsed as a bare Ref (list element) rather than a function call.
     /// Set only inside list-literal element parsing.
     no_whitespace_call: bool,
+    /// Synthetic top-level decls emitted by inline-lambda lifting. Appended to
+    /// `Program.declarations` after the main parse. Each inline lambda
+    /// `(p:t>r;body)` becomes a `Decl::Function { name: "__lit_N", ... }` here
+    /// and the call site is replaced by `Expr::Ref("__lit_N")` so HOFs see a
+    /// fn-ref just like a named helper.
+    lifted_decls: Vec<Decl>,
+    /// Monotonic counter for synthetic lambda names.
+    lambda_counter: usize,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -43,6 +51,8 @@ impl Parser {
             fn_arity,
             fn_param_is_fn,
             no_whitespace_call: false,
+            lifted_decls: Vec::new(),
+            lambda_counter: 0,
         }
     }
 
@@ -187,6 +197,11 @@ impl Parser {
                 }
             }
         }
+
+        // Append synthetic decls emitted by inline-lambda lifting. Their names
+        // start with `__lit_`, which is not a legal user ident (starts with
+        // `_`), so there is no collision risk.
+        declarations.append(&mut self.lifted_decls);
 
         (
             Program {
@@ -1279,9 +1294,13 @@ impl Parser {
         let body_span = body_start.merge(self.prev_span());
 
         // Dangling token detection: after a braceless guard body, the next token
-        // must be `;`, `}`, or EOF. If something else follows, the user likely
-        // wrote a function call without braces: `>=sp 1000 classify sp`
-        if !matches!(self.peek(), None | Some(Token::Semi) | Some(Token::RBrace)) {
+        // must be `;`, `}`, `)` (lambda-body terminator), or EOF. If something
+        // else follows, the user likely wrote a function call without braces:
+        // `>=sp 1000 classify sp`
+        if !matches!(
+            self.peek(),
+            None | Some(Token::Semi) | Some(Token::RBrace) | Some(Token::RParen)
+        ) {
             return Err(self.error_hint(
                 "ILO-P016",
                 "unexpected token after braceless guard body".to_string(),
@@ -2140,6 +2159,15 @@ impl Parser {
                 Ok(Expr::Ref("_".to_string()))
             }
             Some(Token::LParen) => {
+                // Inline-lambda disambiguation. A parenthesised inline fn
+                // literal looks like `(p1:t1 p2:t2 >ret;body)` or `(>ret;body)`
+                // for a zero-param body. The trigger is unambiguous: only a
+                // lambda has an `ident:` pair (or a leading `>`) immediately
+                // inside the paren before the matching `)`, without an
+                // intervening top-level `;` — a grouped expression never does.
+                if self.looks_like_inline_lambda() {
+                    return self.parse_inline_lambda();
+                }
                 self.advance();
                 // Parenthesised expressions are self-contained — restore
                 // normal whitespace-call behaviour inside.
@@ -2214,6 +2242,341 @@ impl Parser {
             }
             Some(tok) => Err(self.error("ILO-P009", format!("expected expression, got {:?}", tok))),
             None => Err(self.error("ILO-P010", "expected expression, got EOF".into())),
+        }
+    }
+
+    /// Lookahead: does the token at `self.pos` (`(`) open an inline lambda?
+    ///
+    /// Triggers (all unambiguous — grouped expressions never start this way):
+    ///   - `( ident : ...`  — at least one typed param
+    ///   - `( > ...`        — zero-param lambda
+    ///
+    /// We also require a `>` to appear at paren-depth 0 before the matching
+    /// `)` — this rejects e.g. `(a:1 b:2)` (record-style key:val, which is
+    /// not currently a valid grouped expression but guards against future
+    /// syntax overlap).
+    fn looks_like_inline_lambda(&self) -> bool {
+        debug_assert_eq!(self.peek(), Some(&Token::LParen));
+        let first = self.token_at(self.pos + 1);
+        let second = self.token_at(self.pos + 2);
+        let starts_like_lambda = matches!(
+            (first, second),
+            (Some(Token::Ident(_)), Some(Token::Colon)) | (Some(Token::Greater), _)
+        );
+        if !starts_like_lambda {
+            return false;
+        }
+        // Confirm a `>` exists at paren-depth 0 inside the parens.
+        let mut depth = 1usize;
+        let mut i = self.pos + 1;
+        while let Some(tok) = self.token_at(i) {
+            match tok {
+                Token::LParen | Token::LBracket | Token::LBrace => depth += 1,
+                Token::RParen | Token::RBracket | Token::RBrace => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return false;
+                    }
+                }
+                Token::Greater if depth == 1 => return true,
+                _ => {}
+            }
+            i += 1;
+        }
+        false
+    }
+
+    /// Parse `(params>return;body)` as an inline lambda. Lifts the body into
+    /// a synthetic top-level `Decl::Function { name: "__lit_N", .. }` and
+    /// returns `Expr::Ref("__lit_N")` so HOFs see a fn-ref identical to a
+    /// named helper.
+    ///
+    /// Phase 1: closures are rejected. Any reference to a name that isn't a
+    /// param, isn't a local binding, and isn't a known function/builtin
+    /// raises ILO-P017 pointing at the Phase 2 follow-up.
+    fn parse_inline_lambda(&mut self) -> Result<Expr> {
+        let start = self.peek_span();
+        self.expect(&Token::LParen)?;
+        // Parens are self-contained; reset whitespace-call mode inside.
+        let prev_no_ws = self.no_whitespace_call;
+        self.no_whitespace_call = false;
+        let params = self.parse_params()?;
+        self.expect(&Token::Greater)?;
+        let return_type = self.parse_type()?;
+        if self.peek() == Some(&Token::Semi) {
+            self.advance();
+        }
+        // The body parses until `)` at the current paren depth. We mark the
+        // RParen as a body terminator by parsing statements one-by-one and
+        // stopping when we see `)`. Reusing `parse_body` would consume the
+        // `)` as part of normal at-body-end logic — instead, parse a
+        // semicolon-separated sequence that terminates on RParen.
+        let body = self.parse_lambda_body()?;
+        self.no_whitespace_call = prev_no_ws;
+        let end = self.peek_span();
+        self.expect(&Token::RParen)?;
+
+        // Free-variable check (Phase 1 rejects captures).
+        let bound: std::collections::HashSet<String> =
+            params.iter().map(|p| p.name.clone()).collect();
+        let mut free = Vec::new();
+        // `local` is shared across the body's statement sequence so that a
+        // `let` in stmt N makes its name visible to stmt N+1.
+        let mut local: Vec<String> = Vec::new();
+        for stmt in &body {
+            self.collect_free_in_stmt(&stmt.node, &bound, &mut local, &mut free);
+        }
+        if let Some(name) = free.first() {
+            return Err(self.error_hint(
+                "ILO-P017",
+                format!("inline lambda captures `{}` from the enclosing scope", name),
+                "Phase 1 inline lambdas cannot close over outer variables. \
+                 Either pass `{name}` as an extra param and use the HOF's \
+                 ctx-arg form (`srt fn ctx xs`), or define a top-level helper. \
+                 Closure capture is tracked as a Phase 2 follow-up."
+                    .replace("{name}", name),
+            ));
+        }
+
+        // Lift to a synthetic top-level decl.
+        let name = format!("__lit_{}", self.lambda_counter);
+        self.lambda_counter += 1;
+        self.register_user_fn(&name, &params);
+        let span = start.merge(end);
+        self.lifted_decls.push(Decl::Function {
+            name: name.clone(),
+            params,
+            return_type,
+            body,
+            span,
+        });
+        Ok(Expr::Ref(name))
+    }
+
+    /// Parse a `;`-separated sequence of statements terminated by `)`.
+    fn parse_lambda_body(&mut self) -> Result<Vec<Spanned<Stmt>>> {
+        let mut stmts = Vec::new();
+        if self.peek() != Some(&Token::RParen) {
+            let span_start = self.peek_span();
+            let stmt = self.parse_stmt()?;
+            stmts.push(Spanned {
+                node: stmt,
+                span: span_start.merge(self.prev_span()),
+            });
+            while self.peek() == Some(&Token::Semi) {
+                self.advance();
+                if self.peek() == Some(&Token::RParen) {
+                    break;
+                }
+                let span_start = self.peek_span();
+                let stmt = self.parse_stmt()?;
+                stmts.push(Spanned {
+                    node: stmt,
+                    span: span_start.merge(self.prev_span()),
+                });
+            }
+        }
+        Ok(stmts)
+    }
+
+    /// Walk a statement and record any `Expr::Ref` that isn't bound by the
+    /// lambda's params, by an enclosing `let`/destructure/foreach inside the
+    /// body, or by a known function/builtin name. `local` carries
+    /// body-introduced bindings as we descend.
+    fn collect_free_in_stmt(
+        &self,
+        stmt: &Stmt,
+        params: &std::collections::HashSet<String>,
+        local: &mut Vec<String>,
+        free: &mut Vec<String>,
+    ) {
+        match stmt {
+            Stmt::Let { name, value } => {
+                self.collect_free_in_expr(value, params, local, free);
+                local.push(name.clone());
+            }
+            Stmt::Guard {
+                condition,
+                body,
+                else_body,
+                ..
+            } => {
+                self.collect_free_in_expr(condition, params, local, free);
+                let depth = local.len();
+                for s in body {
+                    self.collect_free_in_stmt(&s.node, params, local, free);
+                }
+                local.truncate(depth);
+                if let Some(eb) = else_body {
+                    let depth = local.len();
+                    for s in eb {
+                        self.collect_free_in_stmt(&s.node, params, local, free);
+                    }
+                    local.truncate(depth);
+                }
+            }
+            Stmt::Match { subject, arms } => {
+                if let Some(s) = subject {
+                    self.collect_free_in_expr(s, params, local, free);
+                }
+                for arm in arms {
+                    let depth = local.len();
+                    match &arm.pattern {
+                        Pattern::Err(b) | Pattern::Ok(b) => local.push(b.clone()),
+                        Pattern::TypeIs { binding, .. } => local.push(binding.clone()),
+                        _ => {}
+                    }
+                    for s in &arm.body {
+                        self.collect_free_in_stmt(&s.node, params, local, free);
+                    }
+                    local.truncate(depth);
+                }
+            }
+            Stmt::ForEach {
+                binding,
+                collection,
+                body,
+            } => {
+                self.collect_free_in_expr(collection, params, local, free);
+                let depth = local.len();
+                local.push(binding.clone());
+                for s in body {
+                    self.collect_free_in_stmt(&s.node, params, local, free);
+                }
+                local.truncate(depth);
+            }
+            Stmt::ForRange {
+                binding,
+                start,
+                end,
+                body,
+            } => {
+                self.collect_free_in_expr(start, params, local, free);
+                self.collect_free_in_expr(end, params, local, free);
+                let depth = local.len();
+                local.push(binding.clone());
+                for s in body {
+                    self.collect_free_in_stmt(&s.node, params, local, free);
+                }
+                local.truncate(depth);
+            }
+            Stmt::While { condition, body } => {
+                self.collect_free_in_expr(condition, params, local, free);
+                let depth = local.len();
+                for s in body {
+                    self.collect_free_in_stmt(&s.node, params, local, free);
+                }
+                local.truncate(depth);
+            }
+            Stmt::Return(e) | Stmt::Expr(e) => self.collect_free_in_expr(e, params, local, free),
+            Stmt::Break(opt) => {
+                if let Some(e) = opt {
+                    self.collect_free_in_expr(e, params, local, free);
+                }
+            }
+            Stmt::Continue => {}
+            Stmt::Destructure { bindings, value } => {
+                self.collect_free_in_expr(value, params, local, free);
+                for b in bindings {
+                    local.push(b.clone());
+                }
+            }
+        }
+    }
+
+    fn collect_free_in_expr(
+        &self,
+        expr: &Expr,
+        params: &std::collections::HashSet<String>,
+        local: &mut Vec<String>,
+        free: &mut Vec<String>,
+    ) {
+        match expr {
+            Expr::Literal(_) => {}
+            Expr::Ref(name) => {
+                if name == "_" {
+                    return;
+                }
+                if params.contains(name) || local.iter().any(|n| n == name) {
+                    return;
+                }
+                // Known top-level fn (incl. builtins and lifted lambdas) — fine
+                // as a fn-ref. The verifier will reject unknown refs anyway,
+                // but we need to whitelist these so legitimate HOF use inside
+                // a lambda body (`srt slen xs` for a top-level `slen`) doesn't
+                // trip the closure check.
+                if self.fn_arity.contains_key(name) {
+                    return;
+                }
+                if !free.iter().any(|n| n == name) {
+                    free.push(name.clone());
+                }
+            }
+            Expr::Field { object, .. } => self.collect_free_in_expr(object, params, local, free),
+            Expr::Index { object, .. } => self.collect_free_in_expr(object, params, local, free),
+            Expr::Call { function, args, .. } => {
+                // Function name is resolved against the known-fn table; if it
+                // isn't known, the verifier will flag it. We do NOT treat the
+                // callee name as a free var (calls aren't captures).
+                let _ = function;
+                for a in args {
+                    self.collect_free_in_expr(a, params, local, free);
+                }
+            }
+            Expr::BinOp { left, right, .. } => {
+                self.collect_free_in_expr(left, params, local, free);
+                self.collect_free_in_expr(right, params, local, free);
+            }
+            Expr::UnaryOp { operand, .. } => {
+                self.collect_free_in_expr(operand, params, local, free)
+            }
+            Expr::Ok(e) | Expr::Err(e) => self.collect_free_in_expr(e, params, local, free),
+            Expr::List(items) => {
+                for i in items {
+                    self.collect_free_in_expr(i, params, local, free);
+                }
+            }
+            Expr::Record { fields, .. } => {
+                for (_, v) in fields {
+                    self.collect_free_in_expr(v, params, local, free);
+                }
+            }
+            Expr::Match { subject, arms } => {
+                if let Some(s) = subject {
+                    self.collect_free_in_expr(s, params, local, free);
+                }
+                for arm in arms {
+                    let depth = local.len();
+                    match &arm.pattern {
+                        Pattern::Err(b) | Pattern::Ok(b) => local.push(b.clone()),
+                        Pattern::TypeIs { binding, .. } => local.push(binding.clone()),
+                        _ => {}
+                    }
+                    for s in &arm.body {
+                        self.collect_free_in_stmt(&s.node, params, local, free);
+                    }
+                    local.truncate(depth);
+                }
+            }
+            Expr::NilCoalesce { value, default } => {
+                self.collect_free_in_expr(value, params, local, free);
+                self.collect_free_in_expr(default, params, local, free);
+            }
+            Expr::With { object, updates } => {
+                self.collect_free_in_expr(object, params, local, free);
+                for (_, v) in updates {
+                    self.collect_free_in_expr(v, params, local, free);
+                }
+            }
+            Expr::Ternary {
+                condition,
+                then_expr,
+                else_expr,
+            } => {
+                self.collect_free_in_expr(condition, params, local, free);
+                self.collect_free_in_expr(then_expr, params, local, free);
+                self.collect_free_in_expr(else_expr, params, local, free);
+            }
         }
     }
 

--- a/tests/regression_inline_lambda.rs
+++ b/tests/regression_inline_lambda.rs
@@ -1,0 +1,216 @@
+// Phase 1 regression tests for inline lambdas.
+//
+// Inline lambda = `(params>return;body)` literal passed where a fn-ref is
+// expected (HOF arg position). The parser lifts each lambda to a synthetic
+// top-level `Decl::Function { name: "__lit_N", ... }` and replaces the call
+// site with `Expr::Ref("__lit_N")`, so the rest of the toolchain (verifier,
+// tree interpreter, fmt, python codegen, ...) treats it identically to a
+// named helper.
+//
+// Phase 1 deliberately rejects captures: any reference inside the body to a
+// name that is not a param, local binding, or known top-level function/
+// builtin raises ILO-P017 with a hint pointing at Phase 2 / closure-bind.
+//
+// HOF dispatch in the VM and Cranelift JIT is the parked FnRef NaN-tagging
+// effort — every test here runs on `--run-tree` only, matching the
+// closure-bind tests.
+
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn write_src(name: &str, src: &str) -> std::path::PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut path = std::env::temp_dir();
+    path.push(format!("ilo_lam_{name}_{}_{n}.ilo", std::process::id()));
+    std::fs::write(&path, src).expect("write src");
+    path
+}
+
+fn run_ok(src: &str, entry: &str, args: &[&str]) -> String {
+    let path = write_src(entry, src);
+    let mut cmd = ilo();
+    cmd.arg(&path).arg("--run-tree").arg(entry);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        out.status.success(),
+        "ilo failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn run_err(src: &str, entry: &str) -> String {
+    let path = write_src(entry, src);
+    let out = ilo()
+        .arg(&path)
+        .arg("--run-tree")
+        .arg(entry)
+        .output()
+        .expect("failed to run ilo");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        !out.status.success(),
+        "expected failure but ilo succeeded for `{src}`"
+    );
+    let mut s = String::from_utf8_lossy(&out.stderr).into_owned();
+    s.push_str(&String::from_utf8_lossy(&out.stdout));
+    s
+}
+
+// ── srt: 1-arg key fn ──────────────────────────────────────────────────────
+
+#[test]
+fn srt_inline_key_by_length() {
+    let src = "f ws:L t>L t;srt (s:t>n;len s) ws";
+    assert_eq!(
+        run_ok(src, "f", &["[\"banana\",\"fig\",\"apple\"]"]),
+        "[fig, apple, banana]"
+    );
+}
+
+#[test]
+fn srt_inline_key_absolute_value() {
+    // Body uses `abs` builtin — no captures, no helper.
+    let src = "f xs:L n>L n;srt (x:n>n;abs x) xs";
+    assert_eq!(run_ok(src, "f", &["[-3,1,-5,2]"]), "[1, 2, -3, -5]");
+}
+
+// ── flt: 1-arg predicate ───────────────────────────────────────────────────
+
+#[test]
+fn flt_inline_predicate() {
+    let src = "f xs:L n>L n;flt (x:n>b;>x 0) xs";
+    assert_eq!(run_ok(src, "f", &["[-2,3,-1,4,0]"]), "[3, 4]");
+}
+
+// ── map: 1-arg transform ───────────────────────────────────────────────────
+
+#[test]
+fn map_inline_double() {
+    let src = "f xs:L n>L n;map (x:n>n;*x 2) xs";
+    assert_eq!(run_ok(src, "f", &["[1,2,3]"]), "[2, 4, 6]");
+}
+
+// ── fld: 2-arg accumulator ─────────────────────────────────────────────────
+
+#[test]
+fn fld_inline_sum_of_squares() {
+    let src = "f xs:L n>n;fld (a:n x:n>n;+a *x x) xs 0";
+    assert_eq!(run_ok(src, "f", &["[1,2,3,4]"]), "30");
+}
+
+// ── multi-statement body (let + final expression) ──────────────────────────
+
+#[test]
+fn lambda_multi_statement_body() {
+    let src = "f xs:L n>L n;srt (x:n>n;sq=*x x;sq) xs";
+    assert_eq!(run_ok(src, "f", &["[-3,1,-5,2]"]), "[1, 2, -3, -5]");
+}
+
+// ── lambda calling a top-level helper (HOF inside HOF) ─────────────────────
+
+#[test]
+fn lambda_can_call_top_level_helper() {
+    let src = "dbl x:n>n;*x 2\nf xs:L n>L n;map (x:n>n;dbl x) xs";
+    assert_eq!(run_ok(src, "f", &["[1,2,3]"]), "[2, 4, 6]");
+}
+
+// ── lambda calling a builtin ───────────────────────────────────────────────
+
+#[test]
+fn lambda_can_call_builtin() {
+    let src = "f xs:L n>L n;srt (x:n>n;abs x) xs";
+    assert_eq!(run_ok(src, "f", &["[-3,1,-5,2]"]), "[1, 2, -3, -5]");
+}
+
+// ── Multiple lambdas in one function (counter increments) ──────────────────
+
+#[test]
+fn multiple_lambdas_in_one_function() {
+    let src = "f xs:L n>L n;ys=map (x:n>n;*x 2) xs;flt (x:n>b;>x 4) ys";
+    assert_eq!(run_ok(src, "f", &["[1,2,3,4]"]), "[6, 8]");
+}
+
+// ── Lambda inside a top-level helper, used twice via different entries ─────
+
+#[test]
+fn lambda_inside_helper() {
+    let src = "
+sorted xs:L n>L n;srt (x:n>n;abs x) xs
+f xs:L n>L n;sorted xs
+";
+    assert_eq!(run_ok(src, "f", &["[-3,1,-5,2]"]), "[1, 2, -3, -5]");
+}
+
+// ── Phase 1: closure capture rejected with ILO-P017 ────────────────────────
+
+#[test]
+fn closure_capture_rejected_simple() {
+    let src = "f xs:L n thr:n>L n;flt (x:n>b;>x thr) xs";
+    let err = run_err(src, "f");
+    assert!(
+        err.contains("ILO-P017") && err.contains("thr"),
+        "expected ILO-P017 about `thr` capture, got: {err}"
+    );
+}
+
+#[test]
+fn closure_capture_rejected_points_at_phase_2() {
+    let src = "f xs:L n thr:n>L n;flt (x:n>b;>x thr) xs";
+    let err = run_err(src, "f");
+    assert!(
+        err.contains("ctx") || err.contains("Phase 2") || err.contains("phase 2"),
+        "expected ILO-P017 hint to mention ctx-arg or Phase 2, got: {err}"
+    );
+}
+
+// ── Phase 1: ctx-arg form is the documented escape hatch ───────────────────
+
+#[test]
+fn ctx_arg_form_works_with_inline_lambda() {
+    // Phase 1 capture rejection nudges users to ctx-arg form, which already
+    // works for inline lambdas too — the lambda just takes an extra param.
+    let src = "f xs:L n thr:n>L n;flt (x:n c:n>b;>x c) thr xs";
+    assert_eq!(run_ok(src, "f", &["[1,5,3,8,2]", "4"]), "[5, 8]");
+}
+
+// ── No regression: grouped parenthesised expressions still parse ───────────
+
+#[test]
+fn grouped_expression_still_parses() {
+    // `(+a b)` is a grouped expression, not a lambda — no `ident:` and no
+    // leading `>`. Must not trip the inline-lambda lookahead.
+    let src = "f a:n b:n>n;*(+a b) 2";
+    assert_eq!(run_ok(src, "f", &["3", "4"]), "14");
+}
+
+// ── No regression: existing named-helper HOF call still works ──────────────
+
+#[test]
+fn named_helper_hof_unaffected() {
+    let src = "k x:n>n;abs x\nf xs:L n>L n;srt k xs";
+    assert_eq!(run_ok(src, "f", &["[-3,1,-5,2]"]), "[1, 2, -3, -5]");
+}
+
+// ── Lambda inside foreach body shadowing is honored ────────────────────────
+
+#[test]
+fn lambda_local_binding_shadows_nothing_outside() {
+    // The `s` inside the lambda is a param, not a capture of any outer name.
+    // Even though there's no outer `s`, this exercises the param/local
+    // resolution path explicitly.
+    let src = "f ws:L t>L t;srt (s:t>n;n=len s;n) ws";
+    assert_eq!(
+        run_ok(src, "f", &["[\"banana\",\"fig\",\"apple\"]"]),
+        "[fig, apple, banana]"
+    );
+}


### PR DESCRIPTION
## Summary

Inline `(params>ret;body)` fn literals in HOF arg position. Lifts each lambda to a synthetic `__lit_N` top-level decl and rewrites the call site as `Expr::Ref("__lit_N")`, so the rest of the toolchain treats it exactly like a named helper. Retires the recurring "every `srt/map/flt/fld/grp fn xs` needs a one-off top-level helper" tax flagged by nine persona runs (L403, L790, L827, L860, L905, L1218, L1456, L1463, L1724 in the assessment doc).

Manifesto framing: every prior use needed 1-3 extra lines for a helper that's only called once. An inline lambda is cheaper (per-use break-even at ~3 tokens) and reuses the existing decl grammar verbatim — zero new tokens, zero new mental model.

## Scope

Phase 1 only, per the gated investigation:
- Parses `(params>ret;body)` wherever an expression is allowed.
- Lifts to a synthetic `__lit_N` decl appended to `Program.declarations`. `__lit_` is illegal as a user ident, no collision risk.
- Rejects closure capture with **ILO-P017** pointing at the closure-bind ctx-arg form (`srt fn ctx xs`) and Phase 2.
- Tree-walking interpreter only. VM/Cranelift HOF dispatch remains the parked FnRef nan-tagging effort.

Out of scope (explicitly):
- Phase 2 — closure capture by value. Tracked in the diagnostic body and the assessment doc.
- Phase 3 — VM/Cranelift HOF dispatch. Same parked effort the existing HOF examples already engine-skip.

## Repro before / after

**Before:**

```
wlen s:t>n;len s
sorted ws:L t>L t;srt wlen ws
```

**After:**

```
sorted ws:L t>L t;srt (s:t>n;len s) ws
```

Capture attempt now produces a clean diagnostic:

```
$ ilo -e 'f xs:L n thr:n>L n;flt (x:n>b;>x thr) xs'
ILO-P017: inline lambda captures `thr` from the enclosing scope
hint: Phase 1 inline lambdas cannot close over outer variables.
      Either pass `thr` as an extra param and use the HOF's ctx-arg
      form (`srt fn ctx xs`), or define a top-level helper. Closure
      capture is tracked as a Phase 2 follow-up.
```

## What's in the diff

- **`registry: ILO-P017 for inline-lambda capture rejection`** — new diagnostic with both fix variants in the long form.
- **`parser: inline lambdas lifted to synthetic top-level decls`** — `looks_like_inline_lambda` lookahead at `(`, `parse_inline_lambda` reusing `parse_params` + `parse_type` + a body parser that terminates on `)`, free-var collector that whitelists params/locals/known fns, lifting into `lifted_decls` appended at end-of-parse. Same commit relaxes the braceless-guard terminator to accept `)` so a comparison-tail body like `>(len s) 0` works inside a lifted decl.
- **`test: regression coverage for Phase 1 inline lambdas`** — 16 tests on `--run-tree`: srt/map/flt/fld inline forms, multi-statement body, lambda calling top-level helper, lambda calling builtin, multiple lambdas in one fn, lambda inside helper, ctx-arg form with inline lambda, plus two ILO-P017 capture-rejection assertions and two non-regression checks for grouped expressions and named-helper HOF calls.
- **`examples: inline-lambda.ilo demonstrates Phase 1 HOF lambdas`** — four worked cases exercised by `examples_engines.rs` on tree.

## Test plan

- [x] `cargo test --release --test regression_inline_lambda` — 16/16 green
- [x] `cargo test --release --features cranelift --tests --no-fail-fast` — 4250 passed, 7 failed (all pre-existing `vm::compile_cranelift::tests::aot_*` env tests that hardcode `target/release/libilo.a`; they pass on the main checkout and fail unconditionally under `CARGO_TARGET_DIR=target-isolated` regardless of this diff)
- [x] `cargo test --release --features cranelift --lib -- --skip vm::compile_cranelift::tests::aot` — 2859/0
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --release --features cranelift --tests -- -D warnings` — clean
- [x] `examples/inline-lambda.ilo` exercised across all enabled engines via the examples_engines harness

## Follow-ups

- Phase 2: closure capture by value. Free-var scan promoted from rejection to lift transformation; closure values prepend captures to the synthetic decl's param list and the HOF call site materialises them as ctx args.
- Phase 3: VM/Cranelift HOF dispatch. Same parked FnRef nan-tagging effort the existing HOF examples already engine-skip.