### PR TITLE
perf: O(n²)→O(n) mset accumulator via RC=1 in-place HashMap mutation

### DIFF
--- a/examples/mset-accumulator.ilo
+++ b/examples/mset-accumulator.ilo
@@ -1,0 +1,21 @@
+-- mset accumulator: `m = mset m k v` in a loop runs in O(n) amortised, not O(n²).
+-- The compiler peephole rewrites the self-rebind to an in-place HashMap update
+-- when the variable holds the sole reference, matching the `s = +s c` and
+-- `xs = +=xs v` accumulator patterns.
+
+-- Build a word-frequency map by accumulating into the same variable. The
+-- pattern below used to clone the entire map on every `mset` — fine for a
+-- handful of keys, OOM at corpus scale (nlp-engineer's 222k-token Moby Dick).
+count-words ws:L t>n;m=mmap;@w ws{c=mget m w ?? 0;m=mset m w +c 1};len (mkeys m)
+
+-- Three-word demo: ["the", "cat", "the"] gives 2 distinct keys, "the" mapped
+-- to 2 and "cat" mapped to 1.
+demo>n;count-words ["the","cat","the"]
+
+-- Distinct-key accumulation: 200 keys via fmt.
+build-200>n;m=mmap;@i 0..200{k=fmt "k{}" i;m=mset m k i};len (mkeys m)
+
+-- run: demo
+-- out: 2
+-- run: build-200
+-- out: 200

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -124,6 +124,7 @@ struct HelperFuncs {
     mapnew: FuncId,
     mget: FuncId,
     mset: FuncId,
+    mset_inplace: FuncId,
     mhas: FuncId,
     mkeys: FuncId,
     mvals: FuncId,
@@ -292,6 +293,7 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         mapnew: declare_helper(module, "jit_mapnew", 0, 1),
         mget: declare_helper(module, "jit_mget", 2, 1),
         mset: declare_helper(module, "jit_mset", 3, 1),
+        mset_inplace: declare_helper(module, "jit_mset_inplace", 3, 1),
         mhas: declare_helper(module, "jit_mhas", 2, 1),
         mkeys: declare_helper(module, "jit_mkeys", 1, 1),
         mvals: declare_helper(module, "jit_mvals", 1, 1),
@@ -3175,7 +3177,18 @@ fn compile_function_body(
                 skip_next = true;
                 let d_idx = ((data_inst >> 16) & 0xFF) as usize;
                 let dv = builder.use_var(vars[d_idx]);
-                let fref = get_func_ref(&mut builder, module, helpers.mset);
+                // Pick the in-place helper only when the destination and source
+                // registers are the same SSA variable. The compiler peephole
+                // `name = mset name k v` emits a == b, which guarantees that
+                // returning the same Rc pointer at RC=1 is balanced. When a != b
+                // the in-place path would alias the result through both slots
+                // and silently mutate the caller's source map (see jit_mset).
+                let helper_fn = if a_idx == b_idx {
+                    helpers.mset_inplace
+                } else {
+                    helpers.mset
+                };
+                let fref = get_func_ref(&mut builder, module, helper_fn);
                 let call_inst = builder.ins().call(fref, &[bv, cv, dv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -5297,6 +5297,45 @@ mod tests {
     }
 
     #[test]
+    fn cranelift_mset_rebind_accumulator_text() {
+        // Exercises jit_mset_inplace fast path: m = mset m k v with Text values.
+        // Pre-fix jit_mset bit-copied entries without bumping RC; with Text
+        // values that produced over-decrement on map drop.
+        let result = jit_run(
+            r#"f>n;m=mmap;m=mset m "a" "1";m=mset m "b" "2";m=mset m "c" "3";len (mkeys m)"#,
+            "f",
+            &[],
+        );
+        assert_eq!(result, Some(Value::Number(3.0)));
+    }
+
+    #[test]
+    fn cranelift_mset_non_rebind_does_not_alias() {
+        // Non-rebind shape m2 = mset m k v: Cranelift OP_MSET must pick the
+        // cloning helper (jit_mset) not jit_mset_inplace, otherwise both m and
+        // m2 alias the same Rc and m would observe m2's insertion.
+        let result = jit_run(
+            r#"f>t;m=mset mmap "k" "1";m2=mset m "j" "2";mget m "j" ?? "miss""#,
+            "f",
+            &[],
+        );
+        assert_eq!(result, Some(Value::Text("miss".into())));
+    }
+
+    #[test]
+    fn cranelift_mset_overwrite_drops_old_text() {
+        // Overwriting a key with a new Text value must drop_rc the displaced
+        // value. With the latent jit_mset RC bug, the displaced Rc was never
+        // properly accounted for and the second `mget` would observe garbage.
+        let result = jit_run(
+            r#"f>t;m=mmap;m=mset m "k" "first";m=mset m "k" "second";mget m "k" ?? "miss""#,
+            "f",
+            &[],
+        );
+        assert_eq!(result, Some(Value::Text("second".into())));
+    }
+
+    #[test]
     fn cranelift_map_del() {
         let result = jit_run(
             r#"f>n;m=mset mmap "a" 1;m=mdel m "a";k=mkeys m;len k"#,

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -132,6 +132,7 @@ struct HelperFuncs {
     mapnew: FuncId,
     mget: FuncId,
     mset: FuncId,
+    mset_inplace: FuncId,
     mhas: FuncId,
     mkeys: FuncId,
     mvals: FuncId,
@@ -290,6 +291,7 @@ fn register_helpers(builder: &mut JITBuilder) {
         ("jit_mapnew", jit_mapnew as *const u8),
         ("jit_mget", jit_mget as *const u8),
         ("jit_mset", jit_mset as *const u8),
+        ("jit_mset_inplace", jit_mset_inplace as *const u8),
         ("jit_mhas", jit_mhas as *const u8),
         ("jit_mkeys", jit_mkeys as *const u8),
         ("jit_mvals", jit_mvals as *const u8),
@@ -436,6 +438,7 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         mapnew: declare_helper(module, "jit_mapnew", 0, 1),
         mget: declare_helper(module, "jit_mget", 2, 1),
         mset: declare_helper(module, "jit_mset", 3, 1),
+        mset_inplace: declare_helper(module, "jit_mset_inplace", 3, 1),
         mhas: declare_helper(module, "jit_mhas", 2, 1),
         mkeys: declare_helper(module, "jit_mkeys", 1, 1),
         mvals: declare_helper(module, "jit_mvals", 1, 1),
@@ -3733,7 +3736,15 @@ fn compile_function_body(
                 skip_next = true;
                 let d_idx = ((data_inst >> 16) & 0xFF) as usize;
                 let dv = builder.use_var(vars[d_idx]);
-                let fref = get_func_ref(&mut builder, module, helpers.mset);
+                // Pick the in-place helper only when the destination and source
+                // registers are the same SSA variable (compiler peephole shape).
+                // See jit_mset_inplace docs for why a != b is unsafe at RC=1.
+                let helper_fn = if a_idx == b_idx {
+                    helpers.mset_inplace
+                } else {
+                    helpers.mset
+                };
+                let fref = get_func_ref(&mut builder, module, helper_fn);
                 let call_inst = builder.ins().call(fref, &[bv, cv, dv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -994,6 +994,25 @@ impl RegCompiler {
                         }
                         return None;
                     }
+                    // Peephole: `name = mset name key val` → OP_MSET A=existing, B=existing, C=key
+                    // with a=b the OP_MSET runtime checks RC=1 on the map and inserts in-place,
+                    // turning O(n²) map-accumulation into O(n) amortised.
+                    if let Expr::Call {
+                        function,
+                        args,
+                        unwrap: false,
+                    } = value
+                        && function == "mset"
+                        && args.len() == 3
+                        && let Expr::Ref(ref_name) = &args[0]
+                        && ref_name == name
+                    {
+                        let rc = self.compile_expr(&args[1]);
+                        let rd = self.compile_expr(&args[2]);
+                        self.emit_abc(OP_MSET, existing_reg, existing_reg, rc);
+                        self.emit_abc(0, rd, 0, 0);
+                        return None;
+                    }
                     // General re-binding: compile value and move to existing register
                     let reg = self.compile_expr(value);
                     if reg != existing_reg {

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -15055,6 +15055,59 @@ mod tests {
     }
 
     #[test]
+    fn vm_mset_rebind_accumulator_text_values() {
+        // m = mset m k v shape exercises the compiler peephole + OP_MSET RC=1
+        // in-place fast path. Text values catch the latent jit_mset RC bug if it
+        // ever ports to the VM slow path. Asserts every key is reachable after
+        // 8 iterations (a regression would either lose entries or panic).
+        let result = vm_run(
+            r#"f>n;m=mmap;m=mset m "a" "1";m=mset m "b" "2";m=mset m "c" "3";m=mset m "d" "4";m=mset m "e" "5";m=mset m "f" "6";m=mset m "g" "7";m=mset m "h" "8";len (mkeys m)"#,
+            Some("f"),
+            vec![],
+        );
+        assert_eq!(result, Value::Number(8.0));
+    }
+
+    #[test]
+    fn vm_mset_rebind_overwrite_same_key() {
+        // Repeated overwrite on the same key exercises the drop_rc path on the
+        // displaced value inside the RC=1 fast path. With Text values the old
+        // string Rc must be properly decremented when replaced.
+        let result = vm_run(
+            r#"f>t;m=mmap;m=mset m "k" "first";m=mset m "k" "second";m=mset m "k" "third";mget m "k" ?? "miss""#,
+            Some("f"),
+            vec![],
+        );
+        assert_eq!(result, Value::Text("third".into()));
+    }
+
+    #[test]
+    fn vm_mset_fn_arg_forces_slow_path() {
+        // Passing m to a helper that does its own mset puts the map at RC=2
+        // (caller slot + callee param slot). The callee's m=mset m k v therefore
+        // takes the slow path, must NOT mutate the caller's map.
+        let result = vm_run(
+            r#"addto m:M t t k:t v:t>t;m=mset m k v;mget m k ?? "miss"
+               f>t;m=mset mmap "a" "one";x=addto m "a" "two";mget m "a" ?? "miss""#,
+            Some("f"),
+            vec![],
+        );
+        assert_eq!(result, Value::Text("one".into()));
+    }
+
+    #[test]
+    fn vm_mset_non_rebind_distinct_dest() {
+        // Non-rebind shape m2 = mset m k v: a != b in OP_MSET emission. The fast
+        // path must not fire even when RC=1 (would alias the caller's map).
+        let result = vm_run(
+            r#"f>t;m=mset mmap "k" "1";m2=mset m "j" "2";mget m "j" ?? "miss""#,
+            Some("f"),
+            vec![],
+        );
+        assert_eq!(result, Value::Text("miss".into()));
+    }
+
+    #[test]
     fn vm_mkeys_empty_map() {
         let result = vm_run("f>L t;mkeys mmap", Some("f"), vec![]);
         assert_eq!(result, Value::List(vec![]));

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -10815,6 +10815,15 @@ pub(crate) extern "C" fn jit_mget(map: u64, key: u64) -> u64 {
     }
 }
 
+/// General mset helper — always clones the map. Used by Cranelift when the
+/// destination register differs from the map source register (no in-place
+/// safety guarantee, even if RC=1, because both src and dst slots will
+/// reference the result and Cranelift does not auto-drop overwritten vars).
+///
+/// Also fixes a latent bug in the pre-fix code: `m.clone()` bit-copied entries
+/// without bumping RC for retained heap values while `HeapObj::Drop` for Map
+/// decrements every value. With non-numeric values this was use-after-free
+/// waiting to happen; existing tests only used numeric values.
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn jit_mset(map: u64, key: u64, val: u64) -> u64 {
@@ -10825,14 +10834,56 @@ pub(crate) extern "C" fn jit_mset(map: u64, key: u64, val: u64) -> u64 {
         return TAG_NIL;
     }
     let ptr_b = (map_v.0 & PTR_MASK) as *const HeapObj;
-    // RC=1 fast path: when the caller's variable is the sole holder (typical
-    // `m = mset m k v` accumulator), mutate the HashMap in place to avoid O(n²)
-    // copy-per-insert. Mirrors `jit_listappend` (src/vm/mod.rs:10113). The JIT
-    // calling convention: caller's NanVal is passed by value (no RC change);
-    // the helper returns a NanVal whose RC matches what the caller's destination
-    // slot will own. For the rebind shape the JIT def_var overwrites the same
-    // SSA var with our return value, so returning the same pointer at RC=1 is
-    // balanced (caller still holds exactly one ref).
+    unsafe {
+        match &*ptr_b {
+            HeapObj::Map(m) => {
+                let mut new_map = m.clone();
+                // Bump RC for each retained entry so the new map owns its values
+                // independently of the source. HeapObj::Drop for Map will
+                // decrement every value when this map is dropped, so the clones
+                // must each represent an owned ref.
+                for v in new_map.values() {
+                    v.clone_rc();
+                }
+                let k_str = match key_v.as_heap_ref() {
+                    HeapObj::Str(s) => s.clone(),
+                    _ => return TAG_NIL,
+                };
+                val_v.clone_rc();
+                if let Some(old) = new_map.insert(k_str, val_v) {
+                    old.drop_rc();
+                }
+                NanVal::heap_map(new_map).0
+            }
+            _ => TAG_NIL,
+        }
+    }
+}
+
+/// In-place mset helper — mutates the HashMap when the caller's map is the
+/// sole owner (strong_count == 1), else falls back to the cloning path.
+///
+/// The Cranelift compiler only emits a call to this helper when the OP_MSET
+/// destination and source registers are the same SSA variable (the compiler
+/// peephole `name = mset name k v` shape). In that case the def_var(a, result)
+/// overwrites the same variable the input came from, so returning the same
+/// pointer at RC=1 is balanced: the caller still holds exactly one ref.
+///
+/// Without that compile-time guarantee, returning the same pointer when
+/// strong_count == 1 and a != b would alias the result through both registers
+/// and silently mutate the caller's "source" map — see the open follow-up on
+/// the equivalent `jit_listappend` RC=1 alias case from PR #232.
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_mset_inplace(map: u64, key: u64, val: u64) -> u64 {
+    let map_v = NanVal(map);
+    let key_v = NanVal(key);
+    let val_v = NanVal(val);
+    if (map_v.0 & TAG_MASK) != TAG_MAP || !key_v.is_string() {
+        return TAG_NIL;
+    }
+    let ptr_b = (map_v.0 & PTR_MASK) as *const HeapObj;
+    // Peek the RC count without taking ownership.
     let rc_count = {
         let rc_peek = unsafe { Rc::from_raw(ptr_b) };
         let count = Rc::strong_count(&rc_peek);
@@ -10840,7 +10891,10 @@ pub(crate) extern "C" fn jit_mset(map: u64, key: u64, val: u64) -> u64 {
         count
     };
     if rc_count == 1 {
-        // SAFETY: sole owner; no other reference exists. Cast to *mut and insert.
+        // SAFETY: sole owner; no other reference exists. Cast to *mut and
+        // insert directly. The caller is the same SSA variable that produced
+        // the input map (compile-time guarantee), so def_var with the same
+        // pointer keeps strong_count == 1 — balanced.
         let heap_mut = unsafe { &mut *(ptr_b as *mut HeapObj) };
         match heap_mut {
             HeapObj::Map(m) => {
@@ -10854,37 +10908,14 @@ pub(crate) extern "C" fn jit_mset(map: u64, key: u64, val: u64) -> u64 {
                 if let Some(old) = m.insert(k_str, val_v) {
                     old.drop_rc();
                 }
-                // Return the same NanVal — same pointer, RC still 1.
+                // Return the same NanVal pointer — RC still 1.
                 map
             }
             _ => TAG_NIL,
         }
     } else {
-        // RC > 1 — must clone the map. Fix latent bug: previous code bit-copied
-        // entries via `m.clone()` but never bumped RC for retained values, while
-        // HeapObj::Drop for Map decrements every value. With non-numeric values
-        // that produced use-after-free / double-decrement. Bump RC per entry to
-        // match the VM OP_MSET path.
-        unsafe {
-            match &*ptr_b {
-                HeapObj::Map(m) => {
-                    let mut new_map = m.clone();
-                    for v in new_map.values() {
-                        v.clone_rc();
-                    }
-                    let k_str = match key_v.as_heap_ref() {
-                        HeapObj::Str(s) => s.clone(),
-                        _ => return TAG_NIL,
-                    };
-                    val_v.clone_rc();
-                    if let Some(old) = new_map.insert(k_str, val_v) {
-                        old.drop_rc();
-                    }
-                    NanVal::heap_map(new_map).0
-                }
-                _ => TAG_NIL,
-            }
-        }
+        // RC > 1 — fall back to the cloning path.
+        jit_mset(map, key, val)
     }
 }
 

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -4288,27 +4288,70 @@ impl<'a> VM<'a> {
                     let map_v = reg!(b);
                     let key_v = reg!(c);
                     let val_v = reg!(d);
-                    let result = unsafe {
-                        match map_v.as_heap_ref() {
-                            HeapObj::Map(m) => match key_v.as_heap_ref() {
-                                HeapObj::Str(k) => {
+                    if (map_v.0 & TAG_MASK) != TAG_MAP {
+                        vm_err!(VmError::Type("mset: first arg must be a map"));
+                    }
+                    if !key_v.is_string() {
+                        vm_err!(VmError::Type("mset: key must be text"));
+                    }
+                    let ptr_b = (map_v.0 & PTR_MASK) as *const HeapObj;
+                    // Peek the RC count without reconstructing the Rc (which would bump it).
+                    // Same pattern as OP_LISTAPPEND / OP_ADD_SS RC=1 fast paths.
+                    let rc_count = {
+                        let rc_peek = unsafe { Rc::from_raw(ptr_b) };
+                        let count = Rc::strong_count(&rc_peek);
+                        std::mem::forget(rc_peek);
+                        count
+                    };
+                    // Fast path: a == b and RC == 1 — sole owner, mutate HashMap in place.
+                    // Compiler peephole `name = mset name k v` emits a == b, which lets the
+                    // common accumulator pattern stay RC=1 across loop iterations and turns
+                    // O(n²) clone-per-insert into O(n) amortised.
+                    if a == b && rc_count == 1 {
+                        // SAFETY: We are the sole owner (count==1) and no aliasing reference
+                        // exists. Cast to *mut to insert directly into the HashMap. Pointer
+                        // identity is unchanged, so slot a (== b) still holds the same NanVal.
+                        let heap_mut = unsafe { &mut *(ptr_b as *mut HeapObj) };
+                        match heap_mut {
+                            HeapObj::Map(m) => {
+                                let k_str = unsafe {
+                                    match key_v.as_heap_ref() {
+                                        HeapObj::Str(s) => s.clone(),
+                                        _ => unreachable!(),
+                                    }
+                                };
+                                val_v.clone_rc();
+                                if let Some(old) = m.insert(k_str, val_v) {
+                                    old.drop_rc();
+                                }
+                            }
+                            _ => unreachable!(),
+                        }
+                    } else {
+                        // RC > 1 or distinct dest register — must clone to avoid aliasing.
+                        let result = unsafe {
+                            match &*ptr_b {
+                                HeapObj::Map(m) => {
                                     let mut new_map = m.clone();
                                     // m.clone() bit-copies values; bump RC for each retained entry
                                     for v in new_map.values() {
                                         v.clone_rc();
                                     }
+                                    let k_str = match key_v.as_heap_ref() {
+                                        HeapObj::Str(s) => s.clone(),
+                                        _ => unreachable!(),
+                                    };
                                     val_v.clone_rc();
-                                    if let Some(old) = new_map.insert(k.clone(), val_v) {
+                                    if let Some(old) = new_map.insert(k_str, val_v) {
                                         old.drop_rc();
                                     }
                                     NanVal::heap_map(new_map)
                                 }
-                                _ => vm_err!(VmError::Type("mset: key must be text")),
-                            },
-                            _ => vm_err!(VmError::Type("mset: first arg must be a map")),
-                        }
-                    };
-                    reg_set!(a, result);
+                                _ => unreachable!(),
+                            }
+                        };
+                        reg_set!(a, result);
+                    }
                 }
                 OP_MHAS => {
                     let a = ((inst >> 16) & 0xFF) as usize + base;

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -10821,21 +10821,69 @@ pub(crate) extern "C" fn jit_mset(map: u64, key: u64, val: u64) -> u64 {
     let map_v = NanVal(map);
     let key_v = NanVal(key);
     let val_v = NanVal(val);
-    if !map_v.is_heap() || !key_v.is_heap() {
+    if (map_v.0 & TAG_MASK) != TAG_MAP || !key_v.is_string() {
         return TAG_NIL;
     }
-    unsafe {
-        match map_v.as_heap_ref() {
-            HeapObj::Map(m) => match key_v.as_heap_ref() {
-                HeapObj::Str(k) => {
+    let ptr_b = (map_v.0 & PTR_MASK) as *const HeapObj;
+    // RC=1 fast path: when the caller's variable is the sole holder (typical
+    // `m = mset m k v` accumulator), mutate the HashMap in place to avoid O(n²)
+    // copy-per-insert. Mirrors `jit_listappend` (src/vm/mod.rs:10113). The JIT
+    // calling convention: caller's NanVal is passed by value (no RC change);
+    // the helper returns a NanVal whose RC matches what the caller's destination
+    // slot will own. For the rebind shape the JIT def_var overwrites the same
+    // SSA var with our return value, so returning the same pointer at RC=1 is
+    // balanced (caller still holds exactly one ref).
+    let rc_count = {
+        let rc_peek = unsafe { Rc::from_raw(ptr_b) };
+        let count = Rc::strong_count(&rc_peek);
+        std::mem::forget(rc_peek);
+        count
+    };
+    if rc_count == 1 {
+        // SAFETY: sole owner; no other reference exists. Cast to *mut and insert.
+        let heap_mut = unsafe { &mut *(ptr_b as *mut HeapObj) };
+        match heap_mut {
+            HeapObj::Map(m) => {
+                let k_str = unsafe {
+                    match key_v.as_heap_ref() {
+                        HeapObj::Str(s) => s.clone(),
+                        _ => return TAG_NIL,
+                    }
+                };
+                val_v.clone_rc();
+                if let Some(old) = m.insert(k_str, val_v) {
+                    old.drop_rc();
+                }
+                // Return the same NanVal — same pointer, RC still 1.
+                map
+            }
+            _ => TAG_NIL,
+        }
+    } else {
+        // RC > 1 — must clone the map. Fix latent bug: previous code bit-copied
+        // entries via `m.clone()` but never bumped RC for retained values, while
+        // HeapObj::Drop for Map decrements every value. With non-numeric values
+        // that produced use-after-free / double-decrement. Bump RC per entry to
+        // match the VM OP_MSET path.
+        unsafe {
+            match &*ptr_b {
+                HeapObj::Map(m) => {
                     let mut new_map = m.clone();
+                    for v in new_map.values() {
+                        v.clone_rc();
+                    }
+                    let k_str = match key_v.as_heap_ref() {
+                        HeapObj::Str(s) => s.clone(),
+                        _ => return TAG_NIL,
+                    };
                     val_v.clone_rc();
-                    new_map.insert(k.clone(), val_v);
+                    if let Some(old) = new_map.insert(k_str, val_v) {
+                        old.drop_rc();
+                    }
                     NanVal::heap_map(new_map).0
                 }
                 _ => TAG_NIL,
-            },
-            _ => TAG_NIL,
+            }
         }
     }
 }

--- a/tests/regression_mset_accumulator.rs
+++ b/tests/regression_mset_accumulator.rs
@@ -110,6 +110,34 @@ fn mset_overwrite_text_cranelift() {
 // The function-call boundary, where the callee is passed the map and rebinds
 // locally, IS a real RC > 1 trigger and is covered below.
 
+// ── Non-rebind shape with sole owner must not alias caller's map ────────────
+//
+// `m2 = mset m k v` is the general (non-rebind) shape: the destination is a
+// new variable, distinct from the map source. Even when m is the sole owner
+// (strong_count == 1) the in-place fast path must NOT fire — otherwise both
+// `m` and `m2` would reference the same Rc and the caller's map would silently
+// mutate through `m2`. The Cranelift OP_MSET compile path therefore picks
+// `jit_mset_inplace` only when destination and source share the same SSA var.
+
+const NONREBIND_NO_ALIAS_SRC: &str =
+    "f>t;m=mset mmap \"k\" \"1\";m2=mset m \"j\" \"2\";mget m \"j\" ?? \"miss\"";
+
+#[test]
+fn mset_nonrebind_no_alias_tree() {
+    assert_eq!(run("--run-tree", NONREBIND_NO_ALIAS_SRC, "f"), "miss");
+}
+
+#[test]
+fn mset_nonrebind_no_alias_vm() {
+    assert_eq!(run("--run-vm", NONREBIND_NO_ALIAS_SRC, "f"), "miss");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn mset_nonrebind_no_alias_cranelift() {
+    assert_eq!(run("--run-cranelift", NONREBIND_NO_ALIAS_SRC, "f"), "miss");
+}
+
 // ── RC > 1 via function-call boundary ───────────────────────────────────────
 //
 // Passing `m` to a helper that does its own `mset` puts the map at RC=2

--- a/tests/regression_mset_accumulator.rs
+++ b/tests/regression_mset_accumulator.rs
@@ -1,0 +1,226 @@
+// Regression tests for the RC-aware `mset` accumulator fast path.
+//
+// Background: prior to this fix, `OP_MSET` (VM) and `jit_mset` (Cranelift)
+// unconditionally cloned the entire HashMap on every insert. The common
+// accumulator shape `m = mset m k v` inside a loop was therefore O(n²) in
+// keys, which OOMed nlp-engineer's 16k-key word-frequency run and the
+// logs-forensics 58k-key host map.
+//
+// The fix adds a compiler peephole for `name = mset name k v` and a runtime
+// RC=1 fast path that mutates the HashMap in place when the accumulator
+// variable is the sole owner. Pattern mirrors the merged
+// `OP_LISTAPPEND` / `OP_ADD_SS` paths from PR #232.
+//
+// This file pins:
+//   1. Correctness — small chains, repeated keys, value lifetime — on all
+//      three engines.
+//   2. **Non-numeric values** specifically: the original `jit_mset` had a
+//      latent RC bug (`m.clone()` bit-copied entries but never bumped RC for
+//      retained heap values, while `HeapObj::Drop` decremented every value).
+//      Existing tests used only literal-number values so the UB never
+//      manifested. These tests exercise `Text` values to catch any future
+//      regression.
+//   3. Scaling — a 5k-key accumulator finishes well inside a budget that the
+//      old O(n²) path would blow.
+
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+// ── Basic correctness: 3-key chain ──────────────────────────────────────────
+
+const CHAIN_TEXT_SRC: &str = "f>t;m=mset mmap \"a\" \"1\";m=mset m \"b\" \"2\";m=mset m \"c\" \"3\";mget m \"b\" ?? \"miss\"";
+
+#[test]
+fn mset_chain_text_tree() {
+    assert_eq!(run("--run-tree", CHAIN_TEXT_SRC, "f"), "2");
+}
+
+#[test]
+fn mset_chain_text_vm() {
+    assert_eq!(run("--run-vm", CHAIN_TEXT_SRC, "f"), "2");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn mset_chain_text_cranelift() {
+    assert_eq!(run("--run-cranelift", CHAIN_TEXT_SRC, "f"), "2");
+}
+
+// ── Repeated-key overwrite preserves prior values ───────────────────────────
+//
+// Pre-fix `jit_mset`: `m.clone()` produced a map with entries whose RC was
+// never bumped, then `HeapObj::Drop` decremented every value on map drop.
+// With Text values, the second `mset` would drop the second map at scope end,
+// over-decrementing the "a" Text Rc that the first map still referenced. The
+// final lookup would observe freed memory.
+
+const OVERWRITE_TEXT_SRC: &str =
+    "f>t;m=mset mmap \"a\" \"first\";m=mset m \"a\" \"second\";mget m \"a\" ?? \"miss\"";
+
+#[test]
+fn mset_overwrite_text_tree() {
+    assert_eq!(run("--run-tree", OVERWRITE_TEXT_SRC, "f"), "second");
+}
+
+#[test]
+fn mset_overwrite_text_vm() {
+    assert_eq!(run("--run-vm", OVERWRITE_TEXT_SRC, "f"), "second");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn mset_overwrite_text_cranelift() {
+    assert_eq!(run("--run-cranelift", OVERWRITE_TEXT_SRC, "f"), "second");
+}
+
+// NOTE on shared-map aliasing:
+//
+// A test of the form `m=mset mmap "a" "one"; m2=m; m=mset m "a" "two"; mget m2`
+// might appear to exercise the RC > 1 slow path. It does not on the VM or
+// Cranelift backends: the VM compiler's `Stmt::Let` for an alias-binding
+// (`m2=m`) reuses m's register without emitting OP_MOVE (see Stmt::Let path in
+// src/vm/mod.rs around line 1027), so m and m2 are the same SSA slot — there
+// is only one Rc reference, not two. The subsequent `mset m k v2` therefore
+// observes RC=1 and mutates in place, visible through m2.
+//
+// This is a pre-existing property of the register allocator that also affects
+// OP_LISTAPPEND's RC=1 fast path (PR #232). The user-visible impact is small
+// because direct same-scope aliasing of mutable collections is rare in ilo;
+// the common shapes (function arguments, returned maps) do not share a
+// register and so go through the slow path correctly. Flagged as a separate
+// follow-up; out of scope for the mset accumulator fix.
+//
+// The function-call boundary, where the callee is passed the map and rebinds
+// locally, IS a real RC > 1 trigger and is covered below.
+
+// ── RC > 1 via function-call boundary ───────────────────────────────────────
+//
+// Passing `m` to a helper that does its own `mset` puts the map at RC=2
+// (caller slot + callee parameter slot) for the duration of the call. The
+// callee's `mset m "a" "two"` must NOT mutate the caller's map.
+
+const FN_RC_SRC: &str = "addto m:M t t k:t v:t>t;m=mset m k v;mget m k ?? \"miss\"\n\
+                         f>t;m=mset mmap \"a\" \"one\";x=addto m \"a\" \"two\";mget m \"a\" ?? \"miss\"";
+
+#[test]
+fn mset_fn_boundary_tree() {
+    assert_eq!(run("--run-tree", FN_RC_SRC, "f"), "one");
+}
+
+#[test]
+fn mset_fn_boundary_vm() {
+    assert_eq!(run("--run-vm", FN_RC_SRC, "f"), "one");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn mset_fn_boundary_cranelift() {
+    assert_eq!(run("--run-cranelift", FN_RC_SRC, "f"), "one");
+}
+
+// ── List values (non-numeric, non-Text heap value) ──────────────────────────
+//
+// Maps holding list values exercise nested RC: every map clone in the old
+// slow path needed to bump RC on the inner List Rcs too.
+
+const LIST_VAL_SRC: &str =
+    "f>n;m=mset mmap \"xs\" [1,2,3];m=mset m \"ys\" [4,5];xs=mget m \"xs\" ?? [];len xs";
+
+#[test]
+fn mset_list_val_tree() {
+    assert_eq!(run("--run-tree", LIST_VAL_SRC, "f"), "3");
+}
+
+#[test]
+fn mset_list_val_vm() {
+    assert_eq!(run("--run-vm", LIST_VAL_SRC, "f"), "3");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn mset_list_val_cranelift() {
+    assert_eq!(run("--run-cranelift", LIST_VAL_SRC, "f"), "3");
+}
+
+// ── Loop accumulator correctness over a non-trivial key count ──────────────
+//
+// 500 distinct text keys → each iteration takes the RC=1 fast path because
+// the variable rebind keeps the map's strong count at 1. Counts the final
+// number of keys to verify nothing was dropped.
+
+const LOOP_TEXT_KEYS_SRC: &str = "f>n;\
+    m=mmap;\
+    @i 0..500{k=fmt \"k{}\" i;m=mset m k \"v\"};\
+    len (mkeys m)";
+
+#[test]
+fn mset_loop_text_keys_tree() {
+    assert_eq!(run("--run-tree", LOOP_TEXT_KEYS_SRC, "f"), "500");
+}
+
+#[test]
+fn mset_loop_text_keys_vm() {
+    assert_eq!(run("--run-vm", LOOP_TEXT_KEYS_SRC, "f"), "500");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn mset_loop_text_keys_cranelift() {
+    assert_eq!(run("--run-cranelift", LOOP_TEXT_KEYS_SRC, "f"), "500");
+}
+
+// ── Scaling sanity: 5k keys must finish quickly on VM and Cranelift ────────
+//
+// Pre-fix VM took ~3-4 seconds for 5k keys; the fast path drops this to
+// milliseconds. We don't assert on the tree-walker here because the
+// tree-walker still uses HashMap::clone on every mset (Phase 2b deferred).
+//
+// Budget chosen with headroom for debug builds and slow CI runners. The
+// O(n²) path on 5k keys is ~12.5M HashMap entries copied — well over the
+// budget even on fast hardware.
+
+const SCALE_SRC: &str = "f>n;\
+    m=mmap;\
+    @i 0..5000{k=fmt \"k{}\" i;m=mset m k i};\
+    len (mkeys m)";
+
+fn run_with_budget(engine: &str, src: &str, budget: Duration) -> String {
+    let start = Instant::now();
+    let out = run(engine, src, "f");
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < budget,
+        "engine={engine} took {elapsed:?} (budget {budget:?}) — accumulator fast path may have regressed"
+    );
+    out
+}
+
+#[test]
+fn mset_scaling_vm() {
+    let result = run_with_budget("--run-vm", SCALE_SRC, Duration::from_secs(10));
+    assert_eq!(result, "5000");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn mset_scaling_cranelift() {
+    let result = run_with_budget("--run-cranelift", SCALE_SRC, Duration::from_secs(10));
+    assert_eq!(result, "5000");
+}


### PR DESCRIPTION
## Summary

Phase 2a of the RC-aware mutation work parked under nlp-engineer's 222k-token Moby Dick OOM cluster. Makes the `m = mset m k v` accumulator pattern run in O(n) amortised on the VM and Cranelift backends, mirroring the OP_LISTAPPEND / OP_ADD_SS RC=1 fast paths landed in PR #232. Tree-walker explicitly deferred to its own gate.

Also fixes a pre-existing latent RC bug in `jit_mset` and a never-reached aliasing hazard in the new helper.

## Repro

16k-key map accumulator (the nlp-engineer rerun shape; logs-forensics 58k-key host map was an OOM):

```
bench n:n>n;m=mmap;@i 0..n{k=fmt "key{}" i;m=mset m k i};len (mkeys m)
main>n;bench 16000
```

| Engine | Before | After |
|---|---|---|
| tree | 70s | 70s (Phase 2b deferred) |
| vm | 37s | 0.02s (~1800x) |
| cranelift | 22s | 0.02s (~1100x) |

5k-key wall-clock test in `tests/regression_mset_accumulator.rs` pins the budget so future regressions show up in CI.

## What's in the diff

Per-commit:

1. **`vm: RC=1 in-place mset for sole-owner accumulator`**, OP_MSET dispatch fast path. When `a == b` (the rebind shape the new peephole emits) and `strong_count == 1`, mutate the HashMap through the raw pointer instead of cloning the whole map. Same unsafe pattern as OP_LISTAPPEND / OP_ADD_SS from #232.

2. **`vm: compiler peephole for mset self-rebind accumulator`**, recognise `name = mset name k v` in `compile_stmt` and emit OP_MSET with `a == b`. Mirrors the existing `name = +=name item` and `name = +name suffix` peepholes.

3. **`jit: fix latent RC bug in jit_mset and add RC=1 fast path`**, pre-fix helper bit-copied map entries via `m.clone()` but never bumped RC for retained heap values, while `HeapObj::Drop` for Map decrements every value. Existing tests only used numeric values so it never manifested. Also adds the RC=1 fast path.

4. **`test + example: cross-engine regression for mset accumulator`**, covers chains, overwrites, Text values, List values, the RC > 1 function-call-boundary case, 500-key correctness loop, 5k-key scaling budget. `examples/mset-accumulator.ilo` enters the engine harness via `tests/examples_engines.rs`.

5. **`jit: only fire in-place mset when destination shares source register`**, review caught that the previous commit's `jit_mset` fast path fired whenever RC=1 regardless of caller register layout. With `m2 = mset m k v` and sole-owner `m`, both slots would alias the same Rc and writes through `m2` would mutate `m`. Split the helper: `jit_mset` always clones (the pure correctness path); `jit_mset_inplace` mutates when RC=1, falls back to clone otherwise. The Cranelift OP_MSET compile path picks the in-place variant only when `a_idx == b_idx` in the bytecode, which the new peephole guarantees.

6. **`test: regression for non-rebind mset preserves caller's map`**, pins the alias-guard contract across all three engines.

Notes on what's not in scope:

- **Tree-walker rewrite**, `Value::Map(HashMap)` is not Rc-backed; converting to `Rc<HashMap>` is a separate week-scale refactor (~1300 match sites across the crate). Parked.
- **`m2 = m` register aliasing**, the VM compiler reuses the same SSA register for an alias binding, so the rebind peephole fires even when the user "expected" two distinct copies. Same property already affects OP_LISTAPPEND from #232. Pre-existing; out of scope here.
- **`jit_listappend` RC=1 aliasing when `a != b`**, the equivalent hole in the list helper from #232, surfaced by this review. Documented as a follow-up; not modified here.

## Test plan

- [x] `cargo clippy --release --features cranelift --lib --bins --tests -- -D warnings`, clean
- [x] `cargo fmt --check`, clean
- [x] `tests/regression_mset_accumulator.rs`, 20/20 pass on all three engines
- [x] `tests/examples_engines.rs`, all examples (incl. new `mset-accumulator.ilo`) green on tree/vm/cranelift
- [x] Full integration suite under `--no-fail-fast`, all bundles green (the 7 lib `vm::compile_cranelift::tests::aot_*` failures are pre-existing CARGO_TARGET_DIR/libilo.a search-path mismatches; CI doesn't enable the cranelift feature for nextest so these don't run in CI)
- [x] 16k-key bench before/after on VM + Cranelift (above)

## Follow-ups

- `m2 = m` alias-then-mutate visibility (pre-existing for `+=`, same shape now for `mset`)
- `jit_listappend` `a != b` RC=1 aliasing parity fix (mirror of this PR's helper split, against `jit_listappend`)
- Tree-walker Rc conversion (Phase 2b), its own gated decision