### PR TITLE
allow call-form expressions in @ range bounds

### DIFF
--- a/examples/range-call-bounds.ilo
+++ b/examples/range-call-bounds.ilo
@@ -1,0 +1,24 @@
+-- Call-form expressions are allowed on both sides of `..` in @ loops.
+-- Saves the intermediate-binding tax that personas kept tripping over:
+-- `n=len xs;@j 0..n` collapses to `@j 0..len xs`.
+
+-- End bound is a 1-arg call: sum the indices of xs.
+sum-indices xs:L n>n;s=0;@j 0..len xs{s=+s j};+s 0
+
+-- End bound is a 2-arg call: `at ys 0` is the first element of ys.
+sum-to-first ys:L n>n;s=0;@j 0..at ys 0{s=+s j};+s 0
+
+-- Start bound is a call: iterate from xs[0] up to len xs.
+range-from-first xs:L n>L n;out=[];@j at xs 0..len xs{out=+=out j};out
+
+-- Mixed: prefix-binop start with call-form end.
+slide i:n xs:L n>L n;out=[];@j +i 2..len xs{out=+=out j};out
+
+-- run: sum-indices [1,2,3]
+-- out: 3
+-- run: sum-to-first [4,9,9,9]
+-- out: 6
+-- run: range-from-first [2,9,9,9]
+-- out: [2, 3]
+-- run: slide 3 ["a","b","c","d","e","f"]
+-- out: [5]

--- a/examples/range-expr.ilo
+++ b/examples/range-expr.ilo
@@ -13,10 +13,9 @@ trim-both a:n b:n>L n;xs=[];@j -a 1..-b 1{xs=+=xs j};xs
 -- Skip the last one: @j 0..-n 1 iterates 0..(n-1) = [0,1,2,3]
 drop-last n:n>L n;xs=[];@j 0..-n 1{xs=+=xs j};xs
 
--- Call-style bounds still need a binding (`n=len xs` first).
--- This is the documented workaround; the parser does not call-parse
--- inside range bounds.
-sum-via-len xs:L n>n;n=len xs;s=0;@j 0..n{s=+s j};+s 0
+-- Call-style bounds work directly: `len xs`, `at ys 0`, etc.
+-- The previous intermediate-binding workaround is no longer needed.
+sum-via-len xs:L n>n;s=0;@j 0..len xs{s=+s j};+s 0
 
 -- run: skip-first-two 3 10
 -- out: [5, 6, 7, 8, 9]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1224,16 +1224,17 @@ impl Parser {
     fn parse_foreach(&mut self) -> Result<Stmt> {
         self.expect(&Token::At)?;
         let binding = self.expect_ident()?;
-        // Range bounds accept any operand, not just atoms: this lets personas
-        // write `@j +i 2..n` and `@j 0..-n 1` directly instead of binding an
-        // intermediate (`jst=+i 2;@j jst..n`). Call-style bounds like
-        // `@j 0..len xs` still need a binding; see tests/regression_range_expr.rs
-        // for the negative anchor.
-        let start_expr = self.parse_operand()?;
+        // Range bounds accept any expression form: literals, idents, prefix
+        // binops (`+i 2`), unary minus (`-n 1`), and call forms (`len xs`,
+        // `at ys 0`). Call args greedily stop at `..` and `{` because neither
+        // token starts an operand, so `@j 0..len xs{...}` parses cleanly as
+        // `0..Call(len,[xs])`. See tests/regression_range_expr.rs for the
+        // cross-engine matrix.
+        let start_expr = self.parse_expr_inner()?;
         // Check for range syntax: start..end
         if self.peek() == Some(&Token::DotDot) {
             self.advance(); // consume ..
-            let end_expr = self.parse_operand()?;
+            let end_expr = self.parse_expr_inner()?;
             let body = self.parse_brace_body()?;
             return Ok(Stmt::ForRange {
                 binding,
@@ -7460,7 +7461,7 @@ mod tests {
 
     #[test]
     fn zero_arg_call_as_loop_subject() {
-        // `@v xs(){...}` — loop subject goes through parse_operand → parse_atom.
+        // `@v xs(){...}` — loop subject goes through parse_expr_inner → parse_call_or_atom.
         let prog = parse_str("xs>L n;[1 2 3]\nf>n;t=0;@v xs(){t=+t v};t");
         let body = last_fn_body(&prog);
         let foreach = body

--- a/tests/regression_range_expr.rs
+++ b/tests/regression_range_expr.rs
@@ -1,16 +1,13 @@
 // Cross-engine regression tests for range bounds in `@` loops.
 //
-// Until this fix, `parse_foreach` used `parse_atom` for both range bounds,
-// so `@j +i 2..n` (prefix-binop start) and `@j 0..*n 2` (prefix-binop end)
-// were rejected with ILO-P009. Personas had to bind an intermediate
-// (`jst=+i 2;@j jst..n`) for every compound bound. Now both sides accept
-// any operand: literals, idents, prefix-binop forms (`+a b`, `-a b`,
-// `*a b`, `/a b`), and unary forms (`-x` literal negation).
-//
-// Call-style bounds (`@j 0..len xs`) explicitly still require an
-// intermediate binding; the `call_style_bound_still_requires_binding`
-// test below anchors that contract so a future change extending range
-// bounds to `parse_call_or_atom` is a deliberate decision.
+// Previously `parse_foreach` used `parse_atom` (literals/idents only), then
+// `parse_operand` (literals, idents, prefix-binop, unary minus). Personas
+// kept hitting the next ceiling: call forms like `@j 0..len xs` and
+// `@j 0..at ys 0` still required an intermediate binding. The fix switches
+// both bounds to `parse_expr_inner`, which accepts any expression form
+// including calls. Call args naturally stop at `..` and `{` because neither
+// token starts an operand, so `0..len xs{...}` parses as `0..Call(len,[xs])`
+// with the body intact.
 
 use std::process::Command;
 
@@ -113,29 +110,45 @@ fn ident_to_ident_bounds_still_work() {
 }
 
 #[test]
-fn call_style_bound_still_requires_binding() {
-    // Anchor: bare function-call bounds remain unsupported. If this test
-    // starts failing because the call form now parses, that's a deliberate
-    // extension and the test should be updated (and the assessment-doc
-    // entry reopened to consider the call-form follow-up).
-    let out = ilo()
-        .args([
-            "f>n;xs=[1,2,3];s=0;@j 0..len xs{s=+s j};+s 0",
-            "--run-tree",
-            "f",
-        ])
-        .output()
-        .expect("failed to run ilo");
-    assert!(
-        !out.status.success(),
-        "expected call-style range bound to fail; stdout={} stderr={}",
-        String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr)
+fn call_style_end_bound_len() {
+    // `0..len xs` now parses directly; the previous workaround
+    // (`n=len xs;@j 0..n`) is no longer required.
+    check_all("f>n;xs=[1,2,3];s=0;@j 0..len xs{s=+s j};+s 0", "3");
+}
+
+#[test]
+fn call_style_bound_still_works_with_binding() {
+    // The previously documented workaround keeps working too.
+    check_all("f>n;xs=[1,2,3];n=len xs;s=0;@j 0..n{s=+s j};+s 0", "3");
+}
+
+#[test]
+fn call_style_end_bound_at() {
+    // Two-arg call as the end bound: `0..at ys 0` where ys=[4,1,1] →
+    // 0..4 = [0,1,2,3], summed via +=0..3 = 6.
+    check_all("f>n;ys=[4,1,1];s=0;@j 0..at ys 0{s=+s j};+s 0", "6");
+}
+
+#[test]
+fn call_style_start_bound_at() {
+    // Call form on the start side: `at xs 0..len xs` with xs=[2,9,9,9] →
+    // 2..4 = [2, 3], summed = 5.
+    check_all("f>n;xs=[2,9,9,9];s=0;@j at xs 0..len xs{s=+s j};+s 0", "5");
+}
+
+#[test]
+fn prefix_binop_start_with_call_end() {
+    // Mixed: prefix-binop start, call end. `+i 2..len xs` with i=3, xs=[a,b,c,d,e,f]
+    // → 5..6 = [5], summed = 5.
+    check_all(
+        "f>n;i=3;xs=[\"a\",\"b\",\"c\",\"d\",\"e\",\"f\"];s=0;@j +i 2..len xs{s=+s j};+s 0",
+        "5",
     );
 }
 
 #[test]
-fn call_style_bound_works_with_binding() {
-    // The documented workaround: bind first, then range over the binding.
-    check_all("f>n;xs=[1,2,3];n=len xs;s=0;@j 0..n{s=+s j};+s 0", "3");
+fn call_bounds_both_sides() {
+    // Both sides as calls: `at xs 0..len xs`, body iterates xs[0]..len(xs).
+    // xs=[1,3,3,3], so j in 1..4 → sum 1+2+3 = 6.
+    check_all("f>n;xs=[1,3,3,3];s=0;@j at xs 0..len xs{s=+s j};+s 0", "6");
 }


### PR DESCRIPTION
## Summary

`@j 0..len xs` now parses directly. After #229 shipped prefix-binop range bounds, call-form was deliberately deferred behind a negative regression anchor. Personas (html-scraper, others) kept paying the bind-first tax: `n=len xs;@j 0..n` for every collection-length loop. This lifts the restriction.

The mechanism: `parse_foreach` switches from `parse_operand` to `parse_expr_inner` for both bounds. `parse_expr_inner` accepts everything `parse_operand` did (literals, idents, prefix binops, unary minus) plus calls. Crucially, call args stop at `..` and `{` because neither token starts an operand, so `@j 0..len xs{body}` parses as `0..Call(len,[xs])` with the body intact.

## Repro

Before:
```
$ ilo 'f>n;xs=[1,2,3];s=0;@j 0..len xs{s=+s j};+s 0' f
ILO-P011 / parse error
```

After:
```
$ ilo 'f>n;xs=[1,2,3];s=0;@j 0..len xs{s=+s j};+s 0' f
3
```

## What's in the diff

- **Parser** (`src/parser/mod.rs`): both range bounds in `parse_foreach` now go through `parse_expr_inner`. Updated the in-source comment, and an old test comment that referenced the previous parse path.
- **Tests** (`tests/regression_range_expr.rs`): the negative `call_style_bound_still_requires_binding` from #229 is flipped to a positive `call_style_end_bound_len`. New positive cross-engine tests for `0..at ys 0`, `at xs 0..len xs`, mixed `+i 2..len xs`, and both-sides-call `at xs 0..len xs`. Existing prefix-binop tests retained as the regression guard.
- **Examples**: `examples/range-expr.ilo` drops the bind-first workaround in its `sum-via-len` line. New `examples/range-call-bounds.ilo` demonstrates call-form on start side, end side, both sides, and mixed with prefix binop. Both are exercised by `tests/examples_engines.rs` across tree, VM, and Cranelift.

## Test plan

- [x] `cargo test --release --features cranelift --test regression_range_expr` — 14 passed
- [x] `cargo test --release --features cranelift --test examples_engines` — 1 passed (783 multi-engine example invocations)
- [x] Full suite green: `cargo test --release --features cranelift` — 0 failures
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --release --features cranelift --tests -- -D warnings` clean

## Follow-ups

None for this slice. The broader call-in-operator-position family (guard heads, `prnt` args, `wr path fmt`, `wrl fmt`) is still the dominant per-statement friction in the assessment doc and tracked separately under "General `fmt`-in-arg-position parser fix".