### PR TITLE
fix: accept leading-uppercase JSON keys at dot-access

### DIFF
--- a/examples/leading-upper-fields.ilo
+++ b/examples/leading-upper-fields.ilo
@@ -1,0 +1,27 @@
+-- Leading-uppercase JSON keys at dot-access (AWS-style: URL, ID, AccessKey).
+-- PR #220 fixed camelCase tails like `r.gitURL`; this covers keys whose
+-- *first* character is uppercase, where there's no preceding Ident to merge.
+furl j:t>R n t;r=jpar! j;r.URL
+fid j:t>R n t;r=jpar! j;r.ID
+fak j:t>R n t;r=jpar! j;r.AccessKey
+fsafe j:t>R n t;r=jpar! j;r.?URL
+fmix j:t>R n t;r=jpar! j;r.URL_count
+fsigil j:t>R n t;r=jpar! j;r.MetaData
+
+-- run: furl {"URL":"https://x"}
+-- out: https://x
+
+-- run: fid {"ID":42}
+-- out: 42
+
+-- run: fak {"AccessKey":"abc"}
+-- out: abc
+
+-- run: fsafe {"URL":"safe"}
+-- out: safe
+
+-- run: fmix {"URL_count":7}
+-- out: 7
+
+-- run: fsigil {"MetaData":"meta"}
+-- out: meta

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -351,6 +351,22 @@ pub fn lex(source: &str) -> Result<Vec<(Token, std::ops::Range<usize>)>, LexErro
                             prev_span.start,
                         ));
                     }
+                    // Leading-uppercase JSON key flush after a Dot/DotQuestion
+                    // (e.g. `r.URL` where `U` is consumed as a sigil-less
+                    // capital, or `r.MetaData` where `M` is the MapType
+                    // sigil). No preceding Ident to merge into; emit a fresh
+                    // Ident covering the whole identifier-shaped run.
+                    if prev_token_is_dot_flush(&tokens, span.start) {
+                        if let Some(_consumed) = emit_ident_at_dot(
+                            &normalized,
+                            span.start,
+                            span.end,
+                            &mut lexer,
+                            &mut tokens,
+                        ) {
+                            continue;
+                        }
+                    }
                 }
                 tokens.push((token, span));
             }
@@ -388,6 +404,22 @@ pub fn lex(source: &str) -> Result<Vec<(Token, std::ops::Range<usize>)>, LexErro
                             &normalized[span.end..],
                             prev_span.start,
                         ));
+                    }
+                    // Leading-uppercase JSON key flush after `.` or `.?`
+                    // (`r.URL`, `r.ID`, `r.AccessKey`). Logos rejects the
+                    // capital because it isn't a sigil; there is no preceding
+                    // Ident to merge into, so emit a fresh Ident spanning the
+                    // whole identifier-shaped run.
+                    if prev_token_is_dot_flush(&tokens, span.start) {
+                        if let Some(_consumed) = emit_ident_at_dot(
+                            &normalized,
+                            span.start,
+                            span.end,
+                            &mut lexer,
+                            &mut tokens,
+                        ) {
+                            continue;
+                        }
                     }
                 }
                 let (code, suggestion) = lex_error_kind(bad);
@@ -759,6 +791,56 @@ fn absorb_camel_tail(
     // already consumed up to `span_end` (the end of the offending token —
     // either the type sigil's 1 byte or the rejected uppercase byte), so
     // bump by the remaining extent.
+    let bump = end.saturating_sub(span_end);
+    if bump > 0 {
+        lexer.bump(bump);
+    }
+    Some(end)
+}
+
+/// True when the last token in the stream is `Dot`/`DotQuestion` and sits
+/// flush against `span_start` (no whitespace). Used to detect leading-
+/// uppercase JSON keys at post-dot field-access position (e.g. the `U` in
+/// `r.URL`, where there is no preceding Ident to merge into).
+fn prev_token_is_dot_flush(tokens: &[(Token, std::ops::Range<usize>)], span_start: usize) -> bool {
+    let Some((tok, sp)) = tokens.last() else {
+        return false;
+    };
+    matches!(tok, Token::Dot | Token::DotQuestion) && sp.end == span_start
+}
+
+/// Emit a fresh `Ident` token covering a leading-uppercase JSON key that
+/// appears flush after `.` or `.?` (e.g. `r.URL`, `r.AccessKey`). Mirrors
+/// `absorb_camel_tail` but pushes a new token rather than merging into a
+/// preceding `Ident`. Scans `normalized` from `span_start` consuming
+/// `[A-Za-z0-9]` characters, pushes `Token::Ident(slice)` with the
+/// resulting span, and bumps the logos lexer past the absorbed bytes.
+/// Returns `Some(end)` on success, `None` if nothing was absorbed.
+///
+/// Underscores are deliberately excluded — the snake_case post-pass picks
+/// up `_count` etc., so mixed `URL_count` still stitches correctly.
+fn emit_ident_at_dot(
+    normalized: &str,
+    span_start: usize,
+    span_end: usize,
+    lexer: &mut logos::Lexer<'_, Token>,
+    tokens: &mut Vec<(Token, std::ops::Range<usize>)>,
+) -> Option<usize> {
+    let bytes = normalized.as_bytes();
+    let mut end = span_start;
+    while end < bytes.len() {
+        if bytes[end].is_ascii_alphanumeric() {
+            end += 1;
+        } else {
+            break;
+        }
+    }
+    if end == span_start {
+        return None;
+    }
+    let new_span = span_start..end;
+    let new_ident = normalized[new_span.clone()].to_string();
+    tokens.push((Token::Ident(new_ident), new_span));
     let bump = end.saturating_sub(span_end);
     if bump > 0 {
         lexer.bump(bump);

--- a/tests/regression_leading_uppercase_dot.rs
+++ b/tests/regression_leading_uppercase_dot.rs
@@ -1,0 +1,287 @@
+// Regression tests for leading-uppercase JSON keys at dot-access position.
+//
+// PR #220 added camelCase tail absorption (`r.baseSeverity`, `r.gitURL`) by
+// scanning forward through `[A-Za-z0-9]+` and merging into the preceding
+// `Ident`. That fix doesn't help when the *first* character after `.` is
+// uppercase — there's no preceding Ident to merge into, so `r.URL` and
+// `r.ID` still trip the lexer.
+//
+// Real-world JSON keys are commonly leading-uppercase: AWS uses `AccessKey`,
+// `SecretAccessKey`, `URL`, `ID` everywhere, .NET conventions surface
+// `PascalCase` keys across many APIs. This fix extends the post-dot pass to
+// emit a fresh `Ident` token covering the whole identifier-shaped run when
+// the previous token is `Dot`/`DotQuestion` flush against the offending
+// uppercase byte.
+//
+// The strict lowercase rule on bindings is preserved.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str, args: &[&str]) -> String {
+    let mut cmd = ilo();
+    cmd.arg(src).arg(engine).arg(entry);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn run_err(src: &str) -> String {
+    let out = ilo()
+        .args([src, "--run-tree", "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(!out.status.success(), "expected failure for `{src}`");
+    String::from_utf8_lossy(&out.stderr).to_string()
+}
+
+// `r.URL` — `U` is a non-sigil uppercase letter (logos rejects it). The
+// previous token is `Dot` flush, so the lexer emits a fresh `Ident("URL")`.
+const URL: &str = "f j:t>R n t;r=jpar! j;r.URL";
+
+fn check_url(engine: &str) {
+    assert_eq!(
+        run(engine, URL, "f", &[r#"{"URL":"https://example.com"}"#]),
+        "https://example.com",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn leading_upper_url_tree() {
+    check_url("--run-tree");
+}
+
+#[test]
+fn leading_upper_url_vm() {
+    check_url("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn leading_upper_url_cranelift() {
+    check_url("--run-cranelift");
+}
+
+// `r.ID` — `I` is a non-sigil uppercase letter, two letters total.
+const ID: &str = "f j:t>R n t;r=jpar! j;r.ID";
+
+fn check_id(engine: &str) {
+    assert_eq!(
+        run(engine, ID, "f", &[r#"{"ID":42}"#]),
+        "42",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn leading_upper_id_tree() {
+    check_id("--run-tree");
+}
+
+#[test]
+fn leading_upper_id_vm() {
+    check_id("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn leading_upper_id_cranelift() {
+    check_id("--run-cranelift");
+}
+
+// `r.AccessKey` — leading uppercase + mixed-case tail (PascalCase). `A` is
+// not a sigil; the run `AccessKey` becomes a single Ident.
+const ACCESS_KEY: &str = "f j:t>R n t;r=jpar! j;r.AccessKey";
+
+fn check_access_key(engine: &str) {
+    assert_eq!(
+        run(engine, ACCESS_KEY, "f", &[r#"{"AccessKey":"abc123"}"#]),
+        "abc123",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn leading_upper_access_key_tree() {
+    check_access_key("--run-tree");
+}
+
+#[test]
+fn leading_upper_access_key_vm() {
+    check_access_key("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn leading_upper_access_key_cranelift() {
+    check_access_key("--run-cranelift");
+}
+
+// `r.?URL` — safe-access form. Same path, prev token is `DotQuestion`.
+const SAFE_URL: &str = "f j:t>R n t;r=jpar! j;r.?URL";
+
+fn check_safe_url_present(engine: &str) {
+    assert_eq!(
+        run(engine, SAFE_URL, "f", &[r#"{"URL":"https://x"}"#]),
+        "https://x",
+        "engine={engine}"
+    );
+}
+
+fn check_safe_url_missing(engine: &str) {
+    assert_eq!(
+        run(engine, SAFE_URL, "f", &[r#"{"other":1}"#]),
+        "nil",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn leading_upper_safe_url_present_tree() {
+    check_safe_url_present("--run-tree");
+}
+
+#[test]
+fn leading_upper_safe_url_present_vm() {
+    check_safe_url_present("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn leading_upper_safe_url_present_cranelift() {
+    check_safe_url_present("--run-cranelift");
+}
+
+#[test]
+fn leading_upper_safe_url_missing_tree() {
+    check_safe_url_missing("--run-tree");
+}
+
+#[test]
+fn leading_upper_safe_url_missing_vm() {
+    check_safe_url_missing("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn leading_upper_safe_url_missing_cranelift() {
+    check_safe_url_missing("--run-cranelift");
+}
+
+// Mixed camel + snake: `r.URL_count`. The leading-uppercase pass emits a
+// fresh `Ident("URL")` inside the main lex loop, then the post-lex snake
+// pass stitches `_count` onto the end.
+const URL_COUNT: &str = "f j:t>R n t;r=jpar! j;r.URL_count";
+
+fn check_url_count(engine: &str) {
+    assert_eq!(
+        run(engine, URL_COUNT, "f", &[r#"{"URL_count":7}"#]),
+        "7",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn leading_upper_url_count_tree() {
+    check_url_count("--run-tree");
+}
+
+#[test]
+fn leading_upper_url_count_vm() {
+    check_url_count("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn leading_upper_url_count_cranelift() {
+    check_url_count("--run-cranelift");
+}
+
+// Leading-uppercase that happens to be a type sigil: `r.MetaData` (`M` is
+// the MapType sigil) and `r.LeftValue` (`L` is the ListType sigil). These
+// hit the `Ok(token)` sigil branch rather than the `Err(())` branch.
+const META: &str = "f j:t>R n t;r=jpar! j;r.MetaData";
+const LEFT: &str = "f j:t>R n t;r=jpar! j;r.LeftValue";
+
+fn check_meta(engine: &str) {
+    assert_eq!(
+        run(engine, META, "f", &[r#"{"MetaData":"hello"}"#]),
+        "hello",
+        "engine={engine}"
+    );
+}
+
+fn check_left(engine: &str) {
+    assert_eq!(
+        run(engine, LEFT, "f", &[r#"{"LeftValue":99}"#]),
+        "99",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn leading_sigil_meta_tree() {
+    check_meta("--run-tree");
+}
+
+#[test]
+fn leading_sigil_meta_vm() {
+    check_meta("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn leading_sigil_meta_cranelift() {
+    check_meta("--run-cranelift");
+}
+
+#[test]
+fn leading_sigil_left_tree() {
+    check_left("--run-tree");
+}
+
+#[test]
+fn leading_sigil_left_vm() {
+    check_left("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn leading_sigil_left_cranelift() {
+    check_left("--run-cranelift");
+}
+
+// ---- Negative regressions: strict lowercase rule preserved for bindings ----
+
+#[test]
+fn leading_upper_binding_still_errors_non_sigil() {
+    // `URL=5` in a binding position must still emit ILO-L001 (logos rejects
+    // the leading `U` as an unexpected character) — the post-dot fix must
+    // not affect binding-position lexing.
+    let err = run_err("f>n;URL=5;URL");
+    assert!(!err.is_empty(), "expected an error, got empty stderr");
+    // The fix only triggers post-dot; binding position should still reject.
+    assert!(
+        err.contains("ILO-L001") || err.contains("ILO-L003"),
+        "expected lex error, got: {err}"
+    );
+}
+
+#[test]
+fn leading_upper_binding_still_errors_sigil() {
+    // `MetaData=5` — `M` is a sigil but in binding position it shouldn't
+    // be absorbed into an Ident.
+    let err = run_err("f>n;MetaData=5;MetaData");
+    assert!(!err.is_empty(), "expected an error, got empty stderr");
+}


### PR DESCRIPTION
## Summary

PR #220 made camelCase dot-access work (`r.gitURL`, `r.baseSeverity`) but only by *merging* the uppercase tail into a preceding `Ident`. Real-world JSON keys whose first character is uppercase, AWS-style `URL`/`ID`/`AccessKey`, PascalCase .NET APIs, still tripped ILO-L001 because there was no preceding Ident to merge into.

This extends the post-dot pass: when the previous token is `Dot`/`DotQuestion` flush against the offending byte, emit a fresh `Ident` covering the whole identifier-shaped run. The strict lowercase rule on bindings still applies, the fix is scoped to post-dot position only.

Manifesto framing: every uppercase JSON field forced agents into a verbose `jpth!` workaround (extra tokens, extra retries when they tried the natural syntax first). One lexer pass restores the obvious notation for an entire family of real-world keys.

## Repro

```
furl j:t>R n t;r=jpar! j;r.URL
```

Before this fix, `furl '{"URL":"https://x"}'` errored:

```
ILO-L001: unexpected token 'U'
```

After: prints `https://x`.

## What's in the diff

- `lexer: accept leading-uppercase JSON keys at dot-access` — two new helpers (`prev_token_is_dot_flush`, `emit_ident_at_dot`) plus call sites in the sigil Ok-branch (for `r.MetaData`, `r.LeftValue`) and the single-uppercase Err-branch (for `r.URL`, `r.ID`, `r.AccessKey`).
- `test: cross-engine regression for leading-uppercase dot-access` — 26 tests across tree/vm/cranelift covering URL, ID, AccessKey, `.?URL` present + missing, mixed `URL_count`, sigil-leading MetaData/LeftValue, plus negative regressions for binding position.
- `example: leading-uppercase JSON keys at dot-access` — `examples/leading-upper-fields.ilo` exercised by `tests/examples_engines.rs`.

## Test plan

- [x] `cargo test --release --features cranelift` passes (full suite)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --release --features cranelift --all-targets -- -D warnings` clean
- [x] New regression suite (26 tests) passes on tree, vm, cranelift
- [x] Existing camelCase tests (PR #220) still green
- [x] Bindings (`URL=5`, `MetaData=5`) still error

## Follow-ups

None. The two helpers slot in alongside the existing `prev_ident_is_post_dot` / `absorb_camel_tail` pair, no other lex paths affected.