### PR TITLE
fix: scan source tokens for alias hints, not raw text

### DIFF
--- a/examples/tail-alias-comment.ilo
+++ b/examples/tail-alias-comment.ilo
@@ -1,0 +1,17 @@
+-- Demonstrates that alias-hint scanning respects lexer token boundaries.
+-- The word `tail` appears in this comment and inside a string literal,
+-- but neither should trigger the alias hint. The hint only fires when
+-- an alias word is a real source identifier. We deliberately use the
+-- canonical `tl` form here so the example demonstrates an idiomatic
+-- program that produces no hints.
+
+-- Read the tail of a list (canonical short form).
+ltail xs:L n>L n;tl xs
+
+-- Echo a path that happens to contain "tail" - the hint must not fire.
+say-path>t;"/tmp/ilo-persona-streaming-tail-rerun/app.log"
+
+-- run: ltail [1,2,3,4]
+-- out: [2, 3, 4]
+-- run: say-path
+-- out: /tmp/ilo-persona-streaming-tail-rerun/app.log

--- a/src/main.rs
+++ b/src/main.rs
@@ -6622,6 +6622,74 @@ mod tests {
         assert!(hints.is_empty(), "clean code should have no hints");
     }
 
+    // Regression: streaming-tail persona reported `hint: tail → tl` firing on
+    // every Approach B run because the file path contained `tail`. The path
+    // never reaches `collect_hints`, but the same root cause — raw-text scan
+    // ignoring lexer boundaries — let alias words inside comments fire the
+    // hint. These tests pin the lexer-token contract.
+    #[test]
+    fn collect_hints_alias_in_comment_does_not_fire() {
+        // `tail` in a line comment must not trigger the alias hint.
+        let hints = collect_hints("-- reading /tmp/ilo-streaming-tail-rerun/app.log\nf>n;42");
+        assert!(
+            hints.is_empty(),
+            "alias word in comment should not fire hint, got: {:?}",
+            hints
+        );
+    }
+
+    #[test]
+    fn collect_hints_other_alias_words_in_comments_do_not_fire() {
+        // Spot-check a handful of common alias source words — none of these
+        // should fire when they appear only in comments.
+        for word in ["tail", "filter", "flatmap", "length", "head", "append"] {
+            let src = format!("-- builtin: {word} something\nf>n;42");
+            let hints = collect_hints(&src);
+            assert!(
+                hints.is_empty(),
+                "comment-only `{}` should not fire hint, got: {:?}",
+                word,
+                hints
+            );
+        }
+    }
+
+    #[test]
+    fn collect_hints_alias_in_string_does_not_fire() {
+        // `tail` inside a string literal must not trigger the hint.
+        let hints = collect_hints(r#"f>t;"tail of the file""#);
+        assert!(
+            hints.is_empty(),
+            "alias word in string literal should not fire hint, got: {:?}",
+            hints
+        );
+    }
+
+    #[test]
+    fn collect_hints_real_alias_use_still_fires() {
+        // Contract: the hint *should* still fire when the alias appears as
+        // a real source identifier. `tail` is a known alias for `tl`.
+        let hints = collect_hints("f xs:L n>L n;tail xs");
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.contains("`tail`") && h.contains("`tl`")),
+            "expected tail→tl hint on real alias use, got: {:?}",
+            hints
+        );
+    }
+
+    #[test]
+    fn collect_hints_double_equals_inside_comment_no_hint() {
+        // `==` inside a comment shouldn't trigger the equality hint either.
+        let hints = collect_hints("-- compare a == b here\nf x:n y:n>b;=x y");
+        assert!(
+            hints.is_empty(),
+            "`==` inside comment should not fire hint, got: {:?}",
+            hints
+        );
+    }
+
     // ── tools_cmd: error paths ────────────────────────────────────────────────
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1445,11 +1445,19 @@ fn strip_string_contents(source: &str) -> String {
 
 /// Collect idiomatic hints by scanning source text for non-canonical forms.
 /// Returns a list of human-readable hint strings.
+///
+/// Word-boundary scans (alias hints) run over real lexer tokens, not raw text:
+/// re-lexing skips comments, strings, numbers, operators, and CLI argv, so a
+/// `tail` substring inside a comment line, a string literal, or a file path
+/// printed to stderr won't fire `hint: \`tail\` → \`tl\``. The text-based `==`
+/// scan strips both strings and comments first for the same reason.
 fn collect_hints(source: &str) -> Vec<String> {
     let mut hints = Vec::new();
     // Hint: == → = saves 1 character
-    // Scan for `==` outside string literals (reuse strip_string_contents)
-    let stripped = strip_string_contents(source);
+    // Scan for `==` outside string literals and comments. We don't use the
+    // lexer here because logos collapses both `=` and `==` into `Token::Eq`,
+    // so the distinction is only visible in raw text.
+    let stripped = strip_string_and_comment_contents(source);
     let mut pos = 0;
     let bytes = stripped.as_bytes();
     while pos + 1 < bytes.len() {
@@ -1459,16 +1467,53 @@ fn collect_hints(source: &str) -> Vec<String> {
         }
         pos += 1;
     }
-    // Hint: long-form builtin aliases → canonical short form
-    // Scan for word boundaries matching known aliases
-    let mut seen_alias = false;
-    for word in stripped.split(|c: char| !c.is_alphanumeric() && c != '_' && c != '-') {
-        if !seen_alias && let Some(short) = ast::resolve_alias(word) {
-            hints.push(format!("hint: `{word}` → `{short}` (canonical short form)"));
-            seen_alias = true; // one hint per run is enough
+    // Hint: long-form builtin aliases → canonical short form.
+    // Use lexer tokens so we only consider real source identifiers — not words
+    // appearing in comments, string literals, or anything outside the source
+    // itself. Falling back to no hint on lex failure is fine: the run already
+    // succeeded if we got here, so a re-lex failure is implausible, but we
+    // err on the side of "no hint" rather than spurious noise.
+    if let Ok(tokens) = lexer::lex(source) {
+        for (tok, _) in &tokens {
+            if let lexer::Token::Ident(word) = tok
+                && let Some(short) = ast::resolve_alias(word)
+            {
+                hints.push(format!("hint: `{word}` → `{short}` (canonical short form)"));
+                break; // one hint per run is enough
+            }
         }
     }
     hints
+}
+
+/// Strip both string-literal contents and `--`-prefixed line comments,
+/// replacing their contents with spaces so byte offsets are preserved.
+/// Used by the text-based `==` scan so a literal `==` inside a string or
+/// comment doesn't trigger the hint.
+fn strip_string_and_comment_contents(source: &str) -> String {
+    let stripped = strip_string_contents(source);
+    let mut out = String::with_capacity(stripped.len());
+    let mut chars = stripped.chars().peekable();
+    let mut in_comment = false;
+    while let Some(c) = chars.next() {
+        if in_comment {
+            if c == '\n' {
+                in_comment = false;
+                out.push(c);
+            } else {
+                out.push(' ');
+            }
+        } else if c == '-' && chars.peek() == Some(&'-') {
+            // Consume the second '-' and enter comment mode
+            chars.next();
+            out.push(' ');
+            out.push(' ');
+            in_comment = true;
+        } else {
+            out.push(c);
+        }
+    }
+    out
 }
 
 /// Emit hints to the appropriate output channel.


### PR DESCRIPTION
## Summary

`collect_hints` was splitting raw source text after stripping string literals, but comments (`-- ...`) were left in. Any alias source word in a comment, identifier-ish artefact, or path-bearing line could fire `hint: <word> -> <short>` even though the user never wrote that token.

Streaming-tail persona on v0.11.1 caught this every Approach B run: `hint: tail -> tl` fired because the working directory was `/tmp/ilo-persona-streaming-tail-rerun`, and the path leaked into the batch script's header comment. Cosmetic but noisy in pipelines, and exactly the kind of false-positive that erodes trust in agent-facing hints.

Fix: re-lex inside `collect_hints` and scan `Token::Ident` only. Correct by construction — comments, strings, numbers, operators, and CLI argv all sit outside the token stream the user wrote. The `==` text-scan now also ignores comment contents via a small helper, so both hints behave consistently.

## Repro

```
-- counts: tail of error log
main>n;42
```

Before: `hint: \`tail\` → \`tl\` (canonical short form)` printed to stderr on every run.
After: no hint. Real alias use (`tail xs` as a source identifier) still fires.

## What's in the diff

- **9fc9785 fix:** `collect_hints` re-lexes the source and walks `Token::Ident`. New helper `strip_string_and_comment_contents` keeps the `==` scan consistent (logos collapses `=` and `==` to one token, so that scan can't use lexer output).
- **583e04f test:** five new regression tests pin the contract: alias word in comment, alias word in string, the `==` scan in comments, multi-word coverage across `tail`/`filter`/`flatmap`/`length`/`head`/`append`, and a positive test that real alias use still fires.
- **7e79f9c example:** `examples/tail-alias-comment.ilo` shows an idiomatic no-hint program with `tail` in both a comment and a string literal. Multi-engine harness runs it on every backend.

## Test plan

- [x] `cargo test --release --features cranelift` — full suite green (2888 lib + all integration)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --release --features cranelift -- -D warnings` clean
- [x] `cargo test --test examples_engines` passes (including the new example)
- [x] Manual repro: `tail` in comment / string / path no longer fires; `tail xs` as a real call still fires.

## Follow-ups

None planned. The lexer-token approach generalises to any future builtin alias added to `ast::resolve_alias`.