### PR TITLE
fix: exit 1 when entry function returns Value::Err

### DIFF
--- a/examples/main-err-exit-code.ilo
+++ b/examples/main-err-exit-code.ilo
@@ -1,0 +1,18 @@
+-- Demonstrates the `main` exit-code contract for Result-returning entry
+-- functions. A program whose entry function returns `~v` exits 0; one that
+-- returns `^reason` exits 1 with the err line on stderr (companion to the
+-- `!!` panic-unwrap path from PR #248).
+--
+-- The `-- err:` annotation tells the examples harness that the case must
+-- exit non-zero and the assertion is against stderr. The cross-engine
+-- regression test in tests/regression_main_err_exit_code.rs pins the
+-- contract directly.
+
+-- Parse text to a number; returns ~n on success, ^reason on failure.
+parse s:t>R n t;num s
+
+-- run: parse 42
+-- out: ~42
+
+-- run: parse abc
+-- err: ^abc

--- a/examples/nested-generic-types.ilo
+++ b/examples/nested-generic-types.ilo
@@ -8,5 +8,6 @@ nz xs:L n>R (L n) t;l=len xs;=l 0 ^"empty";~xs
 -- run: nz [1,2,3]
 -- out: ~[1, 2, 3]
 
+-- Value::Err from the entry function exits 1 with the err on stderr.
 -- run: nz []
--- out: ^empty
+-- err: ^empty

--- a/examples/results.ilo
+++ b/examples/results.ilo
@@ -10,7 +10,10 @@ parse tx:t>R n t;num tx
 
 -- run: div 10 2
 -- out: ~5
+-- A Value::Err return from the entry function exits 1 with the err line on
+-- stderr, mirroring `!!` panic-unwrap from PR #248. The examples harness
+-- understands `-- err:` for this contract.
 -- run: div 10 0
--- out: ^divide by zero
+-- err: ^divide by zero
 -- run: parse three
--- out: ^three
+-- err: ^three

--- a/src/main.rs
+++ b/src/main.rs
@@ -2595,7 +2595,7 @@ fn run_cranelift_engine(
             Ok(result_bits) => {
                 let result = vm::NanVal(result_bits).to_value();
                 print_value(&result, explicit_json, suppress);
-                0
+                program_exit_code(&result)
             }
             Err(vm::jit_cranelift::JitCallError::Runtime(e)) => {
                 report_diagnostic(&Diagnostic::from(&e).with_source(source.to_string()), mode);
@@ -2765,7 +2765,7 @@ fn run_vm_with_provider(
         match vm::run_with_tools(compiled, func_name, args, provider, rt) {
             Ok(val) => {
                 print_value(&val, explicit_json, suppress_loop_tail);
-                return 0;
+                return program_exit_code(&val);
             }
             Err(e) => {
                 report_diagnostic(&Diagnostic::from(&e).with_source(source.to_string()), mode);
@@ -2798,7 +2798,7 @@ fn run_vm_with_provider(
         ) {
             Ok(val) => {
                 print_value(&val, explicit_json, suppress_loop_tail);
-                0
+                program_exit_code(&val)
             }
             Err(e) => {
                 report_diagnostic(&Diagnostic::from(&e).with_source(source.to_string()), mode);
@@ -2810,7 +2810,7 @@ fn run_vm_with_provider(
     match vm::run(compiled, func_name, args) {
         Ok(val) => {
             print_value(&val, explicit_json, suppress_loop_tail);
-            0
+            program_exit_code(&val)
         }
         Err(e) => {
             report_diagnostic(&Diagnostic::from(&e).with_source(source.to_string()), mode);
@@ -2846,7 +2846,7 @@ fn run_interp_with_provider(
         ) {
             Ok(val) => {
                 print_value(&val, explicit_json, suppress);
-                return 0;
+                return program_exit_code(&val);
             }
             Err(e) => {
                 report_diagnostic(&Diagnostic::from(&e).with_source(source.to_string()), mode);
@@ -2881,7 +2881,7 @@ fn run_interp_with_provider(
         ) {
             Ok(val) => {
                 print_value(&val, explicit_json, suppress);
-                0
+                program_exit_code(&val)
             }
             Err(e) => {
                 report_diagnostic(&Diagnostic::from(&e).with_source(source.to_string()), mode);
@@ -2893,7 +2893,7 @@ fn run_interp_with_provider(
     match interpreter::run(program, func_name, args) {
         Ok(val) => {
             print_value(&val, explicit_json, suppress);
-            0
+            program_exit_code(&val)
         }
         Err(e) => {
             report_diagnostic(&Diagnostic::from(&e).with_source(source.to_string()), mode);
@@ -2945,7 +2945,7 @@ fn run_default(
                     Ok(result_bits) => {
                         let result = vm::NanVal(result_bits).to_value();
                         print_value(&result, explicit_json, suppress);
-                        return 0;
+                        return program_exit_code(&result);
                     }
                     Err(vm::jit_cranelift::JitCallError::Runtime(e)) => {
                         // The JIT executed and surfaced a defined runtime
@@ -2972,7 +2972,7 @@ fn run_default(
     match interpreter::run(program, func_name, args) {
         Ok(val) => {
             print_value(&val, explicit_json, suppress);
-            0
+            program_exit_code(&val)
         }
         Err(e) => {
             report_diagnostic(&Diagnostic::from(&e).with_source(source.to_string()), mode);
@@ -3062,8 +3062,24 @@ fn program_result_should_suppress(program: &ast::Program, func_name: Option<&str
 /// declared `>O n` returning `nil`) is still printed, because the user asked
 /// for it. JSON mode is unchanged so machine-readable consumers always get a
 /// structured result.
+///
+/// `Value::Err(_)` is routed to stderr in plain mode (matching `report_diagnostic`'s
+/// stream convention for failures). In JSON mode the `{"error": ...}` envelope is
+/// still written to stdout, so machine consumers can keep parsing stdout uniformly
+/// and discriminate on the top-level key.
 fn print_value(val: &interpreter::Value, as_json: bool, suppress_loop_tail: bool) {
     if !as_json {
+        // Value::Err always prints to stderr — even when suppress_loop_tail
+        // is on. The loop-tail suppression rule exists to avoid duplicating
+        // the loop body's `prnt` output as a final stdout line for happy-path
+        // tail values; it must not silently swallow a program failure. The
+        // companion exit-code surfacing happens in `program_exit_code`, so
+        // skipping the err here would leave the operator with `exit 1` and
+        // zero diagnostic context.
+        if matches!(val, interpreter::Value::Err(_)) {
+            eprintln!("{}", val);
+            return;
+        }
         if suppress_loop_tail {
             return;
         }
@@ -3089,6 +3105,19 @@ fn print_value(val: &interpreter::Value, as_json: bool, suppress_loop_tail: bool
         }
     };
     println!("{}", json);
+}
+
+/// Exit code for a program's top-level result. `Value::Err(_)` from `main` (or any
+/// entry function) must surface as a non-zero exit so shell pipelines and CI can
+/// detect failure — this is the companion to [#248]'s `!!` panic-unwrap fix, which
+/// addressed the explicit-crash path. Returning the error variant from the `~`/`^`
+/// arm without `!!` is the same kind of failure semantically, just with a value.
+fn program_exit_code(val: &interpreter::Value) -> i32 {
+    if matches!(val, interpreter::Value::Err(_)) {
+        1
+    } else {
+        0
+    }
 }
 
 #[allow(unused_variables, unused_mut)]

--- a/tests/eval_inline.rs
+++ b/tests/eval_inline.rs
@@ -1609,12 +1609,13 @@ fn unwrap_err_path_inline() {
         .output()
         .expect("failed to run ilo");
     std::fs::remove_file(&f).ok();
-    assert!(
-        out.status.success(),
-        "stderr: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "^fail");
+    // `outer` returns `Value::Err("fail")` (the inner err propagates through
+    // `~(inner! x)` unwrap). A Value::Err from the entry function must exit
+    // 1 with the err formatted to stderr — see
+    // tests/regression_main_err_exit_code.rs for the contract.
+    assert_eq!(out.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&out.stdout).trim().is_empty());
+    assert_eq!(String::from_utf8_lossy(&out.stderr).trim(), "^fail");
 }
 
 #[test]
@@ -1625,12 +1626,11 @@ fn unwrap_nested_propagation_inline() {
         .output()
         .expect("failed to run ilo");
     std::fs::remove_file(&f).ok();
-    assert!(
-        out.status.success(),
-        "stderr: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "^deep");
+    // Same contract as `unwrap_err_path_inline`: `a` returns Value::Err,
+    // process exits 1, err goes to stderr.
+    assert_eq!(out.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&out.stdout).trim().is_empty());
+    assert_eq!(String::from_utf8_lossy(&out.stderr).trim(), "^deep");
 }
 
 #[test]
@@ -2183,11 +2183,12 @@ fn json_flag_wraps_err_result() {
         .args(["--json", "-e", "f>R n t;^\"oops\"", "--run", "f"])
         .output()
         .expect("failed to run ilo");
-    assert!(
-        out.status.success(),
-        "stderr: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
+    // Entry function returns Value::Err -> exit 1, but in JSON mode the
+    // `{"error": {...}}` envelope is still emitted on stdout so machine
+    // consumers can parse a single stream and discriminate on the top-level
+    // key. See tests/regression_main_err_exit_code.rs for the cross-engine
+    // contract.
+    assert_eq!(out.status.code(), Some(1));
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
         stdout.contains("\"error\""),

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -6,7 +6,15 @@
 //   -- run: fac 10
 //   -- out: 3628800
 //
-// Multiple run/out pairs per file are supported; they are matched in order.
+// For programs whose entry function returns `Value::Err(_)` (which now
+// correctly exits 1 with the err line on stderr), use `-- err:` instead of
+// `-- out:`:
+//   -- run: parse three
+//   -- err: ^three
+//
+// Multiple run/out (or run/err) pairs per file are supported; they are
+// matched in order. A `-- run:` pairs with whichever of `-- out:` /
+// `-- err:` follows first.
 
 use std::path::PathBuf;
 use std::process::Command;
@@ -27,10 +35,20 @@ fn find_examples() -> Vec<PathBuf> {
     paths
 }
 
+#[derive(Clone, Copy, PartialEq)]
+enum Expect {
+    /// `-- out:` — program must exit 0 and the assertion is against stdout.
+    Stdout,
+    /// `-- err:` — program must exit 1 with the assertion against stderr.
+    /// Used for entry functions that return `Value::Err(_)`.
+    Stderr,
+}
+
 struct TestCase {
     run_args: Vec<String>,
     expected: String,
     line: usize,
+    expect: Expect,
 }
 
 fn parse_cases(src: &str) -> Vec<TestCase> {
@@ -43,13 +61,25 @@ fn parse_cases(src: &str) -> Vec<TestCase> {
             let args = rest.split_whitespace().map(str::to_string).collect();
             pending = Some((args, i + 1));
         } else if let (Some(rest), Some((args, ln))) =
-            (line.strip_prefix("-- out:"), pending.take())
+            (line.strip_prefix("-- out:"), pending.as_ref())
         {
             cases.push(TestCase {
-                run_args: args,
+                run_args: args.clone(),
                 expected: rest.trim().to_string(),
-                line: ln,
+                line: *ln,
+                expect: Expect::Stdout,
             });
+            pending = None;
+        } else if let (Some(rest), Some((args, ln))) =
+            (line.strip_prefix("-- err:"), pending.as_ref())
+        {
+            cases.push(TestCase {
+                run_args: args.clone(),
+                expected: rest.trim().to_string(),
+                line: *ln,
+                expect: Expect::Stderr,
+            });
+            pending = None;
         }
     }
     cases
@@ -77,26 +107,49 @@ fn examples() {
                 .output()
                 .unwrap_or_else(|e| panic!("failed to run ilo for {name}: {e}"));
 
-            let actual = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
 
-            if !out.status.success() {
-                let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
-                failures.push(format!(
-                    "{name} (line {}): `ilo {} {}`\n  FAILED (exit {})\n  stderr: {stderr}",
-                    case.line,
-                    path.display(),
-                    case.run_args.join(" "),
-                    out.status,
-                ));
-            } else if actual != case.expected {
-                failures.push(format!(
-                    "{name} (line {}): `ilo {} {}`\n  expected: {:?}\n  actual:   {:?}",
-                    case.line,
-                    path.display(),
-                    case.run_args.join(" "),
-                    case.expected,
-                    actual,
-                ));
+            match case.expect {
+                Expect::Stdout => {
+                    if !out.status.success() {
+                        failures.push(format!(
+                            "{name} (line {}): `ilo {} {}`\n  FAILED (exit {})\n  stderr: {stderr}",
+                            case.line,
+                            path.display(),
+                            case.run_args.join(" "),
+                            out.status,
+                        ));
+                    } else if stdout != case.expected {
+                        failures.push(format!(
+                            "{name} (line {}): `ilo {} {}`\n  expected: {:?}\n  actual:   {:?}",
+                            case.line,
+                            path.display(),
+                            case.run_args.join(" "),
+                            case.expected,
+                            stdout,
+                        ));
+                    }
+                }
+                Expect::Stderr => {
+                    if out.status.success() {
+                        failures.push(format!(
+                            "{name} (line {}): `ilo {} {}`\n  EXPECTED FAILURE but exit 0\n  stdout: {stdout}",
+                            case.line,
+                            path.display(),
+                            case.run_args.join(" "),
+                        ));
+                    } else if stderr != case.expected {
+                        failures.push(format!(
+                            "{name} (line {}): `ilo {} {}` (-- err:)\n  expected stderr: {:?}\n  actual stderr:   {:?}",
+                            case.line,
+                            path.display(),
+                            case.run_args.join(" "),
+                            case.expected,
+                            stderr,
+                        ));
+                    }
+                }
             }
         }
     }

--- a/tests/examples_engines.rs
+++ b/tests/examples_engines.rs
@@ -29,10 +29,20 @@ fn find_examples() -> Vec<PathBuf> {
     paths
 }
 
+#[derive(Clone, Copy, PartialEq)]
+enum Expect {
+    /// `-- out:` — program must exit 0 and the assertion is against stdout.
+    Stdout,
+    /// `-- err:` — program must exit 1 with the assertion against stderr.
+    /// Used for entry functions that return `Value::Err(_)`.
+    Stderr,
+}
+
 struct TestCase {
     run_args: Vec<String>,
     expected: String,
     line: usize,
+    expect: Expect,
 }
 
 fn parse_cases(src: &str) -> Vec<TestCase> {
@@ -45,13 +55,25 @@ fn parse_cases(src: &str) -> Vec<TestCase> {
             let args = rest.split_whitespace().map(str::to_string).collect();
             pending = Some((args, i + 1));
         } else if let (Some(rest), Some((args, ln))) =
-            (line.strip_prefix("-- out:"), pending.take())
+            (line.strip_prefix("-- out:"), pending.as_ref())
         {
             cases.push(TestCase {
-                run_args: args,
+                run_args: args.clone(),
                 expected: rest.trim().to_string(),
-                line: ln,
+                line: *ln,
+                expect: Expect::Stdout,
             });
+            pending = None;
+        } else if let (Some(rest), Some((args, ln))) =
+            (line.strip_prefix("-- err:"), pending.as_ref())
+        {
+            cases.push(TestCase {
+                run_args: args.clone(),
+                expected: rest.trim().to_string(),
+                line: *ln,
+                expect: Expect::Stderr,
+            });
+            pending = None;
         }
     }
     cases
@@ -132,30 +154,57 @@ fn examples_all_engines() {
                         )
                     });
 
-                let actual = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
 
-                if !out.status.success() {
-                    let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
-                    failures.push(format!(
-                        "{name} [{engine_name}] (line {}): `ilo {} {} {}`\n  FAILED (exit {})\n  stderr: {stderr}",
-                        case.line,
-                        path.display(),
-                        engine.flag,
-                        case.run_args.join(" "),
-                        out.status,
-                        engine_name = engine.name,
-                    ));
-                } else if actual != case.expected {
-                    failures.push(format!(
-                        "{name} [{engine_name}] (line {}): `ilo {} {} {}`\n  expected: {:?}\n  actual:   {:?}",
-                        case.line,
-                        path.display(),
-                        engine.flag,
-                        case.run_args.join(" "),
-                        case.expected,
-                        actual,
-                        engine_name = engine.name,
-                    ));
+                match case.expect {
+                    Expect::Stdout => {
+                        if !out.status.success() {
+                            failures.push(format!(
+                                "{name} [{engine_name}] (line {}): `ilo {} {} {}`\n  FAILED (exit {})\n  stderr: {stderr}",
+                                case.line,
+                                path.display(),
+                                engine.flag,
+                                case.run_args.join(" "),
+                                out.status,
+                                engine_name = engine.name,
+                            ));
+                        } else if stdout != case.expected {
+                            failures.push(format!(
+                                "{name} [{engine_name}] (line {}): `ilo {} {} {}`\n  expected: {:?}\n  actual:   {:?}",
+                                case.line,
+                                path.display(),
+                                engine.flag,
+                                case.run_args.join(" "),
+                                case.expected,
+                                stdout,
+                                engine_name = engine.name,
+                            ));
+                        }
+                    }
+                    Expect::Stderr => {
+                        if out.status.success() {
+                            failures.push(format!(
+                                "{name} [{engine_name}] (line {}): `ilo {} {} {}`\n  EXPECTED FAILURE but exit 0\n  stdout: {stdout}",
+                                case.line,
+                                path.display(),
+                                engine.flag,
+                                case.run_args.join(" "),
+                                engine_name = engine.name,
+                            ));
+                        } else if stderr != case.expected {
+                            failures.push(format!(
+                                "{name} [{engine_name}] (line {}): `ilo {} {} {}` (-- err:)\n  expected stderr: {:?}\n  actual stderr:   {:?}",
+                                case.line,
+                                path.display(),
+                                engine.flag,
+                                case.run_args.join(" "),
+                                case.expected,
+                                stderr,
+                                engine_name = engine.name,
+                            ));
+                        }
+                    }
                 }
             }
         }

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -66,20 +66,26 @@ async fn get_server_error_returns_err_value() {
 
 #[tokio::test]
 async fn get_bad_host_returns_err() {
-    // Unreachable host → runtime Err value, not a crash
+    // Unreachable host → runtime Err *value* (not a crash). The entry function
+    // returns Value::Err so the process exits 1 with the err line on stderr
+    // (see tests/regression_main_err_exit_code.rs for the cross-engine
+    // contract). What matters for this test: the binary completes with a
+    // structured err, never a signal/panic.
     let out = ilo()
         .args([r#"f url:t>R t t;get url"#, "http://127.0.0.1:1"])
         .output()
         .expect("failed to run ilo");
-    assert!(
-        out.status.success(),
-        "process should not crash on connection failure"
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "expected exit 1 from Value::Err return, got {:?}",
+        out.status.code(),
     );
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    // Should print Err(...) — the exact message varies by OS
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    // Should print Err(...) on stderr — the exact message varies by OS
     assert!(
-        stdout.contains("Err") || stdout.contains("err"),
-        "expected Err in output, got: {stdout}"
+        stderr.contains("Err") || stderr.contains("err") || stderr.contains('^'),
+        "expected Err in stderr, got: {stderr}"
     );
 }
 
@@ -168,6 +174,8 @@ async fn post_ok_and_match_result() {
 
 #[tokio::test]
 async fn post_bad_host_returns_err() {
+    // See `get_bad_host_returns_err` above — same contract: structured err
+    // from the entry function -> exit 1 with err on stderr, never a crash.
     let out = ilo()
         .args([
             r#"f url:t body:t>R t t;post url body"#,
@@ -176,14 +184,16 @@ async fn post_bad_host_returns_err() {
         ])
         .output()
         .expect("failed to run ilo");
-    assert!(
-        out.status.success(),
-        "process should not crash on connection failure"
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "expected exit 1 from Value::Err return, got {:?}",
+        out.status.code(),
     );
-    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
-        stdout.contains("Err") || stdout.contains("err"),
-        "expected Err in output, got: {stdout}"
+        stderr.contains("Err") || stderr.contains("err") || stderr.contains('^'),
+        "expected Err in stderr, got: {stderr}"
     );
 }
 

--- a/tests/regression_datetime.rs
+++ b/tests/regression_datetime.rs
@@ -97,14 +97,20 @@ fn dtparse_round_trip() {
 #[test]
 fn dtparse_invalid_input_produces_err() {
     // Err path: `!` short-circuits and returns the Err to the caller. The
-    // surfaced error message includes the `dtparse:` prefix from our impl.
+    // entry function `f` returns Value::Err so the process exits 1 with the
+    // err line on stderr — see tests/regression_main_err_exit_code.rs for the
+    // cross-engine contract. The surfaced message includes the `dtparse:`
+    // prefix from our impl.
     let src = r#"f s:t>R n t;v=dtparse! s "%Y-%m-%d";~v"#;
     for engine in ENGINES {
         let (ok, stdout, stderr) = run(engine, src, &["f", "not-a-date"]);
-        assert!(ok, "{engine}: ilo failed: {stderr}");
         assert!(
-            stdout.contains("dtparse"),
-            "{engine}: expected dtparse error message, got `{stdout}`"
+            !ok,
+            "{engine}: expected exit 1, got success. stdout={stdout}"
+        );
+        assert!(
+            stderr.contains("dtparse"),
+            "{engine}: expected dtparse error message on stderr, got `{stderr}`"
         );
     }
 }

--- a/tests/regression_main_err_exit_code.rs
+++ b/tests/regression_main_err_exit_code.rs
@@ -1,0 +1,204 @@
+// Regression test: a program whose entry function returns `Value::Err(_)`
+// from the plain `~`/`^` arm (no `!!` panic-unwrap) must exit non-zero, with
+// the error formatted to stderr in plain mode or wrapped as
+// `{"error": {...}}` on stdout in JSON mode.
+//
+// Background:
+//
+// PR #248 fixed the half of "errors print and exit nonzero" where the user
+// opts into crash semantics via `!!` (panic-unwrap). The other half — a plain
+// `^"reason"` returned from `main` — was still printed and the process exited
+// 0, which silently broke CI / shell pipelines that try to detect program
+// failure by exit code.
+//
+// The fix is in `src/main.rs`: each of the four CLI exec paths
+// (`run_vm_with_provider`, `run_interp_with_provider`, `run_default`,
+// `run_cranelift_engine`) now inspects the returned `Value` and exits 1 if it
+// is `Value::Err(_)`. `print_value` also routes plain-mode err output to
+// stderr (matching `report_diagnostic`'s stream convention); JSON output
+// stays on stdout so machine consumers can parse uniformly and discriminate
+// on the top-level `error` / `ok` key.
+//
+// All tests cross-engine (tree, VM, Cranelift) so a divergence between
+// backends shows up in CI.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+// A `main` that returns `Value::Err`. Signature `>R n t` = Result<n, t>, body
+// returns `^"oh no"` — the Err variant.
+const ERR_SRC: &str = "m>R n t;^\"oh no\"";
+const OK_SRC: &str = "m>R n t;~7";
+
+// ── Plain mode: Value::Err exits 1 ─────────────────────────────────────────
+
+fn assert_err_exit_plain(engine: &str) {
+    let out = ilo()
+        .args([ERR_SRC, engine])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "{engine}: expected non-zero exit for Value::Err from main, got success. stdout={:?} stderr={:?}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "{engine}: expected exit code 1, got {:?}",
+        out.status.code(),
+    );
+    // Plain-mode err is routed to stderr so stdout-piping callers don't see
+    // an err value mixed in with a successful run's output.
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stdout.trim().is_empty(),
+        "{engine}: expected empty stdout for Value::Err, got {stdout:?}",
+    );
+    assert!(
+        stderr.contains("oh no"),
+        "{engine}: expected err text on stderr, got {stderr:?}",
+    );
+}
+
+#[test]
+fn main_err_exits_one_tree() {
+    assert_err_exit_plain("--run-tree");
+}
+
+#[test]
+fn main_err_exits_one_vm() {
+    assert_err_exit_plain("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn main_err_exits_one_cranelift() {
+    assert_err_exit_plain("--run-cranelift");
+}
+
+// ── JSON mode: Value::Err exits 1 with structured envelope on stdout ───────
+
+fn assert_err_exit_json(engine: &str) {
+    let out = ilo()
+        .args([ERR_SRC, engine, "-j"])
+        .output()
+        .expect("failed to run ilo");
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "{engine} -j: expected exit 1, got {:?}. stdout={:?} stderr={:?}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // JSON consumers parse stdout — the envelope must arrive there even on
+    // failure, so they can discriminate on the top-level key.
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("{engine} -j: stdout was not valid JSON ({e}): {stdout:?}"));
+    let err_obj = parsed
+        .get("error")
+        .unwrap_or_else(|| panic!("{engine} -j: expected `error` key in {parsed:?}"));
+    assert_eq!(
+        err_obj.get("phase").and_then(|v| v.as_str()),
+        Some("program")
+    );
+    assert_eq!(err_obj.get("value").and_then(|v| v.as_str()), Some("oh no"));
+}
+
+#[test]
+fn main_err_exits_one_json_tree() {
+    assert_err_exit_json("--run-tree");
+}
+
+#[test]
+fn main_err_exits_one_json_vm() {
+    assert_err_exit_json("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn main_err_exits_one_json_cranelift() {
+    assert_err_exit_json("--run-cranelift");
+}
+
+// ── OK return still exits 0 (no regression on the happy path) ──────────────
+
+fn assert_ok_exit(engine: &str) {
+    let out = ilo()
+        .args([OK_SRC, engine])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "{engine}: expected success exit for `~7`, got {:?}. stdout={:?} stderr={:?}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("~7"),
+        "{engine}: expected `~7` on stdout, got {stdout:?}",
+    );
+}
+
+#[test]
+fn main_ok_exits_zero_tree() {
+    assert_ok_exit("--run-tree");
+}
+
+#[test]
+fn main_ok_exits_zero_vm() {
+    assert_ok_exit("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn main_ok_exits_zero_cranelift() {
+    assert_ok_exit("--run-cranelift");
+}
+
+// ── Default engine path (no --run-* flag) also surfaces the err exit code ──
+//
+// `dispatch_run`'s default branch routes through `run_default`, which tries
+// Cranelift JIT first and falls back to the interpreter. Both fallback paths
+// must observe the program_exit_code rule.
+
+#[test]
+fn main_err_exits_one_default_engine() {
+    // The default engine path (no --run-* flag) only runs a program when an
+    // entry function can be resolved — for inline source with no rest-arg
+    // that falls through to the legacy AST-dump branch. Write to a temp file
+    // and pass the function name so we exercise `run_default` proper, which
+    // routes through Cranelift JIT with an interpreter fallback.
+    // Unique per-pid temp file so concurrent `cargo test` runs of different
+    // test binaries don't race on the same path. (Within this binary the
+    // test is single-instance, but the harness can run multiple binaries in
+    // parallel.)
+    let path = std::env::temp_dir().join(format!(
+        "ilo_regression_main_err_default_{}.ilo",
+        std::process::id()
+    ));
+    std::fs::write(&path, ERR_SRC).expect("write temp ilo file");
+    let out = ilo()
+        .arg(&path)
+        .arg("m")
+        .output()
+        .expect("failed to run ilo");
+    let _ = std::fs::remove_file(&path);
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "default engine: expected exit 1 for Value::Err from main, got {:?}. stdout={:?} stderr={:?}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}

--- a/tests/regression_mget_bang.rs
+++ b/tests/regression_mget_bang.rs
@@ -192,15 +192,6 @@ fn check_result_ok(engine: &str) {
     );
 }
 
-fn check_result_err(engine: &str) {
-    // Err propagates; the `~v` wrap is bypassed by the early return.
-    let out = run(engine, RESULT_BANG_ERR_SRC, "f");
-    assert!(
-        out.contains("abc"),
-        "expected err containing abc, got {out}"
-    );
-}
-
 #[test]
 fn result_bang_ok_tree() {
     check_result_ok("--run-tree");
@@ -213,10 +204,34 @@ fn result_bang_ok_vm() {
 
 #[test]
 fn result_bang_err_tree() {
-    check_result_err("--run-tree");
+    // Tree: `!` short-circuit returns Value::Err from `f`. The entry function
+    // err contract (regression_main_err_exit_code.rs) means we exit 1 with
+    // the err on stderr.
+    let out = run_err("--run-tree", RESULT_BANG_ERR_SRC, "f");
+    assert!(
+        out.contains("abc"),
+        "expected err containing abc on stderr, got {out}"
+    );
 }
 
 #[test]
 fn result_bang_err_vm() {
-    check_result_err("--run-vm");
+    // VM: known pre-existing divergence. `num! "abc"` does not short-circuit
+    // the enclosing `~v` wrap, so the program returns `Value::Ok(Value::Err)`
+    // (printed as `~^abc`) on the VM where tree returns `Value::Err`. The
+    // tree behaviour is correct. Fixing the VM `!` propagation is its own
+    // change — out of scope for the entry-function exit-code fix. We assert
+    // here that some "abc" surfaces somewhere and the process at least
+    // doesn't crash, to keep coverage and pin the contract until the VM bug
+    // is addressed in a follow-up.
+    let out = ilo()
+        .args([RESULT_BANG_ERR_SRC, "--run-vm", "f"])
+        .output()
+        .expect("failed to run ilo");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stdout.contains("abc") || stderr.contains("abc"),
+        "expected err containing abc somewhere, stdout={stdout} stderr={stderr}",
+    );
 }


### PR DESCRIPTION
## Summary

Companion to #248. That PR fixed `!!` panic-unwrap so an explicit-crash entry function exits 1. This one fixes the quieter half: when `main` returns `Value::Err(_)` from the plain `~`/`^` arm without `!!`, the process was printing the err to stdout and exiting 0. Shell pipelines and CI couldn't detect program failure by exit code.

Manifesto framing: ilo is the language agents reach for when they want to write less code that does more. The exit-code contract is what closes the loop with the rest of the agent's toolchain — make/CI/bash/`set -e` all rely on it. Silently exiting 0 on a structured err breaks every agent that composes ilo into a larger script. Cost-of-correction was small (one helper, four call-sites, one new annotation in the example harness); cost of leaving it broken is that every downstream agent has to manually parse our stdout to discover failure.

## Repro

```ilo
m>R n t;^"oh no"
```

Before:
```
$ ilo /tmp/err.ilo --run-tree; echo $?
^oh no
0
```

After:
```
$ ilo /tmp/err.ilo --run-tree; echo $?
^oh no   # on stderr
1
```

Same fix applies to `--run-vm`, `--run-cranelift`, and the default JIT-with-interpreter-fallback engine. JSON mode keeps the `{"error": {...}}` envelope on stdout (so consumers can keep parsing a single stream) but also exits 1.

## What's in the diff

- **fix: exit 1 when entry function returns Value::Err** — `src/main.rs`. New `program_exit_code(&Value) -> i32` helper. Four exec paths (`run_vm_with_provider`, `run_interp_with_provider`, `run_default`, `run_cranelift_engine`) now call it instead of returning a bare `0`. `print_value` routes plain-mode `Value::Err` to stderr (matching `report_diagnostic`'s convention) and always emits the err even when `suppress_loop_tail` is on, so a failure can't be silently swallowed.
- **test: cross-engine regression for main returning Value::Err** — new `tests/regression_main_err_exit_code.rs`. 10 tests across tree/VM/Cranelift covering plain mode (stderr-only, exit 1), JSON mode (stdout envelope, exit 1), happy path (`~7` stays exit 0), and the default-engine path via a pid-suffixed tempfile.
- **test: add -- err: annotation to examples harness** — `tests/examples.rs` and `tests/examples_engines.rs`. Mirror of `-- out:` that expects exit 1 with the assertion against stderr. Lets example files demonstrate the err contract directly.
- **examples: demonstrate main err-exit contract** — new `examples/main-err-exit-code.ilo`, plus updates to `results.ilo` and `nested-generic-types.ilo` to use `-- err:` for their err arms.
- **test: update suites that asserted the broken err-exit behaviour** — `eval_inline.rs`, `http.rs`, `regression_datetime.rs`, `regression_mget_bang.rs`. Four tests previously assumed Value::Err exited 0 with the err on stdout. Updated to assert the corrected contract. `result_bang_err_vm` softened with a comment: the VM has a separate pre-existing `!`-propagation bug (surfaced by this fix) where `num! "abc"` returns `Value::Ok(Value::Err)` on VM vs `Value::Err` on tree — out of scope here, parked as a follow-up.

## Test plan

- [x] `cargo test --release --features cranelift` — 96 test binaries pass, 0 failures (~3500 tests including the new 10 cross-engine cases)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --features cranelift -- -D warnings` — clean
- [x] Manual repro across all engines: tree, VM, Cranelift, default — all exit 1 with err on stderr (plain) and exit 1 with err envelope on stdout (JSON)
- [x] Happy-path (`~7` from main) still exits 0 on all engines

## Follow-ups

- VM `!`-propagation divergence on `num! "abc"` (tree returns `Value::Err`, VM returns `Value::Ok(Value::Err)`). Surfaced by this fix; previously masked by the exit-code bug. Will park as a separate entry in the assessment doc.