### PR TITLE
fix: short-circuit ! on num and dtfmt builtins in VM

### DIFF
--- a/examples/bang-propagation-result.ilo
+++ b/examples/bang-propagation-result.ilo
@@ -1,0 +1,30 @@
+-- `!` on a Result-returning builtin short-circuits the enclosing function
+-- on Err the same way it does for user functions: Ok(v) extracts v; Err(e)
+-- returns Value::Err(e) out of the function, skipping any tail wraps.
+--
+-- Pre-fix, the VM and Cranelift backends had per-builtin fast-paths for
+-- `num` and `dtfmt` that dropped the `!` flag and produced
+-- `Value::Ok(Value::Err(_))` on the Err branch instead of propagating.
+-- Tree was correct via `RuntimeError.propagate_value`. This example pins
+-- the cross-engine contract.
+
+-- Happy path: num! "42" extracts 42, then `~v` wraps it back as Ok(42).
+parse-ok>R n t;v=num! "42";~v
+
+-- Err path: num! "abc" returns Err("abc") which propagates out of the
+-- function before the explicit `~v` wrap runs. Exit code is 1 and the
+-- err surfaces on stderr (entry-function Err contract from #255).
+parse-err>R n t;v=num! "abc";~v
+
+-- Same contract for dtfmt!: an out-of-range epoch returns Err and `!`
+-- propagates it before the tail wrap.
+fmt-err>R t t;v=dtfmt! 99999999999999 "%Y";~v
+
+-- run: parse-ok
+-- out: ~42
+
+-- run: parse-err
+-- err: ^abc
+
+-- run: fmt-err
+-- err: ^dtfmt: timestamp out of range (99999999999999)

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -1793,6 +1793,22 @@ impl RegCompiler {
                             let rb = self.compile_expr(&args[0]);
                             let ra = self.alloc_reg();
                             self.emit_abc(OP_NUM, ra, rb, 0);
+                            // num returns R n t — handle auto-unwrap (`!`):
+                            //   on Ok(v), extract v; on Err, propagate-RET as
+                            //   the enclosing function's tail return. Tree
+                            //   short-circuits via RuntimeError.propagate_value
+                            //   so the VM must match that contract here rather
+                            //   than letting `Value::Ok(...)` flow on as the
+                            //   result of `num! ...`.
+                            if *unwrap {
+                                let check_reg = self.alloc_reg();
+                                self.emit_abc(OP_ISOK, check_reg, ra, 0);
+                                let skip_ret = self.emit_jmpt(check_reg);
+                                self.emit_abx(OP_RET, ra, 0);
+                                self.current.patch_jump(skip_ret);
+                                self.emit_abc(OP_UNWRAP, ra, ra, 0);
+                                self.next_reg = ra + 1;
+                            }
                             return ra;
                         }
                         (Builtin::Abs, 1) => {
@@ -2168,6 +2184,17 @@ impl RegCompiler {
                             let rc = self.compile_expr(&args[1]);
                             let ra = self.alloc_reg();
                             self.emit_abc(OP_DTFMT, ra, rb, rc);
+                            // dtfmt returns R t t — handle auto-unwrap (`!`).
+                            // Mirrors the Dtparse handling immediately below.
+                            if *unwrap {
+                                let check_reg = self.alloc_reg();
+                                self.emit_abc(OP_ISOK, check_reg, ra, 0);
+                                let skip_ret = self.emit_jmpt(check_reg);
+                                self.emit_abx(OP_RET, ra, 0);
+                                self.current.patch_jump(skip_ret);
+                                self.emit_abc(OP_UNWRAP, ra, ra, 0);
+                                self.next_reg = ra + 1;
+                            }
                             return ra;
                         }
                         (Builtin::Dtparse, 2) => {

--- a/tests/regression_mget_bang.rs
+++ b/tests/regression_mget_bang.rs
@@ -197,7 +197,11 @@ fn check_result_ok(engine: &str) {
     // After the fix, every engine prints `~42` — num! unwraps to 42, then
     // the explicit `~v` wraps it as Ok(42). Previously VM/Cranelift printed
     // `~~42` because num! left the Ok wrap on.
-    assert_eq!(run(engine, RESULT_BANG_OK_SRC, "f"), "~42", "engine={engine}");
+    assert_eq!(
+        run(engine, RESULT_BANG_OK_SRC, "f"),
+        "~42",
+        "engine={engine}"
+    );
 }
 
 fn check_result_err(engine: &str) {

--- a/tests/regression_mget_bang.rs
+++ b/tests/regression_mget_bang.rs
@@ -176,19 +176,38 @@ fn mget_two_step_default_miss_cranelift() {
     check_two_step_miss("--run-cranelift");
 }
 
-// ── existing Result `!` path unchanged ───────────────────────────────────
-// num! returns R n t; propagation should yield the wrapped Err.
+// ── Result `!` propagation: cross-engine contract ───────────────────────
+// `!` on a Result-returning builtin must short-circuit on Err the same way
+// it does for user functions:
+//   - Ok(v)  → extract v; subsequent statements see the inner value.
+//   - Err(e) → return Value::Err(e) from the enclosing function, skipping
+//              any remaining statements (including a tail `~v` wrap).
+//
+// Tree implements this via `RuntimeError.propagate_value`. The VM emits
+// OP_ISOK / OP_RET / OP_UNWRAP at the call site; Cranelift inherits the
+// behaviour because it consumes VM bytecode. All three engines must agree:
+// before this fix `num!` and `dtfmt!` on VM/Cranelift skipped the guard
+// and produced `Value::Ok(Value::Err(_))` on the Err branch.
+
+// num! returns R n t.
 const RESULT_BANG_OK_SRC: &str = r#"f>R n t;v=num! "42";~v"#;
 const RESULT_BANG_ERR_SRC: &str = r#"f>R n t;v=num! "abc";~v"#;
 
 fn check_result_ok(engine: &str) {
-    let out = run(engine, RESULT_BANG_OK_SRC, "f");
-    // Tree prints `~42`, VM prints `~~42` (pre-existing wrap-display
-    // discrepancy unrelated to this change). Both contain "42" and start with
-    // a wrap marker.
+    // After the fix, every engine prints `~42` — num! unwraps to 42, then
+    // the explicit `~v` wraps it as Ok(42). Previously VM/Cranelift printed
+    // `~~42` because num! left the Ok wrap on.
+    assert_eq!(run(engine, RESULT_BANG_OK_SRC, "f"), "~42", "engine={engine}");
+}
+
+fn check_result_err(engine: &str) {
+    // num! "abc" → Err("abc") propagates out of f before the `~v` wrap
+    // runs. Entry-function Err contract (#255) means exit=1 with the err
+    // on stderr.
+    let stderr = run_err(engine, RESULT_BANG_ERR_SRC, "f");
     assert!(
-        out.starts_with('~') && out.contains("42"),
-        "engine={engine}: expected wrapped 42, got {out}"
+        stderr.contains("abc"),
+        "engine={engine}: expected err containing abc on stderr, got {stderr}"
     );
 }
 
@@ -203,35 +222,142 @@ fn result_bang_ok_vm() {
 }
 
 #[test]
+#[cfg(feature = "cranelift")]
+fn result_bang_ok_cranelift() {
+    check_result_ok("--run-cranelift");
+}
+
+#[test]
 fn result_bang_err_tree() {
-    // Tree: `!` short-circuit returns Value::Err from `f`. The entry function
-    // err contract (regression_main_err_exit_code.rs) means we exit 1 with
-    // the err on stderr.
-    let out = run_err("--run-tree", RESULT_BANG_ERR_SRC, "f");
-    assert!(
-        out.contains("abc"),
-        "expected err containing abc on stderr, got {out}"
-    );
+    check_result_err("--run-tree");
 }
 
 #[test]
 fn result_bang_err_vm() {
-    // VM: known pre-existing divergence. `num! "abc"` does not short-circuit
-    // the enclosing `~v` wrap, so the program returns `Value::Ok(Value::Err)`
-    // (printed as `~^abc`) on the VM where tree returns `Value::Err`. The
-    // tree behaviour is correct. Fixing the VM `!` propagation is its own
-    // change — out of scope for the entry-function exit-code fix. We assert
-    // here that some "abc" surfaces somewhere and the process at least
-    // doesn't crash, to keep coverage and pin the contract until the VM bug
-    // is addressed in a follow-up.
-    let out = ilo()
-        .args([RESULT_BANG_ERR_SRC, "--run-vm", "f"])
-        .output()
-        .expect("failed to run ilo");
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    let stderr = String::from_utf8_lossy(&out.stderr);
+    check_result_err("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn result_bang_err_cranelift() {
+    check_result_err("--run-cranelift");
+}
+
+// ── dtfmt!: timestamp-out-of-range Err short-circuit ─────────────────────
+// dtfmt returns R t t. A 14-digit epoch overflows chrono's range and
+// surfaces as Err("dtfmt: timestamp out of range (...)"). Pre-fix, VM and
+// Cranelift wrapped the Err in an Ok and emitted `~^dtfmt: …`. Tree
+// propagated the Err out of f as exit=1.
+const DTFMT_BANG_ERR_SRC: &str = r#"f>R t t;v=dtfmt! 99999999999999 "%Y";~v"#;
+
+fn check_dtfmt_err(engine: &str) {
+    let stderr = run_err(engine, DTFMT_BANG_ERR_SRC, "f");
     assert!(
-        stdout.contains("abc") || stderr.contains("abc"),
-        "expected err containing abc somewhere, stdout={stdout} stderr={stderr}",
+        stderr.contains("dtfmt") && stderr.contains("out of range"),
+        "engine={engine}: expected dtfmt err on stderr, got {stderr}"
     );
+}
+
+#[test]
+fn dtfmt_bang_err_tree() {
+    check_dtfmt_err("--run-tree");
+}
+
+#[test]
+fn dtfmt_bang_err_vm() {
+    check_dtfmt_err("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn dtfmt_bang_err_cranelift() {
+    check_dtfmt_err("--run-cranelift");
+}
+
+// ── num! short-circuit skips subsequent statements ───────────────────────
+// If num! propagates Err, the `~99` literal on the next line must not run.
+const NUM_BANG_SHORTCIRCUIT_SRC: &str = r#"f>R n t;v=num! "abc";~99"#;
+
+fn check_num_shortcircuit(engine: &str) {
+    let stderr = run_err(engine, NUM_BANG_SHORTCIRCUIT_SRC, "f");
+    assert!(
+        stderr.contains("abc"),
+        "engine={engine}: expected propagated err, got {stderr}"
+    );
+}
+
+#[test]
+fn num_bang_shortcircuit_tree() {
+    check_num_shortcircuit("--run-tree");
+}
+
+#[test]
+fn num_bang_shortcircuit_vm() {
+    check_num_shortcircuit("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn num_bang_shortcircuit_cranelift() {
+    check_num_shortcircuit("--run-cranelift");
+}
+
+// ── rd! / rdl! short-circuit on missing file ─────────────────────────────
+// rd / rdl return R _ t. A path that doesn't exist must propagate as Err
+// out of the enclosing function — same contract as num!. These cover the
+// existing OP_RD / OP_RDL fast-paths (already correct pre-fix) so we don't
+// regress them while wiring up num! and dtfmt!.
+const RD_BANG_SRC: &str = r#"f>R t t;v=rd! "/no/such/path/ilo-test";~v"#;
+const RDL_BANG_SRC: &str = r#"f>R (L t) t;v=rdl! "/no/such/path/ilo-test";~v"#;
+
+fn check_rd_err(engine: &str) {
+    let stderr = run_err(engine, RD_BANG_SRC, "f");
+    assert!(
+        stderr.to_lowercase().contains("no such")
+            || stderr.contains("not found")
+            || stderr.contains("/no/such/path"),
+        "engine={engine}: expected file-not-found err, got {stderr}"
+    );
+}
+
+fn check_rdl_err(engine: &str) {
+    let stderr = run_err(engine, RDL_BANG_SRC, "f");
+    assert!(
+        stderr.to_lowercase().contains("no such")
+            || stderr.contains("not found")
+            || stderr.contains("/no/such/path"),
+        "engine={engine}: expected file-not-found err, got {stderr}"
+    );
+}
+
+#[test]
+fn rd_bang_err_tree() {
+    check_rd_err("--run-tree");
+}
+
+#[test]
+fn rd_bang_err_vm() {
+    check_rd_err("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn rd_bang_err_cranelift() {
+    check_rd_err("--run-cranelift");
+}
+
+#[test]
+fn rdl_bang_err_tree() {
+    check_rdl_err("--run-tree");
+}
+
+#[test]
+fn rdl_bang_err_vm() {
+    check_rdl_err("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn rdl_bang_err_cranelift() {
+    check_rdl_err("--run-cranelift");
 }


### PR DESCRIPTION
## Summary

Follow-up to #255. The VM `compile_expr` dispatch had per-builtin fast-paths for Result-returning builtins, most of which emit the canonical `OP_ISOK / JMPT / OP_RET / OP_UNWRAP` guard sequence to honour the auto-unwrap `!` flag. Two fast-paths dropped the flag: `Builtin::Num` and `Builtin::Dtfmt`. The Ok wrap leaked through, so `Value::Err(_)` got nested inside a `Value::Ok(_)` instead of propagating as the enclosing function's tail return.

Tree handled this correctly via `RuntimeError.propagate_value`. Cranelift consumes VM bytecode so it inherited the same divergence.

## Repro

Before:

```
$ ilo 'f>R n t;v=num! "abc";~v' --run-tree f
^abc        # exit 1
$ ilo 'f>R n t;v=num! "abc";~v' --run-vm f
~^abc       # exit 0  ← bug
$ ilo 'f>R n t;v=num! "abc";~v' --run-cranelift f
~^abc       # exit 0  ← bug
```

After: all three engines print `^abc` and exit 1.

Same divergence (and fix) for `dtfmt!` with an out-of-range epoch.

## What's in the diff

- **1fa0922 fix:** wire `Builtin::Num` and `Builtin::Dtfmt` fast-paths through the same guard sequence the 12+ neighbouring Result fast-paths already use. 27 lines, two near-identical hunks. Cranelift gets the fix for free because it consumes VM bytecode and already implements `OP_ISOK` / `OP_UNWRAP`.

- **ca5e524 test:** tighten `result_bang_*` assertions (they pinned the broken contract pre-fix), add `dtfmt_bang_err_*`, `num_bang_shortcircuit_*`, `rd_bang_err_*`, `rdl_bang_err_*` across tree/VM/Cranelift, plus an `examples/bang-propagation-result.ilo` that exercises Ok and Err branches via the `examples_engines` harness.

## Test plan

- [x] `cargo test --release --features cranelift --test regression_mget_bang` — 34 passed (tree + VM + Cranelift)
- [x] `cargo test --release --features cranelift --test examples_engines` — 1 passed (817 example-engine assertions all green)
- [x] `cargo test --release --features cranelift` — full suite passes (AOT tests need libilo.a at default target path, unrelated)
- [x] Manual repro across all three engines

## Follow-ups

None. The original `result_bang_err_vm` test contained a "follow-up" comment pointing at exactly this bug; that note is now obsolete and the test has been updated to assert the correct contract.