### PR TITLE
parser: allow trailing fmt as a nested arg, reject middle position

### DIFF
--- a/examples/fmt-in-arg-position.ilo
+++ b/examples/fmt-in-arg-position.ilo
@@ -1,0 +1,28 @@
+-- `fmt` is variadic (template + N values). When used as a NESTED arg of
+-- another known-arity builtin, it must occupy the LAST slot of that outer
+-- call — in trailing position the parser eagerly consumes the template
+-- plus every remaining operand as fmt's args.
+--
+-- This is the idiomatic shape: no parens, no helper var.
+
+-- prnt is arity 1, fmt is its trailing arg → prnt(fmt("x={}", 42))
+say-x>t;fmt "x={}" 42
+
+-- wr path text — fmt at slot 1 (trailing) of wr
+greeting-text>t;fmt "hi {} from {}" "world" "ilo"
+
+-- nested: prnt upr fmt — fmt at slot 0 of upr (trailing), upr at slot 0 of prnt (trailing)
+loud n:n>t;upr fmt "x={}" n
+
+-- middle-position is rejected with ILO-P018 — wrap in parens to escape.
+-- Example: slc is arity 3 (list, start, end). fmt at slot 0 needs parens:
+slice-fmt n:n>t;slc (fmt "abcdef={}" n) 0 5
+
+-- run: say-x
+-- out: x=42
+-- run: greeting-text
+-- out: hi world from ilo
+-- run: loud 7
+-- out: X=7
+-- run: slice-fmt 9
+-- out: abcde

--- a/src/diagnostic/registry.rs
+++ b/src/diagnostic/registry.rs
@@ -273,6 +273,35 @@ Closure capture is tracked as a Phase 2 follow-up; once it lands, free
 variables will be captured by value automatically.
 "#,
     },
+    ErrorEntry {
+        code: "ILO-P018",
+        short: "variadic builtin not in trailing position",
+        long: r#"## ILO-P018: variadic builtin not in trailing position
+
+`fmt` (and its `format` alias) is variadic — it takes a template plus any
+number of trailing values. When used as a nested argument to another known
+builtin, it MUST occupy the LAST argument slot of the outer call, because the
+parser has no way to know where `fmt`'s args end and the outer's resume.
+
+**Wrong:**
+
+    f x:t y:t z:t>n;f x fmt "tmpl {}" 1 z
+
+`fmt` here is at the middle slot of a 3-arg outer `f`; the parser can't tell
+whether `fmt` consumes `"tmpl {}" 1` or `"tmpl {}" 1 z`.
+
+**Fix A: move `fmt` to the trailing slot** if the outer's signature allows
+(most common idiom — `prnt fmt "..."`, `wr path fmt "..."`, `prnt str fmt
+"..."` all already satisfy this rule).
+
+**Fix B: wrap the `fmt` call in parens** to group its args explicitly:
+
+    f x (fmt "tmpl {}" 1) z
+
+The parens make the `fmt` call self-contained, so the outer's arg counter
+treats it as a single operand.
+"#,
+    },
     // ── Type / Verifier ──────────────────────────────────────────────────────
     ErrorEntry {
         code: "ILO-T001",

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1434,10 +1434,19 @@ impl Parser {
             // expand naturally (e.g. `xs >> map str` keeps `str` as a bare
             // fn-ref since `map`'s first arg is a fn-ref position).
             let mut args = Vec::new();
+            // Piped value will occupy the final slot, so explicit args here
+            // fill slots 0..arity-1. Subtract 1 from the outer-arity advertised
+            // to `parse_call_arg` so `fmt` correctly sees these as middle
+            // slots (and so a misplaced `fmt` in a pipe target gets the
+            // precise ILO-P018 rather than silently mis-parsing).
+            let pipe_outer_arity = self.fn_arity.get(&func_name).copied();
             while self.can_start_operand() {
                 let arg_idx = args.len();
                 let in_fn_pos = self.is_fn_ref_position(&func_name, arg_idx);
-                args.push(self.parse_call_arg(in_fn_pos)?);
+                let outer_ctx = pipe_outer_arity
+                    .filter(|&k| k > 0)
+                    .map(|k| (func_name.as_str(), k - 1, arg_idx));
+                args.push(self.parse_call_arg(in_fn_pos, outer_ctx)?);
             }
             // Piped value becomes last arg
             args.push(expr);
@@ -1775,12 +1784,108 @@ impl Parser {
             .unwrap_or(false)
     }
 
+    /// Is `name` a variadic-trailing builtin — one that, when used as a nested
+    /// call argument, must occupy the LAST arg slot of the outer call and
+    /// then consumes every remaining operand as its own trailing args?
+    ///
+    /// Currently only `fmt`. The rule is intentionally narrow:
+    ///   * trailing slot of a known-arity outer → eagerly parse template + tail.
+    ///   * middle slot → emit ILO-P018 (must be last, or wrap in parens).
+    ///   * outside known-arity context → fall through to existing behaviour
+    ///     (top-level call, list element with comma boundary, etc.).
+    fn is_variadic_trailing_builtin(name: &str) -> bool {
+        name == "fmt" || name == "format"
+    }
+
     /// Parse a single call argument. If `in_fn_ref_pos` is true, falls back
     /// to plain `parse_operand` so an Ident stays as a bare ref (HOF use).
     /// Otherwise, when the next token is an Ident naming a known function
     /// with arity N, eagerly consume that Ident plus its N args as a nested
     /// call — this lets agents write `prnt str nc` and `hd tl xs` naturally.
-    fn parse_call_arg(&mut self, in_fn_ref_pos: bool) -> Result<Expr> {
+    ///
+    /// `outer_ctx` carries the surrounding call's name, total arity, and the
+    /// current slot index (the slot this arg fills). It lets us decide
+    /// whether a variadic-trailing builtin like `fmt` is at the trailing slot
+    /// (eagerly consume its template + remaining operands) or a middle slot
+    /// (emit ILO-P018). `None` means we're not parsing inside a known-arity
+    /// outer, so the variadic-trailing rule doesn't apply.
+    fn parse_call_arg(
+        &mut self,
+        in_fn_ref_pos: bool,
+        outer_ctx: Option<(&str, usize, usize)>,
+    ) -> Result<Expr> {
+        // Variadic-trailing handling for `fmt` (and its `format` alias) when
+        // used as a nested arg of a known-arity outer.
+        if !in_fn_ref_pos
+            && let Some(Token::Ident(name)) = self.peek()
+            && Self::is_variadic_trailing_builtin(name)
+            && let Some((outer_name, outer_arity, arg_idx)) = outer_ctx
+        {
+            // Don't fire on shapes that wouldn't be a plain call anyway —
+            // record fields, field/index access, bang-unwrap, zero-arg paren.
+            let next = self.token_at(self.pos + 1);
+            let is_record = matches!(next, Some(Token::Ident(_)))
+                && self.token_at(self.pos + 2) == Some(&Token::Colon);
+            let is_field = matches!(next, Some(Token::Dot) | Some(Token::DotQuestion));
+            let is_zero_arg_call =
+                next == Some(&Token::LParen) && self.token_at(self.pos + 2) == Some(&Token::RParen);
+            let is_unwrap = next == Some(&Token::Bang) && {
+                let ident_span = self.peek_span();
+                let bang_span = self
+                    .tokens
+                    .get(self.pos + 1)
+                    .map(|(_, s)| *s)
+                    .unwrap_or(Span::UNKNOWN);
+                ident_span.end > 0 && bang_span.start == ident_span.end
+            };
+            if !(is_record || is_field || is_zero_arg_call || is_unwrap) {
+                let fmt_name = name.clone();
+                let is_trailing = arg_idx + 1 == outer_arity;
+                if !is_trailing {
+                    return Err(self.error_hint(
+                        "ILO-P018",
+                        format!(
+                            "`{fmt_name}` must be the last argument to `{outer_name}`; \
+wrap in parens to use it earlier"
+                        ),
+                        format!(
+                            "`{outer_name}` expects {outer_arity} args and `{fmt_name}` is at \
+slot {arg_idx} of {outer_arity}. Either move `{fmt_name}` to the last position, \
+or write `({fmt_name} \"...\" ...)` so its args are grouped."
+                        ),
+                    ));
+                }
+                // Trailing slot — eagerly consume `fmt` + template + all
+                // remaining operands as fmt's args.
+                self.advance(); // consume `fmt`
+                let mut fmt_args = Vec::new();
+                // fmt requires a template (its declared arity 1); if no
+                // operand follows, leave the underfilled call for the
+                // verifier to flag with its usual ILO-T013 error.
+                while self.can_start_operand() {
+                    // fmt's own slots are all value positions (no fn-refs),
+                    // and nested fmt-in-fmt is the same trailing slot of its
+                    // recursive context — pass through.
+                    fmt_args.push(self.parse_call_arg(false, None)?);
+                    // Stop on infix operators so `prnt fmt "x" 1 + 2` keeps
+                    // `+ 2` for the outer expression parser to handle (as it
+                    // would for any nested call's last arg).
+                    if let Some(tok) = self.peek()
+                        && Self::is_infix_or_suffix_op(tok)
+                        && (matches!(tok, Token::NilCoalesce)
+                            || !self.looks_like_prefix_binary(self.pos))
+                    {
+                        break;
+                    }
+                }
+                return Ok(Expr::Call {
+                    function: fmt_name,
+                    args: fmt_args,
+                    unwrap: false,
+                });
+            }
+        }
+
         if !in_fn_ref_pos
             && let Some(Token::Ident(name)) = self.peek()
             && let Some(&arity) = self.fn_arity.get(name)
@@ -1814,7 +1919,8 @@ impl Parser {
                         break;
                     }
                     let inner_fn_pos = self.is_fn_ref_position(&inner_name, i);
-                    inner_args.push(self.parse_call_arg(inner_fn_pos)?);
+                    inner_args
+                        .push(self.parse_call_arg(inner_fn_pos, Some((&inner_name, arity, i)))?);
                 }
                 return Ok(Expr::Call {
                     function: inner_name,
@@ -1866,10 +1972,14 @@ impl Parser {
             // If we consumed !, this must be a call (even with zero args if nothing follows)
             if unwrap {
                 let mut args = Vec::new();
+                let outer_arity_known = self.fn_arity.get(&name).copied();
                 while self.can_start_operand() {
                     let arg_idx = args.len();
                     let in_fn_pos = self.is_fn_ref_position(&name, arg_idx);
-                    args.push(self.parse_call_arg(in_fn_pos)?);
+                    let outer_ctx = outer_arity_known
+                        .filter(|&k| k > 0)
+                        .map(|k| (name.as_str(), k, arg_idx));
+                    args.push(self.parse_call_arg(in_fn_pos, outer_ctx)?);
                 }
                 return Ok(Expr::Call {
                     function: name,
@@ -1916,10 +2026,14 @@ impl Parser {
                     return Ok(atom);
                 }
                 let mut args = Vec::new();
+                let outer_arity_known = self.fn_arity.get(&name).copied();
                 while self.can_start_operand() {
                     let arg_idx = args.len();
                     let in_fn_pos = self.is_fn_ref_position(&name, arg_idx);
-                    args.push(self.parse_call_arg(in_fn_pos)?);
+                    let outer_ctx = outer_arity_known
+                        .filter(|&k| k > 0)
+                        .map(|k| (name.as_str(), k, arg_idx));
+                    args.push(self.parse_call_arg(in_fn_pos, outer_ctx)?);
                     // After each arg, if next is infix, stop. `??` is always
                     // infix once we've already collected at least one arg —
                     // `f a ?? b` means `(f a) ?? b`, never `f a (??b ...)`.

--- a/tests/regression_fmt_in_arg_position.rs
+++ b/tests/regression_fmt_in_arg_position.rs
@@ -1,0 +1,376 @@
+// Regression tests for the trailing-only `fmt`-in-arg-position parser rule.
+//
+// Before this change, `prnt fmt "x={}" 42` failed with ILO-T004 + ILO-T006
+// because `fmt` was deliberately absent from the parser's arity table and
+// fell through to a bare `Ref("fmt")`, leaving the outer call to greedily
+// swallow `fmt`'s template + args as extra outer args.
+//
+// New rule (single sentence): when `fmt` appears as a NESTED arg of a
+// known-arity outer, it must be the LAST slot of that outer; in that
+// position it eagerly consumes the template + every remaining operand as
+// its own args. In any middle slot it raises ILO-P018 with a precise
+// hint ("wrap in parens").
+//
+// Cross-engine: tree, vm, and (when enabled) cranelift JIT — the parser
+// change is shared across all three pipelines, so each engine must see
+// the same AST and produce the same output.
+
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn write_src(name: &str, src: &str) -> std::path::PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut path = std::env::temp_dir();
+    path.push(format!("ilo_fmtarg_{name}_{}_{n}.ilo", std::process::id()));
+    std::fs::write(&path, src).expect("write src");
+    path
+}
+
+fn run_ok(engine: &str, src: &str, entry: &str) -> String {
+    let path = write_src(entry, src);
+    let out = ilo()
+        .arg(&path)
+        .arg(engine)
+        .arg(entry)
+        .output()
+        .expect("failed to run ilo");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn run_err(engine: &str, src: &str, entry: &str) -> String {
+    let path = write_src(entry, src);
+    let out = ilo()
+        .arg(&path)
+        .arg(engine)
+        .arg(entry)
+        .output()
+        .expect("failed to run ilo");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        !out.status.success(),
+        "expected failure but ilo {engine} succeeded for `{src}`"
+    );
+    let mut s = String::from_utf8_lossy(&out.stderr).into_owned();
+    s.push_str(&String::from_utf8_lossy(&out.stdout));
+    s
+}
+
+const ENGINES: &[&str] = &["--run-tree", "--run-vm"];
+
+#[cfg(feature = "cranelift")]
+const CRANELIFT_ENGINE: &str = "--run-cranelift";
+
+// ── 1) Trailing fmt at slot 0 of arity-1 outer ────────────────────────────
+
+const PRNT_FMT: &str = "f>n;prnt fmt \"x={}\" 42; 0";
+
+fn check_prnt_fmt(engine: &str) {
+    assert_eq!(run_ok(engine, PRNT_FMT, "f"), "x=42\n0", "engine={engine}");
+}
+
+#[test]
+fn prnt_fmt_tree() {
+    check_prnt_fmt("--run-tree");
+}
+
+#[test]
+fn prnt_fmt_vm() {
+    check_prnt_fmt("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn prnt_fmt_cranelift() {
+    check_prnt_fmt(CRANELIFT_ENGINE);
+}
+
+// ── 2) Trailing fmt at slot 0 of every text-arg arity-1 builtin ───────────
+//
+// `trm`, `upr`, `lwr`, `cap` all take a single text arg. `fmt` returns
+// text, so each wraps the format result.
+
+#[test]
+fn trm_upr_lwr_cap_fmt_all_engines() {
+    let cases = [
+        ("trm", "f>t;trm fmt \"  x={}  \" 1", "x=1"),
+        ("upr", "f>t;upr fmt \"x={}\" 1", "X=1"),
+        ("lwr", "f>t;lwr fmt \"X={}\" 1", "x=1"),
+        ("cap", "f>t;cap fmt \"hello {}\" 1", "Hello 1"),
+    ];
+    for (label, src, want) in cases {
+        for engine in ENGINES {
+            assert_eq!(run_ok(engine, src, "f"), want, "{label} engine={engine}");
+        }
+        #[cfg(feature = "cranelift")]
+        {
+            assert_eq!(
+                run_ok(CRANELIFT_ENGINE, src, "f"),
+                want,
+                "{label} engine=cranelift"
+            );
+        }
+    }
+}
+
+// ── 3) Trailing fmt at slot 1 of arity-2 outer `wr` ───────────────────────
+//
+// `wr path text` writes `text` to `path`. With the trailing rule,
+// `wr "..." fmt "..." 1` parses as `wr("...", fmt("...", 1))`.
+
+fn wr_fmt_temp(engine: &str) -> String {
+    let tmp = std::env::temp_dir().join(format!(
+        "ilo_wrfmt_{}_{}.txt",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let path_str = tmp.to_string_lossy().to_string().replace('\\', "\\\\");
+    let src = format!("f>n;wr \"{path_str}\" fmt \"x={{}}\" 42; 0");
+    let _ = std::fs::remove_file(&tmp);
+    let stdout = run_ok(engine, &src, "f");
+    let body = std::fs::read_to_string(&tmp).expect("file written");
+    let _ = std::fs::remove_file(&tmp);
+    assert_eq!(stdout, "0", "engine={engine}");
+    body
+}
+
+#[test]
+fn wr_fmt_tree() {
+    assert_eq!(wr_fmt_temp("--run-tree"), "x=42");
+}
+
+#[test]
+fn wr_fmt_vm() {
+    assert_eq!(wr_fmt_temp("--run-vm"), "x=42");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn wr_fmt_cranelift() {
+    assert_eq!(wr_fmt_temp(CRANELIFT_ENGINE), "x=42");
+}
+
+// ── 4) Nested: prnt upr fmt — fmt at slot 0 of slot-0-of-prnt's `upr` ─────
+//
+// `upr` is arity 1, `fmt` is at its trailing slot 0. `prnt` is arity 1,
+// `upr fmt ...` is at its trailing slot 0. Both layers cascade.
+
+const PRNT_UPR_FMT: &str = "f>n;prnt upr fmt \"x={}\" 1; 0";
+
+fn check_prnt_upr_fmt(engine: &str) {
+    assert_eq!(
+        run_ok(engine, PRNT_UPR_FMT, "f"),
+        "X=1\n0",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn prnt_upr_fmt_tree() {
+    check_prnt_upr_fmt("--run-tree");
+}
+
+#[test]
+fn prnt_upr_fmt_vm() {
+    check_prnt_upr_fmt("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn prnt_upr_fmt_cranelift() {
+    check_prnt_upr_fmt(CRANELIFT_ENGINE);
+}
+
+// ── 5) Bare top-level fmt call still parses as a multi-arg call ───────────
+//
+// Sanity: the rule must not regress fmt-as-outer.
+
+const FMT_BARE: &str = "f>t;fmt \"x={}\" 42";
+
+fn check_fmt_bare(engine: &str) {
+    assert_eq!(run_ok(engine, FMT_BARE, "f"), "x=42", "engine={engine}");
+}
+
+#[test]
+fn fmt_bare_tree() {
+    check_fmt_bare("--run-tree");
+}
+
+#[test]
+fn fmt_bare_vm() {
+    check_fmt_bare("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn fmt_bare_cranelift() {
+    check_fmt_bare(CRANELIFT_ENGINE);
+}
+
+// ── 6) fmt inside a list literal still works (comma-delimited) ────────────
+
+const FMT_IN_LIST: &str = "f>n;prnt [fmt \"x={}\" 1, 2]; 0";
+
+fn check_fmt_in_list(engine: &str) {
+    assert_eq!(
+        run_ok(engine, FMT_IN_LIST, "f"),
+        "[x=1, 2]\n0",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn fmt_in_list_tree() {
+    check_fmt_in_list("--run-tree");
+}
+
+#[test]
+fn fmt_in_list_vm() {
+    check_fmt_in_list("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn fmt_in_list_cranelift() {
+    check_fmt_in_list(CRANELIFT_ENGINE);
+}
+
+// ── 7) Parenthesised fmt remains valid in any slot ────────────────────────
+//
+// The paren idiom is the escape hatch for middle-position use and must not
+// regress.
+
+const FMT_PAREN: &str = "f>n;prnt (fmt \"x={}\" 42); 0";
+
+fn check_fmt_paren(engine: &str) {
+    assert_eq!(run_ok(engine, FMT_PAREN, "f"), "x=42\n0", "engine={engine}");
+}
+
+#[test]
+fn fmt_paren_tree() {
+    check_fmt_paren("--run-tree");
+}
+
+#[test]
+fn fmt_paren_vm() {
+    check_fmt_paren("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn fmt_paren_cranelift() {
+    check_fmt_paren(CRANELIFT_ENGINE);
+}
+
+// ── 8) Middle-position fmt emits ILO-P018 with a paren-suggestion hint ────
+//
+// `slc` is arity 3 (`slc list start end`). `fmt` at slot 0 is a middle
+// slot. Same for `rgxsub` (arity 3) at slot 0.
+
+#[test]
+fn fmt_middle_slc_slot0_emits_p018_tree() {
+    let src = "f>L n;slc fmt \"x={}\" 1 0 2";
+    let err = run_err("--run-tree", src, "f");
+    assert!(
+        err.contains("ILO-P018") && err.contains("must be the last argument to `slc`"),
+        "missing ILO-P018 with slc hint: {err}"
+    );
+    assert!(
+        err.contains("wrap in parens"),
+        "missing paren suggestion: {err}"
+    );
+}
+
+#[test]
+fn fmt_middle_rgxsub_slot0_emits_p018_tree() {
+    let src = "f>t;rgxsub fmt \"p={}\" 1 \"abc\" \"X\"";
+    let err = run_err("--run-tree", src, "f");
+    assert!(
+        err.contains("ILO-P018") && err.contains("must be the last argument to `rgxsub`"),
+        "missing ILO-P018 with rgxsub hint: {err}"
+    );
+}
+
+#[test]
+fn fmt_middle_user_fn_slot1_emits_p018_tree() {
+    // User-defined 3-arg fn — `fmt` at slot 1 is a middle slot, must be
+    // rejected with the same diagnostic shape.
+    let src = "g x:t y:t z:t>t;cat x cat y z\nf>t;g \"a\" fmt \"b={}\" 1 \"c\"";
+    let err = run_err("--run-tree", src, "f");
+    assert!(
+        err.contains("ILO-P018"),
+        "missing ILO-P018 for user-fn middle slot: {err}"
+    );
+    assert!(
+        err.contains("slot 1 of 3"),
+        "missing precise slot indicator: {err}"
+    );
+}
+
+// The diagnostic is a parser error — same code surfaces identically under
+// every engine (parsing happens before engine dispatch). Smoke-check on
+// VM and Cranelift to confirm there's no divergence in how the error is
+// surfaced (e.g. exit code, code string).
+
+#[test]
+fn fmt_middle_p018_vm() {
+    let src = "f>L n;slc fmt \"x={}\" 1 0 2";
+    let err = run_err("--run-vm", src, "f");
+    assert!(err.contains("ILO-P018"), "vm missing ILO-P018: {err}");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn fmt_middle_p018_cranelift() {
+    let src = "f>L n;slc fmt \"x={}\" 1 0 2";
+    let err = run_err(CRANELIFT_ENGINE, src, "f");
+    assert!(
+        err.contains("ILO-P018"),
+        "cranelift missing ILO-P018: {err}"
+    );
+}
+
+// ── 9) Paren-around-fmt rescues a middle-position use ─────────────────────
+//
+// The diagnostic suggests "wrap in parens". Verify that paren-wrapping
+// actually fixes the program (so the suggestion isn't a lie).
+
+const SLC_FMT_PAREN: &str = "f>t;slc (fmt \"abcdef={}\" 9) 0 5";
+
+fn check_slc_fmt_paren(engine: &str) {
+    // fmt produces "abcdef=9", slc 0..5 = "abcde".
+    assert_eq!(
+        run_ok(engine, SLC_FMT_PAREN, "f"),
+        "abcde",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn slc_fmt_paren_tree() {
+    check_slc_fmt_paren("--run-tree");
+}
+
+#[test]
+fn slc_fmt_paren_vm() {
+    check_slc_fmt_paren("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn slc_fmt_paren_cranelift() {
+    check_slc_fmt_paren(CRANELIFT_ENGINE);
+}


### PR DESCRIPTION
## Summary

Closes the parked rough edge from `ilo_assessment_feedback.md` - `prnt fmt "x={}" 42`, `wr path fmt "..."`, `prnt upr fmt "..."` etc. all failed today with ILO-T004 + ILO-T006 because `fmt` was deliberately absent from the parser's arity table and fell through to a bare `Ref("fmt")`, leaving the outer's greedy arg loop to swallow fmt's template + values as extra outer args.

New rule, in one sentence: **`fmt` may occupy the LAST slot of a known-arity outer; in that position it eagerly consumes the template + every remaining operand as its own args. In any middle slot it raises ILO-P018 with a "wrap in parens" suggestion.**

Local, predictable, agent-learnable in one sentence. I considered a more general rule that would reserve `outer_arity - arg_idx - 1` operands for the outer and give the rest to fmt, but that needs speculative operand-counting (operands may themselves be calls of unknown arity), and worse, the same `fmt ...` tail would parse differently depending on which outer it was nested under. The trailing-only rule keeps fmt's parse local to its own position.

## Repro before/after

Source: `main>n;prnt fmt "x={}" 42; 0`

Before:

```
{"code":"ILO-T004","message":"undefined variable 'fmt'",...}
{"code":"ILO-T006","message":"arity mismatch: 'prnt' expects 1 args, got 3",...}
```

After:

```
x=42
0
```

Middle-position now emits the precise diagnostic. Source: `f>L n;slc fmt "x={}" 1 0 2`

```
{"code":"ILO-P018","message":"`fmt` must be the last argument to `slc`; wrap in parens to use it earlier",
 "suggestion":"`slc` expects 3 args and `fmt` is at slot 0 of 3. Either move `fmt` to the last position, or write `(fmt \"...\" ...)` so its args are grouped."}
```

## What's in the diff (per-commit)

- **parser: allow trailing fmt as a nested arg, reject middle position** - `parse_call_arg` now takes an optional `(outer_name, outer_arity, arg_idx)` context. When the inner ident is `fmt`/`format` and the context says we're at the trailing slot, eagerly consume the template + remaining operands as a `Call("fmt", ...)`. Middle position raises ILO-P018 via the existing `error_hint` helper. Pipe call sites pass `arity - 1` as the advertised outer arity, since the piped value owns the final slot - so a misplaced fmt in `xs >> wr fmt ...` also lands on ILO-P018 instead of mis-parsing. ILO-P018 entry added to the diagnostic registry with both Fix A (move to trailing) and Fix B (wrap in parens) explanations.

- **example: trailing fmt as a nested arg** - `examples/fmt-in-arg-position.ilo` demonstrates the four idiomatic shapes (`prnt fmt`, `wr-style fmt`, `prnt upr fmt` nested, paren-rescue for slc) with `-- run:`/`-- out:` annotations so the `examples_engines` harness exercises each across tree + VM.

- **test: cross-engine regression for trailing fmt + ILO-P018** - 27 tests in `regression_fmt_in_arg_position.rs` covering trailing-fmt under `prnt`/`trm`/`upr`/`lwr`/`cap`/`wr`, nested `prnt upr fmt`, bare top-level fmt, list-literal fmt, paren-rescue, and ILO-P018 on `slc` / `rgxsub` / user-defined 3-arg fn. Happy-path runs on tree + VM + cranelift; diagnostic cases also assert on all three engines so any engine-specific divergence is caught.

## Test plan

- [x] `cargo test --release --features cranelift` - full suite green (every binary `test result: ok`, zero FAILED).
- [x] New `regression_fmt_in_arg_position` - 27 tests pass on tree, VM, and cranelift.
- [x] `examples_engines` - new example file runs identically on tree + VM via `-- run:`/`-- out:` markers.
- [x] `cargo clippy --release --features cranelift -- -D warnings` - clean.
- [x] `cargo fmt --check` - clean.
- [x] Manual repros across all four call shapes (`prnt fmt`, `wr "p" fmt`, `prnt upr fmt`, middle-position ILO-P018) match the diagnostic + behaviour in this PR description.

## Follow-ups

- Nested `fmt` inside `fmt` (e.g. `prnt fmt "{}" fmt "x" 1`) currently surfaces as a verifier error rather than a precise parse-time rejection. Parens are the workaround. Low priority - agents won't naturally hit this shape, and the existing diagnostic is informative enough.
- ILO-P018's catalogue of variadic-trailing builtins is currently a hard-coded match on `fmt`/`format`. If we ever add a second variadic-trailing builtin, lift it to a per-entry flag on the arity table alongside `fn_param_is_fn`.
