### PR TITLE
fix: cranelift JIT helper nil-sweep batch 2 (recfld, recfld_name, unwrap, mget)

### DIFF
--- a/examples/jit-nil-sweep-batch2.ilo
+++ b/examples/jit-nil-sweep-batch2.ilo
@@ -1,0 +1,22 @@
+-- Positive paths for the batch-2 helpers (strict recfld_name hit, safe
+-- recfld_name miss, mget hit + miss). The companion regression suite
+-- covers the error paths; this example pins the happy paths
+-- cross-engine via the `examples_engines` harness so future codegen
+-- changes can't silently regress them.
+
+strict-hit j:t>R n t;r=jpar! j;~r.present
+safe-miss  j:t>R t t;r=jpar! j;~fmt "{}" r.?missing
+mget-miss>O n;m=mset (mmap) "a" 1;mget m "z"
+mget-hit>O n;m=mset (mmap) "a" 1;mget m "a"
+
+-- run: strict-hit {"present":42}
+-- out: ~42
+
+-- run: safe-miss {"present":1}
+-- out: ~nil
+
+-- run: mget-miss
+-- out: nil
+
+-- run: mget-hit
+-- out: 1

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -113,7 +113,9 @@ struct HelperFuncs {
     listappend_inplace: FuncId,
     index: FuncId,
     recfld: FuncId,
+    recfld_strict: FuncId,
     recfld_name: FuncId,
+    recfld_name_strict: FuncId,
     recnew: FuncId,
     recwith: FuncId,
     recwith_arena: FuncId,
@@ -277,7 +279,12 @@ fn register_helpers(builder: &mut JITBuilder) {
         ),
         ("jit_index", jit_index as *const u8),
         ("jit_recfld", jit_recfld as *const u8),
+        ("jit_recfld_strict", jit_recfld_strict as *const u8),
         ("jit_recfld_name", jit_recfld_name as *const u8),
+        (
+            "jit_recfld_name_strict",
+            jit_recfld_name_strict as *const u8,
+        ),
         ("jit_recnew", jit_recnew as *const u8),
         ("jit_recwith", jit_recwith as *const u8),
         ("jit_recwith_arena", jit_recwith_arena as *const u8),
@@ -426,7 +433,9 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         listappend_inplace: declare_helper(module, "jit_listappend_inplace", 2, 1),
         index: declare_helper(module, "jit_index", 2, 1),
         recfld: declare_helper(module, "jit_recfld", 2, 1),
+        recfld_strict: declare_helper(module, "jit_recfld_strict", 2, 1),
         recfld_name: declare_helper(module, "jit_recfld_name", 3, 1),
+        recfld_name_strict: declare_helper(module, "jit_recfld_name_strict", 3, 1),
         recnew: declare_helper(module, "jit_recnew", 4, 1),
         recwith: declare_helper(module, "jit_recwith", 4, 1),
         recwith_arena: declare_helper(module, "jit_recwith_arena", 5, 1),
@@ -2506,10 +2515,16 @@ fn compile_function_body(
                 builder.switch_to_block(skip_clone_block);
                 builder.ins().jump(merge_block, &[field_val]);
 
-                // Heap path: call jit_recfld
+                // Heap path: call jit_recfld_strict so missing-field /
+                // non-record errors surface via JIT_RUNTIME_ERROR. The arena
+                // fast path above does no bounds check (c_idx is a
+                // compile-time-constant verified by the typechecker on
+                // statically-typed records); a verifier bug there would still
+                // segfault, which is the same shape as the existing
+                // arena-fast-path contract.
                 builder.switch_to_block(heap_block);
                 let field_idx_val = builder.ins().iconst(I64, c_idx as i64);
-                let fref = get_func_ref(&mut builder, module, helpers.recfld);
+                let fref = get_func_ref(&mut builder, module, helpers.recfld_strict);
                 let call_inst = builder.ins().call(fref, &[bv, field_idx_val]);
                 let heap_result = builder.inst_results(call_inst)[0];
                 builder.ins().jump(merge_block, &[heap_result]);
@@ -2536,7 +2551,10 @@ fn compile_function_body(
                 // Get registry pointer
                 let registry_ptr = ACTIVE_REGISTRY.with(|r| r.get() as u64);
                 let registry_val = builder.ins().iconst(I64, registry_ptr as i64);
-                let fref = get_func_ref(&mut builder, module, helpers.recfld_name);
+                // Strict variant: missing-name / non-record surfaces as a
+                // JIT_RUNTIME_ERROR. OP_RECFLD_NAME_SAFE below keeps using
+                // the permissive `jit_recfld_name` for `.?field` semantics.
+                let fref = get_func_ref(&mut builder, module, helpers.recfld_name_strict);
                 let call_inst = builder
                     .ins()
                     .call(fref, &[bv, field_name_val, registry_val]);

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -10653,6 +10653,121 @@ pub extern "C" fn jit_recfld_name(rec: u64, field_name_ptr: u64, registry_ptr: u
     }
 }
 
+/// Strict variant of `jit_recfld` — sets `JIT_RUNTIME_ERROR` on miss or
+/// non-record and still returns `TAG_NIL`. Wired to `OP_RECFLD` (the
+/// error-on-miss op); `OP_RECFLD_SAFE` keeps using the permissive
+/// `jit_recfld`. See PR #248 for the safe/strict split.
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_recfld_strict(rec: u64, field_idx: u64) -> u64 {
+    let rv = NanVal(rec);
+    let idx = field_idx as usize;
+
+    // Fast path: arena record
+    if rv.is_arena_record() {
+        unsafe {
+            let r = rv.as_arena_record();
+            if idx < r.n_fields as usize {
+                let v = NanVal(*r.field_ptr(idx));
+                v.clone_rc();
+                return v.0;
+            }
+        }
+        jit_set_runtime_error(VmError::FieldNotFound {
+            field: format!("index {}", idx),
+        });
+        return TAG_NIL;
+    }
+
+    if !rv.is_heap() {
+        jit_set_runtime_error(VmError::Type("field access on non-record"));
+        return TAG_NIL;
+    }
+    match unsafe { rv.as_heap_ref() } {
+        HeapObj::Record { fields, type_info } => {
+            if idx < fields.len() {
+                let val = fields[idx];
+                val.clone_rc();
+                val.0
+            } else {
+                let name = type_info.fields.get(idx).map(|s| s.as_str()).unwrap_or("?");
+                jit_set_runtime_error(VmError::FieldNotFound {
+                    field: name.to_string(),
+                });
+                TAG_NIL
+            }
+        }
+        _ => {
+            jit_set_runtime_error(VmError::Type("field access on non-record"));
+            TAG_NIL
+        }
+    }
+}
+
+/// Strict variant of `jit_recfld_name` — sets `JIT_RUNTIME_ERROR` on miss
+/// or non-record and still returns `TAG_NIL`. Wired to `OP_RECFLD_NAME`
+/// (the error-on-miss op); `OP_RECFLD_NAME_SAFE` keeps using the
+/// permissive `jit_recfld_name`.
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub extern "C" fn jit_recfld_name_strict(rec: u64, field_name_ptr: u64, registry_ptr: u64) -> u64 {
+    // SAFETY: field_name_ptr is a null-terminated C string created by the JIT
+    // compiler (leaked CString) or AOT compiler (data section). It remains
+    // valid for the call duration.
+    let field_name = unsafe {
+        let cstr = std::ffi::CStr::from_ptr(field_name_ptr as *const std::ffi::c_char);
+        cstr.to_str().unwrap_or("")
+    };
+    let rv = NanVal(rec);
+
+    if rv.is_arena_record() {
+        // SAFETY: is_arena_record() confirmed the NanVal tag. registry_ptr
+        // comes from ACTIVE_REGISTRY (JIT) or jit_get_registry_ptr (AOT) —
+        // valid for call duration.
+        unsafe {
+            let r = rv.as_arena_record();
+            let registry = &*(registry_ptr as *const TypeRegistry);
+            if let Some(type_info) = registry.types.get(r.type_id as usize)
+                && let Some(idx) = type_info.fields.iter().position(|f| f == field_name)
+                && idx < r.n_fields as usize
+            {
+                let v = NanVal(*r.field_ptr(idx));
+                v.clone_rc();
+                return v.0;
+            }
+        }
+        jit_set_runtime_error(VmError::FieldNotFound {
+            field: field_name.to_string(),
+        });
+        return TAG_NIL;
+    }
+
+    if !rv.is_heap() {
+        jit_set_runtime_error(VmError::Type("field access on non-record"));
+        return TAG_NIL;
+    }
+    // SAFETY: is_heap() confirmed the NanVal is a heap pointer.
+    match unsafe { rv.as_heap_ref() } {
+        HeapObj::Record { type_info, fields } => {
+            if let Some(idx) = type_info.fields.iter().position(|f| f == field_name)
+                && idx < fields.len()
+            {
+                let val = fields[idx];
+                val.clone_rc();
+                return val.0;
+            }
+            jit_set_runtime_error(VmError::FieldNotFound {
+                field: field_name.to_string(),
+            });
+            TAG_NIL
+        }
+        _ => {
+            jit_set_runtime_error(VmError::Type("field access on non-record"));
+            TAG_NIL
+        }
+    }
+}
+
 /// Create a new flat record. `arena_ptr` is a pointer to a BumpArena,
 /// `registry_ptr` is a pointer to &TypeRegistry,
 /// `type_id` identifies the type, `regs` has n_fields u64 values.

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -8574,7 +8574,14 @@ pub(crate) extern "C" fn jit_iserr(v: u64) -> u64 {
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn jit_unwrap(v: u64) -> u64 {
     let nv = NanVal(v);
+    // Defensive: OP_UNWRAP is only emitted by the compiler immediately after
+    // a passed OP_ISOK / OP_ISERR branch, which guarantees the value is a
+    // heap-allocated Ok or Err wrapper. These error arms should be
+    // unreachable from well-formed bytecode; setting JIT_RUNTIME_ERROR
+    // matches the tree interpreter's defensive `vm_err!` arm at the
+    // equivalent OP_UNWRAP site and protects against future codegen bugs.
     if !nv.is_heap() {
+        jit_set_runtime_error(VmError::Type("unwrap on non-Ok/Err"));
         return TAG_NIL;
     }
     unsafe {
@@ -8583,7 +8590,10 @@ pub(crate) extern "C" fn jit_unwrap(v: u64) -> u64 {
                 inner.clone_rc();
                 inner.0
             }
-            _ => TAG_NIL,
+            _ => {
+                jit_set_runtime_error(VmError::Type("unwrap on non-Ok/Err"));
+                TAG_NIL
+            }
         }
     }
 }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -11278,7 +11278,15 @@ pub(crate) extern "C" fn jit_mapnew() -> u64 {
 pub(crate) extern "C" fn jit_mget(map: u64, key: u64) -> u64 {
     let map_v = NanVal(map);
     let key_v = NanVal(key);
-    if !map_v.is_heap() || !key_v.is_heap() {
+    // Wrong-type paths must error to match the tree/VM `OP_MGET`
+    // semantics. Missing-key returns `TAG_NIL` — that is the correct
+    // `O _` (Optional) shape, not a failure.
+    if (map_v.0 & TAG_MASK) != TAG_MAP {
+        jit_set_runtime_error(VmError::Type("mget: first arg must be a map"));
+        return TAG_NIL;
+    }
+    if !key_v.is_string() {
+        jit_set_runtime_error(VmError::Type("mget: key must be text"));
         return TAG_NIL;
     }
     unsafe {
@@ -11291,8 +11299,11 @@ pub(crate) extern "C" fn jit_mget(map: u64, key: u64) -> u64 {
                         v.0
                     })
                     .unwrap_or(TAG_NIL),
+                // Unreachable in practice: is_string() above already narrowed
+                // the key to HeapObj::Str. Kept as a defensive nil.
                 _ => TAG_NIL,
             },
+            // Unreachable: TAG_MAP check above already narrowed map_v.
             _ => TAG_NIL,
         }
     }

--- a/tests/regression_jit_nil_sweep_batch2.rs
+++ b/tests/regression_jit_nil_sweep_batch2.rs
@@ -1,0 +1,225 @@
+// Regression tests for the cranelift JIT-helper permissive-nil harmonisation
+// sweep (batch 2): `jit_recfld`, `jit_recfld_name`, `jit_unwrap`, `jit_mget`.
+//
+// Companion to PR #254 (batch: `hd`/`tl`/`at`) and batch 1 (`jit_lst`,
+// `jit_listget`, `jit_index`, `jit_slc`, `jit_jpth`).
+//
+// Per-helper audit decisions encoded as tests:
+//   * `jit_recfld` / `jit_recfld_name`: split into permissive (SAFE op) and
+//     strict variants. OP_RECFLD / OP_RECFLD_NAME now route through the
+//     strict helper that sets `JIT_RUNTIME_ERROR`; OP_RECFLD_SAFE and
+//     OP_RECFLD_NAME_SAFE keep the permissive helper (must still return nil).
+//   * `jit_unwrap`: defensive harmonisation — unreachable arms now error
+//     to match tree's defensive `vm_err!` arm. No observable user behaviour
+//     change from well-formed bytecode.
+//   * `jit_mget`: distinguish — missing-key returns nil (legitimate
+//     `O _` semantics), wrong-type (non-map first arg, non-text key) errors.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_ok(engine: &str, src: &str, entry: &str, args: &[&str]) -> String {
+    let mut cmd = ilo();
+    cmd.arg(src).arg(engine).arg(entry);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn run_err(engine: &str, src: &str, entry: &str, args: &[&str]) -> String {
+    let mut cmd = ilo();
+    cmd.arg(src).arg(engine).arg(entry);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "expected failure for `{src}` on {engine}, stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    String::from_utf8_lossy(&out.stderr).to_string()
+}
+
+// ── jit_recfld_name strict path: missing dynamic field errors ──────────
+//
+// jpar! produces a record whose static field set is unknown to the verifier
+// (`R ? t`). Strict `r.field` access on a missing key hits the heap-record
+// path of jit_recfld_name. Before this fix, Cranelift silently returned nil;
+// tree errors, VM either errored or segfaulted depending on the JMPNN path
+// (see PR #248). Now all three engines error.
+
+const STRICT_MISS: &str = "f j:t>R t t;r=jpar! j;~r.missing";
+
+fn check_strict_miss(engine: &str) {
+    let stderr = run_err(engine, STRICT_MISS, "f", &[r#"{"present":1}"#]);
+    assert!(
+        stderr.contains("missing") || stderr.contains("field"),
+        "engine={engine}: expected missing/field in stderr, got: {stderr}"
+    );
+}
+
+#[test]
+fn strict_recfld_name_miss_tree() {
+    check_strict_miss("--run-tree");
+}
+
+#[test]
+fn strict_recfld_name_miss_vm() {
+    check_strict_miss("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn strict_recfld_name_miss_cranelift() {
+    check_strict_miss("--run-cranelift");
+}
+
+// ── jit_recfld_name strict path: present field returns the value ───────
+//
+// The strict-helper rewire must not regress the happy path.
+
+const STRICT_HIT: &str = "f j:t>R n t;r=jpar! j;~r.present";
+
+fn check_strict_hit(engine: &str) {
+    assert_eq!(
+        run_ok(engine, STRICT_HIT, "f", &[r#"{"present":42}"#]),
+        "~42",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn strict_recfld_name_hit_tree() {
+    check_strict_hit("--run-tree");
+}
+
+#[test]
+fn strict_recfld_name_hit_vm() {
+    check_strict_hit("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn strict_recfld_name_hit_cranelift() {
+    check_strict_hit("--run-cranelift");
+}
+
+// ── jit_recfld_name SAFE path: must still return nil (permissive helper
+//    untouched) ─────────────────────────────────────────────────────────
+//
+// This is the critical guard for the _strict-sibling design: OP_RECFLD_NAME
+// flips to the strict helper, but OP_RECFLD_NAME_SAFE keeps using the
+// permissive helper. A naive in-place edit of jit_recfld_name would have
+// broken `.?` semantics from PR #248.
+
+const SAFE_MISS: &str = "f j:t>R t t;r=jpar! j;~fmt \"{}\" r.?missing";
+
+fn check_safe_miss(engine: &str) {
+    assert_eq!(
+        run_ok(engine, SAFE_MISS, "f", &[r#"{"present":1}"#]),
+        "~nil",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn safe_recfld_name_miss_tree() {
+    check_safe_miss("--run-tree");
+}
+
+#[test]
+fn safe_recfld_name_miss_vm() {
+    check_safe_miss("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn safe_recfld_name_miss_cranelift() {
+    check_safe_miss("--run-cranelift");
+}
+
+// ── jit_mget: missing key returns nil on every engine ──────────────────
+//
+// `mget` returns `O _`. Missing key → nil is the correct (non-error)
+// shape. This pins that the batch-2 wrong-type harmonisation didn't
+// accidentally promote miss to an error.
+
+const MGET_MISS: &str = "f>O n;m=mset (mmap) \"a\" 1;mget m \"z\"";
+
+fn check_mget_miss(engine: &str) {
+    assert_eq!(
+        run_ok(engine, MGET_MISS, "f", &[]),
+        "nil",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn mget_missing_key_tree() {
+    check_mget_miss("--run-tree");
+}
+
+#[test]
+fn mget_missing_key_vm() {
+    check_mget_miss("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn mget_missing_key_cranelift() {
+    check_mget_miss("--run-cranelift");
+}
+
+// ── jit_mget: present key returns the value ────────────────────────────
+
+const MGET_HIT: &str = "f>O n;m=mset (mmap) \"a\" 1;mget m \"a\"";
+
+fn check_mget_hit(engine: &str) {
+    assert_eq!(run_ok(engine, MGET_HIT, "f", &[]), "1", "engine={engine}");
+}
+
+#[test]
+fn mget_present_key_tree() {
+    check_mget_hit("--run-tree");
+}
+
+#[test]
+fn mget_present_key_vm() {
+    check_mget_hit("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn mget_present_key_cranelift() {
+    check_mget_hit("--run-cranelift");
+}
+
+// ── No stale-error leak across successive cranelift calls ──────────────
+//
+// The TLS error cell is cleared by `JitRuntimeErrorGuard` (PR #254). The
+// batch-2 strict-helper errors must not leak into subsequent fresh-process
+// invocations. Pins the guard contract for the new error sites.
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn no_stale_jit_error_leak_after_strict_recfld_miss() {
+    // First process: errors via strict recfld_name miss.
+    let _ = run_err("--run-cranelift", STRICT_MISS, "f", &[r#"{"present":1}"#]);
+    // Second fresh process: must succeed cleanly.
+    assert_eq!(
+        run_ok("--run-cranelift", STRICT_HIT, "f", &[r#"{"present":99}"#],),
+        "~99",
+        "fresh process after strict-miss error must succeed"
+    );
+}


### PR DESCRIPTION
## Summary

Companion to [#254](https://github.com/ilo-lang/ilo/pull/254) and the batch-1 sweep. Routes four more permissive-nil helpers through the `JIT_RUNTIME_ERROR` TLS primitive so Cranelift behaviour matches tree/VM on missing-field, non-record, and wrong-type arguments. Each helper got a per-helper audit because the answer is not "always error":

- `jit_unwrap` — defensive harmonisation only. The error arms are unreachable from well-formed bytecode (OP_UNWRAP only fires after a passed OP_ISOK / OP_ISERR). I still set the TLS cell so a future codegen bug surfaces instead of silently nil-propagating, matching the tree interpreter's defensive `vm_err!` arm.
- `jit_recfld` / `jit_recfld_name` — split into `_strict` siblings. PR [#248](https://github.com/ilo-lang/ilo/pull/248) routes `OP_RECFLD_SAFE` / `OP_RECFLD_NAME_SAFE` through the same helpers and depends on `TAG_NIL` on miss for `.?field`. I added strict variants and pointed only the strict opcodes at them; SAFE ops keep using the permissive helpers so `.?` semantics are untouched.
- `jit_mget` — distinguish miss from wrong-type. Missing-key returning nil is the correct `O _` shape, not an error. Non-map first arg and non-text key now set the TLS cell to match the tree/VM `OP_MGET` interpreter.

Manifesto angle: same as batch 1. Silent-nil propagation on cranelift was costing more tokens downstream than it was saving up front (debug iteration when a wrong-shape value snuck past a `.field` access). Erroring at the source matches tree/VM and matches what the assessment runs expected.

`jit_lstget` from the original task list does not exist in the tree. I read it as a typo for `jit_listget`, which is in the batch-1 exclusion set. Not touched here.

## Repro before / after

Before (Cranelift silently returned nil on a missing dynamic field):

```
$ ilo 'f j:t>R t t;r=jpar! j;~r.missing' --run-cranelift f '{"present":1}'
~nil
$ echo $?
0
```

After (errors on every engine):

```
$ ilo 'f j:t>R t t;r=jpar! j;~r.missing' --run-cranelift f '{"present":1}'
{"code":"ILO-R004","message":"missing","...}
$ echo $?
1
```

`.?missing` on a present record still returns nil cross-engine, which is the contract from #248.

## What's in the diff

Five commits, one logical change per commit.

**`jit_unwrap: set JIT_RUNTIME_ERROR on unreachable arms`** - small defensive addition. No observable user behaviour change from well-formed bytecode.

**`add jit_recfld_strict and jit_recfld_name_strict helpers`** - sibling helpers that mirror the permissive ones but set the TLS cell on every nil-returning arm. Error strings match the tree `vm_err!` literals exactly ("field access on non-record", FieldNotFound by name or by index).

**`wire strict recfld helpers through OP_RECFLD / OP_RECFLD_NAME codegen`** - extends `HelperFuncs`, the helper symbol table, and `declare_all_helpers`; flips OP_RECFLD's heap-block branch and the OP_RECFLD_NAME call site to the strict variants. OP_RECFLD_SAFE / OP_RECFLD_NAME_SAFE explicitly kept on the permissive helpers. The arena fast path of OP_RECFLD is unchanged (c_idx is a compile-time-constant verified by the typechecker for statically-typed records).

**`jit_mget: error on wrong-type args, keep nil for missing key`** - two type-check guards before the helper accesses the inner heap object. Missing-key behaviour preserved.

**`cross-engine regression tests + example for batch-2 helpers`** - 16 tests covering strict miss + hit, safe miss (the guard for the strict-sibling design), mget miss + hit, and a stale-error leak guard pinning `JitRuntimeErrorGuard` for the new error sites. Plus `examples/jit-nil-sweep-batch2.ilo` for the examples_engines harness.

## Trade-offs and follow-ups

- **AOT mode unchanged.** The AOT path in `compile_cranelift.rs` still calls the permissive helpers, same scope as PR #254. The TLS cell is set but never consumed because AOT doesn't install the `JitRuntimeErrorGuard`. Pre-existing limitation from batch 1, parked.
- **Span fidelity.** Inherited from PR #254. Errors carry `span: None`. Tracked separately.
- **Remaining sweep targets.** `jit_listget` and friends are batch 1's territory (parallel worktree, in flight).

## Test plan

- [x] Full suite passes locally with `cargo test --release --features cranelift -- --test-threads=1` (zero failures across all test binaries).
- [x] New `regression_jit_nil_sweep_batch2.rs` test file: 16/16 passing across tree, VM, Cranelift.
- [x] `examples_engines` harness passes including the new `jit-nil-sweep-batch2.ilo` fixture.
- [x] `cargo clippy --features cranelift --release --all-targets -- -D warnings` clean.
- [x] `cargo clippy --release --all-targets -- -D warnings` clean (no cranelift).
- [x] `cargo fmt --check` clean.
- [x] PR #248 safe-field tests (`regression_safe_field_missing.rs`) still pass cross-engine, confirming `.?` semantics are untouched.