### PR TITLE
fix: prevent + non-rebind aliasing on string concat (VM + Cranelift)

### DIFF
--- a/examples/string-concat-non-rebind-alias.ilo
+++ b/examples/string-concat-non-rebind-alias.ilo
@@ -1,0 +1,31 @@
+-- `b = +a suffix` must NOT mutate `a`, even when `a` is RC=1.
+--
+-- The RC=1 in-place fast path on `OP_ADD` / `OP_ADD_SS` (VM) and
+-- `jit_add` / `jit_concat` (Cranelift) only fires for the rebind shape
+-- `name = +name suffix` — the pattern the compiler peephole emits for
+-- string-building accumulators. When the source and destination registers
+-- differ (`b = +a suffix`), we always allocate a fresh string and copy.
+-- Otherwise we'd silently mutate the caller's source.
+--
+-- Mirror of the `OP_LISTAPPEND` split landed in PR #250 and the
+-- `OP_MSET` / `jit_mset_inplace` split landed in PR #249.
+
+-- `a` is built by fmt (RC=1 at the concat). After the non-rebind concat,
+-- `a` must still be the original "k1". Pre-fix, the VM returned nil (slot
+-- nullified) and Cranelift returned "k1_x" (in-place mutation).
+preserve-source>t;a=fmt "k{}" 1;b=+a "_x";a
+
+-- The rebind shape is the accumulator pattern and must still grow in place
+-- (amortised O(n), not O(n²)). This stresses the fast path stays available.
+rebind-accumulator n:n>n;s="";@i 0..n{s=+s "x"};len s
+
+-- Both source and dest visible in one return. Pins the aliasing contract:
+-- `a` must be untouched.
+both-visible>t;a=fmt "k{}" 1;b=+a "_x";fmt "{}|{}" a b
+
+-- run: preserve-source
+-- out: k1
+-- run: rebind-accumulator 50
+-- out: 50
+-- run: both-visible
+-- out: k1|k1_x

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -24,7 +24,9 @@ use std::collections::HashMap;
 #[allow(dead_code)]
 struct HelperFuncs {
     add: FuncId,
+    add_inplace: FuncId,
     concat: FuncId,
+    concat_inplace: FuncId,
     sub: FuncId,
     mul: FuncId,
     div: FuncId,
@@ -195,7 +197,9 @@ fn declare_helper(
 fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
     HelperFuncs {
         add: declare_helper(module, "jit_add", 2, 1),
+        add_inplace: declare_helper(module, "jit_add_inplace", 2, 1),
         concat: declare_helper(module, "jit_concat", 2, 1),
+        concat_inplace: declare_helper(module, "jit_concat_inplace", 2, 1),
         sub: declare_helper(module, "jit_sub", 2, 1),
         mul: declare_helper(module, "jit_mul", 2, 1),
         div: declare_helper(module, "jit_div", 2, 1),
@@ -1314,7 +1318,21 @@ fn compile_function_body(
                     // Slow path: call helper
                     builder.switch_to_block(slow_block);
                     let helper = match op {
-                        OP_ADD => helpers.add,
+                        // OP_ADD is the only one with an in-place string-mutation
+                        // fast path; pick it only when dest == LHS source AND
+                        // RHS source != LHS source (the rebind shape the
+                        // compiler peephole emits, excluding the self-concat
+                        // `s = +s s` case where push_str would self-alias).
+                        // Otherwise the clone-always helper avoids aliasing the
+                        // caller's source string. Mirror of the OP_ADD_SS /
+                        // OP_LISTAPPEND splits.
+                        OP_ADD => {
+                            if a_idx == b_idx && b_idx != c_idx {
+                                helpers.add_inplace
+                            } else {
+                                helpers.add
+                            }
+                        }
                         OP_SUB => helpers.sub,
                         OP_MUL => helpers.mul,
                         OP_DIV => helpers.div,
@@ -1334,7 +1352,21 @@ fn compile_function_body(
             OP_ADD_SS => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
-                let fref = get_func_ref(&mut builder, module, helpers.concat);
+                // Pick the in-place helper only when the destination and LHS
+                // source registers are the same SSA variable AND the RHS is a
+                // different register (no self-concat aliasing). The compiler
+                // peephole `name = +name suffix` emits a == b. When a != b the
+                // in-place path would alias the result through both slots and
+                // silently mutate the caller's source string; when b == c
+                // (`s = +s s`) the helper's push_str would read from the same
+                // buffer it grows, which is UB on realloc. See
+                // jit_concat_inplace docs and the OP_LISTAPPEND split in #250.
+                let helper_fn = if a_idx == b_idx && b_idx != c_idx {
+                    helpers.concat_inplace
+                } else {
+                    helpers.concat
+                };
+                let fref = get_func_ref(&mut builder, module, helper_fn);
                 let call_inst = builder.ins().call(fref, &[bv, cv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -29,7 +29,9 @@ unsafe impl Send for JitFunction {}
 #[allow(dead_code)]
 struct HelperFuncs {
     add: FuncId,
+    add_inplace: FuncId,
     concat: FuncId,
+    concat_inplace: FuncId,
     sub: FuncId,
     mul: FuncId,
     div: FuncId,
@@ -190,7 +192,9 @@ fn declare_helper(module: &mut JITModule, name: &str, n_params: usize, n_returns
 fn register_helpers(builder: &mut JITBuilder) {
     let helpers: &[(&str, *const u8)] = &[
         ("jit_add", jit_add as *const u8),
+        ("jit_add_inplace", jit_add_inplace as *const u8),
         ("jit_concat", jit_concat as *const u8),
+        ("jit_concat_inplace", jit_concat_inplace as *const u8),
         ("jit_sub", jit_sub as *const u8),
         ("jit_mul", jit_mul as *const u8),
         ("jit_div", jit_div as *const u8),
@@ -342,7 +346,9 @@ fn register_helpers(builder: &mut JITBuilder) {
 fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
     HelperFuncs {
         add: declare_helper(module, "jit_add", 2, 1),
+        add_inplace: declare_helper(module, "jit_add_inplace", 2, 1),
         concat: declare_helper(module, "jit_concat", 2, 1),
+        concat_inplace: declare_helper(module, "jit_concat_inplace", 2, 1),
         sub: declare_helper(module, "jit_sub", 2, 1),
         mul: declare_helper(module, "jit_mul", 2, 1),
         div: declare_helper(module, "jit_div", 2, 1),
@@ -1417,7 +1423,16 @@ fn compile_function_body(
                     // Slow path: call helper (handles string concat, etc.)
                     builder.switch_to_block(slow_block);
                     let helper = match op {
-                        OP_ADD => helpers.add,
+                        // OP_ADD is the only one with an in-place string-mutation
+                        // fast path; pick it only when dest == LHS source AND
+                        // RHS != LHS (rebind shape, excluding self-concat).
+                        OP_ADD => {
+                            if a_idx == b_idx && b_idx != c_idx {
+                                helpers.add_inplace
+                            } else {
+                                helpers.add
+                            }
+                        }
                         OP_SUB => helpers.sub,
                         OP_MUL => helpers.mul,
                         OP_DIV => helpers.div,
@@ -1437,7 +1452,15 @@ fn compile_function_body(
             OP_ADD_SS => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
-                let fref = get_func_ref(&mut builder, module, helpers.concat);
+                // Pick the in-place helper only when dest == LHS source AND
+                // RHS != LHS (rebind shape, excluding the self-concat `s = +s s`
+                // case where push_str would self-alias).
+                let helper_fn = if a_idx == b_idx && b_idx != c_idx {
+                    helpers.concat_inplace
+                } else {
+                    helpers.concat
+                };
+                let fref = get_func_ref(&mut builder, module, helper_fn);
                 let call_inst = builder.ins().call(fref, &[bv, cv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -8266,6 +8266,10 @@ fn nanval_truthy(v: NanVal) -> bool {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
+/// Clone-always add helper — the safe path. For string and list inputs always
+/// allocates fresh storage, never mutates the inputs. The Cranelift compiler
+/// picks this for non-rebind OP_ADD (the general `b = +a x` shape) so the
+/// caller's `a` is preserved.
 pub(crate) extern "C" fn jit_add(a: u64, b: u64) -> u64 {
     let av = NanVal(a);
     let bv = NanVal(b);
@@ -8276,37 +8280,18 @@ pub(crate) extern "C" fn jit_add(a: u64, b: u64) -> u64 {
         let result = unsafe {
             let a_ptr = (av.0 & PTR_MASK) as *const HeapObj;
             let b_ptr = (bv.0 & PTR_MASK) as *const HeapObj;
-            // Read the right-hand string via raw pointer (does not touch RC count).
-            // SAFETY: b_ptr was produced by Rc::into_raw; the NanVal keeps it alive.
+            let sa: &str = match &*a_ptr {
+                HeapObj::Str(s) => s.as_str(),
+                _ => unreachable!(),
+            };
             let sb: &str = match &*b_ptr {
                 HeapObj::Str(s) => s.as_str(),
                 _ => unreachable!(),
             };
-            // RC=1 fast path: mutate the left string in place via Rc::get_mut,
-            // avoiding a fresh allocation. Matches CPython's str += optimisation.
-            let mut a_rc = Rc::from_raw(a_ptr);
-            if let Some(heap_obj) = Rc::get_mut(&mut a_rc) {
-                // Sole owner — mutate the inner String directly.
-                match heap_obj {
-                    HeapObj::Str(s) => s.push_str(sb),
-                    _ => unreachable!(),
-                }
-                // The Rc is still intact; encode its pointer as the new NanVal.
-                let ptr = Rc::into_raw(a_rc) as u64;
-                NanVal(TAG_STRING | (ptr & PTR_MASK))
-            } else {
-                // Multiple owners — copy path.
-                let sa: &str = match &*a_ptr {
-                    HeapObj::Str(s) => s.as_str(),
-                    _ => unreachable!(),
-                };
-                let mut out = String::with_capacity(sa.len() + sb.len());
-                out.push_str(sa);
-                out.push_str(sb);
-                // Restore the Rc we reconstructed so its count stays correct.
-                std::mem::forget(a_rc);
-                NanVal::heap_string(out)
-            }
+            let mut out = String::with_capacity(sa.len() + sb.len());
+            out.push_str(sa);
+            out.push_str(sb);
+            NanVal::heap_string(out)
         };
         return result.0;
     }
@@ -8329,11 +8314,137 @@ pub(crate) extern "C" fn jit_add(a: u64, b: u64) -> u64 {
     TAG_NIL // error fallback
 }
 
-/// Fast-path string concatenation — both arguments are guaranteed to be strings.
-/// Called by JIT/AOT OP_ADD_SS handler. Skips numeric and list type checks entirely.
+/// In-place add helper — for string inputs, mutates the left string when the
+/// caller is its sole owner (strong_count == 1), else falls back to the
+/// cloning path. Numbers and lists use the same semantics as `jit_add`.
+///
+/// The Cranelift compiler only emits a call to this helper when the OP_ADD
+/// destination and LHS source registers are the same SSA variable AND the
+/// RHS register is distinct (`a_idx == b_idx && b_idx != c_idx` — the rebind
+/// shape the compiler peephole `name = +name suffix` emits, excluding the
+/// `s = +s s` self-concat case). In that case def_var(a, result) overwrites
+/// the same variable the input came from, so returning the same pointer at
+/// RC=1 is balanced.
+///
+/// Without that compile-time guarantee, returning the same pointer when
+/// strong_count == 1 and a != b would alias the result through both
+/// registers and silently mutate the caller's source string — the same bug
+/// fixed for OP_ADD_SS via the jit_concat / jit_concat_inplace split.
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_add_inplace(a: u64, b: u64) -> u64 {
+    let av = NanVal(a);
+    let bv = NanVal(b);
+    if av.is_number() && bv.is_number() {
+        return NanVal::number(av.as_number() + bv.as_number()).0;
+    }
+    if av.is_string() && bv.is_string() {
+        let result = unsafe {
+            let a_ptr = (av.0 & PTR_MASK) as *const HeapObj;
+            let b_ptr = (bv.0 & PTR_MASK) as *const HeapObj;
+            // Read the right-hand string via raw pointer (does not touch RC).
+            // SAFETY: b_ptr was produced by Rc::into_raw; bv keeps it alive.
+            let sb: &str = match &*b_ptr {
+                HeapObj::Str(s) => s.as_str(),
+                _ => unreachable!(),
+            };
+            let rc_count = {
+                let rc_peek = Rc::from_raw(a_ptr);
+                let count = Rc::strong_count(&rc_peek);
+                std::mem::forget(rc_peek);
+                count
+            };
+            if rc_count == 1 {
+                // SAFETY: sole owner (rc_count == 1); the compile-site
+                // `a_idx == b_idx && b_idx != c_idx` guard ensures dest is
+                // the same SSA variable as LHS source and RHS does not
+                // alias, so no other live reference observes this mutation.
+                let heap_mut = &mut *(a_ptr as *mut HeapObj);
+                match heap_mut {
+                    HeapObj::Str(s) => s.push_str(sb),
+                    _ => unreachable!(),
+                }
+                // Return the same NanVal: same pointer, same tag, RC still 1.
+                return a;
+            }
+            let sa: &str = match &*a_ptr {
+                HeapObj::Str(s) => s.as_str(),
+                _ => unreachable!(),
+            };
+            let mut out = String::with_capacity(sa.len() + sb.len());
+            out.push_str(sa);
+            out.push_str(sb);
+            NanVal::heap_string(out)
+        };
+        return result.0;
+    }
+    if av.is_heap() && bv.is_heap() {
+        let aref = unsafe { av.as_heap_ref() };
+        let bref = unsafe { bv.as_heap_ref() };
+        if let (HeapObj::List(left), HeapObj::List(right)) = (aref, bref) {
+            let mut new_items = Vec::with_capacity(left.len() + right.len());
+            for v in left {
+                v.clone_rc();
+                new_items.push(*v);
+            }
+            for v in right {
+                v.clone_rc();
+                new_items.push(*v);
+            }
+            return NanVal::heap_list(new_items).0;
+        }
+    }
+    TAG_NIL // error fallback
+}
+
+/// Clone-always concat helper — the safe path for OP_ADD_SS / OP_ADD when
+/// both operands are statically-known strings. Always allocates a fresh
+/// String, never mutates the inputs. The Cranelift compiler picks this for
+/// non-rebind OP_ADD_SS (the general `b = +a suffix` shape) so the caller's
+/// `a` is preserved.
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn jit_concat(a: u64, b: u64) -> u64 {
+    let av = NanVal(a);
+    let bv = NanVal(b);
+    unsafe {
+        let a_ptr = (av.0 & PTR_MASK) as *const HeapObj;
+        let b_ptr = (bv.0 & PTR_MASK) as *const HeapObj;
+        let sa: &str = match &*a_ptr {
+            HeapObj::Str(s) => s.as_str(),
+            _ => unreachable!(),
+        };
+        let sb: &str = match &*b_ptr {
+            HeapObj::Str(s) => s.as_str(),
+            _ => unreachable!(),
+        };
+        let mut out = String::with_capacity(sa.len() + sb.len());
+        out.push_str(sa);
+        out.push_str(sb);
+        NanVal::heap_string(out).0
+    }
+}
+
+/// In-place concat helper — mutates the left string when the caller is its
+/// sole owner (strong_count == 1), else falls back to the cloning path.
+///
+/// The Cranelift compiler only emits a call to this helper when the OP_ADD_SS
+/// destination and LHS source registers are the same SSA variable AND the
+/// RHS register is distinct (`a_idx == b_idx && b_idx != c_idx` — the rebind
+/// shape the compiler peephole `name = +name suffix` emits, excluding the
+/// `s = +s s` self-concat case where push_str would self-alias). In that
+/// case def_var(a, result) overwrites the same variable the input came from,
+/// so returning the same pointer at RC=1 is balanced: the caller still holds
+/// exactly one ref.
+///
+/// Without that compile-time guarantee, returning the same pointer when
+/// strong_count == 1 and a != b would alias the result through both
+/// registers and silently mutate the caller's source string — the bug fixed
+/// by splitting this helper out of the old combined `jit_concat`. Mirrors
+/// `jit_listappend_inplace` from PR #250 and `jit_mset_inplace` from #249.
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_concat_inplace(a: u64, b: u64) -> u64 {
     let av = NanVal(a);
     let bv = NanVal(b);
     unsafe {
@@ -8345,17 +8456,27 @@ pub(crate) extern "C" fn jit_concat(a: u64, b: u64) -> u64 {
             HeapObj::Str(s) => s.as_str(),
             _ => unreachable!(),
         };
-        // RC=1 fast path: mutate left string in place via Rc::get_mut.
-        let mut a_rc = Rc::from_raw(a_ptr);
-        if let Some(heap_obj) = Rc::get_mut(&mut a_rc) {
-            match heap_obj {
+        // Peek RC without bumping (Rc::from_raw + forget is balanced).
+        let rc_count = {
+            let rc_peek = Rc::from_raw(a_ptr);
+            let count = Rc::strong_count(&rc_peek);
+            std::mem::forget(rc_peek);
+            count
+        };
+        if rc_count == 1 {
+            // SAFETY: sole owner (rc_count == 1); the compile-site
+            // `a_idx == b_idx && b_idx != c_idx` guard guarantees dest is the
+            // same SSA variable as LHS source and the RHS register is
+            // distinct. def_var with the same pointer keeps strong_count == 1
+            // — balanced. No other live reference observes the mutation.
+            let heap_mut = &mut *(a_ptr as *mut HeapObj);
+            match heap_mut {
                 HeapObj::Str(s) => s.push_str(sb),
                 _ => unreachable!(),
             }
-            let ptr = Rc::into_raw(a_rc) as u64;
-            NanVal(TAG_STRING | (ptr & PTR_MASK)).0
+            a // return same NanVal (same pointer, RC still 1)
         } else {
-            // Multiple owners — copy path.
+            // RC > 1 — copy path.
             let sa: &str = match &*a_ptr {
                 HeapObj::Str(s) => s.as_str(),
                 _ => unreachable!(),
@@ -8363,7 +8484,6 @@ pub(crate) extern "C" fn jit_concat(a: u64, b: u64) -> u64 {
             let mut out = String::with_capacity(sa.len() + sb.len());
             out.push_str(sa);
             out.push_str(sb);
-            std::mem::forget(a_rc);
             NanVal::heap_string(out).0
         }
     }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -4097,76 +4097,50 @@ impl<'a> VM<'a> {
                     if bv.is_number() && cv.is_number() {
                         reg_set!(a, NanVal::number(bv.as_number() + cv.as_number()));
                     } else if bv.is_string() && cv.is_string() {
-                        // Fast path: if left string has RC=1 (sole owner), take ownership
-                        // via Rc::try_unwrap and push_str in place — O(n) amortized instead
-                        // of O(n²) for repeated `s = +s "x"` patterns.
+                        // Peek RC without bumping (Rc::from_raw + forget is balanced).
                         let ptr_b = (bv.0 & PTR_MASK) as *const HeapObj;
                         // SAFETY: bv.is_string() guarantees ptr_b was produced by
                         // Rc::into_raw in heap_string() with strong count >= 1.
-                        let rc_b = unsafe { Rc::from_raw(ptr_b) };
-                        if Rc::strong_count(&rc_b) == 1 {
-                            match Rc::try_unwrap(rc_b) {
-                                Ok(heap_obj) => {
-                                    // HeapObj::Str's Drop impl is a no-op (only non-string
-                                    // variants drop_rc children), so ptr::read of the String
-                                    // out of a ManuallyDrop shell is safe.
-                                    // SAFETY: tag is TAG_STRING → variant is HeapObj::Str.
-                                    let mut owned: String = unsafe {
-                                        let md = std::mem::ManuallyDrop::new(heap_obj);
-                                        std::ptr::read(match &*md {
-                                            HeapObj::Str(s) => s as *const String,
-                                            _ => unreachable!(),
-                                        })
-                                    };
-                                    // rc_b is consumed; the NanVal `bv` is now a dangling
-                                    // pointer. Nullify slot b immediately so that any
-                                    // subsequent OP_MOVE / reg_set! on b won't double-free.
-                                    unsafe {
-                                        *self.stack.as_mut_ptr().add(b) = NanVal::nil();
-                                    }
-                                    // Read the right-hand string BEFORE touching slot a.
-                                    let sc_ptr: *const str = unsafe {
-                                        match cv.as_heap_ref() {
-                                            HeapObj::Str(s) => s.as_str() as *const str,
-                                            _ => unreachable!(),
-                                        }
-                                    };
-                                    // SAFETY: cv still live so sc_ptr is valid.
-                                    owned.push_str(unsafe { &*sc_ptr });
-                                    let new_val = NanVal::heap_string(owned);
-                                    unsafe {
-                                        let slot = self.stack.as_mut_ptr().add(a);
-                                        // a != b: drop old value at slot a (b is nil after above).
-                                        // a == b: slot a == slot b, already nil — just write new_val.
-                                        if a != b {
-                                            (*slot).drop_rc();
-                                        }
-                                        *slot = new_val;
-                                    }
+                        let rc_count = {
+                            let rc_peek = unsafe { Rc::from_raw(ptr_b) };
+                            let count = Rc::strong_count(&rc_peek);
+                            std::mem::forget(rc_peek);
+                            count
+                        };
+                        // Fast path requires `a == b` (rebind shape — the
+                        // compiler peephole `name = +name suffix` emits this),
+                        // `rc_count == 1` (sole owner), AND `b != c` (no
+                        // self-concat aliasing). When `a != b` the caller
+                        // wrote `b = +a suffix` expecting `a` to be preserved;
+                        // mutating in place and aliasing the pointer into slot
+                        // `a` would silently corrupt the caller's source
+                        // string. When `b == c` (self-concat `s = +s s`) the
+                        // mutating push_str would read from the same buffer it
+                        // grows, which is UB if the underlying String
+                        // reallocates. Mirror of the `OP_LISTAPPEND` /
+                        // `OP_MSET` guards.
+                        if a == b && b != c && rc_count == 1 {
+                            // SAFETY: sole owner (count == 1), destination is
+                            // the same SSA variable, and RHS does not alias
+                            // LHS. The String mutation cannot be observed
+                            // through any other live reference.
+                            let heap_mut = unsafe { &mut *(ptr_b as *mut HeapObj) };
+                            let sc_ptr: *const str = unsafe {
+                                match cv.as_heap_ref() {
+                                    HeapObj::Str(s) => s.as_str() as *const str,
+                                    _ => unreachable!(),
                                 }
-                                Err(rc_back) => {
-                                    // Shouldn't happen (RC was 1), but fall back safely.
-                                    std::mem::forget(rc_back);
-                                    let result = unsafe {
-                                        let sb = match bv.as_heap_ref() {
-                                            HeapObj::Str(s) => s,
-                                            _ => unreachable!(),
-                                        };
-                                        let sc = match cv.as_heap_ref() {
-                                            HeapObj::Str(s) => s,
-                                            _ => unreachable!(),
-                                        };
-                                        let mut out = String::with_capacity(sb.len() + sc.len());
-                                        out.push_str(sb);
-                                        out.push_str(sc);
-                                        NanVal::heap_string(out)
-                                    };
-                                    reg_set!(a, result);
-                                }
+                            };
+                            match heap_mut {
+                                // SAFETY: cv is still live so sc_ptr is valid.
+                                HeapObj::Str(s) => s.push_str(unsafe { &*sc_ptr }),
+                                _ => unreachable!(),
                             }
+                            // a == b: bv already in slot a, nothing to write.
                         } else {
-                            // RC > 1 — must copy; restore count by forgetting rc_b.
-                            std::mem::forget(rc_b);
+                            // Non-rebind, RC > 1, or self-concat — clone-and-
+                            // write to avoid aliasing the caller's source
+                            // string or self-aliasing during push.
                             let result = unsafe {
                                 // SAFETY: is_string() confirmed heap-tagged with live RC.
                                 let sb = match bv.as_heap_ref() {
@@ -5857,63 +5831,47 @@ impl<'a> VM<'a> {
                     }
                     // SAFETY: compiler guarantees both are strings; bv.is_string() → heap-tagged.
                     let ptr_b = (bv.0 & PTR_MASK) as *const HeapObj;
-                    let rc_b = unsafe { Rc::from_raw(ptr_b) };
-                    if Rc::strong_count(&rc_b) == 1 {
-                        match Rc::try_unwrap(rc_b) {
-                            Ok(heap_obj) => {
-                                // SAFETY: tag is TAG_STRING → variant is HeapObj::Str.
-                                let mut owned: String = unsafe {
-                                    let md = std::mem::ManuallyDrop::new(heap_obj);
-                                    std::ptr::read(match &*md {
-                                        HeapObj::Str(s) => s as *const String,
-                                        _ => unreachable!(),
-                                    })
-                                };
-                                // Nullify slot b so no double-free.
-                                unsafe {
-                                    *self.stack.as_mut_ptr().add(b) = NanVal::nil();
-                                }
-                                // Read RHS string before touching slot a.
-                                let sc_ptr: *const str = unsafe {
-                                    match cv.as_heap_ref() {
-                                        HeapObj::Str(s) => s.as_str() as *const str,
-                                        _ => unreachable!(),
-                                    }
-                                };
-                                // SAFETY: cv still live so sc_ptr is valid.
-                                owned.push_str(unsafe { &*sc_ptr });
-                                let new_val = NanVal::heap_string(owned);
-                                unsafe {
-                                    let slot = self.stack.as_mut_ptr().add(a);
-                                    if a != b {
-                                        (*slot).drop_rc();
-                                    }
-                                    *slot = new_val;
-                                }
+                    // Peek RC without bumping (Rc::from_raw + forget is balanced).
+                    let rc_count = {
+                        let rc_peek = unsafe { Rc::from_raw(ptr_b) };
+                        let count = Rc::strong_count(&rc_peek);
+                        std::mem::forget(rc_peek);
+                        count
+                    };
+                    // Fast path requires `a == b` (rebind shape — the
+                    // compiler peephole `name = +name suffix` emits this),
+                    // `rc_count == 1` (sole owner), AND `b != c` (no
+                    // self-concat aliasing). When `a != b` the caller wrote
+                    // `b = +a suffix` expecting `a` to be preserved; mutating
+                    // in place and aliasing the pointer into slot `a` would
+                    // silently corrupt the caller's source string. When
+                    // `b == c` (self-concat `s = +s s`) the mutating push_str
+                    // would read from the same buffer it grows, which is UB if
+                    // the underlying String reallocates. Mirror of the
+                    // `OP_LISTAPPEND` / `OP_MSET` guards above.
+                    if a == b && b != c && rc_count == 1 {
+                        // SAFETY: sole owner (count == 1), destination is the
+                        // same SSA variable, and RHS does not alias LHS. The
+                        // String mutation cannot be observed through any other
+                        // live reference.
+                        let heap_mut = unsafe { &mut *(ptr_b as *mut HeapObj) };
+                        // Read RHS string via raw pointer (does not touch RC).
+                        let sc_ptr: *const str = unsafe {
+                            match cv.as_heap_ref() {
+                                HeapObj::Str(s) => s.as_str() as *const str,
+                                _ => unreachable!(),
                             }
-                            Err(rc_back) => {
-                                // Shouldn't happen (RC was 1), fall back safely.
-                                std::mem::forget(rc_back);
-                                let result = unsafe {
-                                    let sb = match bv.as_heap_ref() {
-                                        HeapObj::Str(s) => s,
-                                        _ => unreachable!(),
-                                    };
-                                    let sc = match cv.as_heap_ref() {
-                                        HeapObj::Str(s) => s,
-                                        _ => unreachable!(),
-                                    };
-                                    let mut out = String::with_capacity(sb.len() + sc.len());
-                                    out.push_str(sb);
-                                    out.push_str(sc);
-                                    NanVal::heap_string(out)
-                                };
-                                reg_set!(a, result);
-                            }
+                        };
+                        match heap_mut {
+                            // SAFETY: cv is still live so sc_ptr is valid.
+                            HeapObj::Str(s) => s.push_str(unsafe { &*sc_ptr }),
+                            _ => unreachable!(),
                         }
+                        // a == b: bv already in slot a, nothing to write.
                     } else {
-                        // RC > 1 — must copy; restore count by forgetting rc_b.
-                        std::mem::forget(rc_b);
+                        // Non-rebind, RC > 1, or self-concat — clone-and-write
+                        // to avoid aliasing the caller's source string or
+                        // self-aliasing during push.
                         let result = unsafe {
                             let sb = match bv.as_heap_ref() {
                                 HeapObj::Str(s) => s,

--- a/tests/regression_add_ss_aliasing.rs
+++ b/tests/regression_add_ss_aliasing.rs
@@ -1,0 +1,309 @@
+// Regression tests for the non-rebind aliasing fix on string concat (`+`).
+//
+// Background:
+//
+// PR #232 shipped the RC=1 in-place fast path for `OP_ADD_SS` (VM) and
+// `jit_concat` (Cranelift). PR #249 shipped the same shape for `OP_MSET`,
+// PR #250 for `OP_LISTAPPEND`. Both #249 and #250 also fixed an aliasing hole
+// where the in-place fast path fired whenever RC == 1, regardless of whether
+// the destination register was the same SSA variable as the source. String
+// concat (`+`) still had that hole.
+//
+// The bug:
+//
+// Code shaped like
+//
+//     b = +a suffix      -- non-rebind: distinct LHS source and dest
+//
+// where `a` happens to be RC=1 (e.g. the result of `fmt`, `cat`, a function
+// call, or a prior concat) would:
+//
+//   * VM `OP_ADD_SS` (typed-string path): nullify slot `a` after consuming
+//     the Rc, then store the concatenated result in slot `b`. The caller
+//     observes `a` as nil — silent value loss.
+//   * VM `OP_ADD` (untyped fallback when one side isn't statically marked
+//     `reg_is_str`): same shape, same nullification.
+//   * Cranelift `jit_concat` / `jit_add`: mutate the source string in place
+//     via `Rc::get_mut`, return the same pointer. Both slot `a` and slot `b`
+//     now point at the mutated string — silent corruption.
+//
+// Tree-walker is unaffected (it always clones; same property that makes
+// Phase 2b a separate item).
+//
+// The fix mirrors #249 and #250: gate the in-place path on
+// `a == b && rc_count == 1`. The compiler peephole `name = +name suffix`
+// emits `a == b` so the accumulator perf path is preserved. Non-rebind
+// distinct-register shapes go through the cloning branch and `a` is
+// preserved.
+//
+// All tests cross-engine (tree, VM, Cranelift) so a divergence between
+// backends shows up in CI.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str, arg: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry, arg])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+// ── OP_ADD_SS non-rebind: typed-string param + literal suffix ───────────────
+//
+// `a:t` is statically known to be string, so the compiler emits OP_ADD_SS with
+// `a_idx != b_idx` (fresh result register). At runtime `a`'s string was
+// produced by `cat` so its RC is 1 — pre-fix this triggered the in-place
+// mutation hole.
+
+const ADDSS_NON_REBIND_PRESERVES_A: &str =
+    "mks n:n>t;fmt \"k{}\" n\ngo n:n>t;a=mks n;b=+a \"_x\";a\n";
+
+#[test]
+fn addss_non_rebind_preserves_a_tree() {
+    assert_eq!(
+        run("--run-tree", ADDSS_NON_REBIND_PRESERVES_A, "go", "1"),
+        "k1"
+    );
+}
+
+#[test]
+fn addss_non_rebind_preserves_a_vm() {
+    assert_eq!(
+        run("--run-vm", ADDSS_NON_REBIND_PRESERVES_A, "go", "1"),
+        "k1"
+    );
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn addss_non_rebind_preserves_a_cranelift() {
+    assert_eq!(
+        run("--run-cranelift", ADDSS_NON_REBIND_PRESERVES_A, "go", "1"),
+        "k1"
+    );
+}
+
+// And the same shape returning `b` rather than `a`, to confirm the
+// concatenated result is correct (i.e. we didn't break the happy path).
+
+const ADDSS_NON_REBIND_B_GETS_RESULT: &str =
+    "mks n:n>t;fmt \"k{}\" n\ngo n:n>t;a=mks n;b=+a \"_x\";b\n";
+
+#[test]
+fn addss_non_rebind_b_gets_result_tree() {
+    assert_eq!(
+        run("--run-tree", ADDSS_NON_REBIND_B_GETS_RESULT, "go", "1"),
+        "k1_x"
+    );
+}
+
+#[test]
+fn addss_non_rebind_b_gets_result_vm() {
+    assert_eq!(
+        run("--run-vm", ADDSS_NON_REBIND_B_GETS_RESULT, "go", "1"),
+        "k1_x"
+    );
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn addss_non_rebind_b_gets_result_cranelift() {
+    assert_eq!(
+        run("--run-cranelift", ADDSS_NON_REBIND_B_GETS_RESULT, "go", "1"),
+        "k1_x"
+    );
+}
+
+// Both source and dest visible in the same return — exercises the alias
+// observation in one shot. Format: "a|b".
+
+const ADDSS_NON_REBIND_BOTH_VISIBLE: &str =
+    "mks n:n>t;fmt \"k{}\" n\ngo n:n>t;a=mks n;b=+a \"_x\";fmt \"{}|{}\" a b\n";
+
+#[test]
+fn addss_non_rebind_both_visible_tree() {
+    assert_eq!(
+        run("--run-tree", ADDSS_NON_REBIND_BOTH_VISIBLE, "go", "1"),
+        "k1|k1_x"
+    );
+}
+
+#[test]
+fn addss_non_rebind_both_visible_vm() {
+    assert_eq!(
+        run("--run-vm", ADDSS_NON_REBIND_BOTH_VISIBLE, "go", "1"),
+        "k1|k1_x"
+    );
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn addss_non_rebind_both_visible_cranelift() {
+    assert_eq!(
+        run("--run-cranelift", ADDSS_NON_REBIND_BOTH_VISIBLE, "go", "1"),
+        "k1|k1_x"
+    );
+}
+
+// ── OP_ADD untyped-string path: same shape, no static reg_is_str ────────────
+//
+// When the LHS register doesn't carry static `reg_is_str` info (e.g. `fmt`'s
+// return register isn't marked string-typed), the compiler emits plain OP_ADD
+// instead of OP_ADD_SS. OP_ADD's string branch had the same in-place hole;
+// the fix lives in jit_add / jit_add_inplace and the VM OP_ADD dispatch.
+
+const ADD_UNTYPED_NON_REBIND_PRESERVES_A: &str = "go n:n>t;a=fmt \"k{}\" n;b=+a \"_x\";a";
+
+#[test]
+fn add_untyped_non_rebind_preserves_a_tree() {
+    assert_eq!(
+        run("--run-tree", ADD_UNTYPED_NON_REBIND_PRESERVES_A, "go", "1"),
+        "k1"
+    );
+}
+
+#[test]
+fn add_untyped_non_rebind_preserves_a_vm() {
+    assert_eq!(
+        run("--run-vm", ADD_UNTYPED_NON_REBIND_PRESERVES_A, "go", "1"),
+        "k1"
+    );
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn add_untyped_non_rebind_preserves_a_cranelift() {
+    assert_eq!(
+        run(
+            "--run-cranelift",
+            ADD_UNTYPED_NON_REBIND_PRESERVES_A,
+            "go",
+            "1"
+        ),
+        "k1"
+    );
+}
+
+// ── Rebind shape still in-place (no perf regression) ────────────────────────
+//
+// `name = +name suffix` is the accumulator shape the compiler peephole emits
+// with `a == b`. It MUST still take the in-place path so building up a string
+// in a loop is O(n) amortised, not O(n²). We can't directly observe "ran the
+// fast path" from the language, but we can confirm the result is correct.
+// (The existing #232 perf budget tests guard the wall-clock side.)
+
+const ADD_REBIND_ACCUMULATOR: &str = "go n:n>t;s=\"\";@i 0..n{s=+s \"x\"};s";
+
+#[test]
+fn add_rebind_accumulator_tree() {
+    assert_eq!(
+        run("--run-tree", ADD_REBIND_ACCUMULATOR, "go", "100").len(),
+        100
+    );
+}
+
+#[test]
+fn add_rebind_accumulator_vm() {
+    assert_eq!(
+        run("--run-vm", ADD_REBIND_ACCUMULATOR, "go", "100").len(),
+        100
+    );
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn add_rebind_accumulator_cranelift() {
+    assert_eq!(
+        run("--run-cranelift", ADD_REBIND_ACCUMULATOR, "go", "100").len(),
+        100
+    );
+}
+
+// ── RC > 1 case (function-call boundary) ────────────────────────────────────
+//
+// Pass `a` through a function so the caller's binding bumps its RC to >= 2.
+// The cloning path was always correct for RC > 1; this pin just makes sure
+// the new helper split didn't accidentally drop the RC > 1 branch.
+
+const ADDSS_NON_REBIND_RC_GT_1: &str =
+    "ident s:t>t;s\nmks n:n>t;fmt \"k{}\" n\ngo n:n>t;a=mks n;keep=ident a;b=+a \"_x\";a\n";
+
+#[test]
+fn addss_non_rebind_rc_gt_1_tree() {
+    assert_eq!(run("--run-tree", ADDSS_NON_REBIND_RC_GT_1, "go", "1"), "k1");
+}
+
+#[test]
+fn addss_non_rebind_rc_gt_1_vm() {
+    assert_eq!(run("--run-vm", ADDSS_NON_REBIND_RC_GT_1, "go", "1"), "k1");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn addss_non_rebind_rc_gt_1_cranelift() {
+    assert_eq!(
+        run("--run-cranelift", ADDSS_NON_REBIND_RC_GT_1, "go", "1"),
+        "k1"
+    );
+}
+
+// ── Self-concat (`s = +s s`): in-place path must not self-alias ─────────────
+//
+// The rebind peephole `name = +name suffix` emits `a == b`. When RHS is also
+// the same variable (`s = +s s`), the compiler resolves all three operand
+// registers to the same SSA slot. The in-place path's `push_str(other)` would
+// then read from the same String buffer it's growing — UB if the buffer
+// reallocates. Both VM dispatch and Cranelift codegen guard against this by
+// also requiring `b != c` before taking the in-place branch.
+
+const ADD_SELF_CONCAT: &str = "go n:n>t;s=fmt \"k{}\" n;s=+s s;s";
+
+#[test]
+fn add_self_concat_tree() {
+    assert_eq!(run("--run-tree", ADD_SELF_CONCAT, "go", "1"), "k1k1");
+}
+
+#[test]
+fn add_self_concat_vm() {
+    assert_eq!(run("--run-vm", ADD_SELF_CONCAT, "go", "1"), "k1k1");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn add_self_concat_cranelift() {
+    assert_eq!(run("--run-cranelift", ADD_SELF_CONCAT, "go", "1"), "k1k1");
+}
+
+// Self-concat with statically-typed LHS so the compiler emits OP_ADD_SS rather
+// than OP_ADD. Same self-aliasing risk, fixed at the OP_ADD_SS dispatch site.
+
+const ADDSS_SELF_CONCAT: &str = "go s:t>t;s=+s s;s";
+
+#[test]
+fn addss_self_concat_tree() {
+    assert_eq!(run("--run-tree", ADDSS_SELF_CONCAT, "go", "ab"), "abab");
+}
+
+#[test]
+fn addss_self_concat_vm() {
+    assert_eq!(run("--run-vm", ADDSS_SELF_CONCAT, "go", "ab"), "abab");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn addss_self_concat_cranelift() {
+    assert_eq!(
+        run("--run-cranelift", ADDSS_SELF_CONCAT, "go", "ab"),
+        "abab"
+    );
+}


### PR DESCRIPTION
## Summary

Phase 2 of the RC-aware mutation work, applied to string concat (`+`). Lists got the same treatment in [#250](https://github.com/ilo-lang/ilo/pull/250); `mset` got it in [#249](https://github.com/ilo-lang/ilo/pull/249). String concat still had the hole this PR closes.

Same shape, same fix pattern: the RC=1 in-place fast path fired on `strong_count == 1` alone, without checking that the destination and LHS source registers were the same SSA variable. The natural non-rebind shape `b = +a suffix` with `a` at RC=1 silently corrupted the caller's source.

The token-cost framing: an agent writing `b = +a suffix; ...use a...` (build `b`, keep `a`) gets a wrong answer with zero diagnostic on the JIT default path or `nil` back on `--run-vm`. Tokens spent debugging. Fix preserves the fast path where it's actually safe (`s = +s suffix` rebind accumulator).

## Repro

Both repros below shipped wrong output before this PR. Same shape as the listappend repro #250 pinned, applied to strings.

`b = +a suffix` (non-rebind concat):

```
mkstr n:n>t;fmt "key{}" n
go n:n>t;a=mkstr 1;b=+a "_x";a
```

| Engine | Before | After |
|---|---|---|
| tree | `key1` | `key1` |
| vm | `nil` (slot nullified) | `key1` |
| cranelift | `key1_x` (in-place mutation) | `key1` |

The same shape from [#250](https://github.com/ilo-lang/ilo/pull/250) for posterity, since both bugs are the same family:

```
xs=[1,2,3];ys=+=xs 99;xs
```

| Engine | Pre-#250 | Post-#250 |
|---|---|---|
| tree | `[1, 2, 3]` | `[1, 2, 3]` |
| vm | `[1, 2, 3, 99]` (BUG) | `[1, 2, 3]` |
| cranelift | `[1, 2, 3, 99]` (BUG) | `[1, 2, 3]` |

## What's in the diff

Per-commit:

1. **`vm: guard OP_ADD / OP_ADD_SS in-place against non-rebind aliasing`** — both VM dispatch handlers (`mod.rs:OP_ADD` and `mod.rs:OP_ADD_SS`) now gate the in-place fast path on `a == b && b != c && rc_count == 1`. `a == b` is the rebind shape the compiler peephole emits; `b != c` rules out the `s = +s s` self-concat case where `push_str` would read from the same buffer it grows (UB on realloc). Non-rebind, RC > 1, and self-concat shapes route through the existing clone-and-write path.

2. **`jit: split jit_add and jit_concat into clone-always + inplace siblings`** — direct mirror of the `jit_listappend` / `jit_listappend_inplace` split from #250 and `jit_mset` / `jit_mset_inplace` from #249. `jit_add` and `jit_concat` keep clone-always semantics (the safe path); new `jit_add_inplace` and `jit_concat_inplace` carry the RC=1 fast path. `compile_cranelift.rs` and `jit_cranelift.rs` OP_ADD / OP_ADD_SS lowering picks the inplace variant only when `a_idx == b_idx && b_idx != c_idx` in the bytecode. The compiler peephole guarantees that for the `name = +name suffix` accumulator shape, so #232's amortised O(n) string-building perf win is preserved.

3. **`test: cross-engine regression for + non-rebind + self-concat aliasing`** — 24 tests across tree / VM / Cranelift covering: OP_ADD_SS non-rebind preserves LHS (typed-string param + literal), OP_ADD untyped path same (`fmt` result that isn't reg_is_str-marked routes through plain OP_ADD instead of OP_ADD_SS), both source and dest visible in the same return, RC > 1 via function-call boundary, rebind accumulator shape still runs (perf path not regressed), and self-concat `s = +s s` correctness on both OP_ADD and OP_ADD_SS paths.

4. **`example: demonstrate + non-rebind preserves LHS`** — `examples/string-concat-non-rebind-alias.ilo` enters the engine harness via `tests/examples_engines.rs`, so the correct shape is documented in-context for agents.

## Notes on what's not in scope

- **Tree-walker** unaffected (always clones; same property that makes Phase 2b a separate item).
- **Lists** already fixed in #250; nothing to do here.
- **Phase 2b** (tree-walker `Value::Text` / `Value::List` / `Value::Map` Rc conversion) remains a separate, larger refactor. Independent of this fix.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --release --features cranelift --lib --bins --tests -- -D warnings` clean
- [x] `tests/regression_add_ss_aliasing.rs` 24/24 pass on tree, VM, Cranelift
- [x] `tests/regression_listappend_aliasing.rs` and `tests/regression_mset_accumulator.rs` still pass (no regression in the sibling guards)
- [x] `tests/examples_engines.rs` all examples (incl. new `string-concat-non-rebind-alias.ilo`) green on tree/vm/cranelift
- [x] Full integration suite under `--no-fail-fast` — all bundles green; the pre-existing 7 lib `vm::compile_cranelift::tests::aot_*` failures are the `CARGO_TARGET_DIR/libilo.a` search-path mismatches documented in #249 and #250 (CI doesn't enable the cranelift feature for nextest so these don't run in CI)
- [x] Manual repro above confirms `key1` cross-engine after the fix