### PR TITLE
parser: greedy-parse known functions inside list literals

### DIFF
--- a/examples/list-literal-refs.ilo
+++ b/examples/list-literal-refs.ilo
@@ -1,7 +1,10 @@
 -- List literals with bare variable refs.
--- `[a b c]` parses the same way as `[1 2 3]` — three elements.
--- Use commas (`[floor x, ceil x]`) when you want each element to be a full
--- expression including whitespace-style calls.
+-- `[a b c]` parses the same way as `[1 2 3]` — three elements when each
+-- ident is a local/unknown name. A known function (builtin or declared
+-- fn) followed by operands eats exactly its arity instead, so `[str n]`
+-- or `[at xs 0 at xs 2]` parse as calls; see `listlit-fnref-greedy.ilo`
+-- for that branch. Commas (`[floor x, ceil x]`) still work when you want
+-- each element to be a full whitespace-call expression.
 
 -- Three refs in a list — mirrors `[1 2 3]`.
 trio>L n;a=1;b=2;c=3;[a b c]

--- a/examples/listlit-fnref-greedy.ilo
+++ b/examples/listlit-fnref-greedy.ilo
@@ -1,0 +1,37 @@
+-- Known functions inside list literals are greedy-expanded as calls.
+-- Refined sibling of `list-literal-refs.ilo`:
+--   * Bare local refs still parse as elements: `[a b c]` -> 3 elements.
+--   * Known functions (builtins, declared fns) eat exactly their arity
+--     of operands: `[str n]`, `[at xs 0]`, `[at xs 0 at xs 2]` Just Work.
+--   * HOF fn-ref slots are preserved: `[map dbl xs]` is one Call element.
+--
+-- This shape was the user-facing friction: `cat ["proteins=" str n] ""`
+-- used to fail with ILO-R009 because `str` was held as a bare ref and
+-- lowered to a FnRef. Now it joins to "proteins=42" as expected.
+
+-- The original repro: cat with a formatted value inline.
+protein n:n>t;cat ["proteins=" str n] ""
+
+-- Multiple greedy unary calls side-by-side.
+strs>L t;a=1;b=2;c=3;[str a str b str c]
+
+-- Arity cap on binary builtins: two at calls, not one over-supplied.
+pair>L n;xs=[10 20 30];[at xs 0 at xs 2]
+
+-- Nested known-fn calls collapse into a single capped element.
+nested>L n;xs=[[1 2 3] [4 5]];[len hd xs]
+
+-- Bare locals (not in fn_arity) still parse as elements, preserving the
+-- mirror with `[1 2 3]`.
+locals>L n;a=1;b=2;c=3;[a b c]
+
+-- run: protein 42
+-- out: proteins=42
+-- run: strs
+-- out: [1, 2, 3]
+-- run: pair
+-- out: [10, 30]
+-- run: nested
+-- out: [3]
+-- run: locals
+-- out: [1, 2, 3]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2003,10 +2003,39 @@ or write `({fmt_name} \"...\" ...)` so its args are grouped."
             }
 
             // Inside a list literal, `[a b c]` must yield three list
-            // elements rather than `[Call(a, [b, c])]`. If the next token
-            // would otherwise start a call argument, return the bare Ref.
+            // elements rather than `[Call(a, [b, c])]`. Bare refs to locals
+            // stay as elements. But a known function (in `fn_arity` with
+            // arity > 0) followed by operands parses as a call with EXACTLY
+            // arity operands consumed - same arity-capped rule that the
+            // nested-call path in `parse_call_arg` uses (line 1916). This
+            // lets `[str n]`, `[at xs 0]`, `[map dbl xs]`, and side-by-side
+            // `[str a str b str c]` Just Work without forcing agents to
+            // bind every formatted value first or reach for parens.
+            //
+            // The arity cap is critical: without it, `[at xs 0 at xs 2]`
+            // would parse as `at(xs, 0, at, xs, 2)` (5 args) instead of two
+            // calls. Mirroring `parse_call_arg`'s `for i in 0..arity` keeps
+            // each list element to a single capped call.
             if self.no_whitespace_call {
-                return Ok(atom);
+                let arity = self.fn_arity.get(&name).copied().unwrap_or(0);
+                if arity == 0 || !self.can_start_operand() {
+                    return Ok(atom);
+                }
+                let mut args = Vec::with_capacity(arity);
+                for i in 0..arity {
+                    if !self.can_start_operand() {
+                        // Underfilled - let the verifier report arity
+                        // mismatch with its usual ILO-T006 error.
+                        break;
+                    }
+                    let inner_fn_pos = self.is_fn_ref_position(&name, i);
+                    args.push(self.parse_call_arg(inner_fn_pos, Some((&name, arity, i)))?);
+                }
+                return Ok(Expr::Call {
+                    function: name,
+                    args,
+                    unwrap: false,
+                });
             }
 
             // Check for function call: name followed by args

--- a/tests/regression_list_literal_refs.rs
+++ b/tests/regression_list_literal_refs.rs
@@ -40,14 +40,18 @@ fn check_all(engine: &str) {
     assert_eq!(run(engine, MIXED, "f"), "[1, 2, 3]", "mixed {engine}");
     assert_eq!(run(engine, NUMERIC, "f"), "[1, 2, 3]", "numeric {engine}");
     assert_eq!(run(engine, COMMA_REFS, "f"), "[1, 2, 3]", "comma {engine}");
-    // `[f a]` resolves to a 2-element list of refs, NOT a call to f.
-    // Decision: the list-literal form prioritises the "list of elements"
-    // reading because it's the common case agents write; explicit parens
-    // remain available when a call is intended.
-    // Call form inside a list: use commas to separate elements so each
-    // side parses as a full expression including whitespace-calls.
-    // `[floor x, ceil x]` is the canonical form. The pure-whitespace form
-    // `[floor x ceil x]` would yield four list elements, not two calls.
+    // Refined rule (see `regression_listlit_fnref_greedy.rs` and
+    // `examples/listlit-fnref-greedy.ilo`): bare locals like `a`, `b`,
+    // `c` (not in `fn_arity`) stay as list elements - the assertions
+    // above pin that branch. A known function (builtin or declared fn)
+    // followed by operands eats EXACTLY its arity, so `[str n]` or
+    // `[at xs 0 at xs 2]` parse as calls. The arity cap mirrors the
+    // nested-call rule in `parse_call_arg` (line 1916).
+    //
+    // Commas still work as the explicit "full expression per element"
+    // form, including for `floor`/`ceil` here which aren't in `fn_arity`
+    // (the real builtins are `flr`/`cel`) and so wouldn't be eagerly
+    // expanded anyway. `[floor x, ceil x]` exercises the comma path.
     let out = ilo()
         .args(["f x:n>L n;[floor x, ceil x]", engine, "f", "3.5"])
         .output()

--- a/tests/regression_listlit_fnref_greedy.rs
+++ b/tests/regression_listlit_fnref_greedy.rs
@@ -1,0 +1,219 @@
+// Regression tests for greedy call-expansion of known functions inside list
+// literals. Companion to `regression_list_literal_refs.rs`.
+//
+// Before this change, `cat ["proteins=" str n] ""` failed with ILO-R009
+// (`cat: list items must be text, got FnRef("str")`) because the parser
+// treated every Ident inside a whitespace list-literal as a bare ref. That
+// forced agents to bind every formatted value first (`sn=str n; cat
+// ["proteins=" sn] ""`), which burns tokens on every retry and surfaced
+// 6+ times in a single 100-LOC bioinformatics program.
+//
+// Refined rule: inside a list literal in whitespace mode, an Ident that is
+// a known function (present in `fn_arity` with arity > 0) followed by an
+// operand parses as a call with EXACTLY arity operands consumed, mirroring
+// the nested-call rule in `parse_call_arg`. Idents NOT in `fn_arity` (e.g.
+// local variables) stay as bare elements, so `[a b c]` with `a=1;b=2;c=3`
+// still yields a 3-element list. HOF fn-ref positions (`map dbl xs`,
+// `srt cmp xs`) keep their inner ref because `parse_call_arg` respects
+// `is_fn_ref_position`.
+//
+// The arity cap is critical: without it, `[at xs 0 at xs 2]` would parse
+// as `at(xs, 0, at, xs, 2)` (5 args) instead of two element calls.
+//
+// Cross-engine: tree, vm, and (when enabled) cranelift JIT — the parser
+// change is shared so each engine must see the same AST and emit the same
+// output.
+
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn write_src(name: &str, src: &str) -> std::path::PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "ilo_listlit_fnref_{name}_{}_{n}.ilo",
+        std::process::id()
+    ));
+    std::fs::write(&path, src).expect("write src");
+    path
+}
+
+fn run_ok(engine: &str, src: &str, entry: &str, args: &[&str]) -> String {
+    let path = write_src(entry, src);
+    let mut cmd = ilo();
+    cmd.arg(&path).arg(engine).arg(entry);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+// --- Tier 1: original repro - the exact friction the user hit ----------
+
+// `cat ["proteins=" str n] ""` previously failed with ILO-R009 because
+// `str` was kept as a bare Ref → FnRef and cat barfed. With the fix,
+// `str n` greedy-parses inside the list literal as Call(str, [n]) and the
+// cat join produces the expected text.
+const REPRO_PROTEIN: &str = "f n:n>t;cat [\"proteins=\" str n] \"\"";
+
+fn check_repro(engine: &str) {
+    assert_eq!(
+        run_ok(engine, REPRO_PROTEIN, "f", &["42"]),
+        "proteins=42",
+        "original cat-with-str repro now works {engine}",
+    );
+}
+
+// --- Tier 2: 1-arg builtins as list elements ----------------------------
+
+const STR_OF_LOCAL: &str = "f>L t;n=42;[str n]";
+const LEN_OF_LIST: &str = "f>L n;xs=[1 2 3];[len xs]";
+
+fn check_unary(engine: &str) {
+    assert_eq!(
+        run_ok(engine, STR_OF_LOCAL, "f", &[]),
+        "[42]",
+        "str eats one operand in list literal {engine}",
+    );
+    assert_eq!(
+        run_ok(engine, LEN_OF_LIST, "f", &[]),
+        "[3]",
+        "len eats one operand in list literal {engine}",
+    );
+}
+
+// --- Tier 3: 2-arg builtins (arity-capped greedy) -----------------------
+
+// `at` is binary. Without the arity cap, `[at xs 0 at xs 2]` would parse
+// as `[Call(at, [xs, 0, at, xs, 2])]` and fail with arity-mismatch. With
+// the cap, each `at` eats exactly 2 operands → two list elements.
+const AT_PAIR: &str = "f>L n;xs=[10 20 30];[at xs 0 at xs 2]";
+const MIN_MAX_PAIR: &str = "f>L n;a=2;b=5;[min a b max a b]";
+
+fn check_binary_capped(engine: &str) {
+    assert_eq!(
+        run_ok(engine, AT_PAIR, "f", &[]),
+        "[10, 30]",
+        "two at calls (arity cap) {engine}",
+    );
+    assert_eq!(
+        run_ok(engine, MIN_MAX_PAIR, "f", &[]),
+        "[2, 5]",
+        "min and max side-by-side {engine}",
+    );
+}
+
+// --- Tier 4: multiple unary builtins side-by-side -----------------------
+
+// The shape that bit the user: several `str`/`fmt`/etc. calls in a row.
+// Each consumes exactly one operand.
+const STR_TRIO: &str = "f>L t;a=1;b=2;c=3;[str a str b str c]";
+
+fn check_multi(engine: &str) {
+    assert_eq!(
+        run_ok(engine, STR_TRIO, "f", &[]),
+        "[1, 2, 3]",
+        "three str calls as three list elements {engine}",
+    );
+}
+
+// --- Tier 5: bare-ref behaviour preserved for locals --------------------
+
+// Locals aren't in fn_arity, so `[a b c]` still yields 3 elements - the
+// existing `regression_list_literal_refs.rs` invariant.
+const BARE_LOCALS: &str = "f>L n;a=1;b=2;c=3;[a b c]";
+const MIXED_LOCALS: &str = "f>L n;a=1;c=3;[a 2 c]";
+const PURE_NUMBERS: &str = "f>L n;[1 2 3]";
+
+fn check_locals_unchanged(engine: &str) {
+    assert_eq!(
+        run_ok(engine, BARE_LOCALS, "f", &[]),
+        "[1, 2, 3]",
+        "bare locals stay as 3 elements {engine}",
+    );
+    assert_eq!(
+        run_ok(engine, MIXED_LOCALS, "f", &[]),
+        "[1, 2, 3]",
+        "mixed locals + literals stay as 3 elements {engine}",
+    );
+    assert_eq!(
+        run_ok(engine, PURE_NUMBERS, "f", &[]),
+        "[1, 2, 3]",
+        "pure number list still 3 elements {engine}",
+    );
+}
+
+// --- Tier 6: HOF fn-ref position preserved ------------------------------
+
+// `map` has fn-ref slot 0, so `dbl` must stay a bare ref. The whole
+// `[map dbl xs]` parses as one element: Call(map, [Ref(dbl), Ref(xs)]).
+// `hd` of that one-element list gives the result of the map.
+const MAP_HOF_IN_LIST: &str = "dbl x:n>n;*x 2
+g>L n;xs=[1 2 3];hd [map dbl xs]";
+
+fn check_hof_preserved(engine: &str) {
+    // Tree only: VM/cranelift skip HOF dispatch (FnRef NaN-tagging TBD)
+    if engine != "--run-tree" {
+        return;
+    }
+    assert_eq!(
+        run_ok(engine, MAP_HOF_IN_LIST, "g", &[]),
+        "[2, 4, 6]",
+        "map keeps fn-ref slot 0, no eager expansion {engine}",
+    );
+}
+
+// --- Tier 7: nested-call within a single list element -------------------
+
+// `[len hd xs]` parses as `[Call(len, [Call(hd, [xs])])]` because `hd` is
+// also a known unary builtin and parse_call_arg's eager-expansion rule
+// kicks in at the inner position. Result is a 1-element list of `len(hd(xs))`.
+const NESTED_LEN_HD: &str = "f>L n;xs=[[1 2 3] [4 5]];[len hd xs]";
+
+fn check_nested(engine: &str) {
+    assert_eq!(
+        run_ok(engine, NESTED_LEN_HD, "f", &[]),
+        "[3]",
+        "nested known-fn calls in single list element {engine}",
+    );
+}
+
+// --- Cross-engine harness -----------------------------------------------
+
+fn check_all(engine: &str) {
+    check_repro(engine);
+    check_unary(engine);
+    check_binary_capped(engine);
+    check_multi(engine);
+    check_locals_unchanged(engine);
+    check_hof_preserved(engine);
+    check_nested(engine);
+}
+
+#[test]
+fn listlit_fnref_greedy_tree() {
+    check_all("--run-tree");
+}
+
+#[test]
+fn listlit_fnref_greedy_vm() {
+    check_all("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn listlit_fnref_greedy_cranelift() {
+    check_all("--run-cranelift");
+}


### PR DESCRIPTION
## Summary

Inside `[...]` with no top-level comma, the parser was returning a bare Ref for every Ident, even known builtins. `cat ["proteins=" str n] ""` blew up at runtime with ILO-R009 because `str` lowered to a `FnRef` and `cat` doesn't accept fn-refs as list items. Workaround was to bind every formatted value first - real friction, hit 6+ times in a 100 LOC bioinformatics program. Token-tax exactly the kind the language exists to remove.

Refined rule: in whitespace-list-element context, an Ident that's in `fn_arity` with arity > 0 and followed by an operand parses as a Call consuming EXACTLY arity operands. Same rule the rest of the parser already uses for call-arg positions, so this is consistency restoration, not new magic. Locals (not in `fn_arity`) still parse as bare elements, so `[a b c]` with `a=1;b=2;c=3` stays 3 elements. HOF fn-ref slots are preserved because `parse_call_arg` respects `is_fn_ref_position`.

## Repro

Before:

```
$ ilo 'f n:n>t;cat ["proteins=" str n] ""' --run-tree f 42
ILO-R009: cat: list items must be text, got FnRef("str")
```

After:

```
$ ilo 'f n:n>t;cat ["proteins=" str n] ""' --run-tree f 42
proteins=42
```

## What's in the diff

Three commits, mirroring the recent `fix/fmt-in-arg-position` shape:

1. **`parser: greedy-parse known functions inside list literals`** - the actual fix in `src/parser/mod.rs`. Replaces the unconditional bare-Ref return in `parse_call_or_atom`'s `no_whitespace_call` branch with an arity-capped greedy path that mirrors the nested-call rule in `parse_call_arg` (line 1916). The arity cap is critical - without it, `[at xs 0 at xs 2]` parses as one 5-arg call instead of two element calls. Also refines the documentation in `examples/list-literal-refs.ilo` and `tests/regression_list_literal_refs.rs` to reflect the refined rule.

2. **`example: arity-capped greedy expansion of known fns in list literals`** - new `examples/listlit-fnref-greedy.ilo` with `-- run`/`-- out` annotations so the engine harness exercises the original repro plus 1-arg, 2-arg, multi-call, nested, and locals-preserved cases across tree, VM, and Cranelift.

3. **`test: cross-engine regression for greedy fn refs in list literals`** - new `tests/regression_listlit_fnref_greedy.rs` with 7 tiers: original repro, 1-arg builtins, 2-arg arity cap, multi-call side-by-side, locals unchanged, HOF fn-ref preserved (tree only), nested-call inside element. Runs across `--run-tree`, `--run-vm`, and `--run-cranelift`.

## Test plan

- [x] Original repro `cat ["proteins=" str n] ""` produces `proteins=42` on tree, VM, Cranelift
- [x] `[a b c]` with `a=1;b=2;c=3` still yields `[1, 2, 3]` (existing regression test untouched)
- [x] `[at xs 0 at xs 2]` parses as two elements `[10, 30]` (arity cap)
- [x] `[str a str b str c]` yields `[1, 2, 3]`
- [x] `[map dbl xs]` keeps `dbl` as a fn-ref slot 0
- [x] `[len hd xs]` nests the calls into one capped element
- [x] `[rnd]` (arity-0 fast-path) still works
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --release --features cranelift --tests` clean
- [x] `cargo test --release --features cranelift` all green (2888 lib + integration suites, including the existing `regression_list_literal_refs` cross-engine tests and the new `regression_listlit_fnref_greedy` triplet)

## Follow-ups

None. The change is local to `parse_call_or_atom`'s `no_whitespace_call` branch and reuses the existing arity-driven machinery (`fn_arity`, `is_fn_ref_position`, `parse_call_arg`).