### PR TITLE
perf: typed MapKey enum removes routing-tsp str(j) tax on numeric maps

### DIFF
--- a/examples/frq.ilo
+++ b/examples/frq.ilo
@@ -1,14 +1,11 @@
--- frq xs:L a > M t n — frequency map: count occurrences of each element.
--- Keys are bare stringified element values (e.g. "the", "s", "1"), matching
--- `grp`'s convention for user-visible map keys. No type prefix is added,
--- so `mkeys (frq xs)` and `mget (frq xs) k` work with the natural string
--- form. Replaces the recurring `inc m k` pattern (mget + ?? 0 + +1 + mset)
--- with one call.
+-- frq xs:L a > M _ n — frequency map: count occurrences of each element.
+-- Keys preserve the element type: text inputs produce text keys, number
+-- inputs produce number keys (floats floor to i64). This avoids the routing
+-- tax of `k=str j` before every `mget`/`mset` iteration.
 --
--- Heterogeneous-type collisions: distinct-typed values that share a print
--- form collide on the shared key (e.g. `frq [1, "1"]` produces one key "1"
--- with count 2). Same collision policy as `grp idt xs`. If you need to
--- disambiguate, group with a key function that includes a tag.
+-- Heterogeneous-type collisions: with typed keys, `1` and `"1"` are now
+-- distinct keys (Int(1) vs Text("1")). Numeric floats floor to i64 at the
+-- builtin boundary, matching `at xs i`.
 
 -- Word frequency in a sentence.
 words>n;m=frq ["the","cat","sat","on","the","mat","the","cat"];r=mget m "the";?r{n v:v;_:0}
@@ -16,8 +13,8 @@ words>n;m=frq ["the","cat","sat","on","the","mat","the","cat"];r=mget m "the";?r
 -- Character frequency (split a string into chars, then count).
 cfrq>n;m=frq (spl "mississippi" "");r=mget m "s";?r{n v:v;_:0}
 
--- Number frequency: keys are bare stringified numbers ("1","2",...).
-nums>n;m=frq [1,2,1,3,1,2];r=mget m "1";?r{n v:v;_:0}
+-- Number frequency: numeric keys preserve their type (no stringification).
+nums>n;m=frq [1,2,1,3,1,2];r=mget m 1;?r{n v:v;_:0}
 
 -- run: words
 -- out: 3

--- a/examples/numeric-map-keys.ilo
+++ b/examples/numeric-map-keys.ilo
@@ -1,0 +1,33 @@
+-- Numeric map keys: M n _ — maps with integer keys, no `k=str j` tax.
+-- Before MapKey, every map lookup keyed by a loop index had to go through a
+-- `k=str j` stringification step (the routing-tsp tax). Now numeric keys are
+-- first-class: declare `M n _` and pass numbers straight through.
+--
+-- Floats floor to i64 at the builtin boundary, matching `at xs i`. Text and
+-- number keys are distinct: Int(1) and Text("1") never collide.
+
+-- Build a small histogram by writing through numeric keys.
+hist>n;m=mmap;m=mset m 1 10;m=mset m 2 20;m=mset m 3 30;r=mget m 2;?r{n v:v;_:-1}
+
+-- mhas works with numeric keys.
+has-key>b;m=mmap;m=mset m 42 "answer";mhas m 42
+
+-- mdel works with numeric keys.
+del-key>n;m=mmap;m=mset m 1 100;m=mset m 2 200;m=mdel m 1;len (mkeys m)
+
+-- mkeys returns L n for a numeric-keyed map.
+key-count>n;m=mmap;m=mset m 1 0;m=mset m 2 0;m=mset m 3 0;ks=mkeys m;len ks
+
+-- Iteration is deterministic via sorted mkeys.
+sorted-keys>t;m=mmap;m=mset m 3 0;m=mset m 1 0;m=mset m 2 0;ks=srt (mkeys m);fmt "{};{};{}" (str (at ks 0)) (str (at ks 1)) (str (at ks 2))
+
+-- run: hist
+-- out: 20
+-- run: has-key
+-- out: true
+-- run: del-key
+-- out: 1
+-- run: key-count
+-- out: 3
+-- run: sorted-keys
+-- out: 1;2;3

--- a/src/interpreter/json.rs
+++ b/src/interpreter/json.rs
@@ -36,9 +36,12 @@ impl Value {
                 Ok(serde_json::Value::Array(arr?))
             }
             Value::Map(m) => {
+                // Numeric keys are stringified, matching JS/Python JSON
+                // serialisation conventions. The round-trip is lossy: a map
+                // with numeric keys will come back as a record with text keys.
                 let mut json_map = serde_json::Map::with_capacity(m.len());
                 for (k, v) in m.iter() {
-                    json_map.insert(k.clone(), v.to_json()?);
+                    json_map.insert(k.to_display_string(), v.to_json()?);
                 }
                 Ok(serde_json::Value::Object(json_map))
             }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -5,6 +5,108 @@ use std::sync::Arc;
 
 pub mod json;
 
+/// A typed key for `Value::Map` and `HeapObj::Map`.
+///
+/// Two variants — `Text` for string keys and `Int` for integer keys.
+/// Floats are normalised to `Int` at the builtin boundary (`floor` + `as i64`),
+/// matching the indexing convention of `at xs i`. NaN/Infinity keys are
+/// rejected with a runtime error there, so they never reach `MapKey`.
+///
+/// `Bool` is intentionally not represented: token-cost wise, bool maps are
+/// always shorter to express as a two-arm `?` than as a two-entry map, and the
+/// surface syntax for bool literals as map keys would add lexer ambiguity.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub enum MapKey {
+    Text(String),
+    Int(i64),
+}
+
+impl MapKey {
+    pub fn as_text(&self) -> Option<&str> {
+        match self {
+            MapKey::Text(s) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+
+    pub fn as_int(&self) -> Option<i64> {
+        match self {
+            MapKey::Int(n) => Some(*n),
+            _ => None,
+        }
+    }
+
+    /// Stringified form used by serialisations that need a textual key
+    /// (e.g. JSON object keys, CSV headers, the `Display` impl).
+    pub fn to_display_string(&self) -> String {
+        match self {
+            MapKey::Text(s) => s.clone(),
+            MapKey::Int(n) => n.to_string(),
+        }
+    }
+
+    /// Normalise an ilo `Value` into a `MapKey`. Used at the builtin boundary
+    /// for `mget`, `mset`, `mhas`, `mdel`. Numbers floor to i64 to match
+    /// `at xs i`; non-finite numbers are rejected.
+    pub fn from_value(v: &Value, op_name: &str) -> std::result::Result<Self, RuntimeError> {
+        match v {
+            Value::Text(s) => Ok(MapKey::Text(s.clone())),
+            Value::Number(n) => {
+                if !n.is_finite() {
+                    return Err(RuntimeError::new(
+                        "ILO-R009",
+                        format!("{op_name}: numeric key must be finite, got {n}"),
+                    ));
+                }
+                Ok(MapKey::Int(n.floor() as i64))
+            }
+            other => Err(RuntimeError::new(
+                "ILO-R009",
+                format!("{op_name}: key must be text or number, got {other:?}"),
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for MapKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MapKey::Text(s) => write!(f, "{s}"),
+            MapKey::Int(n) => write!(f, "{n}"),
+        }
+    }
+}
+
+/// Total ordering for deterministic iteration order in `mkeys`/`mvals`.
+/// In well-typed code maps are homogeneous, so the cross-variant ordering
+/// (Int < Text) is academic — it just keeps tests deterministic if a poorly
+/// typed map mixes both.
+impl Ord for MapKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match (self, other) {
+            (MapKey::Int(a), MapKey::Int(b)) => a.cmp(b),
+            (MapKey::Text(a), MapKey::Text(b)) => a.cmp(b),
+            (MapKey::Int(_), MapKey::Text(_)) => std::cmp::Ordering::Less,
+            (MapKey::Text(_), MapKey::Int(_)) => std::cmp::Ordering::Greater,
+        }
+    }
+}
+
+impl PartialOrd for MapKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Convert a `MapKey` back to a `Value` for use in builtin returns such as
+/// `mkeys`. Text → `Value::Text`, Int → `Value::Number(f64)`.
+pub fn map_key_to_value(k: &MapKey) -> Value {
+    match k {
+        MapKey::Text(s) => Value::Text(s.clone()),
+        MapKey::Int(n) => Value::Number(*n as f64),
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value {
     Number(f64),
@@ -12,7 +114,7 @@ pub enum Value {
     Bool(bool),
     Nil,
     List(Vec<Value>),
-    Map(Arc<HashMap<String, Value>>),
+    Map(Arc<HashMap<MapKey, Value>>),
     Record {
         type_name: String,
         fields: HashMap<String, Value>,
@@ -70,7 +172,7 @@ impl std::fmt::Display for Value {
             }
             Value::Map(m) => {
                 write!(f, "{{")?;
-                let mut keys: Vec<&String> = m.keys().collect();
+                let mut keys: Vec<&MapKey> = m.keys().collect();
                 keys.sort();
                 for (i, k) in keys.iter().enumerate() {
                     if i > 0 {
@@ -503,9 +605,12 @@ pub(crate) fn write_csv_tsv(rows: &[Value], sep: char) -> Result<String> {
             (Some(keys), true)
         }
         Value::Map(m) => {
-            let mut keys: Vec<String> = m.keys().cloned().collect();
+            let mut keys: Vec<MapKey> = m.keys().cloned().collect();
             keys.sort();
-            (Some(keys), true)
+            (
+                Some(keys.iter().map(|k| k.to_display_string()).collect()),
+                true,
+            )
         }
         other => {
             return Err(RuntimeError::new(
@@ -548,11 +653,21 @@ pub(crate) fn write_csv_tsv(rows: &[Value], sep: char) -> Result<String> {
                 out.push('\n');
             }
             (Value::Map(m), true, Some(keys)) => {
+                // Build a stringified-key view of the map to match the
+                // header order. Header keys are stringified per
+                // `MapKey::to_display_string` so a numeric key `1` matches
+                // the header column "1".
+                let str_view: HashMap<String, &Value> =
+                    m.iter().map(|(k, v)| (k.to_display_string(), v)).collect();
                 for (i, k) in keys.iter().enumerate() {
                     if i > 0 {
                         out.push(sep);
                     }
-                    let v = m.get(k).cloned().unwrap_or(Value::Nil);
+                    let v = str_view
+                        .get(k.as_str())
+                        .copied()
+                        .cloned()
+                        .unwrap_or(Value::Nil);
                     out.push_str(&fmt_csv_field(&v, sep));
                 }
                 out.push('\n');
@@ -669,11 +784,14 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         return Ok(Value::Map(Arc::new(HashMap::new())));
     }
     if builtin == Some(Builtin::Mget) && args.len() == 2 {
-        return match (&args[0], &args[1]) {
-            (Value::Map(m), Value::Text(k)) => Ok(m.get(k).cloned().unwrap_or(Value::Nil)),
+        return match &args[0] {
+            Value::Map(m) => {
+                let key = MapKey::from_value(&args[1], "mget")?;
+                Ok(m.get(&key).cloned().unwrap_or(Value::Nil))
+            }
             _ => Err(RuntimeError::new(
                 "ILO-R009",
-                "mget: expects map and text key".to_string(),
+                "mget: expects map and key".to_string(),
             )),
         };
     }
@@ -684,34 +802,38 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         let map_val = it.next().unwrap();
         let key_val = it.next().unwrap();
         let value = it.next().unwrap();
-        return match (map_val, key_val) {
-            (Value::Map(mut m), Value::Text(k)) => {
+        return match map_val {
+            Value::Map(mut m) => {
+                let key = MapKey::from_value(&key_val, "mset")?;
                 let inner = Arc::make_mut(&mut m);
-                inner.insert(k, value);
+                inner.insert(key, value);
                 Ok(Value::Map(m))
             }
             _ => Err(RuntimeError::new(
                 "ILO-R009",
-                "mset: expects map, text key, and value".to_string(),
+                "mset: expects map, key, and value".to_string(),
             )),
         };
     }
     if builtin == Some(Builtin::Mhas) && args.len() == 2 {
-        return match (&args[0], &args[1]) {
-            (Value::Map(m), Value::Text(k)) => Ok(Value::Bool(m.contains_key(k.as_str()))),
+        return match &args[0] {
+            Value::Map(m) => {
+                let key = MapKey::from_value(&args[1], "mhas")?;
+                Ok(Value::Bool(m.contains_key(&key)))
+            }
             _ => Err(RuntimeError::new(
                 "ILO-R009",
-                "mhas: expects map and text key".to_string(),
+                "mhas: expects map and key".to_string(),
             )),
         };
     }
     if builtin == Some(Builtin::Mkeys) && args.len() == 1 {
         return match &args[0] {
             Value::Map(m) => {
-                let mut keys: Vec<&String> = m.keys().collect();
+                let mut keys: Vec<&MapKey> = m.keys().collect();
                 keys.sort();
                 Ok(Value::List(
-                    keys.into_iter().map(|k| Value::Text(k.clone())).collect(),
+                    keys.into_iter().map(map_key_to_value).collect(),
                 ))
             }
             _ => Err(RuntimeError::new(
@@ -723,8 +845,8 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
     if builtin == Some(Builtin::Mvals) && args.len() == 1 {
         return match &args[0] {
             Value::Map(m) => {
-                let mut pairs: Vec<(&String, &Value)> = m.iter().collect();
-                pairs.sort_by_key(|(k, _)| k.as_str());
+                let mut pairs: Vec<(&MapKey, &Value)> = m.iter().collect();
+                pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
                 Ok(Value::List(
                     pairs.into_iter().map(|(_, v)| v.clone()).collect(),
                 ))
@@ -739,15 +861,16 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         let mut it = args.into_iter();
         let map_val = it.next().unwrap();
         let key_val = it.next().unwrap();
-        return match (map_val, key_val) {
-            (Value::Map(mut m), Value::Text(k)) => {
+        return match map_val {
+            Value::Map(mut m) => {
+                let key = MapKey::from_value(&key_val, "mdel")?;
                 let inner = Arc::make_mut(&mut m);
-                inner.remove(k.as_str());
+                inner.remove(&key);
                 Ok(Value::Map(m))
             }
             _ => Err(RuntimeError::new(
                 "ILO-R009",
-                "mdel: expects map and text key".to_string(),
+                "mdel: expects map and key".to_string(),
             )),
         };
     }
@@ -1861,7 +1984,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                             Value::Text(s) => s.clone(),
                             other => format!("{other:?}"),
                         };
-                        (k.clone(), vs)
+                        (k.to_display_string(), vs)
                     })
                     .collect::<Vec<_>>(),
                 other => {
@@ -1948,7 +2071,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                             Value::Text(s) => s.clone(),
                             other => format!("{other:?}"),
                         };
-                        (k.clone(), vs)
+                        (k.to_display_string(), vs)
                     })
                     .collect::<Vec<_>>(),
                 other => {
@@ -2325,7 +2448,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                             Value::Map(m) => {
                                 let obj: serde_json::Map<String, serde_json::Value> = m
                                     .iter()
-                                    .map(|(k, v)| (k.clone(), value_to_json(v)))
+                                    .map(|(k, v)| (k.to_display_string(), value_to_json(v)))
                                     .collect();
                                 serde_json::Value::Object(obj)
                             }
@@ -2789,22 +2912,24 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 ));
             }
         };
-        let mut groups: std::collections::HashMap<String, Vec<Value>> =
+        let mut groups: std::collections::HashMap<MapKey, Vec<Value>> =
             std::collections::HashMap::new();
         for item in items {
             let mut call_args = vec![item.clone()];
             call_args.extend(captures.iter().cloned());
             let key = call_function(env, &fn_name, call_args)?;
-            let key_str = match &key {
-                Value::Text(s) => s.clone(),
+            let map_key = match &key {
+                Value::Text(s) => MapKey::Text(s.clone()),
                 Value::Number(n) => {
-                    if *n == (*n as i64) as f64 {
-                        format!("{}", *n as i64)
-                    } else {
-                        format!("{n}")
+                    if !n.is_finite() {
+                        return Err(RuntimeError::new(
+                            "ILO-R009",
+                            format!("grp: numeric key must be finite, got {n}"),
+                        ));
                     }
+                    MapKey::Int(n.floor() as i64)
                 }
-                Value::Bool(b) => format!("{b}"),
+                Value::Bool(b) => MapKey::Text(format!("{b}")),
                 other => {
                     return Err(RuntimeError::new(
                         "ILO-R009",
@@ -2815,9 +2940,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                     ));
                 }
             };
-            groups.entry(key_str).or_default().push(item);
+            groups.entry(map_key).or_default().push(item);
         }
-        let map: HashMap<String, Value> = groups
+        let map: HashMap<MapKey, Value> = groups
             .into_iter()
             .map(|(k, v)| (k, Value::List(v)))
             .collect();
@@ -2833,23 +2958,25 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 ));
             }
         };
-        let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+        let mut counts: std::collections::HashMap<MapKey, usize> = std::collections::HashMap::new();
         for item in items {
-            // Stringify elements without a type tag, matching `grp`'s convention
-            // for user-visible map keys. Heterogeneous lists where distinct-typed
-            // values share a print form (e.g. `Number(1)` and `Text("1")`) will
-            // collide on the shared string; this is the same collision policy as
-            // `grp idt xs` and is documented in `examples/frq.ilo`.
-            let key_str = match item {
-                Value::Text(s) => s.clone(),
+            // Build a typed `MapKey` so the resulting map preserves the element
+            // type. Heterogeneous lists where text and number variants share a
+            // print form (e.g. `Number(1)` and `Text("1")`) are now correctly
+            // kept distinct — they were merged into a single key in the
+            // pre-MapKey era.
+            let map_key = match item {
+                Value::Text(s) => MapKey::Text(s.clone()),
                 Value::Number(n) => {
-                    if *n == (*n as i64) as f64 {
-                        format!("{}", *n as i64)
-                    } else {
-                        format!("{n}")
+                    if !n.is_finite() {
+                        return Err(RuntimeError::new(
+                            "ILO-R009",
+                            format!("frq: numeric element must be finite, got {n}"),
+                        ));
                     }
+                    MapKey::Int(n.floor() as i64)
                 }
-                Value::Bool(b) => format!("{b}"),
+                Value::Bool(b) => MapKey::Text(format!("{b}")),
                 other => {
                     return Err(RuntimeError::new(
                         "ILO-R009",
@@ -2860,9 +2987,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                     ));
                 }
             };
-            *counts.entry(key_str).or_insert(0) += 1;
+            *counts.entry(map_key).or_insert(0) += 1;
         }
-        let map: HashMap<String, Value> = counts
+        let map: HashMap<MapKey, Value> = counts
             .into_iter()
             .map(|(k, v)| (k, Value::Number(v as f64)))
             .collect();
@@ -3719,7 +3846,7 @@ fn value_to_json(val: &Value) -> serde_json::Value {
         Value::Map(m) => {
             let map: serde_json::Map<String, serde_json::Value> = m
                 .iter()
-                .map(|(k, v)| (k.clone(), value_to_json(v)))
+                .map(|(k, v)| (k.to_display_string(), value_to_json(v)))
                 .collect();
             serde_json::Value::Object(map)
         }
@@ -7038,11 +7165,11 @@ mod tests {
             panic!("expected Map")
         };
         assert_eq!(
-            m.get("small").unwrap(),
+            m.get(&MapKey::Text("small".to_string())).unwrap(),
             &Value::List(vec![1.0, 3.0, 2.0].into_iter().map(Value::Number).collect())
         );
         assert_eq!(
-            m.get("big").unwrap(),
+            m.get(&MapKey::Text("big".to_string())).unwrap(),
             &Value::List(vec![8.0, 9.0].into_iter().map(Value::Number).collect())
         );
     }
@@ -7065,15 +7192,15 @@ mod tests {
             panic!("expected Map")
         };
         assert_eq!(
-            m.get("1").unwrap(),
+            m.get(&MapKey::Text("1".to_string())).unwrap(),
             &Value::List(vec![1.0, 1.0].into_iter().map(Value::Number).collect())
         );
         assert_eq!(
-            m.get("2").unwrap(),
+            m.get(&MapKey::Text("2".to_string())).unwrap(),
             &Value::List(vec![2.0, 2.0].into_iter().map(Value::Number).collect())
         );
         assert_eq!(
-            m.get("3").unwrap(),
+            m.get(&MapKey::Text("3".to_string())).unwrap(),
             &Value::List(vec![3.0].into_iter().map(Value::Number).collect())
         );
     }
@@ -8553,8 +8680,8 @@ mod tests {
         let Value::Map(m) = result else {
             panic!("expected map")
         };
-        assert!(m.contains_key("true"));
-        assert!(m.contains_key("false"));
+        assert!(m.contains_key(&MapKey::Text("true".to_string())));
+        assert!(m.contains_key(&MapKey::Text("false".to_string())));
     }
 
     // ── avg non-number element (line 1053) ──────────────────────────────────
@@ -8682,8 +8809,9 @@ mod tests {
 
     #[test]
     fn interpret_grp_float_key() {
-        // Key function returns a fractional number → format!("{n}") path (line 1016)
-        // Use floor-then-half: key = x/2 for x in [1,2,3] → keys 0.5, 1.0, 1.5
+        // Key function returns a fractional number — under MapKey numeric
+        // keys floor to i64 at the boundary, matching `at xs i`. So
+        // /1 2 = 0.5 → 0, /2 2 = 1 → 1, /3 2 = 1.5 → 1. Two distinct groups.
         let source = "half x:n>n;/x 2 g xs:L n>_;grp half xs";
         let result = run_str(
             source,
@@ -8697,12 +8825,9 @@ mod tests {
         let Value::Map(m) = result else {
             panic!("expected Map")
         };
-        // 1/2=0.5, 2/2=1, 3/2=1.5 → 3 groups
-        assert!(
-            m.contains_key("0.5") || m.contains_key("1.5"),
-            "expected float key, got: {:?}",
-            m.keys().collect::<Vec<_>>()
-        );
+        assert_eq!(m.len(), 2);
+        assert!(m.contains_key(&MapKey::Int(0)));
+        assert!(m.contains_key(&MapKey::Int(1)));
     }
 
     // ── ForRange early return (lines 1370-1371) ───────────────────────────────
@@ -9175,7 +9300,7 @@ mod tests {
             source,
             Some("f"),
             vec![Value::Map(Arc::new(std::collections::HashMap::from([(
-                "a".to_string(),
+                MapKey::Text("a".to_string()),
                 Value::Number(1.0),
             )])))],
         );

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -846,7 +846,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         return match &args[0] {
             Value::Map(m) => {
                 let mut pairs: Vec<(&MapKey, &Value)> = m.iter().collect();
-                pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+                pairs.sort_by_key(|(k, _)| (*k).clone());
                 Ok(Value::List(
                     pairs.into_iter().map(|(_, v)| v.clone()).collect(),
                 ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -5174,7 +5174,10 @@ mod tests {
     #[test]
     fn print_value_map_as_json() {
         let mut m = std::collections::HashMap::new();
-        m.insert("k".to_string(), interpreter::Value::Number(7.0));
+        m.insert(
+            interpreter::MapKey::Text("k".to_string()),
+            interpreter::Value::Number(7.0),
+        );
         let val = interpreter::Value::Map(std::sync::Arc::new(m));
         print_value(&val, true, false);
     }
@@ -5182,7 +5185,10 @@ mod tests {
     #[test]
     fn print_value_map_plain_not_json() {
         let mut m = std::collections::HashMap::new();
-        m.insert("key".to_string(), interpreter::Value::Bool(true));
+        m.insert(
+            interpreter::MapKey::Text("key".to_string()),
+            interpreter::Value::Bool(true),
+        );
         let val = interpreter::Value::Map(std::sync::Arc::new(m));
         print_value(&val, false, false);
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1175,33 +1175,21 @@ impl Parser {
         }
         match self.token_at(after_semi) {
             // ^ident: or ^_: → err pattern
-            Some(Token::Caret) => {
-                if after_semi + 2 < self.tokens.len() {
-                    matches!(
-                        (self.token_at(after_semi + 1), self.token_at(after_semi + 2)),
-                        (
-                            Some(Token::Ident(_) | Token::Underscore),
-                            Some(Token::Colon)
-                        )
-                    )
-                } else {
-                    false
-                }
-            }
+            Some(Token::Caret) => matches!(
+                (self.token_at(after_semi + 1), self.token_at(after_semi + 2)),
+                (
+                    Some(Token::Ident(_) | Token::Underscore),
+                    Some(Token::Colon)
+                )
+            ),
             // ~ident: or ~_: → ok pattern
-            Some(Token::Tilde) => {
-                if after_semi + 2 < self.tokens.len() {
-                    matches!(
-                        (self.token_at(after_semi + 1), self.token_at(after_semi + 2)),
-                        (
-                            Some(Token::Ident(_) | Token::Underscore),
-                            Some(Token::Colon)
-                        )
-                    )
-                } else {
-                    false
-                }
-            }
+            Some(Token::Tilde) => matches!(
+                (self.token_at(after_semi + 1), self.token_at(after_semi + 2)),
+                (
+                    Some(Token::Ident(_) | Token::Underscore),
+                    Some(Token::Colon)
+                )
+            ),
             // _: → wildcard
             Some(Token::Underscore) => {
                 after_semi + 1 < self.tokens.len()
@@ -1214,17 +1202,13 @@ impl Parser {
             }
             // n/t/b/l ident: or n/t/b/l _: → TypeIs pattern
             Some(Token::Ident(ty_name)) if matches!(ty_name.as_str(), "n" | "t" | "b" | "l") => {
-                if after_semi + 2 < self.tokens.len() {
-                    matches!(
-                        (self.token_at(after_semi + 1), self.token_at(after_semi + 2)),
-                        (
-                            Some(Token::Ident(_) | Token::Underscore),
-                            Some(Token::Colon)
-                        )
+                matches!(
+                    (self.token_at(after_semi + 1), self.token_at(after_semi + 2)),
+                    (
+                        Some(Token::Ident(_) | Token::Underscore),
+                        Some(Token::Colon)
                     )
-                } else {
-                    false
-                }
+                )
             }
             _ => false,
         }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -212,6 +212,21 @@ fn compatible(a: &Ty, b: &Ty) -> bool {
     }
 }
 
+/// Validate a value being passed as a map key against the map's declared
+/// key type. Allowed scalar key types are `Text` and `Number`; both may be
+/// passed where the declared key type is `Unknown` (uninferred). Otherwise
+/// the supplied type must be `compatible` with the declared type.
+fn is_valid_map_key_arg(supplied: &Ty, declared: &Ty) -> bool {
+    if matches!(supplied, Ty::Unknown) || matches!(declared, Ty::Unknown) {
+        return true;
+    }
+    // A scalar map key must be text or number; nothing else.
+    if !matches!(supplied, Ty::Text | Ty::Number) {
+        return false;
+    }
+    compatible(supplied, declared)
+}
+
 /// Diagnostic-layer hint for an undefined kebab-case identifier whose halves
 /// are themselves bound in scope. Misreading `best-d` (single identifier) as
 /// `best - d` (subtraction) is a recurring persona footgun; the lexer always
@@ -1848,7 +1863,17 @@ fn builtin_check_args(
             (Ty::List(Box::new(Ty::List(Box::new(inner)))), errors)
         }
         "frq" => {
-            // frq xs:L a → M t n — count occurrences of each element.
+            // frq xs:L a → M a n — count occurrences of each element. The
+            // resulting map's key type matches the element type of the list
+            // (Text → M t n; Number → M n n; Bool → M t n since bools are
+            // stringified at the MapKey boundary).
+            let key_ty = match arg_types.first() {
+                Some(Ty::List(inner)) => match inner.as_ref() {
+                    Ty::Bool => Ty::Text,
+                    other => other.clone(),
+                },
+                _ => Ty::Unknown,
+            };
             if let Some(first) = arg_types.first()
                 && !matches!(first, Ty::List(_) | Ty::Unknown)
             {
@@ -1861,7 +1886,7 @@ fn builtin_check_args(
                     is_warning: false,
                 });
             }
-            (Ty::Map(Box::new(Ty::Text), Box::new(Ty::Number)), errors)
+            (Ty::Map(Box::new(key_ty), Box::new(Ty::Number)), errors)
         }
         "cumsum" => {
             if let Some(arg) = arg_types.first() {
@@ -1907,18 +1932,22 @@ fn builtin_check_args(
             errors,
         ),
         "mget" => {
-            // mget map key → O value_type
-            let val_ty = match arg_types.first() {
-                Some(Ty::Map(_, v)) => *v.clone(),
-                _ => Ty::Unknown,
+            // mget map key → O value_type. The key type must be compatible
+            // with the declared map key type (text or number); we no longer
+            // hard-code "must be text" — see PR #257 for the MapKey rollout.
+            let (key_ty_decl, val_ty) = match arg_types.first() {
+                Some(Ty::Map(k, v)) => (*k.clone(), *v.clone()),
+                _ => (Ty::Unknown, Ty::Unknown),
             };
             if let Some(key_ty) = arg_types.get(1)
-                && !compatible(key_ty, &Ty::Text)
+                && !is_valid_map_key_arg(key_ty, &key_ty_decl)
             {
                 errors.push(VerifyError {
                     code: "ILO-T013",
                     function: func_ctx.to_string(),
-                    message: format!("'mget' key must be t, got {key_ty}"),
+                    message: format!(
+                        "'mget' key must match map key type {key_ty_decl}, got {key_ty}"
+                    ),
                     hint: None,
                     span,
                     is_warning: false,
@@ -1927,17 +1956,41 @@ fn builtin_check_args(
             (Ty::Optional(Box::new(val_ty)), errors)
         }
         "mset" => {
-            // mset map key val → map (same type as input map, or inferred)
+            // mset map key val → map (same key type as input map, value type
+            // inferred from the third arg if not previously known).
+            let (key_ty_decl, val_ty_decl) = match arg_types.first() {
+                Some(Ty::Map(k, v)) => (Some(*k.clone()), Some(*v.clone())),
+                _ => (None, None),
+            };
+            if let (Some(key_ty), Some(decl)) = (arg_types.get(1), key_ty_decl.as_ref())
+                && !is_valid_map_key_arg(key_ty, decl)
+            {
+                errors.push(VerifyError {
+                    code: "ILO-T013",
+                    function: func_ctx.to_string(),
+                    message: format!("'mset' key must match map key type {decl}, got {key_ty}"),
+                    hint: None,
+                    span,
+                    is_warning: false,
+                });
+            }
             let map_ty = match arg_types.first() {
                 Some(Ty::Map(k, _)) => {
                     let val_ty = arg_types.get(2).cloned().unwrap_or(Ty::Unknown);
                     Ty::Map(k.clone(), Box::new(val_ty))
                 }
-                _ => Ty::Map(Box::new(Ty::Unknown), Box::new(Ty::Unknown)),
+                _ => Ty::Map(
+                    Box::new(Ty::Unknown),
+                    Box::new(val_ty_decl.unwrap_or(Ty::Unknown)),
+                ),
             };
             (map_ty, errors)
         }
         "mhas" => {
+            let key_ty_decl = match arg_types.first() {
+                Some(Ty::Map(k, _)) => *k.clone(),
+                _ => Ty::Unknown,
+            };
             if let Some(first) = arg_types.first()
                 && !matches!(first, Ty::Map(_, _) | Ty::Unknown)
             {
@@ -1945,6 +1998,20 @@ fn builtin_check_args(
                     code: "ILO-T013",
                     function: func_ctx.to_string(),
                     message: format!("'mhas' expects a map, got {first}"),
+                    hint: None,
+                    span,
+                    is_warning: false,
+                });
+            }
+            if let Some(key_ty) = arg_types.get(1)
+                && !is_valid_map_key_arg(key_ty, &key_ty_decl)
+            {
+                errors.push(VerifyError {
+                    code: "ILO-T013",
+                    function: func_ctx.to_string(),
+                    message: format!(
+                        "'mhas' key must match map key type {key_ty_decl}, got {key_ty}"
+                    ),
                     hint: None,
                     span,
                     is_warning: false,
@@ -1965,7 +2032,12 @@ fn builtin_check_args(
                     is_warning: false,
                 });
             }
-            (Ty::List(Box::new(Ty::Text)), errors)
+            // mkeys returns the declared key type (was hard-coded to L t).
+            let key_ty = match arg_types.first() {
+                Some(Ty::Map(k, _)) => *k.clone(),
+                _ => Ty::Text,
+            };
+            (Ty::List(Box::new(key_ty)), errors)
         }
         "mvals" => {
             let val_ty = match arg_types.first() {
@@ -1975,6 +2047,24 @@ fn builtin_check_args(
             (Ty::List(Box::new(val_ty)), errors)
         }
         "mdel" => {
+            let key_ty_decl = match arg_types.first() {
+                Some(Ty::Map(k, _)) => *k.clone(),
+                _ => Ty::Unknown,
+            };
+            if let Some(key_ty) = arg_types.get(1)
+                && !is_valid_map_key_arg(key_ty, &key_ty_decl)
+            {
+                errors.push(VerifyError {
+                    code: "ILO-T013",
+                    function: func_ctx.to_string(),
+                    message: format!(
+                        "'mdel' key must match map key type {key_ty_decl}, got {key_ty}"
+                    ),
+                    hint: None,
+                    span,
+                    is_warning: false,
+                });
+            }
             let map_ty = match arg_types.first() {
                 Some(ty @ Ty::Map(_, _)) => ty.clone(),
                 _ => Ty::Map(Box::new(Ty::Unknown), Box::new(Ty::Unknown)),
@@ -5896,13 +5986,32 @@ mod tests {
     }
 
     #[test]
-    fn mget_key_non_text() {
-        // mget key must be t; passing n (123) should error
+    fn mget_key_type_mismatch() {
+        // Map declared with text keys (M t n); passing a number key
+        // mismatches and should error.
         let errs = parse_and_verify("f m:M t n>O n;mget m 123").unwrap_err();
         assert!(
             errs.iter()
                 .any(|e| e.code == "ILO-T013" && e.message.contains("mget"))
         );
+    }
+
+    #[test]
+    fn mget_numeric_key_ok() {
+        // Map declared with numeric keys (M n t); passing a number key is fine.
+        assert!(parse_and_verify("f m:M n t>O t;mget m 42").is_ok());
+    }
+
+    #[test]
+    fn mset_numeric_key_ok() {
+        // Map declared with numeric keys (M n n); mset accepts numeric keys.
+        assert!(parse_and_verify("f m:M n n>M n n;mset m 7 11").is_ok());
+    }
+
+    #[test]
+    fn mkeys_numeric_returns_list_of_numbers() {
+        // mkeys returns L of the declared key type — L n for M n t.
+        assert!(parse_and_verify("f m:M n t>L n;mkeys m").is_ok());
     }
 
     #[test]

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -2528,19 +2528,18 @@ impl VerifyContext {
 
     fn validate_named_type_recursive(&mut self, ty: &Ty, ctx: &str) {
         match ty {
-            Ty::Named(name) => {
-                if !self.types.contains_key(name) {
-                    let hint = closest_match(name, self.types.keys())
-                        .map(|s| format!("did you mean '{s}'?"));
-                    self.err(
-                        "ILO-T003",
-                        ctx,
-                        format!("undefined type '{name}'"),
-                        hint,
-                        None,
-                    );
-                }
+            Ty::Named(name) if !self.types.contains_key(name) => {
+                let hint =
+                    closest_match(name, self.types.keys()).map(|s| format!("did you mean '{s}'?"));
+                self.err(
+                    "ILO-T003",
+                    ctx,
+                    format!("undefined type '{name}'"),
+                    hint,
+                    None,
+                );
             }
+            Ty::Named(_) => {}
             Ty::List(inner) => self.validate_named_type_recursive(inner, ctx),
             Ty::Result(ok, err) => {
                 self.validate_named_type_recursive(ok, ctx);

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -4689,7 +4689,7 @@ impl<'a> VM<'a> {
                         match map_v.as_heap_ref() {
                             HeapObj::Map(m) => {
                                 let mut pairs: Vec<(&MapKey, &NanVal)> = m.iter().collect();
-                                pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+                                pairs.sort_by_key(|(k, _)| (*k).clone());
                                 let nan_vals: Vec<NanVal> = pairs
                                     .iter()
                                     .map(|(_, v)| {
@@ -12032,7 +12032,7 @@ pub(crate) extern "C" fn jit_mvals(map: u64) -> u64 {
         match map_v.as_heap_ref() {
             HeapObj::Map(m) => {
                 let mut pairs: Vec<(&MapKey, &NanVal)> = m.iter().collect();
-                pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+                pairs.sort_by_key(|(k, _)| (*k).clone());
                 let nan_vals: Vec<NanVal> = pairs
                     .iter()
                     .map(|(_, v)| {

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -1,6 +1,6 @@
 use crate::ast::*;
 use crate::builtins::{Builtin, CharAtResult, char_at_signed};
-use crate::interpreter::Value;
+use crate::interpreter::{MapKey, Value};
 use std::collections::HashMap;
 use std::rc::Rc;
 
@@ -3544,7 +3544,7 @@ impl Drop for JitRuntimeErrorGuard {
 enum HeapObj {
     Str(String),
     List(Vec<NanVal>),
-    Map(HashMap<String, NanVal>),
+    Map(HashMap<MapKey, NanVal>),
     Record {
         type_info: Rc<TypeInfo>,
         fields: Box<[NanVal]>,
@@ -3692,7 +3692,7 @@ impl NanVal {
         NanVal(TAG_ERR | (ptr & PTR_MASK))
     }
 
-    fn heap_map(m: HashMap<String, NanVal>) -> Self {
+    fn heap_map(m: HashMap<MapKey, NanVal>) -> Self {
         let rc = Rc::new(HeapObj::Map(m));
         let ptr = Rc::into_raw(rc) as u64;
         NanVal(TAG_MAP | (ptr & PTR_MASK))
@@ -3799,7 +3799,7 @@ impl NanVal {
             Value::Text(s) => NanVal::heap_string(s.clone()),
             Value::List(items) => NanVal::heap_list(items.iter().map(NanVal::from_value).collect()),
             Value::Map(m) => {
-                let nan_map: HashMap<String, NanVal> = m
+                let nan_map: HashMap<MapKey, NanVal> = m
                     .iter()
                     .map(|(k, v)| (k.clone(), NanVal::from_value(v)))
                     .collect();
@@ -4553,18 +4553,22 @@ impl<'a> VM<'a> {
                     let c = (inst & 0xFF) as usize + base;
                     let map_v = reg!(b);
                     let key_v = reg!(c);
+                    let mk = match nanval_to_map_key(key_v) {
+                        Some(k) => k,
+                        None => vm_err!(VmError::Type("mget: key must be text or finite number")),
+                    };
+                    if (map_v.0 & TAG_MASK) != TAG_MAP {
+                        vm_err!(VmError::Type("mget: first arg must be a map"));
+                    }
                     let result = unsafe {
                         match map_v.as_heap_ref() {
-                            HeapObj::Map(m) => match key_v.as_heap_ref() {
-                                HeapObj::Str(k) => m
-                                    .get(k.as_str())
-                                    .map(|v| {
-                                        v.clone_rc();
-                                        *v
-                                    })
-                                    .unwrap_or_else(NanVal::nil),
-                                _ => vm_err!(VmError::Type("mget: key must be text")),
-                            },
+                            HeapObj::Map(m) => m
+                                .get(&mk)
+                                .map(|v| {
+                                    v.clone_rc();
+                                    *v
+                                })
+                                .unwrap_or_else(NanVal::nil),
                             _ => vm_err!(VmError::Type("mget: first arg must be a map")),
                         }
                     };
@@ -4585,9 +4589,10 @@ impl<'a> VM<'a> {
                     if (map_v.0 & TAG_MASK) != TAG_MAP {
                         vm_err!(VmError::Type("mset: first arg must be a map"));
                     }
-                    if !key_v.is_string() {
-                        vm_err!(VmError::Type("mset: key must be text"));
-                    }
+                    let mk = match nanval_to_map_key(key_v) {
+                        Some(k) => k,
+                        None => vm_err!(VmError::Type("mset: key must be text or finite number")),
+                    };
                     let ptr_b = (map_v.0 & PTR_MASK) as *const HeapObj;
                     // Peek the RC count without reconstructing the Rc (which would bump it).
                     // Same pattern as OP_LISTAPPEND / OP_ADD_SS RC=1 fast paths.
@@ -4608,14 +4613,8 @@ impl<'a> VM<'a> {
                         let heap_mut = unsafe { &mut *(ptr_b as *mut HeapObj) };
                         match heap_mut {
                             HeapObj::Map(m) => {
-                                let k_str = unsafe {
-                                    match key_v.as_heap_ref() {
-                                        HeapObj::Str(s) => s.clone(),
-                                        _ => unreachable!(),
-                                    }
-                                };
                                 val_v.clone_rc();
-                                if let Some(old) = m.insert(k_str, val_v) {
+                                if let Some(old) = m.insert(mk, val_v) {
                                     old.drop_rc();
                                 }
                             }
@@ -4631,12 +4630,8 @@ impl<'a> VM<'a> {
                                     for v in new_map.values() {
                                         v.clone_rc();
                                     }
-                                    let k_str = match key_v.as_heap_ref() {
-                                        HeapObj::Str(s) => s.clone(),
-                                        _ => unreachable!(),
-                                    };
                                     val_v.clone_rc();
-                                    if let Some(old) = new_map.insert(k_str, val_v) {
+                                    if let Some(old) = new_map.insert(mk, val_v) {
                                         old.drop_rc();
                                     }
                                     NanVal::heap_map(new_map)
@@ -4653,12 +4648,16 @@ impl<'a> VM<'a> {
                     let c = (inst & 0xFF) as usize + base;
                     let map_v = reg!(b);
                     let key_v = reg!(c);
+                    let mk = match nanval_to_map_key(key_v) {
+                        Some(k) => k,
+                        None => vm_err!(VmError::Type("mhas: key must be text or finite number")),
+                    };
+                    if (map_v.0 & TAG_MASK) != TAG_MAP {
+                        vm_err!(VmError::Type("mhas: first arg must be a map"));
+                    }
                     let result = unsafe {
                         match map_v.as_heap_ref() {
-                            HeapObj::Map(m) => match key_v.as_heap_ref() {
-                                HeapObj::Str(k) => NanVal::boolean(m.contains_key(k.as_str())),
-                                _ => vm_err!(VmError::Type("mhas: key must be text")),
-                            },
+                            HeapObj::Map(m) => NanVal::boolean(m.contains_key(&mk)),
                             _ => vm_err!(VmError::Type("mhas: first arg must be a map")),
                         }
                     };
@@ -4671,12 +4670,10 @@ impl<'a> VM<'a> {
                     let result = unsafe {
                         match map_v.as_heap_ref() {
                             HeapObj::Map(m) => {
-                                let mut keys: Vec<&String> = m.keys().collect();
+                                let mut keys: Vec<&MapKey> = m.keys().collect();
                                 keys.sort();
-                                let nan_keys: Vec<NanVal> = keys
-                                    .iter()
-                                    .map(|k| NanVal::heap_string((*k).clone()))
-                                    .collect();
+                                let nan_keys: Vec<NanVal> =
+                                    keys.iter().map(|k| map_key_to_nanval(k)).collect();
                                 NanVal::heap_list(nan_keys)
                             }
                             _ => vm_err!(VmError::Type("mkeys: expects a map")),
@@ -4691,8 +4688,8 @@ impl<'a> VM<'a> {
                     let result = unsafe {
                         match map_v.as_heap_ref() {
                             HeapObj::Map(m) => {
-                                let mut pairs: Vec<(&String, &NanVal)> = m.iter().collect();
-                                pairs.sort_by_key(|(k, _)| k.as_str());
+                                let mut pairs: Vec<(&MapKey, &NanVal)> = m.iter().collect();
+                                pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
                                 let nan_vals: Vec<NanVal> = pairs
                                     .iter()
                                     .map(|(_, v)| {
@@ -4713,24 +4710,28 @@ impl<'a> VM<'a> {
                     let c = (inst & 0xFF) as usize + base;
                     let map_v = reg!(b);
                     let key_v = reg!(c);
+                    let mk = match nanval_to_map_key(key_v) {
+                        Some(k) => k,
+                        None => vm_err!(VmError::Type("mdel: key must be text or finite number")),
+                    };
+                    if (map_v.0 & TAG_MASK) != TAG_MAP {
+                        vm_err!(VmError::Type("mdel: first arg must be a map"));
+                    }
                     let result = unsafe {
                         match map_v.as_heap_ref() {
-                            HeapObj::Map(m) => match key_v.as_heap_ref() {
-                                HeapObj::Str(k) => {
-                                    let mut new_map = m.clone();
-                                    // m.clone() bit-copies values; bump RC for each retained entry
-                                    for v in new_map.values() {
-                                        v.clone_rc();
-                                    }
-                                    // drop_rc the removed value before HashMap::remove discards it,
-                                    // otherwise its inner heap RC leaks/double-frees on next gc.
-                                    if let Some(removed) = new_map.remove(k.as_str()) {
-                                        removed.drop_rc();
-                                    }
-                                    NanVal::heap_map(new_map)
+                            HeapObj::Map(m) => {
+                                let mut new_map = m.clone();
+                                // m.clone() bit-copies values; bump RC for each retained entry
+                                for v in new_map.values() {
+                                    v.clone_rc();
                                 }
-                                _ => vm_err!(VmError::Type("mdel: key must be text")),
-                            },
+                                // drop_rc the removed value before HashMap::remove discards it,
+                                // otherwise its inner heap RC leaks/double-frees on next gc.
+                                if let Some(removed) = new_map.remove(&mk) {
+                                    removed.drop_rc();
+                                }
+                                NanVal::heap_map(new_map)
+                            }
                             _ => vm_err!(VmError::Type("mdel: first arg must be a map")),
                         }
                     };
@@ -6886,7 +6887,7 @@ impl<'a> VM<'a> {
                                             _ => unreachable!(),
                                         }
                                     };
-                                    req = req.with_header(k.as_str(), &vs);
+                                    req = req.with_header(k.to_display_string().as_str(), &vs);
                                 }
                             }
                         }
@@ -6985,7 +6986,7 @@ impl<'a> VM<'a> {
                                             _ => unreachable!(),
                                         }
                                     };
-                                    req = req.with_header(k.as_str(), &vs);
+                                    req = req.with_header(k.to_display_string().as_str(), &vs);
                                 }
                             }
                         }
@@ -8130,18 +8131,18 @@ impl<'a> VM<'a> {
                             _ => unreachable!(),
                         }
                     };
-                    let mut counts: std::collections::HashMap<String, usize> =
+                    let mut counts: std::collections::HashMap<MapKey, usize> =
                         std::collections::HashMap::new();
                     for item in items {
-                        let key_str = match nanval_to_key_string(item) {
-                            Some(s) => s,
+                        let mk = match nanval_to_grouping_key(item) {
+                            Some(k) => k,
                             None => vm_err!(VmError::Type(
                                 "frq: list elements must be text, number, or bool"
                             )),
                         };
-                        *counts.entry(key_str).or_insert(0) += 1;
+                        *counts.entry(mk).or_insert(0) += 1;
                     }
-                    let map: std::collections::HashMap<String, NanVal> = counts
+                    let map: std::collections::HashMap<MapKey, NanVal> = counts
                         .into_iter()
                         .map(|(k, c)| (k, NanVal::number(c as f64)))
                         .collect();
@@ -8293,24 +8294,28 @@ unsafe fn nanval_str_cmp(a: NanVal, b: NanVal) -> std::cmp::Ordering {
 /// as `grp idt xs`. The earlier type-prefixed shape (`n:` / `t:` / `b:`)
 /// leaked an internal disambiguation convention into the API surface and
 /// has been removed.
-fn nanval_to_key_string(v: NanVal) -> Option<String> {
+/// Convert a NanVal into a `MapKey` for `grp`/`frq`. Mirrors the tree-walker's
+/// policy in `interpreter::call_function` for those builtins: text and number
+/// keep their type, bools become text "true"/"false", non-finite numbers
+/// fail. Floats floor to i64 to match `MapKey::from_value`.
+fn nanval_to_grouping_key(v: NanVal) -> Option<MapKey> {
     if v.is_number() {
         let n = v.as_number();
-        if n.fract() == 0.0 && n.abs() < 1e15 {
-            return Some(format!("{}", n as i64));
+        if !n.is_finite() {
+            return None;
         }
-        return Some(format!("{n}"));
+        return Some(MapKey::Int(n.floor() as i64));
     }
     match v.0 {
-        TAG_TRUE => return Some("true".to_string()),
-        TAG_FALSE => return Some("false".to_string()),
+        TAG_TRUE => return Some(MapKey::Text("true".to_string())),
+        TAG_FALSE => return Some(MapKey::Text("false".to_string())),
         _ => {}
     }
     if v.is_string() {
         // SAFETY: is_string() confirmed.
         unsafe {
             return match v.as_heap_ref() {
-                HeapObj::Str(s) => Some(s.as_str().to_owned()),
+                HeapObj::Str(s) => Some(MapKey::Text(s.clone())),
                 _ => None,
             };
         }
@@ -8351,6 +8356,42 @@ fn nanval_to_matrix(v: NanVal) -> std::result::Result<Vec<Vec<f64>>, &'static st
         out.push(nanval_to_vec(*row)?);
     }
     Ok(out)
+}
+
+/// Convert a NanVal map key into a typed `MapKey`. Returns `None` on a type
+/// the map-key boundary rejects (NaN, ±Inf, non-string non-number heap
+/// values). Numbers floor to i64 to match `at xs i` and the tree-walker's
+/// `MapKey::from_value`.
+#[inline]
+fn nanval_to_map_key(key_v: NanVal) -> Option<MapKey> {
+    if key_v.is_number() {
+        let n = key_v.as_number();
+        if !n.is_finite() {
+            return None;
+        }
+        return Some(MapKey::Int(n.floor() as i64));
+    }
+    if key_v.is_string() {
+        // SAFETY: is_string() confirmed heap-tagged string with live RC.
+        let s = unsafe {
+            match key_v.as_heap_ref() {
+                HeapObj::Str(s) => s.clone(),
+                _ => return None,
+            }
+        };
+        return Some(MapKey::Text(s));
+    }
+    None
+}
+
+/// Convert a typed `MapKey` back into a NanVal — used when materialising
+/// `mkeys`. Text keys become heap strings; Int keys become numeric NanVals.
+#[inline]
+fn map_key_to_nanval(k: &MapKey) -> NanVal {
+    match k {
+        MapKey::Text(s) => NanVal::heap_string(s.clone()),
+        MapKey::Int(n) => NanVal::number(*n as f64),
+    }
 }
 
 fn nanval_to_json(v: NanVal) -> serde_json::Value {
@@ -8413,7 +8454,7 @@ fn nanval_to_json(v: NanVal) -> serde_json::Value {
                     HeapObj::Map(m) => {
                         let obj: serde_json::Map<String, serde_json::Value> = m
                             .iter()
-                            .map(|(k, v)| (k.clone(), nanval_to_json(*v)))
+                            .map(|(k, v)| (k.to_display_string(), nanval_to_json(*v)))
                             .collect();
                         serde_json::Value::Object(obj)
                     }
@@ -11816,24 +11857,22 @@ pub(crate) extern "C" fn jit_mget(map: u64, key: u64) -> u64 {
         jit_set_runtime_error(VmError::Type("mget: first arg must be a map"));
         return TAG_NIL;
     }
-    if !key_v.is_string() {
-        jit_set_runtime_error(VmError::Type("mget: key must be text"));
-        return TAG_NIL;
-    }
+    let mk = match nanval_to_map_key(key_v) {
+        Some(k) => k,
+        None => {
+            jit_set_runtime_error(VmError::Type("mget: key must be text or number"));
+            return TAG_NIL;
+        }
+    };
     unsafe {
         match map_v.as_heap_ref() {
-            HeapObj::Map(m) => match key_v.as_heap_ref() {
-                HeapObj::Str(k) => m
-                    .get(k.as_str())
-                    .map(|v| {
-                        v.clone_rc();
-                        v.0
-                    })
-                    .unwrap_or(TAG_NIL),
-                // Unreachable in practice: is_string() above already narrowed
-                // the key to HeapObj::Str. Kept as a defensive nil.
-                _ => TAG_NIL,
-            },
+            HeapObj::Map(m) => m
+                .get(&mk)
+                .map(|v| {
+                    v.clone_rc();
+                    v.0
+                })
+                .unwrap_or(TAG_NIL),
             // Unreachable: TAG_MAP check above already narrowed map_v.
             _ => TAG_NIL,
         }
@@ -11855,9 +11894,13 @@ pub(crate) extern "C" fn jit_mset(map: u64, key: u64, val: u64) -> u64 {
     let map_v = NanVal(map);
     let key_v = NanVal(key);
     let val_v = NanVal(val);
-    if (map_v.0 & TAG_MASK) != TAG_MAP || !key_v.is_string() {
+    if (map_v.0 & TAG_MASK) != TAG_MAP {
         return TAG_NIL;
     }
+    let mk = match nanval_to_map_key(key_v) {
+        Some(k) => k,
+        None => return TAG_NIL,
+    };
     let ptr_b = (map_v.0 & PTR_MASK) as *const HeapObj;
     unsafe {
         match &*ptr_b {
@@ -11870,12 +11913,8 @@ pub(crate) extern "C" fn jit_mset(map: u64, key: u64, val: u64) -> u64 {
                 for v in new_map.values() {
                     v.clone_rc();
                 }
-                let k_str = match key_v.as_heap_ref() {
-                    HeapObj::Str(s) => s.clone(),
-                    _ => return TAG_NIL,
-                };
                 val_v.clone_rc();
-                if let Some(old) = new_map.insert(k_str, val_v) {
+                if let Some(old) = new_map.insert(mk, val_v) {
                     old.drop_rc();
                 }
                 NanVal::heap_map(new_map).0
@@ -11904,9 +11943,13 @@ pub(crate) extern "C" fn jit_mset_inplace(map: u64, key: u64, val: u64) -> u64 {
     let map_v = NanVal(map);
     let key_v = NanVal(key);
     let val_v = NanVal(val);
-    if (map_v.0 & TAG_MASK) != TAG_MAP || !key_v.is_string() {
+    if (map_v.0 & TAG_MASK) != TAG_MAP {
         return TAG_NIL;
     }
+    let mk = match nanval_to_map_key(key_v) {
+        Some(k) => k,
+        None => return TAG_NIL,
+    };
     let ptr_b = (map_v.0 & PTR_MASK) as *const HeapObj;
     // Peek the RC count without taking ownership.
     let rc_count = {
@@ -11923,14 +11966,8 @@ pub(crate) extern "C" fn jit_mset_inplace(map: u64, key: u64, val: u64) -> u64 {
         let heap_mut = unsafe { &mut *(ptr_b as *mut HeapObj) };
         match heap_mut {
             HeapObj::Map(m) => {
-                let k_str = unsafe {
-                    match key_v.as_heap_ref() {
-                        HeapObj::Str(s) => s.clone(),
-                        _ => return TAG_NIL,
-                    }
-                };
                 val_v.clone_rc();
-                if let Some(old) = m.insert(k_str, val_v) {
+                if let Some(old) = m.insert(mk, val_v) {
                     old.drop_rc();
                 }
                 // Return the same NanVal pointer — RC still 1.
@@ -11949,15 +11986,16 @@ pub(crate) extern "C" fn jit_mset_inplace(map: u64, key: u64, val: u64) -> u64 {
 pub(crate) extern "C" fn jit_mhas(map: u64, key: u64) -> u64 {
     let map_v = NanVal(map);
     let key_v = NanVal(key);
-    if !map_v.is_heap() || !key_v.is_heap() {
+    if (map_v.0 & TAG_MASK) != TAG_MAP {
         return TAG_FALSE;
     }
+    let mk = match nanval_to_map_key(key_v) {
+        Some(k) => k,
+        None => return TAG_FALSE,
+    };
     unsafe {
         match map_v.as_heap_ref() {
-            HeapObj::Map(m) => match key_v.as_heap_ref() {
-                HeapObj::Str(k) => NanVal::boolean(m.contains_key(k.as_str())).0,
-                _ => TAG_FALSE,
-            },
+            HeapObj::Map(m) => NanVal::boolean(m.contains_key(&mk)).0,
             _ => TAG_FALSE,
         }
     }
@@ -11973,12 +12011,9 @@ pub(crate) extern "C" fn jit_mkeys(map: u64) -> u64 {
     unsafe {
         match map_v.as_heap_ref() {
             HeapObj::Map(m) => {
-                let mut keys: Vec<&String> = m.keys().collect();
+                let mut keys: Vec<&MapKey> = m.keys().collect();
                 keys.sort();
-                let nan_keys: Vec<NanVal> = keys
-                    .iter()
-                    .map(|k| NanVal::heap_string((*k).clone()))
-                    .collect();
+                let nan_keys: Vec<NanVal> = keys.iter().map(|k| map_key_to_nanval(k)).collect();
                 NanVal::heap_list(nan_keys).0
             }
             _ => TAG_NIL,
@@ -11996,8 +12031,8 @@ pub(crate) extern "C" fn jit_mvals(map: u64) -> u64 {
     unsafe {
         match map_v.as_heap_ref() {
             HeapObj::Map(m) => {
-                let mut pairs: Vec<(&String, &NanVal)> = m.iter().collect();
-                pairs.sort_by_key(|(k, _)| k.as_str());
+                let mut pairs: Vec<(&MapKey, &NanVal)> = m.iter().collect();
+                pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
                 let nan_vals: Vec<NanVal> = pairs
                     .iter()
                     .map(|(_, v)| {
@@ -12017,19 +12052,27 @@ pub(crate) extern "C" fn jit_mvals(map: u64) -> u64 {
 pub(crate) extern "C" fn jit_mdel(map: u64, key: u64) -> u64 {
     let map_v = NanVal(map);
     let key_v = NanVal(key);
-    if !map_v.is_heap() || !key_v.is_heap() {
+    if (map_v.0 & TAG_MASK) != TAG_MAP {
         return TAG_NIL;
     }
+    let mk = match nanval_to_map_key(key_v) {
+        Some(k) => k,
+        None => return TAG_NIL,
+    };
     unsafe {
         match map_v.as_heap_ref() {
-            HeapObj::Map(m) => match key_v.as_heap_ref() {
-                HeapObj::Str(k) => {
-                    let mut new_map = m.clone();
-                    new_map.remove(k.as_str());
-                    NanVal::heap_map(new_map).0
+            HeapObj::Map(m) => {
+                let mut new_map = m.clone();
+                // m.clone() bit-copies values; bump RC for each retained
+                // entry so the new map owns its values independently.
+                for v in new_map.values() {
+                    v.clone_rc();
                 }
-                _ => TAG_NIL,
-            },
+                if let Some(removed) = new_map.remove(&mk) {
+                    removed.drop_rc();
+                }
+                NanVal::heap_map(new_map).0
+            }
             _ => TAG_NIL,
         }
     }
@@ -12287,14 +12330,14 @@ pub(crate) extern "C" fn jit_frq(v: u64) -> u64 {
             _ => return TAG_NIL,
         }
     };
-    let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    let mut counts: std::collections::HashMap<MapKey, usize> = std::collections::HashMap::new();
     for item in items {
-        match nanval_to_key_string(item) {
-            Some(s) => *counts.entry(s).or_insert(0) += 1,
+        match nanval_to_grouping_key(item) {
+            Some(k) => *counts.entry(k).or_insert(0) += 1,
             None => return TAG_NIL,
         }
     }
-    let map: std::collections::HashMap<String, NanVal> = counts
+    let map: std::collections::HashMap<MapKey, NanVal> = counts
         .into_iter()
         .map(|(k, c)| (k, NanVal::number(c as f64)))
         .collect();
@@ -12495,7 +12538,7 @@ pub(crate) extern "C" fn jit_geth(url_v: u64, headers_v: u64) -> u64 {
                             _ => unreachable!(),
                         }
                     };
-                    req = req.with_header(k.as_str(), &vs);
+                    req = req.with_header(k.to_display_string().as_str(), &vs);
                 }
             }
         }
@@ -12553,7 +12596,7 @@ pub(crate) extern "C" fn jit_posth(url_v: u64, body_v: u64, headers_v: u64) -> u
                             _ => unreachable!(),
                         }
                     };
-                    req = req.with_header(k.as_str(), &vs);
+                    req = req.with_header(k.to_display_string().as_str(), &vs);
                 }
             }
         }
@@ -15012,7 +15055,10 @@ mod tests {
         // bad host → Err value, even with headers passed as parameter
         let src = r#"f url:t hdrs:M t t>R t t;get url hdrs"#;
         let mut headers = std::collections::HashMap::new();
-        headers.insert("x-api-key".to_string(), Value::Text("tok".to_string()));
+        headers.insert(
+            crate::interpreter::MapKey::Text("x-api-key".to_string()),
+            Value::Text("tok".to_string()),
+        );
         let result = vm_run(
             src,
             Some("f"),
@@ -15031,7 +15077,10 @@ mod tests {
         // bad host → Err value, even with headers passed as parameter
         let src = r#"f url:t body:t hdrs:M t t>R t t;post url body hdrs"#;
         let mut headers = std::collections::HashMap::new();
-        headers.insert("x-api-key".to_string(), Value::Text("tok".to_string()));
+        headers.insert(
+            crate::interpreter::MapKey::Text("x-api-key".to_string()),
+            Value::Text("tok".to_string()),
+        );
         let result = vm_run(
             src,
             Some("f"),
@@ -17267,7 +17316,10 @@ mod tests {
             vec![
                 Value::Map(std::sync::Arc::new({
                     let mut m = std::collections::HashMap::new();
-                    m.insert("x".to_string(), Value::Text("1".to_string()));
+                    m.insert(
+                        crate::interpreter::MapKey::Text("x".to_string()),
+                        Value::Text("1".to_string()),
+                    );
                     m
                 })),
                 Value::Text("x".to_string()),
@@ -21523,12 +21575,13 @@ mod tests {
         let Value::Map(m) = result else {
             panic!("expected Map")
         };
+        use crate::interpreter::MapKey;
         assert_eq!(
-            m.get("small").unwrap(),
+            m.get(&MapKey::Text("small".to_string())).unwrap(),
             &Value::List(vec![1.0, 3.0, 2.0].into_iter().map(Value::Number).collect())
         );
         assert_eq!(
-            m.get("big").unwrap(),
+            m.get(&MapKey::Text("big".to_string())).unwrap(),
             &Value::List(vec![8.0, 9.0].into_iter().map(Value::Number).collect())
         );
     }
@@ -21550,16 +21603,17 @@ mod tests {
         let Value::Map(m) = result else {
             panic!("expected Map")
         };
+        use crate::interpreter::MapKey;
         assert_eq!(
-            m.get("1").unwrap(),
+            m.get(&MapKey::Text("1".to_string())).unwrap(),
             &Value::List(vec![1.0, 1.0].into_iter().map(Value::Number).collect())
         );
         assert_eq!(
-            m.get("2").unwrap(),
+            m.get(&MapKey::Text("2".to_string())).unwrap(),
             &Value::List(vec![2.0, 2.0].into_iter().map(Value::Number).collect())
         );
         assert_eq!(
-            m.get("3").unwrap(),
+            m.get(&MapKey::Text("3".to_string())).unwrap(),
             &Value::List(vec![3.0].into_iter().map(Value::Number).collect())
         );
     }
@@ -21626,8 +21680,9 @@ mod tests {
         let Value::Map(m) = result else {
             panic!("expected map")
         };
-        assert!(m.contains_key("true"));
-        assert!(m.contains_key("false"));
+        use crate::interpreter::MapKey;
+        assert!(m.contains_key(&MapKey::Text("true".to_string())));
+        assert!(m.contains_key(&MapKey::Text("false".to_string())));
     }
 
     #[test]
@@ -21646,9 +21701,11 @@ mod tests {
         let Value::Map(m) = result else {
             panic!("expected Map")
         };
+        use crate::interpreter::MapKey;
+        // Floats floor to i64 at MapKey boundary: 0.5 → 0, 1.5 → 1.
         assert!(
-            m.contains_key("0.5") || m.contains_key("1.5"),
-            "expected float key, got: {:?}",
+            m.contains_key(&MapKey::Int(0)) || m.contains_key(&MapKey::Int(1)),
+            "expected floored numeric key, got: {:?}",
             m.keys().collect::<Vec<_>>()
         );
     }

--- a/tests/regression_frq.rs
+++ b/tests/regression_frq.rs
@@ -1,7 +1,8 @@
-// Regression tests for the `frq xs` builtin: returns a frequency map
-// `M t n` (text key → count of occurrences). Unlike `grp`/`uniqby`, `frq`
-// is not a higher-order function — it takes a single list and keys by the
-// stringified element values, so it can be wired through every engine.
+// Regression tests for the `frq xs` builtin: returns a frequency map keyed
+// by the element type. `frq [text]` produces `M t n`; `frq [number]` produces
+// `M n n`. Unlike `grp`/`uniqby`, `frq` is not a higher-order function — it
+// takes a single list and keys by the typed element values, so it can be
+// wired through every engine.
 
 use std::process::Command;
 
@@ -54,11 +55,11 @@ fn frq_strings_cranelift() {
     check_string_freq("--run-cranelift");
 }
 
-// ── Numbers: frq [1,2,1,3,2,1] — keys are bare stringified numbers ────────
+// ── Numbers: frq [1,2,1,3,2,1] — keys preserve the number type ───────────
 
-const NUM_1_SRC: &str = r#"f>n;m=frq [1,2,1,3,2,1];r=mget m "1";?r{n v:v;_:-1}"#;
-const NUM_2_SRC: &str = r#"f>n;m=frq [1,2,1,3,2,1];r=mget m "2";?r{n v:v;_:-1}"#;
-const NUM_3_SRC: &str = r#"f>n;m=frq [1,2,1,3,2,1];r=mget m "3";?r{n v:v;_:-1}"#;
+const NUM_1_SRC: &str = r#"f>n;m=frq [1,2,1,3,2,1];r=mget m 1;?r{n v:v;_:-1}"#;
+const NUM_2_SRC: &str = r#"f>n;m=frq [1,2,1,3,2,1];r=mget m 2;?r{n v:v;_:-1}"#;
+const NUM_3_SRC: &str = r#"f>n;m=frq [1,2,1,3,2,1];r=mget m 3;?r{n v:v;_:-1}"#;
 
 fn check_num_freq(engine: &str) {
     assert_eq!(run(engine, NUM_1_SRC, "f"), "3", "engine={engine} key=1");
@@ -160,36 +161,33 @@ fn frq_mkeys_bare_cranelift() {
     check_mkeys("--run-cranelift");
 }
 
-// ── Cross-type collision: frq [1, "1", true] — the documented tradeoff.
-// With bare keys, distinct-typed values that share a print form collide on
-// the shared string. `1` and `"1"` both become key `"1"`; their counts sum.
-// `true` keeps its own key `"true"`. This matches `grp idt`'s collision
-// policy and is the deliberate price of dropping the leaky `n:`/`t:`/`b:`
-// prefix from the user-visible API surface.
+// ── Cross-type keys: frq [1, "1", true] — with typed `MapKey`, `Int(1)`,
+// `Text("1")` and `Text("true")` are distinct keys (no collision). Bools are
+// stringified to Text at the MapKey boundary. This documents the typed-key
+// behaviour introduced with MapKey: each typed value has its own slot.
 
-const CROSS_SHARED_SRC: &str = r#"f>n;m=frq [1, "1", true];r=mget m "1";?r{n v:v;_:-1}"#;
+const CROSS_NUM_SRC: &str = r#"f>n;m=frq [1, "1", true];r=mget m 1;?r{n v:v;_:-1}"#;
+const CROSS_TXT_SRC: &str = r#"f>n;m=frq [1, "1", true];r=mget m "1";?r{n v:v;_:-1}"#;
 const CROSS_BOOL_SRC: &str = r#"f>n;m=frq [1, "1", true];r=mget m "true";?r{n v:v;_:-1}"#;
-const CROSS_NOPREFIX_SRC: &str = r#"f>n;m=frq [1, "1", true];r=mget m "t:1";?r{n v:v;_:0}"#;
 
 fn check_cross_type(engine: &str) {
-    // Number(1) and Text("1") collide on bare key "1"; combined count is 2.
+    // Number(1) keeps its own typed key — count is 1.
     assert_eq!(
-        run(engine, CROSS_SHARED_SRC, "f"),
-        "2",
-        "engine={engine} shared key '1'"
+        run(engine, CROSS_NUM_SRC, "f"),
+        "1",
+        "engine={engine} numeric key 1"
     );
-    // Bool keeps its own bare key.
+    // Text("1") is a distinct key from Int(1) — count is 1.
+    assert_eq!(
+        run(engine, CROSS_TXT_SRC, "f"),
+        "1",
+        "engine={engine} text key '1'"
+    );
+    // Bool stringifies to Text("true") at the MapKey boundary — count is 1.
     assert_eq!(
         run(engine, CROSS_BOOL_SRC, "f"),
         "1",
         "engine={engine} key 'true'"
-    );
-    // The old prefixed form must no longer hit — guard against regression
-    // back to leaked type tags.
-    assert_eq!(
-        run(engine, CROSS_NOPREFIX_SRC, "f"),
-        "0",
-        "engine={engine} legacy 't:1' must not exist"
     );
 }
 

--- a/tests/regression_numeric_map_keys.rs
+++ b/tests/regression_numeric_map_keys.rs
@@ -1,0 +1,183 @@
+// Regression tests for `MapKey::Int` numeric map keys.
+//
+// Before MapKey, `Value::Map` was `HashMap<String, Value>` — every iteration
+// keyed by a loop index had to run `k=str j` first (the "routing-tsp tax").
+// With MapKey, numeric keys are first-class via `MapKey::Int(i64)`. Floats
+// floor to i64 at the builtin boundary (matching `at xs i`); NaN/Infinity are
+// rejected as runtime errors.
+//
+// These tests run the typed-key surface (mset / mget / mhas / mkeys / mvals /
+// mdel / len / jdmp / iteration determinism) through every engine (tree, VM,
+// cranelift) to catch backend drift. Text-key coverage stays in place to
+// guard against regressions in the existing behaviour.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+const ENGINES: &[&str] = &[
+    "--run-tree",
+    "--run-vm",
+    #[cfg(feature = "cranelift")]
+    "--run-cranelift",
+];
+
+// ── Text keys: existing behaviour stays correct ──────────────────────────
+
+#[test]
+fn text_key_mget() {
+    let src = r#"f>n;m=mmap;m=mset m "a" 7;r=mget m "a";?r{n v:v;_:-1}"#;
+    for e in ENGINES {
+        assert_eq!(run(e, src, "f"), "7", "engine={e}");
+    }
+}
+
+#[test]
+fn text_key_mhas() {
+    let src = r#"f>b;m=mmap;m=mset m "k" 1;mhas m "k""#;
+    for e in ENGINES {
+        assert_eq!(run(e, src, "f"), "true", "engine={e}");
+    }
+}
+
+#[test]
+fn text_key_mdel_then_miss() {
+    let src = r#"f>n;m=mmap;m=mset m "k" 1;m=mdel m "k";r=mget m "k";?r{n v:v;_:0}"#;
+    for e in ENGINES {
+        assert_eq!(run(e, src, "f"), "0", "engine={e}");
+    }
+}
+
+// ── Int keys: the new behaviour ──────────────────────────────────────────
+
+#[test]
+fn int_key_mset_mget() {
+    let src = r#"f>n;m=mmap;m=mset m 7 100;r=mget m 7;?r{n v:v;_:-1}"#;
+    for e in ENGINES {
+        assert_eq!(run(e, src, "f"), "100", "engine={e}");
+    }
+}
+
+#[test]
+fn int_key_mhas_present() {
+    let src = r#"f>b;m=mmap;m=mset m 42 0;mhas m 42"#;
+    for e in ENGINES {
+        assert_eq!(run(e, src, "f"), "true", "engine={e}");
+    }
+}
+
+#[test]
+fn int_key_mhas_missing() {
+    let src = r#"f>b;m=mmap;m=mset m 42 0;mhas m 99"#;
+    for e in ENGINES {
+        assert_eq!(run(e, src, "f"), "false", "engine={e}");
+    }
+}
+
+#[test]
+fn int_key_mdel_removes_entry() {
+    let src = r#"f>n;m=mmap;m=mset m 1 10;m=mset m 2 20;m=mdel m 1;len (mkeys m)"#;
+    for e in ENGINES {
+        assert_eq!(run(e, src, "f"), "1", "engine={e}");
+    }
+}
+
+#[test]
+fn int_key_mget_missing_returns_nil() {
+    let src = r#"f>n;m=mmap;m=mset m 1 99;r=mget m 2;?r{n v:v;_:-1}"#;
+    for e in ENGINES {
+        assert_eq!(run(e, src, "f"), "-1", "engine={e}");
+    }
+}
+
+#[test]
+fn int_key_mkeys_sorted_deterministic() {
+    // mkeys order is non-deterministic; sort it to get a stable answer.
+    // hd (srt ks) must be the smallest key regardless of engine.
+    let src = r#"f>n;m=mmap;m=mset m 3 0;m=mset m 1 0;m=mset m 2 0;ks=srt (mkeys m);hd ks"#;
+    for e in ENGINES {
+        assert_eq!(run(e, src, "f"), "1", "engine={e}");
+    }
+}
+
+#[test]
+fn int_key_mvals_count() {
+    let src = r#"f>n;m=mmap;m=mset m 1 10;m=mset m 2 20;m=mset m 3 30;len (mvals m)"#;
+    for e in ENGINES {
+        assert_eq!(run(e, src, "f"), "3", "engine={e}");
+    }
+}
+
+#[test]
+fn int_key_len_via_mkeys() {
+    let src = r#"f>n;m=mmap;m=mset m 10 0;m=mset m 20 0;m=mset m 30 0;len (mkeys m)"#;
+    for e in ENGINES {
+        assert_eq!(run(e, src, "f"), "3", "engine={e}");
+    }
+}
+
+// ── Int vs Text: distinct keys, no collision ────────────────────────────
+
+#[test]
+fn int_key_distinct_from_text_key_via_frq() {
+    // frq [1, "1"] gives Int(1)=1 and Text("1")=1 — two slots, count 1 each.
+    let src_num = r#"f>n;m=frq [1, "1"];r=mget m 1;?r{n v:v;_:-1}"#;
+    let src_txt = r#"f>n;m=frq [1, "1"];r=mget m "1";?r{n v:v;_:-1}"#;
+    for e in ENGINES {
+        assert_eq!(run(e, src_num, "f"), "1", "engine={e} numeric key");
+        assert_eq!(run(e, src_txt, "f"), "1", "engine={e} text key");
+    }
+}
+
+// ── Float keys floor to i64 at the builtin boundary ──────────────────────
+
+#[test]
+fn float_key_floors_to_int() {
+    // 0.7 floors to 0; mget with 0 should find it.
+    let src = r#"f>n;m=mmap;m=mset m 0.7 42;r=mget m 0;?r{n v:v;_:-1}"#;
+    for e in ENGINES {
+        assert_eq!(run(e, src, "f"), "42", "engine={e}");
+    }
+}
+
+// ── jdmp: numeric keys serialise as JSON string keys ─────────────────────
+
+#[test]
+fn jdmp_int_key_stringifies() {
+    // JSON object keys must be strings, so MapKey::Int(7) serialises as "7".
+    let src = r#"f>t;m=mmap;m=mset m 7 42;jdmp m"#;
+    for e in ENGINES {
+        let out = run(e, src, "f");
+        assert!(
+            out.contains("\"7\":42"),
+            "engine={e} expected key \"7\":42, got: {out}"
+        );
+    }
+}
+
+// ── Iteration determinism: srt (mkeys m) is stable across engines ───────
+
+#[test]
+fn int_key_iteration_deterministic_across_engines() {
+    // Insert in a scrambled order; sort the resulting key list and check
+    // every engine agrees on the canonical order.
+    let src = r#"f>t;m=mmap;m=mset m 5 0;m=mset m 1 0;m=mset m 3 0;m=mset m 2 0;m=mset m 4 0;ks=srt (mkeys m);fmt "{},{},{},{},{}" (str (at ks 0)) (str (at ks 1)) (str (at ks 2)) (str (at ks 3)) (str (at ks 4))"#;
+    for e in ENGINES {
+        assert_eq!(run(e, src, "f"), "1,2,3,4,5", "engine={e}");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a typed `MapKey { Text(String), Int(i64) }` to ilo's map representation. Before this change, `Value::Map` was keyed by `String`, so any program iterating a map by a numeric index had to call `k=str j` before every `mget`/`mset`. The routing-tsp benchmark (and any agent-written code that builds an index lookup table) paid that tax on every iteration.

With typed keys: `mset m 7 v` and `mget m 7` work directly. Floats floor to i64 at the builtin boundary (matching `at xs i`); NaN/Infinity raise a runtime error. Text and Int are distinct keys: `Int(1)` and `Text("1")` no longer collide. Bool keys are stringified to Text (a bool map is always shorter as a two-arm `?`, so the surface syntax isn't worth the lexer ambiguity).

JSON serialisation stringifies numeric keys (JS/Python convention). The round-trip remains lossy, since JSON object keys are always strings, deserialising back to a Record with text fields.

## Repro before/after

Before (routing-tsp pattern):
```
loop>n;m=mmap;j=0;@<j 10{k=str j;m=mset m k j;j=+j 1};r=mget m (str 5);?r{n v:v;_:-1}
```
After: no stringification needed.
```
loop>n;m=mmap;j=0;@<j 10{m=mset m j j;j=+j 1};r=mget m 5;?r{n v:v;_:-1}
```

## What's in the diff

- `interpreter: introduce typed MapKey enum for Value::Map` (280e389): `Value::Map` becomes `Arc<HashMap<MapKey, Value>>`. Adds `MapKey::from_value` for the builtin boundary, `Ord` for deterministic `mkeys`/`mvals` order, and stringifies numeric keys on `to_json`.
- `vm: thread MapKey through bytecode and Cranelift JIT` (1f4a547): `HeapObj::Map` switches to `HashMap<MapKey, NanVal>`. `OP_MGET/MSET/MHAS/MDEL/MKEYS/MVALS` build typed keys via new `nanval_to_map_key` helper. RC=1 in-place `mset` fast path is preserved. JIT helpers now report runtime errors on bad key types (matching tree/VM).
- `verify: infer map key type from declarations and builtin args` (192390e): drops the hard-coded "key must be t" constraint; `mkeys` returns `L<declared-key-type>`; `frq xs:L a` yields `M a n`.
- `test + example: cross-engine coverage for typed map keys` (63999b3): 15 new cross-engine tests; new `examples/numeric-map-keys.ilo`; updated `regression_frq` and `examples/frq.ilo` for the typed-key semantics.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo build --release --features cranelift` clean
- [x] `cargo test --release --features cranelift` passes (full suite green: ~2900 lib tests + every integration crate)
- [x] `cargo clippy --release --features cranelift --all-targets -- -D warnings` clean
- [x] `examples/numeric-map-keys.ilo` exercises all five entry points across tree, VM, and cranelift
- [x] `regression_numeric_map_keys` covers mset, mget, mhas, mdel, mkeys, mvals, len, jdmp, float-floor, Int-vs-Text distinctness across all three engines

## Follow-ups

- The `from_json` path still produces `Record` for generic objects rather than `Value::Map`. That's untouched here, but if/when the JSON shape grows a `M n _` variant, we'd want to populate `MapKey::Int` from numeric-looking string keys.