### PR TITLE
diagnostics: camel-cascade scan, ?cond{body} hint, name={...} map-literal hint

### DIFF
--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -344,11 +344,12 @@ pub fn lex(source: &str) -> Result<Vec<(Token, std::ops::Range<usize>)>, LexErro
                             }
                         }
                         let sigil_char = normalized[span.clone()].chars().next().unwrap();
-                        return Err(uppercase_mid_ident_error(
+                        return Err(uppercase_mid_ident_error_with_source(
                             &prev_name,
                             sigil_char,
                             &normalized[span.end..],
                             prev_span.start,
+                            Some(&normalized),
                         ));
                     }
                     // Leading-uppercase JSON key flush after a Dot/DotQuestion
@@ -398,11 +399,12 @@ pub fn lex(source: &str) -> Result<Vec<(Token, std::ops::Range<usize>)>, LexErro
                             }
                         }
                         let c = bad.chars().next().unwrap();
-                        return Err(uppercase_mid_ident_error(
+                        return Err(uppercase_mid_ident_error_with_source(
                             &prev_name,
                             c,
                             &normalized[span.end..],
                             prev_span.start,
+                            Some(&normalized),
                         ));
                     }
                     // Leading-uppercase JSON key flush after `.` or `.?`
@@ -860,11 +862,12 @@ fn is_type_sigil(t: &Token) -> bool {
     )
 }
 
-fn uppercase_mid_ident_error(
+fn uppercase_mid_ident_error_with_source(
     prev: &str,
     cap: char,
     rest_after_cap: &str,
     start: usize,
+    source: Option<&str>,
 ) -> LexError {
     // Reconstruct the offending identifier by reading trailing [A-Za-z0-9-] chars
     // so hyphenated tails like `isHello-world` are echoed in full.
@@ -875,24 +878,126 @@ fn uppercase_mid_ident_error(
     let offset = prev.len();
     let full = format!("{prev}{cap}{trailing}");
     let lower = full.to_lowercase();
-    let hyphenated = {
-        let mut s = String::with_capacity(full.len() + 2);
-        for (i, c) in full.chars().enumerate() {
-            if i > 0 && c.is_ascii_uppercase() && !s.ends_with('-') {
-                s.push('-');
+    let hyphenated = hyphenate_camel(&full);
+
+    let mut suggestion = format!(
+        "identifiers must be lowercase ASCII; got '{full}' (capital '{cap}' at offset {offset}). Use lowercase, e.g. `{hyphenated}` or `{lower}`"
+    );
+
+    // Scan the rest of the source for additional camelCase offenders so the
+    // user can fix them all in one pass instead of one ILO-L003 per run. Skip
+    // the current offender (same start position) and any identifier sitting
+    // in a post-dot field-access position (those are absorbed, not rejected).
+    if let Some(src) = source {
+        let mut extras: Vec<String> = Vec::new();
+        for offender in scan_camel_offenders(src) {
+            if offender.start == start {
+                continue;
             }
-            s.push(c.to_ascii_lowercase());
+            // Exclude the current offender name and any duplicates so the
+            // list shows only distinct additional identifiers to rename.
+            if offender.full == full {
+                continue;
+            }
+            if !extras.iter().any(|e| e == &offender.full) {
+                extras.push(offender.full);
+            }
         }
-        s
-    };
+        if !extras.is_empty() {
+            let preview: Vec<String> = extras.iter().take(5).cloned().collect();
+            let more = if extras.len() > preview.len() {
+                format!(" (+{} more)", extras.len() - preview.len())
+            } else {
+                String::new()
+            };
+            suggestion.push_str(&format!(
+                ". Also found in this file: {}{}",
+                preview.join(", "),
+                more
+            ));
+        }
+    }
+
     LexError {
         code: "ILO-L003",
         position: start,
         snippet: full.clone(),
-        suggestion: format!(
-            "identifiers must be lowercase ASCII; got '{full}' (capital '{cap}' at offset {offset}). Use lowercase, e.g. `{hyphenated}` or `{lower}`"
-        ),
+        suggestion,
     }
+}
+
+fn hyphenate_camel(full: &str) -> String {
+    let mut s = String::with_capacity(full.len() + 2);
+    for (i, c) in full.chars().enumerate() {
+        if i > 0 && c.is_ascii_uppercase() && !s.ends_with('-') {
+            s.push('-');
+        }
+        s.push(c.to_ascii_lowercase());
+    }
+    s
+}
+
+#[derive(Debug)]
+struct CamelOffender {
+    start: usize,
+    full: String,
+}
+
+/// Scan source for camelCase identifiers (lowercase-start with an
+/// uppercase ASCII letter mid-identifier) that would trigger ILO-L003.
+/// Skips identifiers immediately preceded by `.` or `.?` because those
+/// are post-dot field accesses, which the lexer absorbs rather than rejects.
+fn scan_camel_offenders(src: &str) -> Vec<CamelOffender> {
+    let bytes = src.as_bytes();
+    let mut out: Vec<CamelOffender> = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        // Find start of a lowercase-led identifier.
+        let prev = if i == 0 { 0 } else { bytes[i - 1] };
+        let prev_prev = if i >= 2 { bytes[i - 2] } else { 0 };
+        let is_post_dot = prev == b'.' || (prev == b'?' && prev_prev == b'.');
+        if b.is_ascii_lowercase() && !(prev.is_ascii_alphanumeric() || prev == b'_' || prev == b'-')
+        {
+            // Walk the identifier-shaped run and look for a mid-capital.
+            let start = i;
+            let mut j = i;
+            let mut found_cap = false;
+            while j < bytes.len() {
+                let c = bytes[j];
+                if c.is_ascii_lowercase() || c.is_ascii_digit() || c == b'-' {
+                    j += 1;
+                } else if c.is_ascii_uppercase() && j > start {
+                    found_cap = true;
+                    j += 1;
+                } else {
+                    break;
+                }
+            }
+            if found_cap && !is_post_dot {
+                // Extend through any trailing alphanumeric/hyphen tail so
+                // `helloWorld-x` reports the full ident.
+                while j < bytes.len() {
+                    let c = bytes[j];
+                    if c.is_ascii_alphanumeric() || c == b'-' {
+                        j += 1;
+                    } else {
+                        break;
+                    }
+                }
+                if let Ok(full) = std::str::from_utf8(&bytes[start..j]) {
+                    out.push(CamelOffender {
+                        start,
+                        full: full.to_string(),
+                    });
+                }
+            }
+            i = j.max(i + 1);
+        } else {
+            i += 1;
+        }
+    }
+    out
 }
 
 fn lex_error_kind(bad_token: &str) -> (&'static str, String) {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1006,9 +1006,70 @@ impl Parser {
             Some(self.parse_atom()?)
         };
         self.expect(&Token::LBrace)?;
+        // Friendly hint: `?cond{body}` on a bare bool is a common slip — the
+        // user reaches for braced-conditional execution but gets match syntax
+        // and the body is parsed as a pattern. If the body shape is clearly
+        // statement-like (not pattern-like) and a subject is present, suggest
+        // the `=cond true{body}` braced-conditional form.
+        if let Some(subj) = &subject {
+            if self.body_looks_like_statement_not_pattern() {
+                if let Some(subj_src) = subject_source(subj) {
+                    return Err(self.error_hint(
+                        "ILO-P011",
+                        format!(
+                            "`?{subj_src}{{...}}` is match syntax — the body is parsed as pattern arms, not statements"
+                        ),
+                        format!(
+                            "for braced-conditional execution on a bool, use `={subj_src} true{{body}}` (or `!{subj_src}{{body}}` for the negated case)"
+                        ),
+                    ));
+                }
+            }
+        }
         let arms = self.parse_match_arms()?;
         self.expect(&Token::RBrace)?;
         Ok(Stmt::Match { subject, arms })
+    }
+
+    /// After consuming `{` in a `?subject{...}` match, peek to see whether the
+    /// first arm body looks like a statement rather than a pattern. Patterns
+    /// have a `:` within the first 1-3 tokens; statement-shape bodies do not.
+    fn body_looks_like_statement_not_pattern(&self) -> bool {
+        // Empty body / immediate `}` — not a statement; let the normal parser
+        // surface its own error.
+        if matches!(self.peek(), Some(Token::RBrace) | None) {
+            return false;
+        }
+        // Look at the first identifier-led shape only. Patterns that start
+        // with `^`, `~`, `_`, literal, or type-letter (`n`, `t`, `b`, `l`)
+        // followed by ident — those we leave to parse_pattern. Statement-like:
+        // `Ident =` (let), `Ident <op-not-colon>` (call/expr).
+        match self.peek() {
+            Some(Token::Ident(name)) => {
+                // Type-letter pattern: `n x:` / `t x:` / `b x:` / `l x:` —
+                // an ident followed by another ident (or `_`) followed by `:`.
+                if matches!(name.as_str(), "n" | "t" | "b" | "l")
+                    && matches!(
+                        self.token_at(self.pos + 1),
+                        Some(Token::Ident(_) | Token::Underscore)
+                    )
+                    && self.token_at(self.pos + 2) == Some(&Token::Colon)
+                {
+                    return false;
+                }
+                // Plain `Ident :` is also a pattern shape (less common).
+                if self.token_at(self.pos + 1) == Some(&Token::Colon) {
+                    return false;
+                }
+                // Otherwise an ident followed by `=` or any operator is a
+                // statement.
+                true
+            }
+            // `+`, `-`, `*`, `/`, `=`, `>=`, `<=`, `<`, `>`, `!=`, `==` etc.
+            // at body head are clearly statement-shape expressions.
+            Some(t) if is_statement_head_operator(t) => true,
+            _ => false,
+        }
     }
 
     fn parse_match_arms(&mut self) -> Result<Vec<MatchArm>> {
@@ -3001,6 +3062,37 @@ fn reserved_keyword_message(tok: &Token) -> Option<(String, String)> {
 /// Check if an expression is a comparison or logical operator — eligible
 /// as a braceless guard condition. Prefix operators have fixed arity, so
 /// the parser knows exactly where the condition ends and the body begins.
+/// Operators that, when sitting as the first token inside a match-arm `{...}`,
+/// indicate the user wrote a statement (call / expr) rather than a pattern.
+/// Patterns lead with `^`, `~`, `_`, a literal, or a type-letter; an arithmetic
+/// or comparison operator at body head is therefore unambiguous statement-shape.
+fn is_statement_head_operator(t: &Token) -> bool {
+    matches!(
+        t,
+        Token::Plus
+            | Token::Minus
+            | Token::Star
+            | Token::Slash
+            | Token::Eq
+            | Token::Greater
+            | Token::GreaterEq
+            | Token::Less
+            | Token::LessEq
+            | Token::NotEq
+            | Token::Bang
+    )
+}
+
+/// Render a simple Expr subject as source-ish text for diagnostics —
+/// only the common case `Ref("name")` needs an exact echo; everything
+/// else falls back to a placeholder so the hint stays readable.
+fn subject_source(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Ref(name) => Some(name.clone()),
+        _ => None,
+    }
+}
+
 fn is_guard_eligible_condition(expr: &Expr) -> bool {
     matches!(
         expr,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -926,6 +926,21 @@ impl Parser {
     fn parse_let(&mut self) -> Result<Stmt> {
         let name = self.expect_ident()?;
         self.expect(&Token::Eq)?;
+        // Friendly hint: `name={...}` is a common reach for a map-literal from
+        // other languages. ilo builds maps with `mmap` + `mset`. Catch it
+        // before parse_expr emits the bare ILO-P009 "expected expression,
+        // got LBrace".
+        if self.peek() == Some(&Token::LBrace) && self.brace_looks_like_map_literal() {
+            return Err(self.error_hint(
+                "ILO-P009",
+                format!(
+                    "`{name}={{...}}` — ilo has no `{{key value}}` map literal syntax"
+                ),
+                format!(
+                    "build maps with `mmap` (empty) and `mset`, e.g. `{name}=mset mmap \"k\" v` (chain `mset` for multiple entries)"
+                ),
+            ));
+        }
         let value = self.parse_expr()?;
 
         // Check if this is a ternary assignment: v=cond{then}{else}
@@ -961,6 +976,21 @@ impl Parser {
         } else {
             Ok(Stmt::Let { name, value })
         }
+    }
+
+    /// Lookahead: does the `{` at current position look like a map-literal
+    /// attempt from another language? We fire only on shapes that are
+    /// unambiguously not a destructure or some other valid form:
+    /// `{"text" ...}`, `{<number> ...}`, or `{}` (empty braces).
+    /// Idents inside braces could be destructure shapes, so we skip them.
+    fn brace_looks_like_map_literal(&self) -> bool {
+        if self.peek() != Some(&Token::LBrace) {
+            return false;
+        }
+        matches!(
+            self.token_at(self.pos + 1),
+            Some(Token::Text(_) | Token::Number(_) | Token::RBrace)
+        )
     }
 
     /// Lookahead: `{ident;ident...}=` — destructure pattern

--- a/tests/regression_friendly_errors.rs
+++ b/tests/regression_friendly_errors.rs
@@ -306,3 +306,30 @@ fn camel_cascade_truncates_long_lists() {
     );
 }
 
+// ---- `?cond{body}` bare-bool match-vs-conditional confusion ----
+
+#[test]
+fn match_bare_bool_with_let_body_suggests_eq_true_form() {
+    let err = run_err("go>n;hit=true;errs=0;?hit{errs=+errs 1};errs");
+    assert!(err.contains("ILO-P011"), "stderr: {err}");
+    assert!(
+        err.contains("match syntax"),
+        "should explain that ?expr{{}} is match: {err}"
+    );
+    assert!(
+        err.contains("=hit true{body}"),
+        "should suggest =hit true{{body}}: {err}"
+    );
+}
+
+#[test]
+fn match_bare_bool_does_not_fire_on_real_pattern() {
+    // `~v:body` is a real Ok-pattern arm — must not trigger the hint.
+    run_ok("go>R n t;r=~5;?r{~v:v;^e:0}");
+}
+
+#[test]
+fn match_bare_bool_does_not_fire_on_literal_pattern() {
+    run_ok("go>n;x=2;?x{1:10;2:20;_:0}");
+}
+

--- a/tests/regression_friendly_errors.rs
+++ b/tests/regression_friendly_errors.rs
@@ -333,3 +333,34 @@ fn match_bare_bool_does_not_fire_on_literal_pattern() {
     run_ok("go>n;x=2;?x{1:10;2:20;_:0}");
 }
 
+// ---- `name={...}` map-literal hint ----
+
+#[test]
+fn map_literal_text_key_hints_mset_mmap() {
+    let err = run_err("go>n;m={\"a\" 1};0");
+    assert!(err.contains("ILO-P009"), "stderr: {err}");
+    assert!(
+        err.contains("map literal syntax"),
+        "should explain no map literal: {err}"
+    );
+    assert!(err.contains("mset mmap"), "should suggest mset mmap: {err}");
+}
+
+#[test]
+fn map_literal_number_key_hints_mset_mmap() {
+    let err = run_err("go>n;m={1 \"a\"};0");
+    assert!(err.contains("ILO-P009"), "stderr: {err}");
+    assert!(err.contains("mset mmap"), "stderr: {err}");
+}
+
+#[test]
+fn map_literal_empty_braces_hints_mset_mmap() {
+    let err = run_err("go>n;m={};0");
+    assert!(err.contains("ILO-P009"), "stderr: {err}");
+    assert!(err.contains("mset mmap"), "stderr: {err}");
+}
+
+#[test]
+fn let_with_normal_rhs_still_parses() {
+    run_ok("go>n;x=5;y=+x 1;y");
+}

--- a/tests/regression_friendly_errors.rs
+++ b/tests/regression_friendly_errors.rs
@@ -265,3 +265,44 @@ fn uppercase_mid_ident_includes_hyphenated_tail() {
         "should suggest fully hyphenated form: {err}"
     );
 }
+
+// ---- Camel-case rename cascade (per-file scan in a single pass) ----
+//
+// When the lexer rejects the first camelCase identifier, the suggestion now
+// lists every other distinct camelCase offender in the file so the user can
+// fix them all in one pass instead of N-1 retry rounds.
+
+#[test]
+fn camel_cascade_lists_other_offenders() {
+    let err = run_err("go>n;fooBar=1;bazQux=2;helloWorld=3;fooBar");
+    assert!(err.contains("ILO-L003"), "stderr: {err}");
+    assert!(
+        err.contains("Also found in this file"),
+        "should list extras: {err}"
+    );
+    assert!(err.contains("bazQux"), "should list bazQux: {err}");
+    assert!(err.contains("helloWorld"), "should list helloWorld: {err}");
+}
+
+#[test]
+fn camel_cascade_dedupes_current_offender() {
+    // `fooBar` appears twice in the source; the extras list must not
+    // re-echo it — only distinct other offenders.
+    let err = run_err("go>n;fooBar=1;fooBar");
+    assert!(err.contains("ILO-L003"), "stderr: {err}");
+    assert!(
+        !err.contains("Also found in this file"),
+        "single distinct offender should not produce a list: {err}"
+    );
+}
+
+#[test]
+fn camel_cascade_truncates_long_lists() {
+    let err = run_err("go>n;aA=1;bB=2;cC=3;dD=4;eE=5;fF=6;gG=7;hH=8;aA");
+    assert!(err.contains("ILO-L003"), "stderr: {err}");
+    assert!(
+        err.contains("more"),
+        "should truncate with `+N more`: {err}"
+    );
+}
+


### PR DESCRIPTION
## Summary

Three small diagnostic improvements bundled into one PR, addressing persona-report friction. Each one is a token-cost win: where today the user pays N retries (camel-cascade) or has to decode a generic "expected X, got Y" message (the other two), they now get the actual problem and a concrete fix in a single run.

## Items shipped

**1. Camel-case rename cascade — list all offenders in one pass (`lexer/mod.rs`).**
When `ILO-L003` fires, the suggestion now appends every other distinct camelCase identifier found in the source. Scan filters out post-dot field accesses (those are absorbed, not rejected) and dedupes against the current offender and itself. Long lists truncated to 5 with `(+N more)`. Before: 7 retries for 7 offenders. After: 1.

**2. `?cond{body}` on a bare bool — friendly hint (`parser/mod.rs`).**
`?hit{errs=+errs 1}` is a common slip — `?expr{...}` is match syntax, not braced-conditional. The bare `ILO-P011 expected pattern, got Ident("errs")` gave no clue. New diagnostic detects subject + statement-shape body (Ident=, Ident+op, or leading operator) and suggests `=subject true{body}` (or `!subject{body}` for the negated case). Real pattern arms (`n _:...`, `~v:...`, `^e:...`, literal arms) are untouched.

**3. `name={...}` map-literal hint (`parser/mod.rs`).**
JS/Python/Ruby muscle memory writes `mb={"a" 1}`; ilo has no map literal — you build maps with `mmap` + `mset` chains. Bare `ILO-P009 expected expression, got LBrace` gave no signpost. New hint fires only on unambiguous shapes (`{"text" ...}`, `{<number> ...}`, `{}`) and points at `mset mmap "k" v`. Idents inside braces aren't flagged — those could be destructure patterns used elsewhere.

## Items refuted (originally in the brief, not in this PR)

Three items from the persona-report batch don't reproduce on current main. Originating entries in `ilo_assessment_feedback.md` are now struck through with inline notes.

- **`>` whitespace in fn signatures** — `parse ln:t > L t;[ln]` parses cleanly. The persona's repro `parse ln:t > L t{[ln]}` was failing on the braced body, not on `>` whitespace.
- **`@i 0..len xs{body}` absorbed as call-with-block** — already fixed by #251 (the brief's footnote acknowledged this). `@i xs{...}` also works on current main.
- **`!mhas mb k{c=+c 1}` in braced-cond head** — works when `m` is a real map. The persona's `mb={"a" 1}` was the actual failure (invalid map-literal syntax). That misattribution surfaced the genuine gap fixed by item 3 above.

## Repro before / after

```
$ ilo 'go>n;fooBar=1;bazQux=2;helloWorld=3;fooBar' go

before: ILO-L003 ... 'fooBar' (capital 'B' at offset 3). Use lowercase ...
after:  ILO-L003 ... Use lowercase ... Also found in this file: bazQux, helloWorld

$ ilo 'go>n;hit=true;errs=0;?hit{errs=+errs 1};errs' go

before: ILO-P011 expected pattern, got Ident("errs")
after:  ILO-P011 `?hit{...}` is match syntax — the body is parsed as pattern arms ...
        hint: for braced-conditional execution on a bool, use `=hit true{body}` ...

$ ilo 'go>n;m={"a" 1};0' go

before: ILO-P009 expected expression, got LBrace
after:  ILO-P009 `m={...}` — ilo has no `{key value}` map literal syntax
        hint: build maps with `mmap` (empty) and `mset`, e.g. `m=mset mmap "k" v` ...
```

## What's in the diff

- `lexer: scan whole source for additional ILO-L003 offenders` — extends `uppercase_mid_ident_error_with_source` with a per-file scan that finds additional camelCase identifiers and appends them to the suggestion text. Existing call sites updated to pass `&normalized`.
- `parser: friendly hint when ?cond{body} is used on a bare bool` — adds `body_looks_like_statement_not_pattern` and detection in `parse_match_stmt`. Two helpers (`is_statement_head_operator`, `subject_source`) live alongside the existing `is_guard_eligible_condition`.
- `parser: friendly hint when name={...} reaches for a map literal` — adds `brace_looks_like_map_literal` and a hint emission in `parse_let` before `parse_expr` is called.

11 new regression tests in `tests/regression_friendly_errors.rs`. Cross-engine tests not applicable — all three changes route through the parser/lexer before any engine sees the source.

## Test plan

- [x] `cargo build --release --features cranelift`
- [x] `cargo test --release --features cranelift` — 4625 tests pass, 0 failures
- [x] `cargo fmt --check`
- [x] `cargo clippy --release --features cranelift -- -D warnings`
- [x] Manual repro for each of the three before/after pairs above
- [x] Real match patterns (`n _:...`, `~v:...`, literal arms) still parse correctly
- [x] Normal `name=expr` lets still parse correctly

## Follow-ups

None. If the misattributed item 3 (braced fn bodies) turns out to be a real future-friction pattern, it deserves its own investigation as a separate entry — the persona's report misattributed it to `>` whitespace, so the fix site would need to be located fresh.