### PR TITLE
cranelift: thread source span through jit_hd/jit_at/jit_tl

### DIFF
--- a/examples/cranelift-error-span.ilo
+++ b/examples/cranelift-error-span.ilo
@@ -1,0 +1,24 @@
+-- Cranelift JIT runtime errors now carry source spans, matching tree / VM.
+-- The previous JIT_RUNTIME_ERROR TLS only stored a bare VmError so cranelift
+-- diagnostics rendered with an empty `labels: []`. The fix packs the call-
+-- site span as a u64 immediate at compile time and threads it through the
+-- helper signature for jit_hd / jit_at / jit_tl.
+--
+-- The positive-path cases below succeed on every engine and exercise the
+-- newly-extended helper ABI: each call site now emits an extra iconst with
+-- the packed (start << 32 | end) span bits. If the immediate were ever
+-- forgotten on a call site, the function would crash at JIT-time on the
+-- arity mismatch, not run cleanly to completion.
+
+firstn xs:L n>n;hd xs
+last xs:L n>n;at xs -1
+rest xs:L n>L n;tl xs
+
+-- run: firstn [10,20,30]
+-- out: 10
+
+-- run: last [10,20,30]
+-- out: 30
+
+-- run: rest [10,20,30]
+-- out: [20, 30]

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -181,6 +181,19 @@ struct HelperFuncs {
     call_builtin_tree: FuncId,
 }
 
+/// Pack a `Span { start, end }` into a single i64 immediate for passing to
+/// erroring JIT helpers. High 32 bits = start, low 32 bits = end. `start ==
+/// end == 0` (i.e. `Span::UNKNOWN`) round-trips to `0`, which helpers decode
+/// as `None`. Spans whose offsets exceed `u32::MAX` (i.e. source files
+/// larger than ~4 GiB) are clamped to `u32::MAX`; this only affects
+/// diagnostic rendering, never program correctness.
+#[inline]
+fn pack_span_bits(span: crate::ast::Span) -> i64 {
+    let start = span.start.min(u32::MAX as usize) as u64;
+    let end = span.end.min(u32::MAX as usize) as u64;
+    ((start << 32) | end) as i64
+}
+
 fn declare_helper(module: &mut JITModule, name: &str, n_params: usize, n_returns: usize) -> FuncId {
     let mut sig = module.make_signature();
     for _ in 0..n_params {
@@ -414,8 +427,12 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         spl: declare_helper(module, "jit_spl", 2, 1),
         cat: declare_helper(module, "jit_cat", 2, 1),
         has: declare_helper(module, "jit_has", 2, 1),
-        hd: declare_helper(module, "jit_hd", 1, 1),
-        at: declare_helper(module, "jit_at", 2, 1),
+        // jit_hd / jit_at / jit_tl take a packed (start<<32)|end span_bits
+        // immediate as their trailing arg so cranelift runtime errors carry
+        // a source span like tree / VM. See `vm/mod.rs` JIT runtime-error
+        // signalling section.
+        hd: declare_helper(module, "jit_hd", 2, 1),
+        at: declare_helper(module, "jit_at", 3, 1),
         fmt2: declare_helper(module, "jit_fmt2", 2, 1),
         zip: declare_helper(module, "jit_zip", 2, 1),
         enumerate: declare_helper(module, "jit_enumerate", 1, 1),
@@ -425,7 +442,7 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         setunion: declare_helper(module, "jit_setunion", 2, 1),
         setinter: declare_helper(module, "jit_setinter", 2, 1),
         setdiff: declare_helper(module, "jit_setdiff", 2, 1),
-        tl: declare_helper(module, "jit_tl", 1, 1),
+        tl: declare_helper(module, "jit_tl", 2, 1),
         rev: declare_helper(module, "jit_rev", 1, 1),
         srt: declare_helper(module, "jit_srt", 1, 1),
         rsrt: declare_helper(module, "jit_rsrt", 1, 1),
@@ -2206,16 +2223,20 @@ fn compile_function_body(
             }
             OP_HD => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.hd);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_AT => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.at);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
@@ -2292,8 +2313,10 @@ fn compile_function_body(
             }
             OP_TL => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.tl);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
@@ -4307,10 +4330,10 @@ pub fn call(func: &JitFunction, args: &[u64]) -> Result<u64, JitCallError> {
     }
     jit_arena_reset();
 
-    if let Some(err) = jit_take_runtime_error() {
+    if let Some((err, span)) = jit_take_runtime_error() {
         return Err(JitCallError::Runtime(VmRuntimeError {
             error: err,
-            span: None,
+            span,
             call_stack: Vec::new(),
         }));
     }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -3479,40 +3479,73 @@ pub(crate) fn jit_arena_reset() {
 // `VmRuntimeError` and propagates it as a `Result::Err` instead of treating
 // the `TAG_NIL` return as a successful result.
 //
-// Spans/call-stacks are not yet carried through helpers (the JIT IR doesn't
-// thread the source span across the C ABI); cranelift JIT errors surface
-// without a precise span for now. Helpers continue to return `TAG_NIL` on the
-// error path so the generated IR doesn't need to special-case a sentinel.
+// Spans are carried through helpers by packing `Span { start, end }` into a
+// u64 immediate (high 32 bits = start, low 32 bits = end) at the cranelift
+// call site and passing it as an extra extern "C" arg. Helpers store the
+// `(VmError, Span)` pair in the TLS cell; the entry point surfaces both on
+// the resulting `VmRuntimeError` so cranelift errors render with a caret like
+// tree / VM.
 //
 // v1 scope: applied to `jit_hd`, `jit_at`, `jit_tl` only. Other helpers
 // (`jit_lst`, `jit_listget`, `jit_index`, `jit_jpth`, `jit_slc`, ...) keep
-// the existing permissive-nil semantics; harmonising them is parked.
+// the existing permissive-nil semantics; harmonising them is parked. Each
+// new erroring helper costs +1 u64 arg and +1 iconst at the call site.
 thread_local! {
-    static JIT_RUNTIME_ERROR: std::cell::RefCell<Option<VmError>> =
+    static JIT_RUNTIME_ERROR: std::cell::RefCell<Option<(VmError, Option<crate::ast::Span>)>> =
         const { std::cell::RefCell::new(None) };
 }
 
-/// Record a runtime error from inside a JIT helper. The entry point will
-/// pick this up after the JIT function returns and surface it as a
-/// `VmRuntimeError`. Helpers should still return `TAG_NIL` after calling
+/// Decode the (start, end) span bits packed by the cranelift call site.
+/// Returns `None` for `0` (the `Span::UNKNOWN` sentinel) so helpers can
+/// pass `0` from contexts where no span is available.
+#[cfg(feature = "cranelift")]
+#[inline]
+fn decode_span_bits(bits: u64) -> Option<crate::ast::Span> {
+    if bits == 0 {
+        None
+    } else {
+        let start = (bits >> 32) as usize;
+        let end = (bits & 0xFFFF_FFFF) as usize;
+        Some(crate::ast::Span { start, end })
+    }
+}
+
+/// Record a runtime error from inside a JIT helper, with the source span
+/// passed in as a packed `(start << 32) | end` u64 immediate. The entry
+/// point will pick this up after the JIT function returns and surface it as
+/// a `VmRuntimeError`. Helpers should still return `TAG_NIL` after calling
 /// this so the generated IR can carry on without a special-case sentinel.
 #[cfg(feature = "cranelift")]
-pub(crate) fn jit_set_runtime_error(err: VmError) {
+pub(crate) fn jit_set_runtime_error_with_span(err: VmError, span_bits: u64) {
+    let span = decode_span_bits(span_bits);
     JIT_RUNTIME_ERROR.with(|cell| {
         // Preserve the first error if a later helper also errors before the
         // entry point unwinds — keeps the surfaced message closest to root
         // cause.
         let mut slot = cell.borrow_mut();
         if slot.is_none() {
-            *slot = Some(err);
+            *slot = Some((err, span));
         }
     });
 }
 
-/// Pop any pending JIT runtime error. Called by the JIT entry point after
-/// the compiled function returns.
+/// Backwards-compatible wrapper for helpers that do not (yet) thread a
+/// source span. Passes `0` (decoded as `None`) so the surfaced
+/// `VmRuntimeError` carries `span: None`, matching pre-span-plumbing
+/// behaviour. New helpers should prefer `jit_set_runtime_error_with_span`
+/// and have the cranelift call site pack and pass the span bits.
 #[cfg(feature = "cranelift")]
-pub(crate) fn jit_take_runtime_error() -> Option<VmError> {
+#[inline]
+pub(crate) fn jit_set_runtime_error(err: VmError) {
+    jit_set_runtime_error_with_span(err, 0);
+}
+
+/// Pop any pending JIT runtime error. Called by the JIT entry point after
+/// the compiled function returns. Returns the `(VmError, Option<Span>)`
+/// pair so the entry point can attach the span to the surfaced
+/// `VmRuntimeError`.
+#[cfg(feature = "cranelift")]
+pub(crate) fn jit_take_runtime_error() -> Option<(VmError, Option<crate::ast::Span>)> {
     JIT_RUNTIME_ERROR.with(|cell| cell.borrow_mut().take())
 }
 
@@ -9741,7 +9774,7 @@ pub(crate) extern "C" fn jit_has(a: u64, b: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_hd(a: u64) -> u64 {
+pub(crate) extern "C" fn jit_hd(a: u64, span_bits: u64) -> u64 {
     let v = NanVal(a);
     if v.is_string() {
         let s = unsafe {
@@ -9751,7 +9784,7 @@ pub(crate) extern "C" fn jit_hd(a: u64) -> u64 {
             }
         };
         if s.is_empty() {
-            jit_set_runtime_error(VmError::Type("hd: empty text"));
+            jit_set_runtime_error_with_span(VmError::Type("hd: empty text"), span_bits);
             return TAG_NIL;
         }
         return NanVal::heap_string(
@@ -9766,13 +9799,13 @@ pub(crate) extern "C" fn jit_hd(a: u64) -> u64 {
         && let HeapObj::List(items) = unsafe { v.as_heap_ref() }
     {
         if items.is_empty() {
-            jit_set_runtime_error(VmError::Type("hd: empty list"));
+            jit_set_runtime_error_with_span(VmError::Type("hd: empty list"), span_bits);
             return TAG_NIL;
         }
         items[0].clone_rc();
         return items[0].0;
     }
-    jit_set_runtime_error(VmError::Type("hd requires a list or text"));
+    jit_set_runtime_error_with_span(VmError::Type("hd requires a list or text"), span_bits);
     TAG_NIL
 }
 
@@ -9796,16 +9829,16 @@ pub(crate) extern "C" fn jit_fmt2(a: u64, b: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_at(a: u64, b: u64) -> u64 {
+pub(crate) extern "C" fn jit_at(a: u64, b: u64, span_bits: u64) -> u64 {
     let v = NanVal(a);
     let i = NanVal(b);
     if !i.is_number() {
-        jit_set_runtime_error(VmError::Type("at: index must be a number"));
+        jit_set_runtime_error_with_span(VmError::Type("at: index must be a number"), span_bits);
         return TAG_NIL;
     }
     let n = i.as_number();
     if n.fract() != 0.0 {
-        jit_set_runtime_error(VmError::Type("at: index must be an integer"));
+        jit_set_runtime_error_with_span(VmError::Type("at: index must be an integer"), span_bits);
         return TAG_NIL;
     }
     let raw = n as i64;
@@ -9819,7 +9852,7 @@ pub(crate) extern "C" fn jit_at(a: u64, b: u64) -> u64 {
         return match char_at_signed(s, raw) {
             CharAtResult::Found(c) => NanVal::heap_string(c.to_string()).0,
             CharAtResult::OutOfRange { .. } => {
-                jit_set_runtime_error(VmError::Type("at: index out of range"));
+                jit_set_runtime_error_with_span(VmError::Type("at: index out of range"), span_bits);
                 TAG_NIL
             }
         };
@@ -9830,14 +9863,14 @@ pub(crate) extern "C" fn jit_at(a: u64, b: u64) -> u64 {
         let len = items.len() as i64;
         let adjusted = if raw < 0 { raw + len } else { raw };
         if adjusted < 0 || adjusted >= len {
-            jit_set_runtime_error(VmError::Type("at: index out of range"));
+            jit_set_runtime_error_with_span(VmError::Type("at: index out of range"), span_bits);
             return TAG_NIL;
         }
         let idx = adjusted as usize;
         items[idx].clone_rc();
         return items[idx].0;
     }
-    jit_set_runtime_error(VmError::Type("at requires a list or text"));
+    jit_set_runtime_error_with_span(VmError::Type("at requires a list or text"), span_bits);
     TAG_NIL
 }
 
@@ -10102,7 +10135,7 @@ pub(crate) extern "C" fn jit_chunks(a: u64, b: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_tl(a: u64) -> u64 {
+pub(crate) extern "C" fn jit_tl(a: u64, span_bits: u64) -> u64 {
     let v = NanVal(a);
     if v.is_string() {
         let s = unsafe {
@@ -10112,7 +10145,7 @@ pub(crate) extern "C" fn jit_tl(a: u64) -> u64 {
             }
         };
         if s.is_empty() {
-            jit_set_runtime_error(VmError::Type("tl: empty text"));
+            jit_set_runtime_error_with_span(VmError::Type("tl: empty text"), span_bits);
             return TAG_NIL;
         }
         let mut chars = s.chars();
@@ -10123,7 +10156,7 @@ pub(crate) extern "C" fn jit_tl(a: u64) -> u64 {
         && let HeapObj::List(items) = unsafe { v.as_heap_ref() }
     {
         if items.is_empty() {
-            jit_set_runtime_error(VmError::Type("tl: empty list"));
+            jit_set_runtime_error_with_span(VmError::Type("tl: empty list"), span_bits);
             return TAG_NIL;
         }
         let tail: Vec<NanVal> = items[1..]
@@ -10135,7 +10168,7 @@ pub(crate) extern "C" fn jit_tl(a: u64) -> u64 {
             .collect();
         return NanVal::heap_list(tail).0;
     }
-    jit_set_runtime_error(VmError::Type("tl requires a list or text"));
+    jit_set_runtime_error_with_span(VmError::Type("tl requires a list or text"), span_bits);
     TAG_NIL
 }
 
@@ -17965,7 +17998,7 @@ mod tests {
 
         #[test]
         fn jit_hd_string_returns_first_char() {
-            let r = jit_hd(str_val("hello"));
+            let r = jit_hd(str_val("hello"), 0);
             let rv = NanVal(r);
             assert!(rv.is_string());
             let HeapObj::Str(s) = (unsafe { rv.as_heap_ref() }) else {
@@ -17977,7 +18010,7 @@ mod tests {
 
         #[test]
         fn jit_hd_empty_string_returns_nil() {
-            let r = jit_hd(str_val(""));
+            let r = jit_hd(str_val(""), 0);
             assert!(is_nil(r));
         }
 
@@ -17985,7 +18018,7 @@ mod tests {
         fn jit_hd_list_returns_first() {
             let items = vec![NanVal::number(10.0), NanVal::number(20.0)];
             let list = NanVal::heap_list(items);
-            let r = jit_hd(list.0);
+            let r = jit_hd(list.0, 0);
             assert!(is_num(r));
             assert_eq!(as_num(r), 10.0);
         }
@@ -17993,13 +18026,13 @@ mod tests {
         #[test]
         fn jit_hd_empty_list_returns_nil() {
             let list = NanVal::heap_list(vec![]);
-            let r = jit_hd(list.0);
+            let r = jit_hd(list.0, 0);
             assert!(is_nil(r));
         }
 
         #[test]
         fn jit_hd_non_string_non_list_returns_nil() {
-            let r = jit_hd(TAG_NIL);
+            let r = jit_hd(TAG_NIL, 0);
             assert!(is_nil(r));
         }
 
@@ -18007,7 +18040,7 @@ mod tests {
 
         #[test]
         fn jit_tl_string_returns_tail() {
-            let r = jit_tl(str_val("hello"));
+            let r = jit_tl(str_val("hello"), 0);
             let rv = NanVal(r);
             assert!(rv.is_string());
             let HeapObj::Str(s) = (unsafe { rv.as_heap_ref() }) else {
@@ -18019,7 +18052,7 @@ mod tests {
 
         #[test]
         fn jit_tl_empty_string_returns_nil() {
-            let r = jit_tl(str_val(""));
+            let r = jit_tl(str_val(""), 0);
             assert!(is_nil(r));
         }
 
@@ -18031,7 +18064,7 @@ mod tests {
                 NanVal::number(3.0),
             ];
             let list = NanVal::heap_list(items);
-            let r = jit_tl(list.0);
+            let r = jit_tl(list.0, 0);
             let rv = NanVal(r);
             assert!(rv.is_heap());
         }
@@ -18039,7 +18072,7 @@ mod tests {
         #[test]
         fn jit_tl_empty_list_returns_nil() {
             let list = NanVal::heap_list(vec![]);
-            let r = jit_tl(list.0);
+            let r = jit_tl(list.0, 0);
             assert!(is_nil(r));
         }
 
@@ -25739,7 +25772,7 @@ f>n;r=mk 10 20;+r.x r.y";
             NanVal::number(20.0),
             NanVal::number(30.0),
         ]);
-        let v = NanVal(jit_at(list.0, NanVal::number(-1.0).0));
+        let v = NanVal(jit_at(list.0, NanVal::number(-1.0).0, 0));
         assert!(v.is_number());
         assert_eq!(v.as_number(), 30.0);
     }
@@ -25752,7 +25785,7 @@ f>n;r=mk 10 20;+r.x r.y";
             NanVal::number(20.0),
             NanVal::number(30.0),
         ]);
-        let v = NanVal(jit_at(list.0, NanVal::number(-3.0).0));
+        let v = NanVal(jit_at(list.0, NanVal::number(-3.0).0, 0));
         assert!(v.is_number());
         assert_eq!(v.as_number(), 10.0);
     }
@@ -25761,7 +25794,7 @@ f>n;r=mk 10 20;+r.x r.y";
     #[test]
     fn jit_at_list_negative_out_of_range() {
         let list = NanVal::heap_list(vec![NanVal::number(1.0), NanVal::number(2.0)]);
-        let bits = jit_at(list.0, NanVal::number(-3.0).0);
+        let bits = jit_at(list.0, NanVal::number(-3.0).0, 0);
         assert_eq!(bits, TAG_NIL);
     }
 
@@ -25769,7 +25802,7 @@ f>n;r=mk 10 20;+r.x r.y";
     #[test]
     fn jit_at_text_negative_last() {
         let s = NanVal::heap_string("abc".to_string());
-        let v = NanVal(jit_at(s.0, NanVal::number(-1.0).0));
+        let v = NanVal(jit_at(s.0, NanVal::number(-1.0).0, 0));
         assert!(v.is_string());
         let got = unsafe {
             match v.as_heap_ref() {
@@ -25784,7 +25817,7 @@ f>n;r=mk 10 20;+r.x r.y";
     #[test]
     fn jit_at_text_negative_out_of_range() {
         let s = NanVal::heap_string("ab".to_string());
-        let bits = jit_at(s.0, NanVal::number(-3.0).0);
+        let bits = jit_at(s.0, NanVal::number(-3.0).0, 0);
         assert_eq!(bits, TAG_NIL);
     }
 
@@ -25792,7 +25825,7 @@ f>n;r=mk 10 20;+r.x r.y";
     #[test]
     fn jit_at_fractional_index_returns_nil() {
         let list = NanVal::heap_list(vec![NanVal::number(1.0)]);
-        let bits = jit_at(list.0, NanVal::number(0.5).0);
+        let bits = jit_at(list.0, NanVal::number(0.5).0, 0);
         assert_eq!(bits, TAG_NIL);
     }
 

--- a/tests/regression_cranelift_error_span.rs
+++ b/tests/regression_cranelift_error_span.rs
@@ -1,0 +1,153 @@
+// Regression: cranelift JIT runtime errors must carry the same source span
+// as tree / VM so the diagnostic renderer can underline the offending site.
+//
+// Before this fix, the JIT runtime-error TLS cell stored only `VmError`, so
+// every cranelift error surfaced with `span: None` and the diagnostic JSON
+// emitted an empty `labels: []`. The fix packs the call-site span into a
+// u64 immediate at compile time and threads it through the helper signature
+// for `jit_hd`, `jit_at`, `jit_tl`. These tests assert byte-for-byte parity
+// of the `labels[0]` field across tree, VM, and cranelift for the v1 helpers.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+/// Run `ilo` in JSON-diagnostic mode and return stderr.
+fn run_err(engine: &str, src: &str) -> String {
+    let out = ilo()
+        .args([src, engine, "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "engine={engine}: expected runtime error for `{src}`, stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+/// Extract `"start":NUM,"end":NUM` from a diagnostic JSON label. Returns
+/// `None` if the line has no label (i.e. `labels: []`).
+fn extract_span(stderr: &str) -> Option<(u32, u32)> {
+    // Diagnostic JSON looks like:
+    //   "labels":[{"col":7,"end":11,"line":1,"message":"here","primary":true,"start":6}]
+    // We want start/end. Bail if labels is empty.
+    if stderr.contains("\"labels\":[]") {
+        return None;
+    }
+    let start_key = "\"start\":";
+    let end_key = "\"end\":";
+    let s_pos = stderr.find(start_key)?;
+    let after_start = &stderr[s_pos + start_key.len()..];
+    let start: u32 = after_start
+        .split(|c: char| !c.is_ascii_digit())
+        .next()?
+        .parse()
+        .ok()?;
+    let e_pos = stderr.find(end_key)?;
+    let after_end = &stderr[e_pos + end_key.len()..];
+    let end: u32 = after_end
+        .split(|c: char| !c.is_ascii_digit())
+        .next()?
+        .parse()
+        .ok()?;
+    Some((start, end))
+}
+
+/// Asserts that cranelift produces the same `(start, end)` span as VM for the
+/// same source program. Tree is checked too as a sanity baseline.
+#[cfg(feature = "cranelift")]
+fn assert_span_parity(src: &str) {
+    let vm_err = run_err("--run-vm", src);
+    let cl_err = run_err("--run-cranelift", src);
+
+    let vm_span = extract_span(&vm_err)
+        .unwrap_or_else(|| panic!("VM stderr had no labels for `{src}`: {vm_err}"));
+    let cl_span = extract_span(&cl_err).unwrap_or_else(|| {
+        panic!(
+            "cranelift stderr had no labels for `{src}` (span did not survive JIT helper): {cl_err}"
+        )
+    });
+
+    assert_eq!(
+        cl_span, vm_span,
+        "engine span divergence for `{src}`: cranelift={cl_span:?} vs vm={vm_span:?}\nvm stderr={vm_err}\ncl stderr={cl_err}"
+    );
+}
+
+// ── jit_hd ────────────────────────────────────────────────────────────
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn hd_empty_list_span_matches_vm() {
+    assert_span_parity("f>n;hd []");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn hd_empty_text_span_matches_vm() {
+    assert_span_parity("f>t;hd \"\"");
+}
+
+// ── jit_tl ────────────────────────────────────────────────────────────
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn tl_empty_list_span_matches_vm() {
+    assert_span_parity("f>L n;tl []");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn tl_empty_text_span_matches_vm() {
+    assert_span_parity("f>t;tl \"\"");
+}
+
+// ── jit_at ────────────────────────────────────────────────────────────
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn at_oob_positive_list_span_matches_vm() {
+    assert_span_parity("f>n;at [1,2,3] 99");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn at_oob_negative_list_span_matches_vm() {
+    assert_span_parity("f>n;at [1,2,3] -99");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn at_oob_text_span_matches_vm() {
+    assert_span_parity("f>t;at \"hi\" 99");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn at_fractional_index_span_matches_vm() {
+    assert_span_parity("f>n;at [1,2,3] 1.5");
+}
+
+// ── Sanity: a span must actually be present (not None) ────────────────
+//
+// Belt-and-braces guard against a future regression that silently drops to
+// `span: None` without breaking the cross-engine equality above (which would
+// fail because vm has a span and cl doesn't, but better to assert presence
+// explicitly).
+#[test]
+#[cfg(feature = "cranelift")]
+fn cranelift_hd_error_carries_some_span() {
+    let stderr = run_err("--run-cranelift", "f>n;hd []");
+    assert!(
+        !stderr.contains("\"labels\":[]"),
+        "cranelift hd error must carry a source span, got: {stderr}"
+    );
+    let (start, end) = extract_span(&stderr).expect("expected start/end in stderr");
+    assert!(
+        end > start,
+        "span end must be > start, got start={start} end={end}"
+    );
+}


### PR DESCRIPTION
## Summary

Cranelift JIT runtime errors used to surface with `span: None` because the JIT_RUNTIME_ERROR TLS cell only stored a bare `VmError`. The diagnostic renderer had nothing to underline so errors came out with empty `labels: []`, breaking parity with tree and VM and forcing agents to re-read source code to locate the offending site. Manifesto cost: extra tokens on every cranelift failure.

This PR plumbs the call-site `Span` through the JIT helper ABI by packing it as a u64 immediate (`start << 32 | end`) at the cranelift call site and threading it as a trailing extern "C" arg into `jit_hd`, `jit_at`, `jit_tl`. The helpers store the `(VmError, Span)` pair on error; the entry point decodes the optional span onto the surfaced `VmRuntimeError`. Zero is the `Span::UNKNOWN` sentinel and round-trips to `None`.

Scoped to those three helpers for v1, as agreed. The other erroring helpers (`jit_lst`, `jit_listget`, `jit_index`, `jit_jpth`, `jit_slc`, ...) keep their existing permissive-nil semantics; widening them is parked. Each newly-promoted helper now costs +1 u64 arg and +1 iconst at the call site, which is the dominant runtime cost of this approach.

## Repro

```
$ echo 'f>n;hd []' > /tmp/repro.ilo
$ ilo /tmp/repro.ilo --run-cranelift f --diagnostics-json
```

Before:
```
"labels":[]
```

After (matches `--run-vm` / `--run-tree`):
```
"labels":[{"col":7,"end":9,"line":1,"message":"here","primary":true,"start":6}]
```

## What's in the diff

**Commit 1, `cranelift: thread source span through jit_hd/jit_at/jit_tl`**
- `src/vm/mod.rs`: JIT_RUNTIME_ERROR now holds `Option<(VmError, Option<Span>)>`. New `jit_set_runtime_error_with_span(err, span_bits)`; old `jit_set_runtime_error(err)` is a 0-bits wrapper for helpers not yet plumbed. `jit_take_runtime_error` returns the tuple. New `decode_span_bits` helper. `jit_hd`, `jit_at`, `jit_tl` extern "C" signatures gain a trailing `span_bits: u64` and route every error path through the new helper. Inline unit-test calls updated.
- `src/vm/jit_cranelift.rs`: New `pack_span_bits(Span) -> i64`. `helpers.hd` / `helpers.at` / `helpers.tl` declared with the new arity. Compile sites for OP_HD / OP_AT / OP_TL pack `chunk.spans[ip]` into an iconst and append it to the call args. JIT entry point attaches the decoded span to `VmRuntimeError`.

**Commit 2, `test + example: cross-engine span parity for cranelift errors`**
- `tests/regression_cranelift_error_span.rs`: 9 tests asserting cranelift `(start, end)` equals VM `(start, end)` across every v1 helper error path, plus a belt-and-braces "labels not empty" check.
- `examples/cranelift-error-span.ilo`: positive-path coverage of the extended helper ABI through the cross-engine harness, so a future call site that forgets the immediate crashes loudly on arity mismatch.

## Test plan

- [x] `cargo build --release --features cranelift`
- [x] `cargo test --release --features cranelift --test regression_cranelift_error_span` (9 passed)
- [x] `cargo test --release --features cranelift` full suite (4700 passed, 0 failed)
- [x] `cargo fmt --check`
- [x] `cargo clippy --release --features cranelift --all-targets -- -D warnings`
- [ ] CI green

## Follow-ups

- Widen span plumbing to the remaining erroring JIT helpers (`jit_lst`, `jit_listget`, `jit_index`, `jit_jpth`, `jit_slc`, the arithmetic helpers, ...). Each is mechanically the same change: +1 u64 arg, +1 iconst, swap to `_with_span`. Parking until a real diagnostic complaint surfaces from one of those paths.
- Carry the JIT call stack through too. Currently `VmRuntimeError::call_stack` is always empty for cranelift; the helper TLS would need a `Vec<Frame>` push at every JIT call site, which is more invasive.