### PR TITLE
interpreter: RC-aware Value::List with self-rebind append peephole

### DIFF
--- a/examples/list-accumulator-tree.ilo
+++ b/examples/list-accumulator-tree.ilo
@@ -1,0 +1,29 @@
+-- Demonstrates the tree-walker list-append accumulator fast path.
+--
+-- Phase 2b.2 (this commit's parent PR) makes `Value::List` RC-aware via
+-- `Arc<Vec<Value>>` and adds an eval_stmt peephole for the self-rebind
+-- shapes `xs = +=xs v` and `xs = xs + ys`. With refcount=1 the peephole
+-- calls `Arc::make_mut` and mutates the inner Vec in place, so the loop
+-- below runs in O(n) instead of O(n²).
+--
+-- Mirror of the Phase 2b.1 Map fast path (PR #261).
+
+-- The canonical accumulator: build [0, 1, 2, ..., n-1] one element at a time.
+-- Pre-Phase-2b.2 the tree engine cloned the whole Vec on every iteration.
+-- After the fix it mutates in place because env's `xs` is the sole holder.
+build-range n:n>n;xs=[];@i 0..n{xs=+=xs i};len xs
+
+-- Concat self-rebind: same fast path via `+` on two lists.
+build-by-concat n:n>n;xs=[];@i 0..n{xs=+xs [i]};len xs
+
+-- Aliased concat must NOT use the fast path. `xs = +xs xs` reads `xs` after
+-- env.take() would have replaced it with Nil, so the peephole bails out and
+-- the general cloning path doubles the list correctly.
+self-double>n;xs=[1,2,3];xs=+xs xs;len xs
+
+-- run: build-range 50
+-- out: 50
+-- run: build-by-concat 20
+-- out: 20
+-- run: self-double
+-- out: 6

--- a/src/interpreter/json.rs
+++ b/src/interpreter/json.rs
@@ -96,7 +96,7 @@ impl Value {
             serde_json::Value::Array(arr) => {
                 let items: Result<Vec<_>, _> =
                     arr.iter().map(|v| Value::from_json(v, None)).collect();
-                Ok(Value::List(items?))
+                Ok(Value::List(std::sync::Arc::new(items?)))
             }
             serde_json::Value::Object(map) => {
                 // `{"ok": ...}` → Value::Ok(...)
@@ -129,6 +129,7 @@ impl Value {
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::sync::Arc;
 
     // ── to_json ─────────────────────────────────────────────────────────
 
@@ -175,7 +176,10 @@ mod tests {
 
     #[test]
     fn to_json_list() {
-        let v = Value::List(vec![Value::Number(1.0), Value::Text("a".to_string())]);
+        let v = Value::List(Arc::new(vec![
+            Value::Number(1.0),
+            Value::Text("a".to_string()),
+        ]));
         assert_eq!(v.to_json().unwrap(), json!([1, "a"]));
     }
 
@@ -241,11 +245,11 @@ mod tests {
         let v = Value::from_json(&json!([1, 2, 3]), None).unwrap();
         assert_eq!(
             v,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0)
-            ])
+            ]))
         );
     }
 
@@ -321,10 +325,10 @@ mod tests {
 
     #[test]
     fn round_trip_list_of_text() {
-        let v = Value::List(vec![
+        let v = Value::List(Arc::new(vec![
             Value::Text("a".to_string()),
             Value::Text("b".to_string()),
-        ]);
+        ]));
         let j = v.to_json().unwrap();
         let back = Value::from_json(&j, None).unwrap();
         assert_eq!(back, v);

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -3970,6 +3970,124 @@ fn eval_self_rebind_mset(
     call_function(env, "mset", args)
 }
 
+/// Returns `true` if `expr` contains a `Ref(name)` anywhere in its subtree.
+/// Used by the self-rebind peepholes to detect aliasing: if the RHS reads the
+/// same binding we're about to take, the fast path would observe Nil and we
+/// must fall back to the general (cloning) path.
+fn expr_refers_to(name: &str, expr: &Expr) -> bool {
+    match expr {
+        Expr::Ref(n) => n == name,
+        Expr::Field { object, .. } => expr_refers_to(name, object),
+        Expr::Index { object, .. } => expr_refers_to(name, object),
+        Expr::Call { args, .. } => args.iter().any(|a| expr_refers_to(name, a)),
+        Expr::BinOp { left, right, .. } => {
+            expr_refers_to(name, left) || expr_refers_to(name, right)
+        }
+        Expr::UnaryOp { operand, .. } => expr_refers_to(name, operand),
+        Expr::Ok(inner) | Expr::Err(inner) => expr_refers_to(name, inner),
+        Expr::List(items) => items.iter().any(|e| expr_refers_to(name, e)),
+        Expr::Record { fields, .. } => fields.iter().any(|(_, e)| expr_refers_to(name, e)),
+        // Conservative: assume Match arms might reference `name`. Falls back
+        // to the general path, which is correct (just slower) in the rare
+        // case where a self-rebind RHS is wrapped in a match.
+        Expr::Match { .. } => true,
+        Expr::NilCoalesce { value, default } => {
+            expr_refers_to(name, value) || expr_refers_to(name, default)
+        }
+        Expr::With { object, updates } => {
+            expr_refers_to(name, object) || updates.iter().any(|(_, e)| expr_refers_to(name, e))
+        }
+        Expr::Ternary {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            expr_refers_to(name, condition)
+                || expr_refers_to(name, then_expr)
+                || expr_refers_to(name, else_expr)
+        }
+        Expr::MakeClosure { captures, .. } => captures.iter().any(|c| expr_refers_to(name, c)),
+        Expr::Literal(_) => false,
+    }
+}
+
+/// If `value` is the self-rebind list-append shape `name = +=name v`, return
+/// `Some(val_expr)`. Returns `None` for any other shape (different target,
+/// different operator, wrong operand order, or RHS that aliases `name`),
+/// which falls through to the general path.
+fn match_self_rebind_append<'a>(name: &str, value: &'a Expr) -> Option<&'a Expr> {
+    if let Expr::BinOp { op, left, right } = value
+        && matches!(op, BinOp::Append)
+        && let Expr::Ref(left_name) = left.as_ref()
+        && left_name == name
+        && !expr_refers_to(name, right)
+    {
+        return Some(right.as_ref());
+    }
+    None
+}
+
+/// Fast-path executor for `xs = +=xs v`. Caller has taken the previous binding
+/// out of env (leaving Value::Nil), so the Arc<Vec<Value>> in `prev` is the
+/// sole reference. `Arc::make_mut` then mutates the inner Vec in place,
+/// turning the classic `xs = +=xs v` loop accumulator from O(n²) to O(n)
+/// amortised on the tree-walker.
+fn eval_self_rebind_append(env: &mut Env, val_expr: &Expr, prev: Value) -> Result<Value> {
+    let val_val = eval_expr(env, val_expr)?;
+    match prev {
+        Value::List(mut items) => {
+            let inner = Arc::make_mut(&mut items);
+            inner.push(val_val);
+            Ok(Value::List(items))
+        }
+        // Non-list `prev` is impossible in well-typed code, but if it occurs
+        // (e.g. the binding was previously nil) we surface the same error as
+        // the general BinOp::Append path would.
+        other => Err(RuntimeError::new(
+            "ILO-R004",
+            format!(
+                "unsupported operation: {:?} on {:?} and {:?}",
+                BinOp::Append,
+                other,
+                val_val
+            ),
+        )),
+    }
+}
+
+/// If `value` is the self-rebind list-concat shape `name = name + ys`, return
+/// `Some(rhs_expr)`. Returns `None` for any other shape, including any case
+/// where the rhs references `name` (e.g. `s = s + s` self-concat), which
+/// would observe Nil after the fast path takes the binding.
+fn match_self_rebind_concat<'a>(name: &str, value: &'a Expr) -> Option<&'a Expr> {
+    if let Expr::BinOp { op, left, right } = value
+        && matches!(op, BinOp::Add)
+        && let Expr::Ref(left_name) = left.as_ref()
+        && left_name == name
+        && !expr_refers_to(name, right)
+    {
+        return Some(right.as_ref());
+    }
+    None
+}
+
+/// Fast-path executor for `xs = xs + ys`. Caller has taken the previous
+/// binding out of env. If both sides are lists, we use `Arc::make_mut` on the
+/// prev (which now has refcount=1) and `extend` from ys, again giving O(n)
+/// amortised behaviour for repeated concatenation. If the values aren't both
+/// lists (e.g. numeric add), we fall back to `apply_binop` so semantics match
+/// the general path exactly.
+fn eval_self_rebind_concat(env: &mut Env, rhs_expr: &Expr, prev: Value) -> Result<Value> {
+    let rhs = eval_expr(env, rhs_expr)?;
+    match (prev, rhs) {
+        (Value::List(mut items), Value::List(other)) => {
+            let inner = Arc::make_mut(&mut items);
+            inner.extend(other.iter().cloned());
+            Ok(Value::List(items))
+        }
+        (prev, rhs) => eval_binop(&BinOp::Add, &prev, &rhs),
+    }
+}
 
 fn eval_stmt(env: &mut Env, stmt: &Stmt) -> Result<Option<BodyResult>> {
     match stmt {
@@ -3995,6 +4113,29 @@ fn eval_stmt(env: &mut Env, stmt: &Stmt) -> Result<Option<BodyResult>> {
                 // catch/recover form), so user code never observes the
                 // intermediate Nil.
                 let val = eval_self_rebind_mset(env, key_expr, val_expr, prev)?;
+                env.set(name, val);
+                return Ok(None);
+            }
+            // Peephole: `xs = +=xs v` self-rebind list append. Same trick as
+            // the Map mset peephole: take prev so Arc<Vec<Value>> refcount=1,
+            // then `Arc::make_mut` mutates the inner Vec in place. Turns the
+            // classic accumulator loop from O(n²) (clone-per-push) to O(n)
+            // amortised. Phase 2b.2 of the RC-aware mutation rollout.
+            if let Some(val_expr) = match_self_rebind_append(name, value)
+                && let Some(prev) = env.take(name)
+            {
+                let val = eval_self_rebind_append(env, val_expr, prev)?;
+                env.set(name, val);
+                return Ok(None);
+            }
+            // Peephole: `xs = xs + ys` self-rebind list concat. Mirrors the
+            // append peephole but extends from the rhs list. Falls back to the
+            // general apply_binop path if either side isn't a list (so numeric
+            // `x = x + y` works unchanged).
+            if let Some(rhs_expr) = match_self_rebind_concat(name, value)
+                && let Some(prev) = env.take(name)
+            {
+                let val = eval_self_rebind_concat(env, rhs_expr, prev)?;
                 env.set(name, val);
                 return Ok(None);
             }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -113,7 +113,7 @@ pub enum Value {
     Text(String),
     Bool(bool),
     Nil,
-    List(Vec<Value>),
+    List(Arc<Vec<Value>>),
     Map(Arc<HashMap<MapKey, Value>>),
     Record {
         type_name: String,
@@ -451,10 +451,10 @@ fn parse_format(fmt: &str, content: &str) -> std::result::Result<Value, String> 
                         .into_iter()
                         .map(Value::Text)
                         .collect();
-                    Value::List(fields)
+                    Value::List(Arc::new(fields))
                 })
                 .collect();
-            Ok(Value::List(rows))
+            Ok(Value::List(Arc::new(rows)))
         }
         "json" => serde_json::from_str::<serde_json::Value>(content)
             .map(serde_json_to_value)
@@ -507,7 +507,7 @@ fn matrix_from_value(v: &Value, name: &str) -> Result<Vec<Vec<f64>>> {
         }
     };
     let mut mat: Vec<Vec<f64>> = Vec::with_capacity(rows.len());
-    for row in rows {
+    for row in rows.iter() {
         let cells = match row {
             Value::List(cs) => cs,
             other => {
@@ -518,7 +518,7 @@ fn matrix_from_value(v: &Value, name: &str) -> Result<Vec<Vec<f64>>> {
             }
         };
         let mut r: Vec<f64> = Vec::with_capacity(cells.len());
-        for c in cells {
+        for c in cells.iter() {
             match c {
                 Value::Number(n) => r.push(*n),
                 other => {
@@ -546,7 +546,7 @@ fn vec_from_value(v: &Value, name: &str) -> Result<Vec<f64>> {
         }
     };
     let mut out: Vec<f64> = Vec::with_capacity(items.len());
-    for item in items {
+    for item in items.iter() {
         match item {
             Value::Number(n) => out.push(*n),
             other => {
@@ -832,9 +832,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             Value::Map(m) => {
                 let mut keys: Vec<&MapKey> = m.keys().collect();
                 keys.sort();
-                Ok(Value::List(
+                Ok(Value::List(Arc::new(
                     keys.into_iter().map(map_key_to_value).collect(),
-                ))
+                )))
             }
             _ => Err(RuntimeError::new(
                 "ILO-R009",
@@ -847,9 +847,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             Value::Map(m) => {
                 let mut pairs: Vec<(&MapKey, &Value)> = m.iter().collect();
                 pairs.sort_by_key(|(k, _)| (*k).clone());
-                Ok(Value::List(
+                Ok(Value::List(Arc::new(
                     pairs.into_iter().map(|(_, v)| v.clone()).collect(),
-                ))
+                )))
             }
             _ => Err(RuntimeError::new(
                 "ILO-R009",
@@ -927,14 +927,14 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         // Assemble row-major: result[i][j] = cols[j][i]
         let rows: Vec<Value> = (0..n)
             .map(|i| {
-                Value::List(
+                Value::List(Arc::new(
                     (0..n)
                         .map(|j| Value::Number(cols[j][i]))
                         .collect::<Vec<_>>(),
-                )
+                ))
             })
             .collect();
-        return Ok(Value::List(rows));
+        return Ok(Value::List(Arc::new(rows)));
     }
     if builtin == Some(Builtin::Solve) && args.len() == 2 {
         let mat = matrix_from_value(&args[0], "solve")?;
@@ -968,7 +968,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             ));
         }
         let x = lu_solve(&lu, &piv, &b);
-        return Ok(Value::List(x.into_iter().map(Value::Number).collect()));
+        return Ok(Value::List(Arc::new(
+            x.into_iter().map(Value::Number).collect(),
+        )));
     }
     if builtin == Some(Builtin::Str) {
         if args.len() != 1 {
@@ -1262,7 +1264,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                     .split(sep.as_str())
                     .map(|p| Value::Text(p.to_string()))
                     .collect();
-                Ok(Value::List(parts))
+                Ok(Value::List(Arc::new(parts)))
             }
             _ => Err(RuntimeError::new(
                 "ILO-R009",
@@ -1274,7 +1276,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         return match (&args[0], &args[1]) {
             (Value::List(items), Value::Text(sep)) => {
                 let mut parts = Vec::new();
-                for item in items {
+                for item in items.iter() {
                     match item {
                         Value::Text(s) => parts.push(s.clone()),
                         other => {
@@ -1407,9 +1409,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                         ),
                     ))
                 } else {
-                    let mut new_items = items.clone();
+                    let mut new_items = (**items).clone();
                     new_items[idx] = args[2].clone();
-                    Ok(Value::List(new_items))
+                    Ok(Value::List(Arc::new(new_items)))
                 }
             }
             other => Err(RuntimeError::new(
@@ -1446,13 +1448,13 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             }
         };
         if n > xs.len() {
-            return Ok(Value::List(vec![]));
+            return Ok(Value::List(Arc::new(vec![])));
         }
         let mut out = Vec::with_capacity(xs.len() - n + 1);
         for w in xs.windows(n) {
-            out.push(Value::List(w.to_vec()));
+            out.push(Value::List(Arc::new(w.to_vec())));
         }
-        return Ok(Value::List(out));
+        return Ok(Value::List(Arc::new(out)));
     }
     if builtin == Some(Builtin::Zip) && args.len() == 2 {
         let xs = match &args[0] {
@@ -1476,9 +1478,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         let n = xs.len().min(ys.len());
         let mut out = Vec::with_capacity(n);
         for i in 0..n {
-            out.push(Value::List(vec![xs[i].clone(), ys[i].clone()]));
+            out.push(Value::List(Arc::new(vec![xs[i].clone(), ys[i].clone()])));
         }
-        return Ok(Value::List(out));
+        return Ok(Value::List(Arc::new(out)));
     }
     if builtin == Some(Builtin::Enumerate) && args.len() == 1 {
         let xs = match &args[0] {
@@ -1492,9 +1494,12 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         };
         let mut out = Vec::with_capacity(xs.len());
         for (i, v) in xs.iter().enumerate() {
-            out.push(Value::List(vec![Value::Number(i as f64), v.clone()]));
+            out.push(Value::List(Arc::new(vec![
+                Value::Number(i as f64),
+                v.clone(),
+            ])));
         }
-        return Ok(Value::List(out));
+        return Ok(Value::List(Arc::new(out)));
     }
     if builtin == Some(Builtin::Range) && args.len() == 2 {
         return match (&args[0], &args[1]) {
@@ -1510,7 +1515,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 let start = *a as i64;
                 let end = *b as i64;
                 if start >= end {
-                    return Ok(Value::List(Vec::new()));
+                    return Ok(Value::List(Arc::new(Vec::new())));
                 }
                 let len = (end - start) as u64;
                 if len > 1_000_000 {
@@ -1523,7 +1528,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 for i in start..end {
                     out.push(Value::Number(i as f64));
                 }
-                Ok(Value::List(out))
+                Ok(Value::List(Arc::new(out)))
             }
             _ => Err(RuntimeError::new(
                 "ILO-R009",
@@ -1559,9 +1564,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         };
         let mut out: Vec<Value> = Vec::with_capacity(xs.len().div_ceil(n));
         for chunk in xs.chunks(n) {
-            out.push(Value::List(chunk.to_vec()));
+            out.push(Value::List(Arc::new(chunk.to_vec())));
         }
-        return Ok(Value::List(out));
+        return Ok(Value::List(Arc::new(out)));
     }
     if matches!(
         builtin,
@@ -1617,7 +1622,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         use std::collections::{HashMap, HashSet};
         let mut set_a: HashSet<String> = HashSet::new();
         let mut a_first: HashMap<String, Value> = HashMap::new();
-        for v in xs {
+        for v in xs.iter() {
             let k = key_for(v, op_name)?;
             if set_a.insert(k.clone()) {
                 a_first.insert(k, v.clone());
@@ -1625,7 +1630,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         }
         let mut set_b: HashSet<String> = HashSet::new();
         let mut b_first: HashMap<String, Value> = HashMap::new();
-        for v in ys {
+        for v in ys.iter() {
             let k = key_for(v, op_name)?;
             if set_b.insert(k.clone()) {
                 b_first.insert(k, v.clone());
@@ -1648,7 +1653,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                         out.push(v.clone());
                     }
                 }
-                return Ok(Value::List(out));
+                return Ok(Value::List(Arc::new(out)));
             }
             Some(Builtin::Setinter) => (
                 set_a.intersection(&set_b).cloned().collect::<Vec<_>>(),
@@ -1668,7 +1673,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 out.push(v.clone());
             }
         }
-        return Ok(Value::List(out));
+        return Ok(Value::List(Arc::new(out)));
     }
     if builtin == Some(Builtin::Tl) && args.len() == 1 {
         return match &args[0] {
@@ -1676,7 +1681,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 if items.is_empty() {
                     Err(RuntimeError::new("ILO-R009", "tl: empty list".to_string()))
                 } else {
-                    Ok(Value::List(items[1..].to_vec()))
+                    Ok(Value::List(Arc::new(items[1..].to_vec())))
                 }
             }
             Value::Text(s) => {
@@ -1697,9 +1702,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
     if builtin == Some(Builtin::Rev) && args.len() == 1 {
         return match &args[0] {
             Value::List(items) => {
-                let mut reversed = items.clone();
+                let mut reversed: Vec<Value> = (**items).clone();
                 reversed.reverse();
-                Ok(Value::List(reversed))
+                Ok(Value::List(Arc::new(reversed)))
             }
             Value::Text(s) => Ok(Value::Text(s.chars().rev().collect())),
             other => Err(RuntimeError::new(
@@ -1712,12 +1717,12 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         return match &args[0] {
             Value::List(items) => {
                 if items.is_empty() {
-                    return Ok(Value::List(vec![]));
+                    return Ok(Value::List(Arc::new(vec![])));
                 }
                 let all_numbers = items.iter().all(|v| matches!(v, Value::Number(_)));
                 let all_text = items.iter().all(|v| matches!(v, Value::Text(_)));
                 if all_numbers {
-                    let mut sorted = items.clone();
+                    let mut sorted: Vec<Value> = (**items).clone();
                     sorted.sort_by(|a, b| {
                         if let (Value::Number(x), Value::Number(y)) = (a, b) {
                             x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal)
@@ -1725,9 +1730,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                             unreachable!()
                         }
                     });
-                    Ok(Value::List(sorted))
+                    Ok(Value::List(Arc::new(sorted)))
                 } else if all_text {
-                    let mut sorted = items.clone();
+                    let mut sorted: Vec<Value> = (**items).clone();
                     sorted.sort_by(|a, b| {
                         if let (Value::Text(x), Value::Text(y)) = (a, b) {
                             x.cmp(y)
@@ -1735,7 +1740,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                             unreachable!()
                         }
                     });
-                    Ok(Value::List(sorted))
+                    Ok(Value::List(Arc::new(sorted)))
                 } else {
                     Err(RuntimeError::new(
                         "ILO-R009",
@@ -1780,8 +1785,10 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 ));
             }
         };
-        // Compute keys for each item, then sort by key
-        let mut keyed: Vec<(Value, Value)> = items
+        // Compute keys for each item, then sort by key.
+        // `items: Arc<Vec<Value>>` — unwrap if refcount=1, else clone the Vec.
+        let owned_items: Vec<Value> = Arc::try_unwrap(items).unwrap_or_else(|arc| (*arc).clone());
+        let mut keyed: Vec<(Value, Value)> = owned_items
             .into_iter()
             .map(|item| {
                 let mut call_args = match &ctx {
@@ -1800,18 +1807,20 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             (Value::Text(a), Value::Text(b)) => a.cmp(b),
             _ => std::cmp::Ordering::Equal,
         });
-        return Ok(Value::List(keyed.into_iter().map(|(_, v)| v).collect()));
+        return Ok(Value::List(Arc::new(
+            keyed.into_iter().map(|(_, v)| v).collect(),
+        )));
     }
     if builtin == Some(Builtin::Rsrt) && args.len() == 1 {
         return match &args[0] {
             Value::List(items) => {
                 if items.is_empty() {
-                    return Ok(Value::List(vec![]));
+                    return Ok(Value::List(Arc::new(vec![])));
                 }
                 let all_numbers = items.iter().all(|v| matches!(v, Value::Number(_)));
                 let all_text = items.iter().all(|v| matches!(v, Value::Text(_)));
                 if all_numbers {
-                    let mut sorted = items.clone();
+                    let mut sorted: Vec<Value> = (**items).clone();
                     sorted.sort_by(|a, b| {
                         if let (Value::Number(x), Value::Number(y)) = (a, b) {
                             y.partial_cmp(x).unwrap_or(std::cmp::Ordering::Equal)
@@ -1819,9 +1828,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                             unreachable!()
                         }
                     });
-                    Ok(Value::List(sorted))
+                    Ok(Value::List(Arc::new(sorted)))
                 } else if all_text {
-                    let mut sorted = items.clone();
+                    let mut sorted: Vec<Value> = (**items).clone();
                     sorted.sort_by(|a, b| {
                         if let (Value::Text(x), Value::Text(y)) = (a, b) {
                             y.cmp(x)
@@ -1829,7 +1838,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                             unreachable!()
                         }
                     });
-                    Ok(Value::List(sorted))
+                    Ok(Value::List(Arc::new(sorted)))
                 } else {
                     Err(RuntimeError::new(
                         "ILO-R009",
@@ -1891,7 +1900,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 let len = items.len();
                 let end = crate::builtins::resolve_slice_bound(end_raw, len);
                 let start = crate::builtins::resolve_slice_bound(start_raw, len).min(end);
-                Ok(Value::List(items[start..end].to_vec()))
+                Ok(Value::List(Arc::new(items[start..end].to_vec())))
             }
             Value::Text(s) => {
                 let chars: Vec<char> = s.chars().collect();
@@ -1929,7 +1938,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         return match &args[1] {
             Value::List(items) => {
                 let end = crate::builtins::resolve_take_count(n, items.len());
-                Ok(Value::List(items[..end].to_vec()))
+                Ok(Value::List(Arc::new(items[..end].to_vec())))
             }
             Value::Text(s) => {
                 let chars: Vec<char> = s.chars().collect();
@@ -1965,7 +1974,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         return match &args[1] {
             Value::List(items) => {
                 let start = crate::builtins::resolve_drop_count(n, items.len());
-                Ok(Value::List(items[start..].to_vec()))
+                Ok(Value::List(Arc::new(items[start..].to_vec())))
             }
             Value::Text(s) => {
                 let chars: Vec<char> = s.chars().collect();
@@ -2063,7 +2072,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 ));
             }
         };
-        return Ok(Value::List(get_many_fetch(&urls)));
+        return Ok(Value::List(Arc::new(get_many_fetch(&urls))));
     }
     if builtin == Some(Builtin::Post) && (args.len() == 2 || args.len() == 3) {
         let (url, body) = match (&args[0], &args[1]) {
@@ -2257,9 +2266,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
     }
     if builtin == Some(Builtin::Chars) && args.len() == 1 {
         return match &args[0] {
-            Value::Text(s) => Ok(Value::List(
+            Value::Text(s) => Ok(Value::List(Arc::new(
                 s.chars().map(|c| Value::Text(c.to_string())).collect(),
-            )),
+            ))),
             other => Err(RuntimeError::new(
                 "ILO-R009",
                 format!("chars requires text, got {:?}", other),
@@ -2271,13 +2280,13 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             Value::List(xs) => {
                 let mut seen = std::collections::HashSet::new();
                 let mut out = Vec::new();
-                for v in xs {
+                for v in xs.iter() {
                     let key = format!("{v:?}");
                     if seen.insert(key) {
                         out.push(v.clone());
                     }
                 }
-                Ok(Value::List(out))
+                Ok(Value::List(Arc::new(out)))
             }
             Value::Text(s) => {
                 let mut seen = std::collections::HashSet::new();
@@ -2402,7 +2411,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                         .lines()
                         .map(|l| Value::Text(l.to_string()))
                         .collect();
-                    Ok(Value::Ok(Box::new(Value::List(lines))))
+                    Ok(Value::Ok(Box::new(Value::List(Arc::new(lines)))))
                 }
                 Err(e) => Ok(Value::Err(Box::new(Value::Text(e.to_string())))),
             },
@@ -2499,7 +2508,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         return match (&args[0], &args[1]) {
             (Value::Text(path), Value::List(lines)) => {
                 let mut content = String::new();
-                for line in lines {
+                for line in lines.iter() {
                     match line {
                         Value::Text(s) => {
                             content.push_str(s);
@@ -2601,7 +2610,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                         };
                         items.push(parsed);
                     }
-                    Ok(Value::List(items))
+                    Ok(Value::List(Arc::new(items)))
                 }
                 Err(e) => Err(RuntimeError::new(
                     "ILO-R009",
@@ -2680,7 +2689,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             }
         };
         let mut result = Vec::with_capacity(items.len());
-        for item in items {
+        for item in items.iter().cloned() {
             let mut call_args = match &ctx {
                 Some(c) => vec![item, c.clone()],
                 None => vec![item],
@@ -2688,7 +2697,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             call_args.extend(captures.iter().cloned());
             result.push(call_function(env, &fn_name, call_args)?);
         }
-        return Ok(Value::List(result));
+        return Ok(Value::List(Arc::new(result)));
     }
     if builtin == Some(Builtin::Flt) && (args.len() == 2 || args.len() == 3) {
         let fn_name = resolve_fn_ref(&args[0]).ok_or_else(|| {
@@ -2716,14 +2725,14 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             }
         };
         let mut result = Vec::new();
-        for item in items {
+        for item in items.iter() {
             let mut call_args = match &ctx {
                 Some(c) => vec![item.clone(), c.clone()],
                 None => vec![item.clone()],
             };
             call_args.extend(captures.iter().cloned());
             match call_function(env, &fn_name, call_args)? {
-                Value::Bool(true) => result.push(item),
+                Value::Bool(true) => result.push(item.clone()),
                 Value::Bool(false) => {}
                 other => {
                     return Err(RuntimeError::new(
@@ -2733,7 +2742,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 }
             }
         }
-        return Ok(Value::List(result));
+        return Ok(Value::List(Arc::new(result)));
     }
     if builtin == Some(Builtin::Fld) && (args.len() == 3 || args.len() == 4) {
         let fn_name = resolve_fn_ref(&args[0]).ok_or_else(|| {
@@ -2762,10 +2771,10 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             }
         };
         let mut acc = init;
-        for item in items {
+        for item in items.iter() {
             let mut call_args = match &ctx {
-                Some(c) => vec![acc, item, c.clone()],
-                None => vec![acc, item],
+                Some(c) => vec![acc, item.clone(), c.clone()],
+                None => vec![acc, item.clone()],
             };
             call_args.extend(captures.iter().cloned());
             acc = call_function(env, &fn_name, call_args)?;
@@ -2795,12 +2804,12 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         };
         let mut pass: Vec<Value> = Vec::new();
         let mut fail: Vec<Value> = Vec::new();
-        for item in items {
+        for item in items.iter() {
             let mut call_args = vec![item.clone()];
             call_args.extend(captures.iter().cloned());
             match call_function(env, &fn_name, call_args)? {
-                Value::Bool(true) => pass.push(item),
-                Value::Bool(false) => fail.push(item),
+                Value::Bool(true) => pass.push(item.clone()),
+                Value::Bool(false) => fail.push(item.clone()),
                 other => {
                     return Err(RuntimeError::new(
                         "ILO-R009",
@@ -2809,7 +2818,10 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 }
             }
         }
-        return Ok(Value::List(vec![Value::List(pass), Value::List(fail)]));
+        return Ok(Value::List(Arc::new(vec![
+            Value::List(Arc::new(pass)),
+            Value::List(Arc::new(fail)),
+        ])));
     }
 
     if builtin == Some(Builtin::Flatmap) && args.len() == 2 {
@@ -2833,11 +2845,11 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             }
         };
         let mut result: Vec<Value> = Vec::new();
-        for item in items {
+        for item in items.iter().cloned() {
             let mut call_args = vec![item];
             call_args.extend(captures.iter().cloned());
             match call_function(env, &fn_name, call_args)? {
-                Value::List(inner) => result.extend(inner),
+                Value::List(inner) => result.extend(inner.iter().cloned()),
                 other => {
                     return Err(RuntimeError::new(
                         "ILO-R009",
@@ -2846,7 +2858,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 }
             }
         }
-        return Ok(Value::List(result));
+        return Ok(Value::List(Arc::new(result)));
     }
 
     if builtin == Some(Builtin::Uniqby) && args.len() == 2 {
@@ -2871,7 +2883,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         };
         let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
         let mut out: Vec<Value> = Vec::new();
-        for item in items {
+        for item in items.iter() {
             let mut call_args = vec![item.clone()];
             call_args.extend(captures.iter().cloned());
             let key = call_function(env, &fn_name, call_args)?;
@@ -2899,10 +2911,10 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 }
             };
             if seen.insert(key_str) {
-                out.push(item);
+                out.push(item.clone());
             }
         }
-        return Ok(Value::List(out));
+        return Ok(Value::List(Arc::new(out)));
     }
 
     if builtin == Some(Builtin::Grp) && args.len() == 2 {
@@ -2927,7 +2939,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         };
         let mut groups: std::collections::HashMap<MapKey, Vec<Value>> =
             std::collections::HashMap::new();
-        for item in items {
+        for item in items.iter() {
             let mut call_args = vec![item.clone()];
             call_args.extend(captures.iter().cloned());
             let key = call_function(env, &fn_name, call_args)?;
@@ -2953,11 +2965,11 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                     ));
                 }
             };
-            groups.entry(map_key).or_default().push(item);
+            groups.entry(map_key).or_default().push(item.clone());
         }
         let map: HashMap<MapKey, Value> = groups
             .into_iter()
-            .map(|(k, v)| (k, Value::List(v)))
+            .map(|(k, v)| (k, Value::List(Arc::new(v))))
             .collect();
         return Ok(Value::Map(Arc::new(map)));
     }
@@ -2972,7 +2984,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             }
         };
         let mut counts: std::collections::HashMap<MapKey, usize> = std::collections::HashMap::new();
-        for item in items {
+        for item in items.iter() {
             // Build a typed `MapKey` so the resulting map preserves the element
             // type. Heterogeneous lists where text and number variants share a
             // print form (e.g. `Number(1)` and `Text("1")`) are now correctly
@@ -3019,11 +3031,11 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             }
         };
         if rows.is_empty() {
-            return Ok(Value::List(vec![]));
+            return Ok(Value::List(Arc::new(vec![])));
         }
         let mut row_data: Vec<&Vec<Value>> = Vec::with_capacity(rows.len());
         let mut ncols: Option<usize> = None;
-        for row in rows {
+        for row in rows.iter() {
             match row {
                 Value::List(r) => {
                     match ncols {
@@ -3056,9 +3068,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             for r in &row_data {
                 col.push(r[j].clone());
             }
-            result.push(Value::List(col));
+            result.push(Value::List(Arc::new(col)));
         }
-        return Ok(Value::List(result));
+        return Ok(Value::List(Arc::new(result)));
     }
     if builtin == Some(Builtin::Matmul) && args.len() == 2 {
         let a_rows = match &args[0] {
@@ -3085,7 +3097,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         // Extract a as Vec<Vec<f64>>
         let mut a: Vec<Vec<f64>> = Vec::with_capacity(a_rows.len());
         let mut a_cols: Option<usize> = None;
-        for row in a_rows {
+        for row in a_rows.iter() {
             match row {
                 Value::List(r) => {
                     match a_cols {
@@ -3102,7 +3114,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                         _ => {}
                     }
                     let mut nums = Vec::with_capacity(r.len());
-                    for v in r {
+                    for v in r.iter() {
                         match v {
                             Value::Number(n) => nums.push(*n),
                             other => {
@@ -3125,7 +3137,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         }
         let mut b: Vec<Vec<f64>> = Vec::with_capacity(b_rows.len());
         let mut b_cols: Option<usize> = None;
-        for row in b_rows {
+        for row in b_rows.iter() {
             match row {
                 Value::List(r) => {
                     match b_cols {
@@ -3142,7 +3154,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                         _ => {}
                     }
                     let mut nums = Vec::with_capacity(r.len());
-                    for v in r {
+                    for v in r.iter() {
                         match v {
                             Value::Number(n) => nums.push(*n),
                             other => {
@@ -3186,9 +3198,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 }
                 row.push(Value::Number(s));
             }
-            out.push(Value::List(row));
+            out.push(Value::List(Arc::new(row)));
         }
-        return Ok(Value::List(out));
+        return Ok(Value::List(Arc::new(out)));
     }
     if builtin == Some(Builtin::Dot) && args.len() == 2 {
         let xs = match &args[0] {
@@ -3244,7 +3256,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             }
         };
         let mut total = 0.0_f64;
-        for item in items {
+        for item in items.iter() {
             match item {
                 Value::Number(n) => total += n,
                 other => {
@@ -3269,7 +3281,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         };
         let mut total = 0.0_f64;
         let mut out: Vec<Value> = Vec::with_capacity(items.len());
-        for item in items {
+        for item in items.iter() {
             match item {
                 Value::Number(n) => {
                     total += n;
@@ -3283,7 +3295,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 }
             }
         }
-        return Ok(Value::List(out));
+        return Ok(Value::List(Arc::new(out)));
     }
     if builtin == Some(Builtin::Avg) && args.len() == 1 {
         let items = match &args[0] {
@@ -3302,7 +3314,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             ));
         }
         let mut total = 0.0_f64;
-        for item in items {
+        for item in items.iter() {
             match item {
                 Value::Number(n) => total += n,
                 other => {
@@ -3332,7 +3344,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             ));
         }
         let mut nums: Vec<f64> = Vec::with_capacity(items.len());
-        for item in items {
+        for item in items.iter() {
             match item {
                 Value::Number(n) => nums.push(*n),
                 other => {
@@ -3384,7 +3396,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             ));
         }
         let mut nums: Vec<f64> = Vec::with_capacity(items.len());
-        for item in items {
+        for item in items.iter() {
             match item {
                 Value::Number(n) => nums.push(*n),
                 other => {
@@ -3429,7 +3441,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             ));
         }
         let mut nums: Vec<f64> = Vec::with_capacity(items.len());
-        for item in items {
+        for item in items.iter() {
             match item {
                 Value::Number(n) => nums.push(*n),
                 other => {
@@ -3472,7 +3484,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             ));
         }
         let mut nums: Vec<f64> = Vec::with_capacity(items.len());
-        for item in items {
+        for item in items.iter() {
             match item {
                 Value::Number(n) => nums.push(*n),
                 other => {
@@ -3535,7 +3547,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 .map(|m| Value::Text(m.as_str().to_string()))
                 .collect()
         };
-        return Ok(Value::List(result));
+        return Ok(Value::List(Arc::new(result)));
     }
     if builtin == Some(Builtin::Rgxall) && args.len() == 2 {
         let pattern = match &args[0] {
@@ -3580,15 +3592,15 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                     let groups: Vec<Value> = (1..caps.len())
                         .filter_map(|i| caps.get(i).map(|m| Value::Text(m.as_str().to_string())))
                         .collect();
-                    Value::List(groups)
+                    Value::List(Arc::new(groups))
                 })
                 .collect()
         } else {
             re.find_iter(input)
-                .map(|m| Value::List(vec![Value::Text(m.as_str().to_string())]))
+                .map(|m| Value::List(Arc::new(vec![Value::Text(m.as_str().to_string())])))
                 .collect()
         };
-        return Ok(Value::List(result));
+        return Ok(Value::List(Arc::new(result)));
     }
     if builtin == Some(Builtin::Rgxsub) && args.len() == 3 {
         let pattern = match &args[0] {
@@ -3644,14 +3656,14 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 ));
             }
         };
-        let mut result = Vec::new();
-        for item in items {
+        let mut result: Vec<Value> = Vec::new();
+        for item in items.iter() {
             match item {
-                Value::List(inner) => result.extend(inner),
-                other => result.push(other),
+                Value::List(inner) => result.extend(inner.iter().cloned()),
+                other => result.push(other.clone()),
             }
         }
-        return Ok(Value::List(result));
+        return Ok(Value::List(Arc::new(result)));
     }
     if builtin == Some(Builtin::Fft) && args.len() == 1 {
         let items = match &args[0] {
@@ -3670,7 +3682,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             ));
         }
         let mut reals: Vec<f64> = Vec::with_capacity(items.len());
-        for item in items {
+        for item in items.iter() {
             match item {
                 Value::Number(n) => reals.push(*n),
                 other => {
@@ -3689,9 +3701,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         let result: Vec<Value> = re
             .into_iter()
             .zip(im)
-            .map(|(r, i)| Value::List(vec![Value::Number(r), Value::Number(i)]))
+            .map(|(r, i)| Value::List(Arc::new(vec![Value::Number(r), Value::Number(i)])))
             .collect();
-        return Ok(Value::List(result));
+        return Ok(Value::List(Arc::new(result)));
     }
     if builtin == Some(Builtin::Ifft) && args.len() == 1 {
         let items = match &args[0] {
@@ -3711,7 +3723,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         }
         let mut re: Vec<f64> = Vec::with_capacity(items.len());
         let mut im: Vec<f64> = Vec::with_capacity(items.len());
-        for item in items {
+        for item in items.iter() {
             match item {
                 Value::List(pair) if pair.len() == 2 => {
                     let r = match &pair[0] {
@@ -3751,7 +3763,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         im.resize(n, 0.0);
         cooley_tukey(&mut re, &mut im, true);
         let result: Vec<Value> = re.into_iter().map(Value::Number).collect();
-        return Ok(Value::List(result));
+        return Ok(Value::List(Arc::new(result)));
     }
 
     // Dynamic dispatch: callee resolved to a FnRef at runtime
@@ -3885,7 +3897,7 @@ fn serde_json_to_value(v: serde_json::Value) -> Value {
             }
         }
         serde_json::Value::Array(arr) => {
-            Value::List(arr.into_iter().map(serde_json_to_value).collect())
+            Value::List(Arc::new(arr.into_iter().map(serde_json_to_value).collect()))
         }
         serde_json::Value::String(s) => Value::Text(s),
         serde_json::Value::Number(n) => Value::Number(n.as_f64().unwrap_or(0.0)),
@@ -3957,6 +3969,7 @@ fn eval_self_rebind_mset(
     let args = vec![prev, key_val, val_val];
     call_function(env, "mset", args)
 }
+
 
 fn eval_stmt(env: &mut Env, stmt: &Stmt) -> Result<Option<BodyResult>> {
     match stmt {
@@ -4088,7 +4101,7 @@ fn eval_stmt(env: &mut Env, stmt: &Stmt) -> Result<Option<BodyResult>> {
             match coll {
                 Value::List(items) => {
                     let mut last = Value::Nil;
-                    for item in items {
+                    for item in items.iter().cloned() {
                         env.push_scope();
                         env.define(binding, item);
                         let result = eval_body(env, body);
@@ -4351,7 +4364,7 @@ fn eval_expr(env: &mut Env, expr: &Expr) -> Result<Value> {
             for item in items {
                 vals.push(eval_expr(env, item)?);
             }
-            Ok(Value::List(vals))
+            Ok(Value::List(Arc::new(vals)))
         }
         Expr::Record { type_name, fields } => {
             let mut field_map = HashMap::new();
@@ -4468,7 +4481,7 @@ fn eval_binop(op: &BinOp, left: &Value, right: &Value) -> Result<Value> {
             let mut out = Vec::with_capacity(a.len() + b.len());
             out.extend_from_slice(a);
             out.extend_from_slice(b);
-            Ok(Value::List(out))
+            Ok(Value::List(Arc::new(out)))
         }
         // Comparisons on numbers
         (BinOp::GreaterThan, Value::Number(a), Value::Number(b)) => Ok(Value::Bool(a > b)),
@@ -4482,9 +4495,14 @@ fn eval_binop(op: &BinOp, left: &Value, right: &Value) -> Result<Value> {
         (BinOp::LessOrEqual, Value::Text(a), Value::Text(b)) => Ok(Value::Bool(a <= b)),
         // List append
         (BinOp::Append, Value::List(items), val) => {
-            let mut new_items = items.clone();
+            // Slow path: items is borrowed (`&Arc<Vec<Value>>`), so we always
+            // clone the inner Vec here. The hot accumulator pattern
+            // `xs = +=xs v` is short-circuited in eval_stmt via the
+            // self-rebind peephole, which owns the Arc and uses
+            // `Arc::make_mut` for O(1) amortised in-place push.
+            let mut new_items = (**items).clone();
             new_items.push(val.clone());
-            Ok(Value::List(new_items))
+            Ok(Value::List(Arc::new(new_items)))
         }
         // Equality
         (BinOp::Equals, a, b) => Ok(Value::Bool(values_equal(a, b))),
@@ -5106,11 +5124,11 @@ mod tests {
         let source = "f>L n;xs=[1, 2];+=xs 3";
         assert_eq!(
             run_str(source, Some("f"), vec![]),
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0)
-            ])
+            ]))
         );
     }
 
@@ -5119,7 +5137,7 @@ mod tests {
         let source = "f>L n;xs=[];+=xs 42";
         assert_eq!(
             run_str(source, Some("f"), vec![]),
-            Value::List(vec![Value::Number(42.0)])
+            Value::List(Arc::new(vec![Value::Number(42.0)]))
         );
     }
 
@@ -5128,12 +5146,12 @@ mod tests {
         let source = "f>L n;a=[1, 2];b=[3, 4];+a b";
         assert_eq!(
             run_str(source, Some("f"), vec![]),
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0),
                 Value::Number(4.0)
-            ])
+            ]))
         );
     }
 
@@ -5307,17 +5325,17 @@ mod tests {
 
     #[test]
     fn display_list() {
-        let list = Value::List(vec![
+        let list = Value::List(Arc::new(vec![
             Value::Number(1.0),
             Value::Number(2.0),
             Value::Number(3.0),
-        ]);
+        ]));
         assert_eq!(format!("{}", list), "[1, 2, 3]");
     }
 
     #[test]
     fn display_list_empty() {
-        assert_eq!(format!("{}", Value::List(vec![])), "[]");
+        assert_eq!(format!("{}", Value::List(Arc::new(vec![]))), "[]");
     }
 
     #[test]
@@ -5637,8 +5655,8 @@ mod tests {
 
     #[test]
     fn is_truthy_list() {
-        assert!(!is_truthy(&Value::List(vec![])));
-        assert!(is_truthy(&Value::List(vec![Value::Number(1.0)])));
+        assert!(!is_truthy(&Value::List(Arc::new(vec![]))));
+        assert!(is_truthy(&Value::List(Arc::new(vec![Value::Number(1.0)]))));
     }
 
     #[test]
@@ -5790,11 +5808,11 @@ mod tests {
         let result = run_str(
             source,
             Some("f"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(5.0),
                 Value::Number(2.0),
-            ])],
+            ]))],
         );
         assert_eq!(result, Value::Number(5.0));
     }
@@ -6045,11 +6063,11 @@ mod tests {
         let source = r#"f>L t;spl "a,b,c" ",""#;
         assert_eq!(
             run_str(source, Some("f"), vec![]),
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Text("a".to_string()),
                 Value::Text("b".to_string()),
                 Value::Text("c".to_string()),
-            ])
+            ]))
         );
     }
 
@@ -6058,7 +6076,7 @@ mod tests {
         let source = r#"f>L t;spl "" ",""#;
         assert_eq!(
             run_str(source, Some("f"), vec![]),
-            Value::List(vec![Value::Text("".to_string())])
+            Value::List(Arc::new(vec![Value::Text("".to_string())]))
         );
     }
 
@@ -6069,11 +6087,11 @@ mod tests {
             run_str(
                 source,
                 Some("f"),
-                vec![Value::List(vec![
+                vec![Value::List(Arc::new(vec![
                     Value::Text("a".into()),
                     Value::Text("b".into()),
                     Value::Text("c".into()),
-                ])]
+                ]))]
             ),
             Value::Text("a,b,c".into())
         );
@@ -6083,7 +6101,7 @@ mod tests {
     fn interpret_cat_empty_list() {
         let source = "f items:L t>t;cat items \"-\"";
         assert_eq!(
-            run_str(source, Some("f"), vec![Value::List(vec![])]),
+            run_str(source, Some("f"), vec![Value::List(Arc::new(vec![]))]),
             Value::Text("".into())
         );
     }
@@ -6096,7 +6114,7 @@ mod tests {
                 source,
                 Some("f"),
                 vec![
-                    Value::List(vec![Value::Number(1.0), Value::Number(2.0)]),
+                    Value::List(Arc::new(vec![Value::Number(1.0), Value::Number(2.0)])),
                     Value::Number(2.0)
                 ]
             ),
@@ -6106,7 +6124,10 @@ mod tests {
             run_str(
                 source,
                 Some("f"),
-                vec![Value::List(vec![Value::Number(1.0)]), Value::Number(5.0)]
+                vec![
+                    Value::List(Arc::new(vec![Value::Number(1.0)])),
+                    Value::Number(5.0)
+                ]
             ),
             Value::Bool(false)
         );
@@ -6139,7 +6160,7 @@ mod tests {
         let source = "f>L n;xs=[10, 20, 30];tl xs";
         assert_eq!(
             run_str(source, Some("f"), vec![]),
-            Value::List(vec![Value::Number(20.0), Value::Number(30.0)])
+            Value::List(Arc::new(vec![Value::Number(20.0), Value::Number(30.0)]))
         );
     }
 
@@ -6166,11 +6187,11 @@ mod tests {
         let source = "f>L n;rev [1, 2, 3]";
         assert_eq!(
             run_str(source, Some("f"), vec![]),
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(3.0),
                 Value::Number(2.0),
                 Value::Number(1.0)
-            ])
+            ]))
         );
     }
 
@@ -6188,11 +6209,11 @@ mod tests {
         let source = "f>L n;srt [3, 1, 2]";
         assert_eq!(
             run_str(source, Some("f"), vec![]),
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0)
-            ])
+            ]))
         );
     }
 
@@ -6201,11 +6222,11 @@ mod tests {
         let source = r#"f>L t;srt ["c", "a", "b"]"#;
         assert_eq!(
             run_str(source, Some("f"), vec![]),
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Text("a".into()),
                 Value::Text("b".into()),
                 Value::Text("c".into())
-            ])
+            ]))
         );
     }
 
@@ -6223,7 +6244,7 @@ mod tests {
         let source = "f>L n;slc [1, 2, 3, 4, 5] 1 3";
         assert_eq!(
             run_str(source, Some("f"), vec![]),
-            Value::List(vec![Value::Number(2.0), Value::Number(3.0)])
+            Value::List(Arc::new(vec![Value::Number(2.0), Value::Number(3.0)]))
         );
     }
 
@@ -6241,7 +6262,7 @@ mod tests {
         let source = "f>L n;slc [1, 2, 3] 1 100";
         assert_eq!(
             run_str(source, Some("f"), vec![]),
-            Value::List(vec![Value::Number(2.0), Value::Number(3.0)])
+            Value::List(Arc::new(vec![Value::Number(2.0), Value::Number(3.0)]))
         );
     }
 
@@ -6312,11 +6333,11 @@ mod tests {
         let result = run_str(
             source,
             Some("mx"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Number(3.0),
                 Value::Number(1.0),
                 Value::Number(5.0),
-            ])],
+            ]))],
         );
         assert_eq!(result, Value::Number(5.0));
     }
@@ -6403,11 +6424,11 @@ mod tests {
     #[test]
     fn interpret_ret_in_foreach() {
         let source = "f xs:L n>n;@x xs{>=x 10{ret x}};0";
-        let list = Value::List(vec![
+        let list = Value::List(Arc::new(vec![
             Value::Number(1.0),
             Value::Number(15.0),
             Value::Number(3.0),
-        ]);
+        ]));
         assert_eq!(run_str(source, Some("f"), vec![list]), Value::Number(15.0));
     }
 
@@ -6850,7 +6871,10 @@ mod tests {
     #[test]
     fn ok_srt_empty_list() {
         let source = "f>L n;srt []";
-        assert_eq!(run_str(source, Some("f"), vec![]), Value::List(vec![]));
+        assert_eq!(
+            run_str(source, Some("f"), vec![]),
+            Value::List(Arc::new(vec![]))
+        );
     }
 
     // ---- Destructuring bind tests ----
@@ -7055,11 +7079,11 @@ mod tests {
         };
         assert_eq!(
             *inner,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0)
-            ])
+            ]))
         );
     }
 
@@ -7120,21 +7144,21 @@ mod tests {
         let result = run_str(
             source,
             Some("main"),
-            vec![Value::List(
+            vec![Value::List(Arc::new(
                 vec![1.0, 2.0, 3.0, 4.0, 5.0]
                     .into_iter()
                     .map(Value::Number)
                     .collect(),
-            )],
+            ))],
         );
         assert_eq!(
             result,
-            Value::List(
+            Value::List(Arc::new(
                 vec![1.0, 4.0, 9.0, 16.0, 25.0]
                     .into_iter()
                     .map(Value::Number)
                     .collect()
-            )
+            ))
         );
     }
 
@@ -7145,16 +7169,18 @@ mod tests {
         let result = run_str(
             source,
             Some("main"),
-            vec![Value::List(
+            vec![Value::List(Arc::new(
                 vec![-3.0, -1.0, 0.0, 2.0, 4.0]
                     .into_iter()
                     .map(Value::Number)
                     .collect(),
-            )],
+            ))],
         );
         assert_eq!(
             result,
-            Value::List(vec![2.0, 4.0].into_iter().map(Value::Number).collect())
+            Value::List(Arc::new(
+                vec![2.0, 4.0].into_iter().map(Value::Number).collect()
+            ))
         );
     }
 
@@ -7165,12 +7191,12 @@ mod tests {
         let result = run_str(
             source,
             Some("main"),
-            vec![Value::List(
+            vec![Value::List(Arc::new(
                 vec![1.0, 2.0, 3.0, 4.0, 5.0]
                     .into_iter()
                     .map(Value::Number)
                     .collect(),
-            )],
+            ))],
         );
         assert_eq!(result, Value::Number(15.0));
     }
@@ -7182,23 +7208,27 @@ mod tests {
         let result = run_str(
             source,
             Some("main"),
-            vec![Value::List(
+            vec![Value::List(Arc::new(
                 vec![1.0, 8.0, 3.0, 9.0, 2.0]
                     .into_iter()
                     .map(Value::Number)
                     .collect(),
-            )],
+            ))],
         );
         let Value::Map(m) = result else {
             panic!("expected Map")
         };
         assert_eq!(
             m.get(&MapKey::Text("small".to_string())).unwrap(),
-            &Value::List(vec![1.0, 3.0, 2.0].into_iter().map(Value::Number).collect())
+            &Value::List(Arc::new(
+                vec![1.0, 3.0, 2.0].into_iter().map(Value::Number).collect()
+            ))
         );
         assert_eq!(
             m.get(&MapKey::Text("big".to_string())).unwrap(),
-            &Value::List(vec![8.0, 9.0].into_iter().map(Value::Number).collect())
+            &Value::List(Arc::new(
+                vec![8.0, 9.0].into_iter().map(Value::Number).collect()
+            ))
         );
     }
 
@@ -7209,34 +7239,38 @@ mod tests {
         let result = run_str(
             source,
             Some("main"),
-            vec![Value::List(
+            vec![Value::List(Arc::new(
                 vec![1.0, 2.0, 1.0, 3.0, 2.0]
                     .into_iter()
                     .map(Value::Number)
                     .collect(),
-            )],
+            ))],
         );
         let Value::Map(m) = result else {
             panic!("expected Map")
         };
         assert_eq!(
             m.get(&MapKey::Text("1".to_string())).unwrap(),
-            &Value::List(vec![1.0, 1.0].into_iter().map(Value::Number).collect())
+            &Value::List(Arc::new(
+                vec![1.0, 1.0].into_iter().map(Value::Number).collect()
+            ))
         );
         assert_eq!(
             m.get(&MapKey::Text("2".to_string())).unwrap(),
-            &Value::List(vec![2.0, 2.0].into_iter().map(Value::Number).collect())
+            &Value::List(Arc::new(
+                vec![2.0, 2.0].into_iter().map(Value::Number).collect()
+            ))
         );
         assert_eq!(
             m.get(&MapKey::Text("3".to_string())).unwrap(),
-            &Value::List(vec![3.0].into_iter().map(Value::Number).collect())
+            &Value::List(Arc::new(vec![3.0].into_iter().map(Value::Number).collect()))
         );
     }
 
     #[test]
     fn interp_grp_empty_list() {
         let source = "id x:n>t;str x main xs:L n>M t L n;grp id xs";
-        let result = run_str(source, Some("main"), vec![Value::List(vec![])]);
+        let result = run_str(source, Some("main"), vec![Value::List(Arc::new(vec![]))]);
         assert_eq!(
             result,
             Value::Map(Arc::new(std::collections::HashMap::new()))
@@ -7261,12 +7295,12 @@ mod tests {
         let result = run_str(
             source,
             Some("f"),
-            vec![Value::List(
+            vec![Value::List(Arc::new(
                 vec![1.0, 2.0, 3.0, 4.0, 5.0]
                     .into_iter()
                     .map(Value::Number)
                     .collect(),
-            )],
+            ))],
         );
         assert_eq!(result, Value::Number(15.0));
     }
@@ -7274,7 +7308,7 @@ mod tests {
     #[test]
     fn interp_sum_empty() {
         let source = "f xs:L n>n;sum xs";
-        let result = run_str(source, Some("f"), vec![Value::List(vec![])]);
+        let result = run_str(source, Some("f"), vec![Value::List(Arc::new(vec![]))]);
         assert_eq!(result, Value::Number(0.0));
     }
 
@@ -7296,9 +7330,9 @@ mod tests {
         let result = run_str(
             source,
             Some("f"),
-            vec![Value::List(
+            vec![Value::List(Arc::new(
                 vec![2.0, 4.0, 6.0].into_iter().map(Value::Number).collect(),
-            )],
+            ))],
         );
         assert_eq!(result, Value::Number(4.0));
     }
@@ -7381,7 +7415,10 @@ mod tests {
         );
         assert_eq!(
             result,
-            Value::List(vec![Value::Text("123".into()), Value::Text("456".into()),])
+            Value::List(Arc::new(vec![
+                Value::Text("123".into()),
+                Value::Text("456".into()),
+            ]))
         );
     }
 
@@ -7397,10 +7434,10 @@ mod tests {
         // Returns first match's groups
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Text("name".into()),
                 Value::Text("alice".into()),
-            ])
+            ]))
         );
     }
 
@@ -7412,7 +7449,7 @@ mod tests {
             Some("f"),
             vec![Value::Text("no numbers here".into())],
         );
-        assert_eq!(result, Value::List(vec![]));
+        assert_eq!(result, Value::List(Arc::new(vec![])));
     }
 
     #[test]
@@ -7434,12 +7471,12 @@ mod tests {
         let result = run_str(source, Some("f"), vec![]);
         assert_eq!(
             result,
-            Value::List(
+            Value::List(Arc::new(
                 vec![1.0, 2.0, 3.0, 4.0, 5.0]
                     .into_iter()
                     .map(Value::Number)
                     .collect()
-            )
+            ))
         );
     }
 
@@ -7450,7 +7487,9 @@ mod tests {
         let result = run_str(source, Some("f"), vec![]);
         assert_eq!(
             result,
-            Value::List(vec![1.0, 2.0, 3.0].into_iter().map(Value::Number).collect())
+            Value::List(Arc::new(
+                vec![1.0, 2.0, 3.0].into_iter().map(Value::Number).collect()
+            ))
         );
     }
 
@@ -7458,7 +7497,7 @@ mod tests {
     fn interp_flat_empty() {
         let source = "f>L n;flat []";
         let result = run_str(source, Some("f"), vec![]);
-        assert_eq!(result, Value::List(vec![]));
+        assert_eq!(result, Value::List(Arc::new(vec![])));
     }
 
     #[test]
@@ -7527,21 +7566,21 @@ mod tests {
         let result = run_str(
             "f xs:L n>L n;unq xs",
             Some("f"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(1.0),
                 Value::Number(3.0),
                 Value::Number(2.0),
-            ])],
+            ]))],
         );
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0)
-            ])
+            ]))
         );
     }
 
@@ -7550,15 +7589,18 @@ mod tests {
         let result = run_str(
             "f xs:L t>L t;unq xs",
             Some("f"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Text("a".into()),
                 Value::Text("b".into()),
                 Value::Text("a".into()),
-            ])],
+            ]))],
         );
         assert_eq!(
             result,
-            Value::List(vec![Value::Text("a".into()), Value::Text("b".into())])
+            Value::List(Arc::new(vec![
+                Value::Text("a".into()),
+                Value::Text("b".into())
+            ]))
         );
     }
 
@@ -7574,8 +7616,12 @@ mod tests {
 
     #[test]
     fn interpret_unq_empty_list() {
-        let result = run_str("f xs:L n>L n;unq xs", Some("f"), vec![Value::List(vec![])]);
-        assert_eq!(result, Value::List(vec![]));
+        let result = run_str(
+            "f xs:L n>L n;unq xs",
+            Some("f"),
+            vec![Value::List(Arc::new(vec![]))],
+        );
+        assert_eq!(result, Value::List(Arc::new(vec![])));
     }
 
     #[test]
@@ -7583,21 +7629,21 @@ mod tests {
         let result = run_str(
             "f xs:L n>L n;unq xs",
             Some("f"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Number(3.0),
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(1.0),
                 Value::Number(3.0),
-            ])],
+            ]))],
         );
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(3.0),
                 Value::Number(1.0),
                 Value::Number(2.0)
-            ])
+            ]))
         );
     }
 
@@ -7647,19 +7693,19 @@ mod tests {
         let result = run_str(
             source,
             Some("main"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Text("banana".into()),
                 Value::Text("a".into()),
                 Value::Text("cc".into()),
-            ])],
+            ]))],
         );
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Text("a".into()),
                 Value::Text("cc".into()),
                 Value::Text("banana".into()),
-            ])
+            ]))
         );
     }
 
@@ -7669,20 +7715,20 @@ mod tests {
         let result = run_str(
             source,
             Some("main"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(3.0),
                 Value::Number(2.0),
-            ])],
+            ]))],
         );
         // sort by negative: highest first
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(3.0),
                 Value::Number(2.0),
                 Value::Number(1.0)
-            ])
+            ]))
         );
     }
 
@@ -8016,19 +8062,19 @@ mod tests {
         let result = run_str(
             source,
             Some("main"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Text("banana".into()),
                 Value::Text("apple".into()),
                 Value::Text("cherry".into()),
-            ])],
+            ]))],
         );
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Text("apple".into()),
                 Value::Text("banana".into()),
                 Value::Text("cherry".into()),
-            ])
+            ]))
         );
     }
 
@@ -8199,7 +8245,10 @@ mod tests {
             "wrl",
             vec![
                 Value::Text(path_str.clone()),
-                Value::List(vec![Value::Text("ok".into()), Value::Number(99.0)]),
+                Value::List(Arc::new(vec![
+                    Value::Text("ok".into()),
+                    Value::Number(99.0),
+                ])),
             ],
         );
         std::fs::remove_file(&path).ok();
@@ -8292,7 +8341,7 @@ mod tests {
         let err = run_str_err(
             source,
             Some("f"),
-            vec![Value::List(vec![Value::Number(1.0)])],
+            vec![Value::List(Arc::new(vec![Value::Number(1.0)]))],
         );
         assert!(err.contains("flt") || err.contains("bool"), "got: {err}");
     }
@@ -8384,7 +8433,10 @@ mod tests {
         let result = run_str(
             source,
             Some("f"),
-            vec![Value::List(vec![Value::Number(1.0), Value::Number(2.0)])],
+            vec![Value::List(Arc::new(vec![
+                Value::Number(1.0),
+                Value::Number(2.0),
+            ]))],
         );
         // Iteration: x=1 → cnt (continue), x=2 → 2. Last value of foreach body = 2.
         assert_eq!(result, Value::Number(2.0));
@@ -8398,7 +8450,10 @@ mod tests {
         let result = run_str(
             source,
             Some("f"),
-            vec![Value::List(vec![Value::Number(0.0), Value::Number(1.0)])],
+            vec![Value::List(Arc::new(vec![
+                Value::Number(0.0),
+                Value::Number(1.0),
+            ]))],
         );
         // x=0: true → 10, x=1: false → 20. Last value = 20.
         assert_eq!(result, Value::Number(20.0));
@@ -8411,7 +8466,10 @@ mod tests {
         let result = run_str(
             source,
             Some("f"),
-            vec![Value::List(vec![Value::Number(1.0), Value::Number(5.0)])],
+            vec![Value::List(Arc::new(vec![
+                Value::Number(1.0),
+                Value::Number(5.0),
+            ]))],
         );
         assert_eq!(result, Value::Number(5.0));
     }
@@ -8424,11 +8482,11 @@ mod tests {
         let result = run_str(
             source,
             Some("f"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(5.0),
                 Value::Number(9.0),
-            ])],
+            ]))],
         );
         // x=1 → 0, x=5 → 5, x=9 → 0; last value of foreach = 0
         assert_eq!(result, Value::Number(0.0));
@@ -8481,7 +8539,7 @@ mod tests {
         let result = run_str(
             source,
             Some("f"),
-            vec![Value::List(vec![Value::Number(1.0)])],
+            vec![Value::List(Arc::new(vec![Value::Number(1.0)]))],
         );
         assert_eq!(result, Value::Text("list".into()));
     }
@@ -8531,7 +8589,10 @@ mod tests {
         );
         assert_eq!(
             result,
-            Value::List(vec![Value::Text("a".into()), Value::Text("b".into())])
+            Value::List(Arc::new(vec![
+                Value::Text("a".into()),
+                Value::Text("b".into())
+            ]))
         );
     }
 
@@ -8545,7 +8606,7 @@ mod tests {
         );
         assert_eq!(
             result,
-            Value::List(vec![Value::Number(1.0), Value::Number(2.0)])
+            Value::List(Arc::new(vec![Value::Number(1.0), Value::Number(2.0)]))
         );
     }
 
@@ -8568,7 +8629,7 @@ mod tests {
         let err = run_str_err(
             "f xs:L n>L n;srt 42 xs",
             Some("f"),
-            vec![Value::List(vec![Value::Number(1.0)])],
+            vec![Value::List(Arc::new(vec![Value::Number(1.0)]))],
         );
         assert!(err.contains("srt"), "got: {err}");
     }
@@ -8580,7 +8641,7 @@ mod tests {
         let err = run_str_err(
             "f xs:L n>L n;flt 42 xs",
             Some("f"),
-            vec![Value::List(vec![Value::Number(1.0)])],
+            vec![Value::List(Arc::new(vec![Value::Number(1.0)]))],
         );
         assert!(err.contains("flt"), "got: {err}");
     }
@@ -8596,10 +8657,10 @@ mod tests {
             Some("f"),
             vec![
                 Value::Text("sq".into()),
-                Value::List(vec![Value::Number(3.0)]),
+                Value::List(Arc::new(vec![Value::Number(3.0)])),
             ],
         );
-        assert_eq!(result, Value::List(vec![Value::Number(9.0)]));
+        assert_eq!(result, Value::List(Arc::new(vec![Value::Number(9.0)])));
     }
 
     // ── rd 2-arg explicit format (lines 736, 749, 750-751) ──────────────────
@@ -8680,11 +8741,11 @@ mod tests {
         let result = run_str(
             source,
             Some("g"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(1.0),
-            ])],
+            ]))],
         );
         let Value::Map(m) = result else {
             panic!("expected map")
@@ -8699,11 +8760,11 @@ mod tests {
         let result = run_str(
             source,
             Some("g"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Number(-1.0),
                 Value::Number(1.0),
                 Value::Number(2.0),
-            ])],
+            ]))],
         );
         let Value::Map(m) = result else {
             panic!("expected map")
@@ -8719,7 +8780,7 @@ mod tests {
         let err = run_str_err(
             "f xs:L n>n;avg xs",
             Some("f"),
-            vec![Value::List(vec![Value::Text("x".into())])],
+            vec![Value::List(Arc::new(vec![Value::Text("x".into())]))],
         );
         assert!(err.contains("avg"), "got: {err}");
     }
@@ -8844,11 +8905,11 @@ mod tests {
         let result = run_str(
             source,
             Some("g"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0),
-            ])],
+            ]))],
         );
         let Value::Map(m) = result else {
             panic!("expected Map")
@@ -8966,7 +9027,10 @@ mod tests {
         let err = run_str_err(
             source,
             Some("g"),
-            vec![Value::List(vec![Value::Number(1.0), Value::Number(2.0)])],
+            vec![Value::List(Arc::new(vec![
+                Value::Number(1.0),
+                Value::Number(2.0),
+            ]))],
         );
         assert!(
             err.contains("grp") || err.contains("key") || err.contains("string"),
@@ -9304,7 +9368,10 @@ mod tests {
         let result = run_str(
             source,
             Some("f"),
-            vec![Value::List(vec![Value::Number(1.0), Value::Number(2.0)])],
+            vec![Value::List(Arc::new(vec![
+                Value::Number(1.0),
+                Value::Number(2.0),
+            ]))],
         );
         assert_eq!(result, Value::Text("list".to_string()));
     }
@@ -9426,11 +9493,11 @@ mod tests {
         let result = run_str(source, Some("f"), vec![]);
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(10.0),
                 Value::Number(99.0),
                 Value::Number(30.0),
-            ])
+            ]))
         );
     }
 
@@ -9440,11 +9507,11 @@ mod tests {
         let result = run_str(source, Some("f"), vec![]);
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(7.0),
                 Value::Number(20.0),
                 Value::Number(30.0),
-            ])
+            ]))
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3535,13 +3535,13 @@ fn parse_cli_arg(s: &str) -> interpreter::Value {
     if s.starts_with('[') && s.ends_with(']') {
         let inner = s[1..s.len() - 1].trim();
         if inner.is_empty() {
-            return interpreter::Value::List(vec![]);
+            return interpreter::Value::List(std::sync::Arc::new(vec![]));
         }
-        let items = split_top_level_commas(inner)
+        let items: Vec<interpreter::Value> = split_top_level_commas(inner)
             .into_iter()
             .map(|part| parse_cli_arg(part.trim()))
             .collect();
-        return interpreter::Value::List(items);
+        return interpreter::Value::List(std::sync::Arc::new(items));
     }
     // Quoted string: strip surrounding double quotes and treat as text.
     // This preserves the raw contents (no escape decoding) which mirrors how
@@ -3551,11 +3551,11 @@ fn parse_cli_arg(s: &str) -> interpreter::Value {
     }
     // Bare comma list: 1,2,3
     if s.contains(',') {
-        let items = split_top_level_commas(s)
+        let items: Vec<interpreter::Value> = split_top_level_commas(s)
             .into_iter()
             .map(|part| parse_cli_arg(part.trim()))
             .collect();
-        return interpreter::Value::List(items);
+        return interpreter::Value::List(std::sync::Arc::new(items));
     }
     if s == "nil" {
         return interpreter::Value::Nil;
@@ -3640,7 +3640,7 @@ fn parse_cli_args_typed(
             if matches!(expected, Some(ast::Type::List(_)))
                 && !matches!(&v, interpreter::Value::List(_))
             {
-                v = interpreter::Value::List(vec![v]);
+                v = interpreter::Value::List(std::sync::Arc::new(vec![v]));
             }
             v
         })
@@ -3671,7 +3671,7 @@ fn coerce_cli_args(
         if matches!(&param.ty, ast::Type::List(_))
             && !matches!(&args[i], interpreter::Value::List(_))
         {
-            args[i] = interpreter::Value::List(vec![args[i].clone()]);
+            args[i] = interpreter::Value::List(std::sync::Arc::new(vec![args[i].clone()]));
         }
     }
     args
@@ -3682,6 +3682,7 @@ fn coerce_cli_args(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
 
     // ── test helpers ──────────────────────────────────────────────────────────
 
@@ -3775,28 +3776,31 @@ mod tests {
     fn cli_arg_bracketed_list() {
         assert_eq!(
             parse_cli_arg("[1,2,3]"),
-            interpreter::Value::List(vec![
+            interpreter::Value::List(Arc::new(vec![
                 interpreter::Value::Number(1.0),
                 interpreter::Value::Number(2.0),
                 interpreter::Value::Number(3.0),
-            ])
+            ]))
         );
     }
 
     #[test]
     fn cli_arg_empty_bracketed_list() {
-        assert_eq!(parse_cli_arg("[]"), interpreter::Value::List(vec![]));
+        assert_eq!(
+            parse_cli_arg("[]"),
+            interpreter::Value::List(Arc::new(vec![]))
+        );
     }
 
     #[test]
     fn cli_arg_comma_list() {
         assert_eq!(
             parse_cli_arg("1,2,3"),
-            interpreter::Value::List(vec![
+            interpreter::Value::List(Arc::new(vec![
                 interpreter::Value::Number(1.0),
                 interpreter::Value::Number(2.0),
                 interpreter::Value::Number(3.0),
-            ])
+            ]))
         );
     }
 
@@ -3804,11 +3808,11 @@ mod tests {
     fn cli_arg_mixed_comma_list() {
         assert_eq!(
             parse_cli_arg("1,hello,true"),
-            interpreter::Value::List(vec![
+            interpreter::Value::List(Arc::new(vec![
                 interpreter::Value::Number(1.0),
                 interpreter::Value::Text("hello".into()),
                 interpreter::Value::Bool(true),
-            ])
+            ]))
         );
     }
 
@@ -4617,10 +4621,10 @@ mod tests {
 
     #[test]
     fn print_value_list_as_json() {
-        let val = interpreter::Value::List(vec![
+        let val = interpreter::Value::List(Arc::new(vec![
             interpreter::Value::Number(1.0),
             interpreter::Value::Number(2.0),
-        ]);
+        ]));
         print_value(&val, true, false);
     }
 
@@ -4842,9 +4846,9 @@ mod tests {
         let coerced = coerce_cli_args(&program, Some("f"), args);
         assert_eq!(
             coerced,
-            vec![interpreter::Value::List(vec![interpreter::Value::Number(
-                10.0
-            )])]
+            vec![interpreter::Value::List(Arc::new(vec![
+                interpreter::Value::Number(10.0)
+            ]))]
         );
     }
 
@@ -4865,10 +4869,10 @@ mod tests {
             })
             .collect();
         let (program, _) = crate::parser::parse(spans);
-        let args = vec![interpreter::Value::List(vec![
+        let args = vec![interpreter::Value::List(Arc::new(vec![
             interpreter::Value::Number(1.0),
             interpreter::Value::Number(2.0),
-        ])];
+        ]))];
         let coerced = coerce_cli_args(&program, Some("f"), args.clone());
         assert_eq!(coerced, args);
     }
@@ -4921,7 +4925,7 @@ mod tests {
         assert_eq!(
             coerced,
             vec![
-                interpreter::Value::List(vec![interpreter::Value::Number(5.0)]),
+                interpreter::Value::List(Arc::new(vec![interpreter::Value::Number(5.0)])),
                 interpreter::Value::Number(3.0),
             ]
         );
@@ -4983,9 +4987,9 @@ mod tests {
         let parsed = parse_cli_args_typed(&program, Some("f"), &raw);
         assert_eq!(
             parsed,
-            vec![interpreter::Value::List(vec![interpreter::Value::Number(
-                10.0
-            )])]
+            vec![interpreter::Value::List(Arc::new(vec![
+                interpreter::Value::Number(10.0)
+            ]))]
         );
     }
 
@@ -5164,10 +5168,10 @@ mod tests {
 
     #[test]
     fn print_value_list_plain_not_json() {
-        let val = interpreter::Value::List(vec![
+        let val = interpreter::Value::List(Arc::new(vec![
             interpreter::Value::Number(1.0),
             interpreter::Value::Text("x".into()),
-        ]);
+        ]));
         print_value(&val, false, false);
     }
 

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -4613,11 +4613,11 @@ mod tests {
         let result = jit_run(
             "f xs:L n>n;len xs",
             "f",
-            &[Value::List(vec![
+            &[Value::List(std::sync::Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0),
-            ])],
+            ]))],
         );
         assert_eq!(result, Some(Value::Number(3.0)));
     }
@@ -4768,11 +4768,11 @@ mod tests {
         );
         assert_eq!(
             result,
-            Some(Value::List(vec![
+            Some(Value::List(std::sync::Arc::new(vec![
                 Value::Text("a".into()),
                 Value::Text("b".into()),
                 Value::Text("c".into()),
-            ]))
+            ])))
         );
     }
 
@@ -4782,7 +4782,10 @@ mod tests {
             r#"f xs:L t sep:t>t;cat xs sep"#,
             "f",
             &[
-                Value::List(vec![Value::Text("x".into()), Value::Text("y".into())]),
+                Value::List(std::sync::Arc::new(vec![
+                    Value::Text("x".into()),
+                    Value::Text("y".into()),
+                ])),
                 Value::Text("-".into()),
             ],
         );
@@ -4797,11 +4800,11 @@ mod tests {
             "f xs:L n v:n>b;has xs v",
             "f",
             &[
-                Value::List(vec![
+                Value::List(std::sync::Arc::new(vec![
                     Value::Number(1.0),
                     Value::Number(2.0),
                     Value::Number(3.0),
-                ]),
+                ])),
                 Value::Number(2.0),
             ],
         );
@@ -4813,7 +4816,10 @@ mod tests {
         let result = jit_run(
             "f xs:L n>n;hd xs",
             "f",
-            &[Value::List(vec![Value::Number(10.0), Value::Number(20.0)])],
+            &[Value::List(std::sync::Arc::new(vec![
+                Value::Number(10.0),
+                Value::Number(20.0),
+            ]))],
         );
         assert_eq!(result, Some(Value::Number(10.0)));
     }
@@ -4823,15 +4829,18 @@ mod tests {
         let result = jit_run(
             "f xs:L n>L n;tl xs",
             "f",
-            &[Value::List(vec![
+            &[Value::List(std::sync::Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0),
-            ])],
+            ]))],
         );
         assert_eq!(
             result,
-            Some(Value::List(vec![Value::Number(2.0), Value::Number(3.0)]))
+            Some(Value::List(std::sync::Arc::new(vec![
+                Value::Number(2.0),
+                Value::Number(3.0)
+            ])))
         );
     }
 
@@ -4840,19 +4849,19 @@ mod tests {
         let result = jit_run(
             "f xs:L n>L n;rev xs",
             "f",
-            &[Value::List(vec![
+            &[Value::List(std::sync::Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0),
-            ])],
+            ]))],
         );
         assert_eq!(
             result,
-            Some(Value::List(vec![
+            Some(Value::List(std::sync::Arc::new(vec![
                 Value::Number(3.0),
                 Value::Number(2.0),
                 Value::Number(1.0)
-            ]))
+            ])))
         );
     }
 
@@ -4861,19 +4870,19 @@ mod tests {
         let result = jit_run(
             "f xs:L n>L n;srt xs",
             "f",
-            &[Value::List(vec![
+            &[Value::List(std::sync::Arc::new(vec![
                 Value::Number(3.0),
                 Value::Number(1.0),
                 Value::Number(2.0),
-            ])],
+            ]))],
         );
         assert_eq!(
             result,
-            Some(Value::List(vec![
+            Some(Value::List(std::sync::Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0)
-            ]))
+            ])))
         );
     }
 
@@ -4883,19 +4892,22 @@ mod tests {
             "f xs:L n a:n b:n>L n;slc xs a b",
             "f",
             &[
-                Value::List(vec![
+                Value::List(std::sync::Arc::new(vec![
                     Value::Number(10.0),
                     Value::Number(20.0),
                     Value::Number(30.0),
                     Value::Number(40.0),
-                ]),
+                ])),
                 Value::Number(1.0),
                 Value::Number(3.0),
             ],
         );
         assert_eq!(
             result,
-            Some(Value::List(vec![Value::Number(20.0), Value::Number(30.0)]))
+            Some(Value::List(std::sync::Arc::new(vec![
+                Value::Number(20.0),
+                Value::Number(30.0)
+            ])))
         );
     }
 
@@ -4908,17 +4920,20 @@ mod tests {
             "f xs:L n v:n>L n;r=+=xs v;r",
             "f",
             &[
-                Value::List(vec![Value::Number(1.0), Value::Number(2.0)]),
+                Value::List(std::sync::Arc::new(vec![
+                    Value::Number(1.0),
+                    Value::Number(2.0),
+                ])),
                 Value::Number(3.0),
             ],
         );
         assert_eq!(
             result,
-            Some(Value::List(vec![
+            Some(Value::List(std::sync::Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0)
-            ]))
+            ])))
         );
     }
 
@@ -4932,7 +4947,10 @@ mod tests {
         );
         assert_eq!(
             result,
-            Some(Value::List(vec![Value::Number(5.0), Value::Number(6.0)]))
+            Some(Value::List(std::sync::Arc::new(vec![
+                Value::Number(5.0),
+                Value::Number(6.0)
+            ])))
         );
     }
 
@@ -4942,11 +4960,11 @@ mod tests {
         let result = jit_run(
             "f xs:L n>n;xs.0",
             "f",
-            &[Value::List(vec![
+            &[Value::List(std::sync::Arc::new(vec![
                 Value::Number(10.0),
                 Value::Number(20.0),
                 Value::Number(30.0),
-            ])],
+            ]))],
         );
         assert_eq!(result, Some(Value::Number(10.0)));
     }
@@ -5066,7 +5084,7 @@ mod tests {
     fn cranelift_empty_list_literal() {
         // [] compiles to OP_LISTNEW with n=0 — exercises the empty-list JIT path
         let result = jit_run("f>L n;[]", "f", &[]);
-        assert_eq!(result, Some(Value::List(vec![])));
+        assert_eq!(result, Some(Value::List(std::sync::Arc::new(vec![]))));
     }
 
     // ── jit_run_numeric _ => None (line 1300) ────────────────────────────────
@@ -5218,11 +5236,11 @@ mod tests {
         let result = jit_run(
             "f xs:L n>n;s=0;@x xs{s=+s x};s",
             "f",
-            &[Value::List(vec![
+            &[Value::List(std::sync::Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0),
-            ])],
+            ]))],
         );
         assert_eq!(result, Some(Value::Number(6.0)));
     }
@@ -5234,11 +5252,11 @@ mod tests {
         let result = jit_run(
             "f xs:L n>n;s=0;@x xs{s=+s 1};s",
             "f",
-            &[Value::List(vec![
+            &[Value::List(std::sync::Arc::new(vec![
                 Value::Text("a".to_string()),
                 Value::Text("b".to_string()),
                 Value::Text("c".to_string()),
-            ])],
+            ]))],
         );
         assert_eq!(result, Some(Value::Number(3.0)));
     }
@@ -5249,7 +5267,7 @@ mod tests {
         let result = jit_run(
             "f xs:L n>n;s=0;@x xs{s=+s x};s",
             "f",
-            &[Value::List(vec![])],
+            &[Value::List(std::sync::Arc::new(vec![]))],
         );
         assert_eq!(result, Some(Value::Number(0.0)));
     }
@@ -5485,7 +5503,7 @@ mod tests {
         let result = jit_run(
             "f x:t>b;?x{l _:true;_:false}",
             "f",
-            &[Value::List(vec![Value::Number(1.0)])],
+            &[Value::List(std::sync::Arc::new(vec![Value::Number(1.0)]))],
         );
         assert_eq!(result, Some(Value::Bool(true)));
     }
@@ -5590,12 +5608,12 @@ mod tests {
         let result = jit_run(
             "f xs:L n>n;u=unq xs;len u",
             "f",
-            &[Value::List(vec![
+            &[Value::List(std::sync::Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(1.0),
                 Value::Number(3.0),
-            ])],
+            ]))],
         );
         assert_eq!(result, Some(Value::Number(3.0)));
     }
@@ -5955,11 +5973,11 @@ mod tests {
         let result = jit_run(
             "f xs:L n>n;@x xs{*x x}",
             "f",
-            &[Value::List(vec![
+            &[Value::List(std::sync::Arc::new(vec![
                 Value::Number(3.0),
                 Value::Number(4.0),
                 Value::Number(5.0),
-            ])],
+            ]))],
         );
         // Last squared value: 5^2=25
         assert_eq!(result, Some(Value::Number(25.0)));

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -3076,20 +3076,20 @@ impl RegCompiler {
 
                     // Store as constant: indices (numbers) for resolved, names (strings) for unresolved
                     let const_val = if all_resolved {
-                        Value::List(
+                        Value::List(std::sync::Arc::new(
                             update_indices
                                 .iter()
                                 .map(|i| Value::Number(i.unwrap() as f64))
                                 .collect(),
-                        )
+                        ))
                     } else {
                         // Fallback: store field names for runtime resolution
-                        Value::List(
+                        Value::List(std::sync::Arc::new(
                             updates
                                 .iter()
                                 .map(|(n, _)| Value::Text(n.clone()))
                                 .collect(),
-                        )
+                        ))
                     };
                     let const_idx = self.current.add_const_raw(const_val);
 
@@ -3876,9 +3876,9 @@ impl NanVal {
                 );
                 match self.as_heap_ref() {
                     HeapObj::Str(s) => Value::Text(s.clone()),
-                    HeapObj::List(items) => {
-                        Value::List(items.iter().map(|v| v.to_value()).collect())
-                    }
+                    HeapObj::List(items) => Value::List(std::sync::Arc::new(
+                        items.iter().map(|v| v.to_value()).collect(),
+                    )),
                     HeapObj::Map(m) => Value::Map(std::sync::Arc::new(
                         m.iter().map(|(k, v)| (k.clone(), v.to_value())).collect(),
                     )),
@@ -12868,6 +12868,7 @@ mod tests {
     use super::*;
     use crate::lexer;
     use crate::parser;
+    use std::sync::Arc;
 
     static ENV_TEST_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
@@ -13169,11 +13170,11 @@ mod tests {
         let result = vm_run(source, Some("f"), vec![]);
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0),
-            ])
+            ]))
         );
     }
 
@@ -13423,11 +13424,11 @@ mod tests {
         let source = "f>L n;xs=[1, 2];+=xs 3";
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0)
-            ])
+            ]))
         );
     }
 
@@ -13436,7 +13437,7 @@ mod tests {
         let source = "f>L n;xs=[];+=xs 42";
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
-            Value::List(vec![Value::Number(42.0)])
+            Value::List(Arc::new(vec![Value::Number(42.0)]))
         );
     }
 
@@ -13445,12 +13446,12 @@ mod tests {
         let source = "f>L n;a=[1, 2];b=[3, 4];+a b";
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0),
                 Value::Number(4.0)
-            ])
+            ]))
         );
     }
 
@@ -13459,7 +13460,7 @@ mod tests {
         let source = "f>L n;a=[1, 2];b=[];+a b";
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
-            Value::List(vec![Value::Number(1.0), Value::Number(2.0)])
+            Value::List(Arc::new(vec![Value::Number(1.0), Value::Number(2.0)]))
         );
     }
 
@@ -14012,11 +14013,11 @@ mod tests {
         let source = "f>L n;xs=[10, 20, 30];@x xs{x};xs";
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(10.0),
                 Value::Number(20.0),
                 Value::Number(30.0)
-            ])
+            ]))
         );
     }
 
@@ -14196,7 +14197,7 @@ mod tests {
         let source = "f>L n;xs=[1, 2];ys=[3];|xs ys";
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
-            Value::List(vec![Value::Number(1.0), Value::Number(2.0)])
+            Value::List(Arc::new(vec![Value::Number(1.0), Value::Number(2.0)]))
         );
     }
 
@@ -14761,7 +14762,7 @@ mod tests {
         // OP_ADD: both heap but not both lists (list+ok) → type error
         // Declare params as list type to avoid NN/SS specialisations, pass list+ok at runtime.
         let source = "f x:L n y:L n>L n;+x y";
-        let list = Value::List(vec![Value::Number(1.0)]);
+        let list = Value::List(Arc::new(vec![Value::Number(1.0)]));
         let ok_val = Value::Ok(Box::new(Value::Number(1.0)));
         let err = vm_run_err(source, Some("f"), vec![list, ok_val]);
         assert!(err.contains("cannot add"), "got: {err}");
@@ -14924,7 +14925,7 @@ mod tests {
     fn vm_recfld_on_non_record() {
         // OP_RECFLD: field access on a list (heap but not record) → L1590
         let source = "f x:t>t;x.name";
-        let err = vm_run_err(source, Some("f"), vec![Value::List(vec![])]);
+        let err = vm_run_err(source, Some("f"), vec![Value::List(Arc::new(vec![]))]);
         assert!(
             err.contains("field access") || err.contains("record"),
             "got: {err}"
@@ -14965,7 +14966,7 @@ mod tests {
     fn vm_with_on_non_record() {
         // OP_RECWITH: with on a list (heap but not record) → L1786
         let source = "f x:t>t;x with name:\"bob\"";
-        let err = vm_run_err(source, Some("f"), vec![Value::List(vec![])]);
+        let err = vm_run_err(source, Some("f"), vec![Value::List(Arc::new(vec![]))]);
         assert!(err.contains("record") || err.contains("with"), "got: {err}");
     }
 
@@ -15225,11 +15226,11 @@ mod tests {
         let source = r#"f>L t;spl "a,b,c" ",""#;
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Text("a".to_string()),
                 Value::Text("b".to_string()),
                 Value::Text("c".to_string()),
-            ])
+            ]))
         );
     }
 
@@ -15238,7 +15239,7 @@ mod tests {
         let source = r#"f>L t;spl "" ",""#;
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
-            Value::List(vec![Value::Text("".to_string())])
+            Value::List(Arc::new(vec![Value::Text("".to_string())]))
         );
     }
 
@@ -15249,11 +15250,11 @@ mod tests {
             vm_run(
                 source,
                 Some("f"),
-                vec![Value::List(vec![
+                vec![Value::List(Arc::new(vec![
                     Value::Text("a".into()),
                     Value::Text("b".into()),
                     Value::Text("c".into()),
-                ])]
+                ]))]
             ),
             Value::Text("a,b,c".into())
         );
@@ -15263,7 +15264,7 @@ mod tests {
     fn vm_cat_empty_list() {
         let source = "f items:L t>t;cat items \"-\"";
         assert_eq!(
-            vm_run(source, Some("f"), vec![Value::List(vec![])]),
+            vm_run(source, Some("f"), vec![Value::List(Arc::new(vec![]))]),
             Value::Text("".into())
         );
     }
@@ -15276,11 +15277,11 @@ mod tests {
                 source,
                 Some("f"),
                 vec![
-                    Value::List(vec![
+                    Value::List(Arc::new(vec![
                         Value::Number(1.0),
                         Value::Number(2.0),
                         Value::Number(3.0)
-                    ]),
+                    ])),
                     Value::Number(2.0)
                 ]
             ),
@@ -15290,7 +15291,10 @@ mod tests {
             vm_run(
                 source,
                 Some("f"),
-                vec![Value::List(vec![Value::Number(1.0)]), Value::Number(5.0)]
+                vec![
+                    Value::List(Arc::new(vec![Value::Number(1.0)])),
+                    Value::Number(5.0)
+                ]
             ),
             Value::Bool(false)
         );
@@ -15323,7 +15327,7 @@ mod tests {
         let source = "f>L n;xs=[10, 20, 30];tl xs";
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
-            Value::List(vec![Value::Number(20.0), Value::Number(30.0)])
+            Value::List(Arc::new(vec![Value::Number(20.0), Value::Number(30.0)]))
         );
     }
 
@@ -15350,11 +15354,11 @@ mod tests {
         let source = "f>L n;rev [1, 2, 3]";
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(3.0),
                 Value::Number(2.0),
                 Value::Number(1.0)
-            ])
+            ]))
         );
     }
 
@@ -15369,11 +15373,11 @@ mod tests {
         let source = "f>L n;srt [3, 1, 2]";
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0)
-            ])
+            ]))
         );
     }
 
@@ -15382,11 +15386,11 @@ mod tests {
         let source = r#"f>L t;srt ["c", "a", "b"]"#;
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Text("a".into()),
                 Value::Text("b".into()),
                 Value::Text("c".into())
-            ])
+            ]))
         );
     }
 
@@ -15395,7 +15399,7 @@ mod tests {
         let source = "f>L n;slc [1, 2, 3, 4, 5] 1 3";
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
-            Value::List(vec![Value::Number(2.0), Value::Number(3.0)])
+            Value::List(Arc::new(vec![Value::Number(2.0), Value::Number(3.0)]))
         );
     }
 
@@ -15452,11 +15456,11 @@ mod tests {
     #[test]
     fn vm_ret_in_foreach() {
         let source = "f xs:L n>n;@x xs{>=x 10{ret x}};0";
-        let list = Value::List(vec![
+        let list = Value::List(Arc::new(vec![
             Value::Number(1.0),
             Value::Number(15.0),
             Value::Number(3.0),
-        ]);
+        ]));
         assert_eq!(vm_run(source, Some("f"), vec![list]), Value::Number(15.0));
     }
 
@@ -15911,11 +15915,11 @@ mod tests {
         };
         assert_eq!(
             *inner,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0)
-            ])
+            ]))
         );
     }
 
@@ -16013,20 +16017,20 @@ mod tests {
         let result = vm_run(
             "f xs:L n>L n;unq xs",
             Some("f"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(1.0),
                 Value::Number(3.0),
-            ])],
+            ]))],
         );
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0)
-            ])
+            ]))
         );
     }
 
@@ -16037,21 +16041,21 @@ mod tests {
         let result = vm_run(
             "f xs:L t>L t;unq xs",
             Some("f"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Text("a".into()),
                 Value::Text("b".into()),
                 Value::Text("a".into()),
                 Value::Text("c".into()),
                 Value::Text("b".into()),
-            ])],
+            ]))],
         );
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Text("a".into()),
                 Value::Text("b".into()),
                 Value::Text("c".into()),
-            ])
+            ]))
         );
     }
 
@@ -16060,27 +16064,31 @@ mod tests {
         let result = vm_run(
             "f xs:L n>L n;unq xs",
             Some("f"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Number(3.0),
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(1.0),
-            ])],
+            ]))],
         );
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(3.0),
                 Value::Number(1.0),
                 Value::Number(2.0)
-            ])
+            ]))
         );
     }
 
     #[test]
     fn vm_unq_empty_list() {
-        let result = vm_run("f xs:L n>L n;unq xs", Some("f"), vec![Value::List(vec![])]);
-        assert_eq!(result, Value::List(vec![]));
+        let result = vm_run(
+            "f xs:L n>L n;unq xs",
+            Some("f"),
+            vec![Value::List(Arc::new(vec![]))],
+        );
+        assert_eq!(result, Value::List(Arc::new(vec![])));
     }
 
     #[test]
@@ -16180,11 +16188,11 @@ mod tests {
         );
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Text("a".into()),
                 Value::Text("b".into()),
                 Value::Text("c".into()),
-            ])
+            ]))
         );
     }
 
@@ -16198,11 +16206,11 @@ mod tests {
         );
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0),
-            ])
+            ]))
         );
     }
 
@@ -16293,13 +16301,13 @@ mod tests {
     #[test]
     fn vm_mkeys_empty_map() {
         let result = vm_run("f>L t;mkeys mmap", Some("f"), vec![]);
-        assert_eq!(result, Value::List(vec![]));
+        assert_eq!(result, Value::List(Arc::new(vec![])));
     }
 
     #[test]
     fn vm_mvals_empty_map() {
         let result = vm_run("f>L n;mvals mmap", Some("f"), vec![]);
-        assert_eq!(result, Value::List(vec![]));
+        assert_eq!(result, Value::List(Arc::new(vec![])));
     }
 
     #[test]
@@ -16322,7 +16330,11 @@ mod tests {
 
     #[test]
     fn vm_hd_empty_list_is_error() {
-        let err = vm_run_err("f xs:L n>n;hd xs", Some("f"), vec![Value::List(vec![])]);
+        let err = vm_run_err(
+            "f xs:L n>n;hd xs",
+            Some("f"),
+            vec![Value::List(Arc::new(vec![]))],
+        );
         assert!(err.contains("hd"), "expected hd error, got: {err}");
     }
 
@@ -16334,7 +16346,11 @@ mod tests {
 
     #[test]
     fn vm_tl_empty_list_is_error() {
-        let err = vm_run_err("f xs:L n>n;tl xs", Some("f"), vec![Value::List(vec![])]);
+        let err = vm_run_err(
+            "f xs:L n>n;tl xs",
+            Some("f"),
+            vec![Value::List(Arc::new(vec![]))],
+        );
         assert!(err.contains("tl"), "expected tl error, got: {err}");
     }
 
@@ -16349,10 +16365,10 @@ mod tests {
         let err = vm_run_err(
             "f xs:L n>t;srt xs",
             Some("f"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Text("a".into()),
-            ])],
+            ]))],
         );
         assert!(err.contains("srt"), "expected srt error, got: {err}");
     }
@@ -16362,11 +16378,11 @@ mod tests {
         let result = vm_run(
             "f items:L t>t;cat items \"\"",
             Some("f"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Text("a".into()),
                 Value::Text("b".into()),
                 Value::Text("c".into()),
-            ])],
+            ]))],
         );
         assert_eq!(result, Value::Text("abc".into()));
     }
@@ -16377,11 +16393,11 @@ mod tests {
             "f xs:L n x:n>b;has xs x",
             Some("f"),
             vec![
-                Value::List(vec![
+                Value::List(Arc::new(vec![
                     Value::Number(1.0),
                     Value::Number(2.0),
                     Value::Number(3.0),
-                ]),
+                ])),
                 Value::Number(2.0),
             ],
         );
@@ -16394,11 +16410,11 @@ mod tests {
             "f xs:L n x:n>b;has xs x",
             Some("f"),
             vec![
-                Value::List(vec![
+                Value::List(Arc::new(vec![
                     Value::Number(1.0),
                     Value::Number(2.0),
                     Value::Number(3.0),
-                ]),
+                ])),
                 Value::Number(9.0),
             ],
         );
@@ -16411,32 +16427,40 @@ mod tests {
         let result = vm_run(
             "f xs:L n>L n;slc xs 0 100",
             Some("f"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0),
-            ])],
+            ]))],
         );
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0),
-            ])
+            ]))
         );
     }
 
     #[test]
     fn vm_rev_empty_list() {
-        let result = vm_run("f xs:L n>L n;rev xs", Some("f"), vec![Value::List(vec![])]);
-        assert_eq!(result, Value::List(vec![]));
+        let result = vm_run(
+            "f xs:L n>L n;rev xs",
+            Some("f"),
+            vec![Value::List(Arc::new(vec![]))],
+        );
+        assert_eq!(result, Value::List(Arc::new(vec![])));
     }
 
     #[test]
     fn vm_srt_empty_list() {
-        let result = vm_run("f xs:L n>L n;srt xs", Some("f"), vec![Value::List(vec![])]);
-        assert_eq!(result, Value::List(vec![]));
+        let result = vm_run(
+            "f xs:L n>L n;srt xs",
+            Some("f"),
+            vec![Value::List(Arc::new(vec![]))],
+        );
+        assert_eq!(result, Value::List(Arc::new(vec![])));
     }
 
     #[test]
@@ -16521,7 +16545,11 @@ mod tests {
     fn vm_type_check_islist_match() {
         let src = r#"f x:n>b;?x{l _:true;_:false}"#;
         assert_eq!(
-            vm_run(src, Some("f"), vec![Value::List(vec![Value::Number(1.0)])]),
+            vm_run(
+                src,
+                Some("f"),
+                vec![Value::List(Arc::new(vec![Value::Number(1.0)]))]
+            ),
             Value::Bool(true)
         );
         assert_eq!(
@@ -16685,7 +16713,7 @@ mod tests {
             Some("f"),
             vec![
                 Value::Number(42.0),
-                Value::List(vec![Value::Text("a".into())]),
+                Value::List(Arc::new(vec![Value::Text("a".into())])),
             ],
         );
         assert!(
@@ -16724,10 +16752,10 @@ mod tests {
             Some("f"),
             vec![
                 Value::Text(path_str.into()),
-                Value::List(vec![
+                Value::List(Arc::new(vec![
                     Value::Text("line1".into()),
                     Value::Text("line2".into()),
-                ]),
+                ])),
             ],
         );
         assert!(
@@ -16876,16 +16904,16 @@ mod tests {
         let result = vm_run(
             "f xs:L n>L n;slc xs 1 3",
             Some("f"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Number(10.0),
                 Value::Number(20.0),
                 Value::Number(30.0),
                 Value::Number(40.0),
-            ])],
+            ]))],
         );
         assert_eq!(
             result,
-            Value::List(vec![Value::Number(20.0), Value::Number(30.0)])
+            Value::List(Arc::new(vec![Value::Number(20.0), Value::Number(30.0)]))
         );
     }
 
@@ -16896,7 +16924,7 @@ mod tests {
             "f xs:L n sep:t>t;cat xs sep",
             Some("f"),
             vec![
-                Value::List(vec![Value::Number(1.0)]),
+                Value::List(Arc::new(vec![Value::Number(1.0)])),
                 Value::Text(",".into()),
             ],
         );
@@ -16990,7 +17018,7 @@ mod tests {
     fn vm_srt_single_element() {
         // Single-element list: returns as-is
         let result = vm_run("f>L n;srt [42]", Some("f"), vec![]);
-        assert_eq!(result, Value::List(vec![Value::Number(42.0)]));
+        assert_eq!(result, Value::List(Arc::new(vec![Value::Number(42.0)])));
     }
 
     // --- OP_CAT where first arg is heap but not list (string) ---
@@ -17018,7 +17046,11 @@ mod tests {
     #[test]
     fn vm_not_on_empty_list_is_true() {
         // ![] → falsy, so !falsy = true
-        let result = vm_run("f xs:L n>b;!xs", Some("f"), vec![Value::List(vec![])]);
+        let result = vm_run(
+            "f xs:L n>b;!xs",
+            Some("f"),
+            vec![Value::List(Arc::new(vec![]))],
+        );
         assert_eq!(result, Value::Bool(true));
     }
 
@@ -17364,7 +17396,10 @@ mod tests {
         let result = vm_run(
             source,
             Some("f"),
-            vec![Value::List(vec![Value::Number(1.0), Value::Number(2.0)])],
+            vec![Value::List(Arc::new(vec![
+                Value::Number(1.0),
+                Value::Number(2.0),
+            ]))],
         );
         assert_eq!(result, Value::Text("[1,2]".to_string()));
     }
@@ -17428,7 +17463,7 @@ mod tests {
             "f xs:L n sep:t>t;cat xs sep",
             Some("f"),
             vec![
-                Value::List(vec![Value::Number(1.0), Value::Number(2.0)]),
+                Value::List(Arc::new(vec![Value::Number(1.0), Value::Number(2.0)])),
                 Value::Text(" ".to_string()),
             ],
         );
@@ -18682,7 +18717,7 @@ mod tests {
         let result = vm_run(
             r#"f xs:L n>t;?xs{l v:"got list";_:"other"}"#,
             Some("f"),
-            vec![Value::List(vec![Value::Number(1.0)])],
+            vec![Value::List(Arc::new(vec![Value::Number(1.0)]))],
         );
         assert_eq!(result, Value::Text("got list".into()));
     }
@@ -18816,7 +18851,7 @@ mod tests {
         let result = vm_run(
             r#"f xs:L n>t;?xs{l v:"list";_:"other"}"#,
             Some("f"),
-            vec![Value::List(vec![])],
+            vec![Value::List(Arc::new(vec![]))],
         );
         assert_eq!(result, Value::Text("list".into()));
     }
@@ -19226,7 +19261,7 @@ mod tests {
         );
 
         let list_src = r#"f x:n>b;?x{l _:true;_:false}"#;
-        let list = Value::List(vec![Value::Number(1.0)]);
+        let list = Value::List(Arc::new(vec![Value::Number(1.0)]));
         assert_eq!(vm_run(list_src, Some("f"), vec![list]), Value::Bool(true));
     }
 
@@ -19294,7 +19329,11 @@ mod tests {
     fn vm_safe_field_on_list_returns_nil() {
         let src = "f xs:L n>n;xs.?0??77";
         assert_eq!(
-            vm_run(src, Some("f"), vec![Value::List(vec![Value::Number(99.0)])]),
+            vm_run(
+                src,
+                Some("f"),
+                vec![Value::List(Arc::new(vec![Value::Number(99.0)]))]
+            ),
             Value::Number(99.0)
         );
     }
@@ -19539,7 +19578,7 @@ mod tests {
             Some("f"),
             vec![
                 Value::Map(std::sync::Arc::new(std::collections::HashMap::new())),
-                Value::List(vec![Value::Number(1.0)]),
+                Value::List(Arc::new(vec![Value::Number(1.0)])),
             ],
         );
         assert!(
@@ -19556,7 +19595,7 @@ mod tests {
             "f x:z k:t>n;mget x k",
             Some("f"),
             vec![
-                Value::List(vec![Value::Number(1.0)]),
+                Value::List(Arc::new(vec![Value::Number(1.0)])),
                 Value::Text("key".into()),
             ],
         );
@@ -19571,7 +19610,7 @@ mod tests {
             Some("f"),
             vec![
                 Value::Map(std::sync::Arc::new(std::collections::HashMap::new())),
-                Value::List(vec![Value::Number(1.0)]),
+                Value::List(Arc::new(vec![Value::Number(1.0)])),
                 Value::Text("val".into()),
             ],
         );
@@ -19605,7 +19644,7 @@ mod tests {
             Some("f"),
             vec![
                 Value::Map(std::sync::Arc::new(std::collections::HashMap::new())),
-                Value::List(vec![Value::Number(1.0)]),
+                Value::List(Arc::new(vec![Value::Number(1.0)])),
             ],
         );
         assert!(
@@ -19622,7 +19661,7 @@ mod tests {
             "f x:z k:t>n;mhas x k",
             Some("f"),
             vec![
-                Value::List(vec![Value::Number(1.0)]),
+                Value::List(Arc::new(vec![Value::Number(1.0)])),
                 Value::Text("k".into()),
             ],
         );
@@ -19635,7 +19674,7 @@ mod tests {
         let err = vm_run_err(
             "f x:z>n;mkeys x",
             Some("f"),
-            vec![Value::List(vec![Value::Text("a".into())])],
+            vec![Value::List(Arc::new(vec![Value::Text("a".into())]))],
         );
         assert!(err.contains("mkeys") || err.contains("map"), "got: {err}");
     }
@@ -19659,7 +19698,7 @@ mod tests {
             Some("f"),
             vec![
                 Value::Map(std::sync::Arc::new(std::collections::HashMap::new())),
-                Value::List(vec![Value::Number(7.0)]),
+                Value::List(Arc::new(vec![Value::Number(7.0)])),
             ],
         );
         assert!(
@@ -19675,7 +19714,7 @@ mod tests {
             "f x:z k:t>n;mdel x k",
             Some("f"),
             vec![
-                Value::List(vec![Value::Number(1.0)]),
+                Value::List(Arc::new(vec![Value::Number(1.0)])),
                 Value::Text("k".into()),
             ],
         );
@@ -19727,7 +19766,7 @@ mod tests {
             Some("f"),
             vec![
                 Value::Text("/nonexistent_dir_ilo/lines.txt".into()),
-                Value::List(vec![Value::Text("line1".into())]),
+                Value::List(Arc::new(vec![Value::Text("line1".into())])),
             ],
         );
         assert!(
@@ -19927,7 +19966,7 @@ mod tests {
             Some("f"),
             vec![
                 Value::Text("/tmp/ilo_wrl_elem.txt".into()),
-                Value::List(vec![Value::Number(42.0)]),
+                Value::List(Arc::new(vec![Value::Number(42.0)])),
             ],
         );
         assert!(
@@ -19995,7 +20034,7 @@ mod tests {
         let err = vm_run_err(
             r#"f xs:L t>t;cat xs 42"#,
             Some("f"),
-            vec![Value::List(vec![Value::Text("a".into())])],
+            vec![Value::List(Arc::new(vec![Value::Text("a".into())]))],
         );
         assert!(err.contains("cat") || err.contains("text"), "got: {err}");
     }
@@ -20081,7 +20120,7 @@ mod tests {
             r#"f xs:L n s:t e:t>L n;slc xs s e"#,
             Some("f"),
             vec![
-                Value::List(vec![Value::Number(1.0), Value::Number(2.0)]),
+                Value::List(Arc::new(vec![Value::Number(1.0), Value::Number(2.0)])),
                 Value::Text("a".into()),
                 Value::Text("b".into()),
             ],
@@ -20605,11 +20644,11 @@ mod tests {
         let result = vm_run(
             source,
             Some("f"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(5.0),
                 Value::Number(2.0),
-            ])],
+            ]))],
         );
         assert_eq!(result, Value::Number(5.0));
     }
@@ -20629,11 +20668,11 @@ mod tests {
         let result = vm_run(
             source,
             Some("f"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(5.0),
                 Value::Number(9.0),
-            ])],
+            ]))],
         );
         assert_eq!(result, Value::Number(0.0));
     }
@@ -20676,11 +20715,11 @@ mod tests {
         let result = vm_run(
             source,
             Some("mx"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Number(3.0),
                 Value::Number(1.0),
                 Value::Number(5.0),
-            ])],
+            ]))],
         );
         assert_eq!(result, Value::Number(5.0));
     }
@@ -20728,7 +20767,10 @@ mod tests {
         let result = vm_run(
             source,
             Some("f"),
-            vec![Value::List(vec![Value::Number(0.0), Value::Number(1.0)])],
+            vec![Value::List(Arc::new(vec![
+                Value::Number(0.0),
+                Value::Number(1.0),
+            ]))],
         );
         assert_eq!(result, Value::Number(20.0));
     }
@@ -20785,7 +20827,10 @@ mod tests {
         let result = vm_run(
             source,
             Some("f"),
-            vec![Value::List(vec![Value::Number(1.0), Value::Number(2.0)])],
+            vec![Value::List(Arc::new(vec![
+                Value::Number(1.0),
+                Value::Number(2.0),
+            ]))],
         );
         assert_eq!(result, Value::Number(2.0));
     }
@@ -20796,7 +20841,10 @@ mod tests {
         let result = vm_run(
             source,
             Some("f"),
-            vec![Value::List(vec![Value::Number(1.0), Value::Number(5.0)])],
+            vec![Value::List(Arc::new(vec![
+                Value::Number(1.0),
+                Value::Number(5.0),
+            ]))],
         );
         assert_eq!(result, Value::Number(5.0));
     }
@@ -20856,7 +20904,7 @@ mod tests {
         let result = vm_run(
             r#"f x:L n>t;?x{l v:"list";_:"other"}"#,
             Some("f"),
-            vec![Value::List(vec![Value::Number(1.0)])],
+            vec![Value::List(Arc::new(vec![Value::Number(1.0)]))],
         );
         assert_eq!(result, Value::Text("list".into()));
     }
@@ -21509,21 +21557,21 @@ mod tests {
         let result = vm_run(
             source,
             Some("main"),
-            vec![Value::List(
+            vec![Value::List(Arc::new(
                 vec![1.0, 2.0, 3.0, 4.0, 5.0]
                     .into_iter()
                     .map(Value::Number)
                     .collect(),
-            )],
+            ))],
         );
         assert_eq!(
             result,
-            Value::List(
+            Value::List(Arc::new(
                 vec![1.0, 4.0, 9.0, 16.0, 25.0]
                     .into_iter()
                     .map(Value::Number)
                     .collect()
-            )
+            ))
         );
     }
 
@@ -21553,10 +21601,10 @@ mod tests {
             Some("f"),
             vec![
                 Value::Text("sq".into()),
-                Value::List(vec![Value::Number(3.0)]),
+                Value::List(Arc::new(vec![Value::Number(3.0)])),
             ],
         );
-        assert_eq!(result, Value::List(vec![Value::Number(9.0)]));
+        assert_eq!(result, Value::List(Arc::new(vec![Value::Number(9.0)])));
     }
 
     #[test]
@@ -21566,16 +21614,18 @@ mod tests {
         let result = vm_run(
             source,
             Some("main"),
-            vec![Value::List(
+            vec![Value::List(Arc::new(
                 vec![-3.0, -1.0, 0.0, 2.0, 4.0]
                     .into_iter()
                     .map(Value::Number)
                     .collect(),
-            )],
+            ))],
         );
         assert_eq!(
             result,
-            Value::List(vec![2.0, 4.0].into_iter().map(Value::Number).collect())
+            Value::List(Arc::new(
+                vec![2.0, 4.0].into_iter().map(Value::Number).collect()
+            ))
         );
     }
 
@@ -21586,7 +21636,7 @@ mod tests {
         let err = vm_run_err(
             source,
             Some("f"),
-            vec![Value::List(vec![Value::Number(1.0)])],
+            vec![Value::List(Arc::new(vec![Value::Number(1.0)]))],
         );
         assert!(err.contains("flt") || err.contains("bool"), "got: {err}");
     }
@@ -21604,7 +21654,7 @@ mod tests {
         let err = vm_run_err(
             "f xs:L n>L n;flt 42 xs",
             Some("f"),
-            vec![Value::List(vec![Value::Number(1.0)])],
+            vec![Value::List(Arc::new(vec![Value::Number(1.0)]))],
         );
         assert!(
             err.contains("flt") || err.contains("fn") || err.contains("function"),
@@ -21619,12 +21669,12 @@ mod tests {
         let result = vm_run(
             source,
             Some("main"),
-            vec![Value::List(
+            vec![Value::List(Arc::new(
                 vec![1.0, 2.0, 3.0, 4.0, 5.0]
                     .into_iter()
                     .map(Value::Number)
                     .collect(),
-            )],
+            ))],
         );
         assert_eq!(result, Value::Number(15.0));
     }
@@ -21653,12 +21703,12 @@ mod tests {
         let result = vm_run(
             source,
             Some("main"),
-            vec![Value::List(
+            vec![Value::List(Arc::new(
                 vec![1.0, 8.0, 3.0, 9.0, 2.0]
                     .into_iter()
                     .map(Value::Number)
                     .collect(),
-            )],
+            ))],
         );
         let Value::Map(m) = result else {
             panic!("expected Map")
@@ -21666,11 +21716,15 @@ mod tests {
         use crate::interpreter::MapKey;
         assert_eq!(
             m.get(&MapKey::Text("small".to_string())).unwrap(),
-            &Value::List(vec![1.0, 3.0, 2.0].into_iter().map(Value::Number).collect())
+            &Value::List(Arc::new(
+                vec![1.0, 3.0, 2.0].into_iter().map(Value::Number).collect()
+            ))
         );
         assert_eq!(
             m.get(&MapKey::Text("big".to_string())).unwrap(),
-            &Value::List(vec![8.0, 9.0].into_iter().map(Value::Number).collect())
+            &Value::List(Arc::new(
+                vec![8.0, 9.0].into_iter().map(Value::Number).collect()
+            ))
         );
     }
 
@@ -21681,12 +21735,12 @@ mod tests {
         let result = vm_run(
             source,
             Some("main"),
-            vec![Value::List(
+            vec![Value::List(Arc::new(
                 vec![1.0, 2.0, 1.0, 3.0, 2.0]
                     .into_iter()
                     .map(Value::Number)
                     .collect(),
-            )],
+            ))],
         );
         let Value::Map(m) = result else {
             panic!("expected Map")
@@ -21694,15 +21748,19 @@ mod tests {
         use crate::interpreter::MapKey;
         assert_eq!(
             m.get(&MapKey::Text("1".to_string())).unwrap(),
-            &Value::List(vec![1.0, 1.0].into_iter().map(Value::Number).collect())
+            &Value::List(Arc::new(
+                vec![1.0, 1.0].into_iter().map(Value::Number).collect()
+            ))
         );
         assert_eq!(
             m.get(&MapKey::Text("2".to_string())).unwrap(),
-            &Value::List(vec![2.0, 2.0].into_iter().map(Value::Number).collect())
+            &Value::List(Arc::new(
+                vec![2.0, 2.0].into_iter().map(Value::Number).collect()
+            ))
         );
         assert_eq!(
             m.get(&MapKey::Text("3".to_string())).unwrap(),
-            &Value::List(vec![3.0].into_iter().map(Value::Number).collect())
+            &Value::List(Arc::new(vec![3.0].into_iter().map(Value::Number).collect()))
         );
     }
 
@@ -21710,7 +21768,7 @@ mod tests {
     #[ignore] // VM missing HOF/FnRef resolution
     fn vm_grp_empty_list() {
         let source = "id x:n>t;str x main xs:L n>M t L n;grp id xs";
-        let result = vm_run(source, Some("main"), vec![Value::List(vec![])]);
+        let result = vm_run(source, Some("main"), vec![Value::List(Arc::new(vec![]))]);
         assert_eq!(
             result,
             Value::Map(std::sync::Arc::new(std::collections::HashMap::new()))
@@ -21740,11 +21798,11 @@ mod tests {
         let result = vm_run(
             source,
             Some("g"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(1.0),
-            ])],
+            ]))],
         );
         let Value::Map(m) = result else {
             panic!("expected map")
@@ -21759,11 +21817,11 @@ mod tests {
         let result = vm_run(
             source,
             Some("g"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Number(-1.0),
                 Value::Number(1.0),
                 Value::Number(2.0),
-            ])],
+            ]))],
         );
         let Value::Map(m) = result else {
             panic!("expected map")
@@ -21780,11 +21838,11 @@ mod tests {
         let result = vm_run(
             source,
             Some("g"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0),
-            ])],
+            ]))],
         );
         let Value::Map(m) = result else {
             panic!("expected Map")
@@ -21805,7 +21863,10 @@ mod tests {
         let err = vm_run_err(
             source,
             Some("g"),
-            vec![Value::List(vec![Value::Number(1.0), Value::Number(2.0)])],
+            vec![Value::List(Arc::new(vec![
+                Value::Number(1.0),
+                Value::Number(2.0),
+            ]))],
         );
         assert!(
             err.contains("grp") || err.contains("key") || err.contains("string"),
@@ -21822,12 +21883,12 @@ mod tests {
         let result = vm_run(
             source,
             Some("f"),
-            vec![Value::List(
+            vec![Value::List(Arc::new(
                 vec![1.0, 2.0, 3.0, 4.0, 5.0]
                     .into_iter()
                     .map(Value::Number)
                     .collect(),
-            )],
+            ))],
         );
         assert_eq!(result, Value::Number(15.0));
     }
@@ -21837,7 +21898,7 @@ mod tests {
     fn vm_sum_empty() {
         let source = "f xs:L n>n;sum xs";
         assert_eq!(
-            vm_run(source, Some("f"), vec![Value::List(vec![])]),
+            vm_run(source, Some("f"), vec![Value::List(Arc::new(vec![]))]),
             Value::Number(0.0)
         );
     }
@@ -21861,9 +21922,9 @@ mod tests {
         let result = vm_run(
             source,
             Some("f"),
-            vec![Value::List(
+            vec![Value::List(Arc::new(
                 vec![2.0, 4.0, 6.0].into_iter().map(Value::Number).collect(),
-            )],
+            ))],
         );
         assert_eq!(result, Value::Number(4.0));
     }
@@ -21885,7 +21946,7 @@ mod tests {
         let err = vm_run_err(
             "f xs:L n>n;avg xs",
             Some("f"),
-            vec![Value::List(vec![Value::Text("x".into())])],
+            vec![Value::List(Arc::new(vec![Value::Text("x".into())]))],
         );
         assert!(err.contains("avg") || err.contains("number"), "got: {err}");
     }
@@ -21899,12 +21960,12 @@ mod tests {
         let result = vm_run(source, Some("f"), vec![]);
         assert_eq!(
             result,
-            Value::List(
+            Value::List(Arc::new(
                 vec![1.0, 2.0, 3.0, 4.0, 5.0]
                     .into_iter()
                     .map(Value::Number)
                     .collect()
-            )
+            ))
         );
     }
 
@@ -21915,7 +21976,9 @@ mod tests {
         let result = vm_run(source, Some("f"), vec![]);
         assert_eq!(
             result,
-            Value::List(vec![1.0, 2.0, 3.0].into_iter().map(Value::Number).collect())
+            Value::List(Arc::new(
+                vec![1.0, 2.0, 3.0].into_iter().map(Value::Number).collect()
+            ))
         );
     }
 
@@ -21924,7 +21987,7 @@ mod tests {
     fn vm_flat_empty() {
         assert_eq!(
             vm_run("f>L n;flat []", Some("f"), vec![]),
-            Value::List(vec![])
+            Value::List(Arc::new(vec![]))
         );
     }
 
@@ -21943,19 +22006,19 @@ mod tests {
         let result = vm_run(
             source,
             Some("main"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Text("banana".into()),
                 Value::Text("a".into()),
                 Value::Text("cc".into()),
-            ])],
+            ]))],
         );
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Text("a".into()),
                 Value::Text("cc".into()),
                 Value::Text("banana".into()),
-            ])
+            ]))
         );
     }
 
@@ -21966,19 +22029,19 @@ mod tests {
         let result = vm_run(
             source,
             Some("main"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(3.0),
                 Value::Number(2.0),
-            ])],
+            ]))],
         );
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(3.0),
                 Value::Number(2.0),
                 Value::Number(1.0)
-            ])
+            ]))
         );
     }
 
@@ -21989,19 +22052,19 @@ mod tests {
         let result = vm_run(
             source,
             Some("main"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Text("banana".into()),
                 Value::Text("apple".into()),
                 Value::Text("cherry".into()),
-            ])],
+            ]))],
         );
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Text("apple".into()),
                 Value::Text("banana".into()),
                 Value::Text("cherry".into()),
-            ])
+            ]))
         );
     }
 
@@ -22018,7 +22081,7 @@ mod tests {
         let err = vm_run_err(
             "f xs:L n>L n;srt 42 xs",
             Some("f"),
-            vec![Value::List(vec![Value::Number(1.0)])],
+            vec![Value::List(Arc::new(vec![Value::Number(1.0)]))],
         );
         assert!(
             err.contains("srt") || err.contains("fn") || err.contains("function"),
@@ -22049,7 +22112,7 @@ mod tests {
     fn vm_ok_srt_empty_list() {
         assert_eq!(
             vm_run("f>L n;srt []", Some("f"), vec![]),
-            Value::List(vec![])
+            Value::List(Arc::new(vec![]))
         );
     }
 
@@ -22060,7 +22123,7 @@ mod tests {
         let source = "f>L n;slc [1, 2, 3] 1 100";
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
-            Value::List(vec![Value::Number(2.0), Value::Number(3.0)])
+            Value::List(Arc::new(vec![Value::Number(2.0), Value::Number(3.0)]))
         );
     }
 
@@ -22071,15 +22134,18 @@ mod tests {
         let result = vm_run(
             "f xs:L t>L t;unq xs",
             Some("f"),
-            vec![Value::List(vec![
+            vec![Value::List(Arc::new(vec![
                 Value::Text("a".into()),
                 Value::Text("b".into()),
                 Value::Text("a".into()),
-            ])],
+            ]))],
         );
         assert_eq!(
             result,
-            Value::List(vec![Value::Text("a".into()), Value::Text("b".into())])
+            Value::List(Arc::new(vec![
+                Value::Text("a".into()),
+                Value::Text("b".into())
+            ]))
         );
     }
 
@@ -22184,7 +22250,10 @@ mod tests {
         );
         assert_eq!(
             result,
-            Value::List(vec![Value::Text("123".into()), Value::Text("456".into()),])
+            Value::List(Arc::new(vec![
+                Value::Text("123".into()),
+                Value::Text("456".into()),
+            ]))
         );
     }
 
@@ -22199,10 +22268,10 @@ mod tests {
         );
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Text("name".into()),
                 Value::Text("alice".into()),
-            ])
+            ]))
         );
     }
 
@@ -22215,7 +22284,7 @@ mod tests {
             Some("f"),
             vec![Value::Text("no numbers here".into())],
         );
-        assert_eq!(result, Value::List(vec![]));
+        assert_eq!(result, Value::List(Arc::new(vec![])));
     }
 
     #[test]
@@ -22403,7 +22472,10 @@ mod tests {
         );
         assert_eq!(
             result,
-            Value::List(vec![Value::Text("a".into()), Value::Text("b".into())])
+            Value::List(Arc::new(vec![
+                Value::Text("a".into()),
+                Value::Text("b".into())
+            ]))
         );
     }
 
@@ -22423,7 +22495,7 @@ mod tests {
         );
         assert_eq!(
             result,
-            Value::List(vec![Value::Number(1.0), Value::Number(2.0)])
+            Value::List(Arc::new(vec![Value::Number(1.0), Value::Number(2.0)]))
         );
     }
 
@@ -23460,11 +23532,11 @@ f>n;r=mk 10 20;+r.x r.y";
         let src = "f>L n;[1 2 3]";
         assert_eq!(
             vm_run(src, Some("f"), vec![]),
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0),
-            ])
+            ]))
         );
     }
 
@@ -23473,10 +23545,10 @@ f>n;r=mk 10 20;+r.x r.y";
         let src = r#"f w:t>L t;["hi" w]"#;
         assert_eq!(
             vm_run(src, Some("f"), vec![Value::Text("world".to_string())]),
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Text("hi".to_string()),
                 Value::Text("world".to_string())
-            ])
+            ]))
         );
     }
 
@@ -23485,11 +23557,11 @@ f>n;r=mk 10 20;+r.x r.y";
         let src = r#"f>L a;["search" 10 true]"#;
         assert_eq!(
             vm_run(src, Some("f"), vec![]),
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Text("search".to_string()),
                 Value::Number(10.0),
                 Value::Bool(true),
-            ])
+            ]))
         );
     }
 
@@ -23498,11 +23570,11 @@ f>n;r=mk 10 20;+r.x r.y";
         let src = "f>L n;[1, 2 3]";
         assert_eq!(
             vm_run(src, Some("f"), vec![]),
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0),
-            ])
+            ]))
         );
     }
 
@@ -23651,11 +23723,11 @@ f>n;r=mk 10 20;+r.x r.y";
         let result = vm_run(src, Some("f"), vec![Value::Number(1.0)]);
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0),
-            ])
+            ]))
         );
     }
 
@@ -23968,7 +24040,7 @@ f>n;r=mk 10 20;+r.x r.y";
         let result = vm_run("f>L n;slc [1, 2, 3, 4, 5] 1 3", Some("f"), vec![]);
         assert_eq!(
             result,
-            Value::List(vec![Value::Number(2.0), Value::Number(3.0)])
+            Value::List(Arc::new(vec![Value::Number(2.0), Value::Number(3.0)]))
         );
     }
 
@@ -24043,7 +24115,7 @@ f>n;r=mk 10 20;+r.x r.y";
         let result = vm_run("f>L n;xs=[10, 20, 30];tl xs", Some("f"), vec![]);
         assert_eq!(
             result,
-            Value::List(vec![Value::Number(20.0), Value::Number(30.0)])
+            Value::List(Arc::new(vec![Value::Number(20.0), Value::Number(30.0)]))
         );
     }
 
@@ -24352,11 +24424,11 @@ f>n;r=mk 10 20;+r.x r.y";
         let result = vm_run("f>L n;rev [1, 2, 3]", Some("f"), vec![]);
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(3.0),
                 Value::Number(2.0),
                 Value::Number(1.0),
-            ])
+            ]))
         );
     }
 
@@ -24376,11 +24448,11 @@ f>n;r=mk 10 20;+r.x r.y";
         );
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Text("apple".into()),
                 Value::Text("banana".into()),
                 Value::Text("cherry".into()),
-            ])
+            ]))
         );
     }
 
@@ -24389,18 +24461,18 @@ f>n;r=mk 10 20;+r.x r.y";
         let result = vm_run("f>L n;srt [3,1,2]", Some("f"), vec![]);
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(1.0),
                 Value::Number(2.0),
                 Value::Number(3.0),
-            ])
+            ]))
         );
     }
 
     #[test]
     fn vm_cov_srt_single_item_list() {
         let result = vm_run("f>L n;srt [42]", Some("f"), vec![]);
-        assert_eq!(result, Value::List(vec![Value::Number(42.0)]));
+        assert_eq!(result, Value::List(Arc::new(vec![Value::Number(42.0)])));
     }
 
     // ── OP_SLC — slice string ──────────────────────────────────────────────
@@ -24422,18 +24494,21 @@ f>n;r=mk 10 20;+r.x r.y";
         let result = vm_run(r#"f>L t;spl "a,b,c" ",""#, Some("f"), vec![]);
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Text("a".into()),
                 Value::Text("b".into()),
                 Value::Text("c".into()),
-            ])
+            ]))
         );
     }
 
     #[test]
     fn vm_cov_spl_no_match() {
         let result = vm_run(r#"f>L t;spl "abc" ",""#, Some("f"), vec![]);
-        assert_eq!(result, Value::List(vec![Value::Text("abc".into())]));
+        assert_eq!(
+            result,
+            Value::List(Arc::new(vec![Value::Text("abc".into())]))
+        );
     }
 
     // ── OP_UNQ — unique string characters ─────────────────────────────────
@@ -25008,11 +25083,11 @@ f>n;r=mk 10 20;+r.x r.y";
             is_tool: vec![false],
         };
 
-        let list_arg = Value::List(vec![
+        let list_arg = Value::List(Arc::new(vec![
             Value::Number(10.0),
             Value::Number(20.0),
             Value::Number(30.0),
-        ]);
+        ]));
         let result = run(&program, Some("f"), vec![list_arg]).expect("should succeed");
         assert_eq!(result, Value::Number(20.0)); // index 1 → 20.0
     }
@@ -25060,11 +25135,11 @@ f>n;r=mk 10 20;+r.x r.y";
             is_tool: vec![false],
         };
 
-        let list_arg = Value::List(vec![
+        let list_arg = Value::List(Arc::new(vec![
             Value::Number(10.0),
             Value::Number(20.0),
             Value::Number(30.0),
-        ]);
+        ]));
         let result = run(&program, Some("f"), vec![list_arg]).expect("should succeed");
         assert_eq!(result, Value::Nil); // out of bounds → nil
     }
@@ -25256,7 +25331,11 @@ f>n;r=mk 10 20;+r.x r.y";
         // → returns false (line 721), falls through to general binding.
         let src = "f xs:L n>L n;xs=+=[] xs;xs";
         // This just tests that the program runs, not the specific opcode path
-        let result = vm_run(src, Some("f"), vec![Value::List(vec![Value::Number(1.0)])]);
+        let result = vm_run(
+            src,
+            Some("f"),
+            vec![Value::List(Arc::new(vec![Value::Number(1.0)]))],
+        );
         match result {
             Value::List(items) => assert!(!items.is_empty()),
             other => panic!("expected list, got {:?}", other),
@@ -25346,7 +25425,7 @@ f>n;r=mk 10 20;+r.x r.y";
             is_tool: vec![false],
         };
 
-        let list_arg = Value::List(vec![Value::Number(1.0), Value::Number(2.0)]);
+        let list_arg = Value::List(Arc::new(vec![Value::Number(1.0), Value::Number(2.0)]));
         let result = run(&program, Some("f"), vec![list_arg]);
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
@@ -25970,11 +26049,11 @@ f>n;r=mk 10 20;+r.x r.y";
         let result = run(&compiled, Some("f"), vec![]).expect("run lst");
         assert_eq!(
             result,
-            Value::List(vec![
+            Value::List(Arc::new(vec![
                 Value::Number(10.0),
                 Value::Number(99.0),
                 Value::Number(30.0),
-            ])
+            ]))
         );
     }
 

--- a/tests/regression_list_accumulator_tree.rs
+++ b/tests/regression_list_accumulator_tree.rs
@@ -1,0 +1,171 @@
+// Regression tests for the tree-walker RC-aware list-append fast path.
+//
+// Background: Phase 2b.1 (PR #261) made `Value::Map` RC-aware via
+// `Arc<HashMap>` and added an eval_stmt peephole for `m = mset m k v`. Phase
+// 2b.2 (this PR) does the same for `Value::List`:
+//
+//   1. `Value::List(Vec<Value>)` becomes `Value::List(Arc<Vec<Value>>)`, so
+//      cloning a list is a refcount bump rather than a full Vec copy.
+//   2. Two eval_stmt peepholes detect self-rebind accumulator shapes:
+//        `xs = +=xs v`   (BinOp::Append)
+//        `xs = xs + ys`  (BinOp::Add on two lists)
+//      Both take the env's binding out before evaluating the rhs so the
+//      Arc<Vec<Value>> reaches the fast path with refcount=1, and
+//      `Arc::make_mut` mutates the inner Vec in place.
+//
+// On a 5k-element accumulator loop this drops tree wall-clock from O(n²) to
+// O(n). This file pins:
+//   1. Correctness for `xs = +=xs v` with numbers and text on the tree
+//      engine.
+//   2. Correctness for `xs = xs + ys` list-concat with empty / non-empty
+//      sides.
+//   3. The non-rebind shape (`ys = +=xs v`, different name) still produces a
+//      fresh list, leaving the original `xs` unchanged.
+//   4. Aliased rhs (`s = s + s` self-concat) still works correctly because
+//      the peephole bails out when the rhs references the same binding.
+//   5. Scaling: a 5k-element accumulator finishes well under a second.
+
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_tree(src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, "--run-tree", entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo --run-tree failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+// ── Self-rebind: append numbers ────────────────────────────────────────────
+
+#[test]
+fn tree_list_append_self_rebind_numbers() {
+    // Three appends via the self-rebind shape. Exercises the eval_stmt
+    // append peephole on every assignment.
+    let src = r#"f>n;xs=[];xs=+=xs 1;xs=+=xs 2;xs=+=xs 3;len xs"#;
+    assert_eq!(run_tree(src, "f"), "3");
+}
+
+#[test]
+fn tree_list_append_self_rebind_text() {
+    let src = r#"f>t;xs=[];xs=+=xs "a";xs=+=xs "b";xs=+=xs "c";at xs 2 ?? "miss""#;
+    assert_eq!(run_tree(src, "f"), "c");
+}
+
+// ── Self-rebind: append inside foreach ─────────────────────────────────────
+
+#[test]
+fn tree_list_append_self_rebind_in_foreach() {
+    // Classic accumulator shape inside a loop. This is the pattern Phase 2b.2
+    // targets: every iteration goes through the peephole, so the loop runs
+    // in O(n) instead of O(n²).
+    let src = r#"f>n;xs=[];@i 0..5{xs=+=xs i};len xs"#;
+    assert_eq!(run_tree(src, "f"), "5");
+}
+
+// ── Non-rebind: caller's list is preserved ─────────────────────────────────
+
+#[test]
+fn tree_list_append_non_rebind_preserves_caller() {
+    // Append into a fresh name — the peephole must NOT fire. The original
+    // `xs` is held by a second binding, so the Arc has refcount=2 and
+    // `Arc::make_mut` must clone rather than mutate in place.
+    let src = r#"f>n;xs=[];xs=+=xs 1;xs=+=xs 2;ys=+=xs 99;len xs"#;
+    assert_eq!(run_tree(src, "f"), "2");
+}
+
+#[test]
+fn tree_list_append_non_rebind_target_gets_extra() {
+    // The non-rebind target receives the appended element.
+    let src = r#"f>n;xs=[];xs=+=xs 1;ys=+=xs 99;len ys"#;
+    assert_eq!(run_tree(src, "f"), "2");
+}
+
+// ── Self-rebind: list concat ───────────────────────────────────────────────
+
+#[test]
+fn tree_list_concat_self_rebind_two_singletons() {
+    let src = r#"f>n;xs=[];xs=+xs [1];xs=+xs [2];len xs"#;
+    assert_eq!(run_tree(src, "f"), "2");
+}
+
+#[test]
+fn tree_list_concat_self_rebind_empty_rhs() {
+    let src = r#"f>n;xs=[];xs=+xs [1];xs=+xs [];len xs"#;
+    assert_eq!(run_tree(src, "f"), "1");
+}
+
+// ── Aliasing: rhs references same binding ──────────────────────────────────
+
+#[test]
+fn tree_list_concat_self_alias_doubles() {
+    // `xs = xs + xs` — the peephole MUST bail out because evaluating the rhs
+    // after `env.take("xs")` would observe Nil. Phase 2b.1 hit the same trap
+    // on text-concat (`s = s + s`), fixed by the rhs-refers-to-name check.
+    let src = r#"f>n;xs=[1,2];xs=+xs xs;len xs"#;
+    assert_eq!(run_tree(src, "f"), "4");
+}
+
+// ── Numeric add still works under the same operator ────────────────────────
+
+#[test]
+fn tree_numeric_add_self_rebind_unaffected() {
+    // `n = n + n` — the peephole's match_self_rebind_concat fires, but
+    // eval_self_rebind_concat sees non-list values and falls back to
+    // eval_binop. The semantics must match the general path exactly.
+    //
+    // Wait — `n = n + n` also has rhs referring to `n`, so the peephole
+    // bails out via expr_refers_to. This test pins the general-path path
+    // works correctly when peephole bails out on numeric self-rebind.
+    let src = r#"f>n;n=3;n=+n n;n"#;
+    assert_eq!(run_tree(src, "f"), "6");
+}
+
+#[test]
+fn tree_numeric_add_self_rebind_distinct_rhs() {
+    // `n = n + 1` — peephole fires because rhs is a literal (no self-ref).
+    // eval_self_rebind_concat falls back to eval_binop because values
+    // aren't both lists. Result must be 4.
+    let src = r#"f>n;n=3;n=+n 1;n"#;
+    assert_eq!(run_tree(src, "f"), "4");
+}
+
+// ── Scale: 5k-element accumulator under 5s ─────────────────────────────────
+//
+// The pre-Phase-2b.2 tree path was O(n²) — every `+=` cloned the whole Vec.
+// On a recent MacBook 5k iterations took 10+ seconds. With Arc + the
+// peephole it's milliseconds. 5s ceiling catches an accidental regression to
+// the quadratic path while being lenient on slow CI runners.
+
+#[test]
+fn tree_list_append_scale_5k_under_5s() {
+    let src = r#"build n:n>n;xs=[];@i 0..n{xs=+=xs i};len xs
+demo>n;build 5000"#;
+    let start = Instant::now();
+    let out = ilo()
+        .args([src, "--run-tree", "demo"])
+        .output()
+        .expect("failed to run ilo");
+    let elapsed = start.elapsed();
+    assert!(
+        out.status.success(),
+        "ilo --run-tree demo failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(stdout.trim(), "5000", "wrong list length: {stdout}");
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "tree list-append 5k took {elapsed:?} — expected <5s; the O(n²) \
+         path used to take 10+s. The eval_stmt peephole may have regressed."
+    );
+}


### PR DESCRIPTION
## Summary

Phase 2b.2 of the RC-aware mutation rollout. Phase 2b.1 (#261) shipped the same shape for `Value::Map`; this PR does it for `Value::List`.

The tree-walker's list accumulator (`xs=[];@i 0..n{xs=+=xs i}`) was O(n²) because every `+=` cloned the whole `Vec<Value>`. After this PR it's O(n) amortised: cloning a list is now a refcount bump on `Arc<Vec<Value>>`, and the new eval_stmt peephole takes the env binding out before evaluating the RHS so `Arc::make_mut` mutates the inner Vec in place.

## Repro before/after

```
build n:n>n;xs=[];@i 0..n{xs=+=xs i};len xs
```

Pre-fix on tree: 5k iterations took ~10s (12.5M Value clones across 5000 Vec rebuilds). Post-fix: under a second. The Cranelift / VM backends already had the equivalent fast path landed in #249 / #250.

## What's in the diff

Three commits, each one coherent change so review can be done independently:

1. `interpreter: switch Value::List to Arc<Vec<Value>> with RC=1 in-place append` - mechanical representation change across the interpreter, VM HeapObj boundary, CLI parse_cli_arg, JSON deserialisation, and all unit-test constructors. Builtins that mutate their result on the way out switch to `(**items).clone()` to materialise an owned Vec before re-wrapping. Iteration sites that previously moved values out of the Vec switch to `iter().cloned()`.

2. `interpreter: eval_stmt peephole for self-rebind list append and concat` - the two new peepholes, plus an `expr_refers_to` helper that walks the rhs and bails out when it references the same binding (the trap PR #260 hit on string self-concat). Numeric `+` falls back through `eval_binop` so non-list paths are unaffected.

3. `test + example: tree-walker list accumulator regression coverage` - 11 new tests covering self-rebind correctness, non-rebind aliasing, list-concat empty/non-empty rhs, self-aliased rhs (`xs = +xs xs`), the numeric-add fallback, and a 5k-element scale test with a 5s ceiling. Plus `examples/list-accumulator-tree.ilo` so the engine harness runs the same shapes cross-engine.

## Test plan

- [x] `cargo build --release --features cranelift` clean
- [x] `cargo test --release --features cranelift` - 4702 passed, 0 failed (added 11 new tests)
- [x] `cargo clippy --release --features cranelift --all-targets -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] Phase 2b.1's mset accumulator tests still pass (no regression to the Map peephole)
- [x] String self-concat aliasing tests pass (no regression to PR #260)
- [x] examples_engines harness runs the new example across tree, VM, and Cranelift

## Follow-ups

- Phase 2b.3 (Text): same pattern for `Value::Text(String)` -> `Value::Text(Arc<String>)` with `s = +s c` peephole. Will land as a separate PR after this one merges.