### PR TITLE
Phase 2b.3: switch Value::Text to Arc<String> with RC=1 in-place concat

### DIFF
--- a/examples/string-accumulator-tree.ilo
+++ b/examples/string-accumulator-tree.ilo
@@ -1,0 +1,39 @@
+-- Demonstrates the tree-walker string-concat accumulator fast path.
+--
+-- Phase 2b.3 (this commit's parent PR) makes `Value::Text` RC-aware via
+-- `Arc<String>` and extends the existing eval_stmt self-rebind concat
+-- peephole to cover the Text/Text case. With refcount=1 the peephole
+-- calls `Arc::make_mut` and `push_str` to mutate the inner String in
+-- place, so the loop below runs in O(n) instead of O(n^2).
+--
+-- Mirror of the Phase 2b.1 Map fast path (PR #261) and the Phase 2b.2
+-- List fast path (PR #273).
+
+-- The canonical accumulator: build "xxx...x" of length n.
+-- Pre-Phase-2b.3 the tree engine cloned the whole String on every
+-- iteration. After the fix it mutates in place because env's `s` is the
+-- sole holder.
+build-xs n:n>n;s="";@i 0..n{s=+s "x"};len s
+
+-- Variable suffix: the rhs is a Ref, not a literal. The peephole still
+-- fires because `name` is a different binding from `s`.
+greet name:t>t;s="hello ";s=+s name;s
+
+-- Aliased concat must NOT use the fast path. `s = +s s` reads `s` after
+-- env.take() would have replaced it with Nil, so the peephole bails out
+-- and the general allocating path doubles the string correctly.
+self-double>t;s="ab";s=+s s;s
+
+-- Non-rebind shape: `b = +a c` must leave `a` untouched. The peephole's
+-- name-match fails, so apply_binop allocates a fresh String and the
+-- caller's `a` is preserved.
+preserve-source>t;a="k1";b=+a "_x";a
+
+-- run: build-xs 50
+-- out: 50
+-- run: greet world
+-- out: hello world
+-- run: self-double
+-- out: abab
+-- run: preserve-source
+-- out: k1

--- a/src/interpreter/json.rs
+++ b/src/interpreter/json.rs
@@ -5,6 +5,7 @@
 
 use super::Value;
 use crate::ast::Type;
+use std::sync::Arc;
 
 #[allow(dead_code)] // used when `tools` feature is enabled and in tests
 impl Value {
@@ -28,7 +29,7 @@ impl Value {
                         .ok_or_else(|| format!("cannot serialize number {n} to JSON"))
                 }
             }
-            Value::Text(s) => Ok(serde_json::Value::String(s.clone())),
+            Value::Text(s) => Ok(serde_json::Value::String((**s).clone())),
             Value::Bool(b) => Ok(serde_json::Value::Bool(*b)),
             Value::Nil => Ok(serde_json::Value::Null),
             Value::List(items) => {
@@ -76,9 +77,9 @@ impl Value {
         // Type::Text escape hatch: coerce any JSON value to a text string.
         if matches!(type_hint, Some(Type::Text)) {
             if let serde_json::Value::String(s) = json {
-                return Ok(Value::Text(s.clone()));
+                return Ok(Value::Text(Arc::new(s.clone())));
             }
-            return Ok(Value::Text(json.to_string()));
+            return Ok(Value::Text(Arc::new(json.to_string())));
         }
 
         match json {
@@ -90,7 +91,7 @@ impl Value {
                     .unwrap_or(0.0);
                 Ok(Value::Number(f))
             }
-            serde_json::Value::String(s) => Ok(Value::Text(s.clone())),
+            serde_json::Value::String(s) => Ok(Value::Text(Arc::new(s.clone()))),
             serde_json::Value::Bool(b) => Ok(Value::Bool(*b)),
             serde_json::Value::Null => Ok(Value::Nil),
             serde_json::Value::Array(arr) => {
@@ -159,7 +160,7 @@ mod tests {
 
     #[test]
     fn to_json_text() {
-        let v = Value::Text("hello".to_string());
+        let v = Value::Text(Arc::new("hello".to_string()));
         assert_eq!(v.to_json().unwrap(), json!("hello"));
     }
 
@@ -178,7 +179,7 @@ mod tests {
     fn to_json_list() {
         let v = Value::List(Arc::new(vec![
             Value::Number(1.0),
-            Value::Text("a".to_string()),
+            Value::Text(Arc::new("a".to_string())),
         ]));
         assert_eq!(v.to_json().unwrap(), json!([1, "a"]));
     }
@@ -203,7 +204,7 @@ mod tests {
 
     #[test]
     fn to_json_err() {
-        let v = Value::Err(Box::new(Value::Text("oops".to_string())));
+        let v = Value::Err(Box::new(Value::Text(Arc::new("oops".to_string()))));
         assert_eq!(v.to_json().unwrap(), json!({"err": "oops"}));
     }
 
@@ -224,7 +225,7 @@ mod tests {
     #[test]
     fn from_json_string() {
         let v = Value::from_json(&json!("hi"), None).unwrap();
-        assert_eq!(v, Value::Text("hi".to_string()));
+        assert_eq!(v, Value::Text(Arc::new("hi".to_string())));
     }
 
     #[test]
@@ -260,7 +261,7 @@ mod tests {
             Value::Record { type_name, fields } => {
                 assert_eq!(type_name, "_");
                 assert_eq!(fields["a"], Value::Number(1.0));
-                assert_eq!(fields["b"], Value::Text("two".to_string()));
+                assert_eq!(fields["b"], Value::Text(Arc::new("two".to_string())));
             }
             other => panic!("expected Record, got {:?}", other),
         }
@@ -275,21 +276,24 @@ mod tests {
     #[test]
     fn from_json_err_wrapper() {
         let v = Value::from_json(&json!({"err": "bad"}), None).unwrap();
-        assert_eq!(v, Value::Err(Box::new(Value::Text("bad".to_string()))));
+        assert_eq!(
+            v,
+            Value::Err(Box::new(Value::Text(Arc::new("bad".to_string()))))
+        );
     }
 
     #[test]
     fn from_json_type_hint_text_coerces() {
         // A JSON number coerced to text when hint is Type::Text
         let v = Value::from_json(&json!(42), Some(&Type::Text)).unwrap();
-        assert_eq!(v, Value::Text("42".to_string()));
+        assert_eq!(v, Value::Text(Arc::new("42".to_string())));
     }
 
     #[test]
     fn from_json_type_hint_text_passthrough() {
         // A JSON string stays text when hint is Type::Text
         let v = Value::from_json(&json!("hello"), Some(&Type::Text)).unwrap();
-        assert_eq!(v, Value::Text("hello".to_string()));
+        assert_eq!(v, Value::Text(Arc::new("hello".to_string())));
     }
 
     // ── round-trips ──────────────────────────────────────────────────────
@@ -326,8 +330,8 @@ mod tests {
     #[test]
     fn round_trip_list_of_text() {
         let v = Value::List(Arc::new(vec![
-            Value::Text("a".to_string()),
-            Value::Text("b".to_string()),
+            Value::Text(Arc::new("a".to_string())),
+            Value::Text(Arc::new("b".to_string())),
         ]));
         let j = v.to_json().unwrap();
         let back = Value::from_json(&j, None).unwrap();

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -4071,10 +4071,11 @@ fn eval_self_rebind_append(env: &mut Env, val_expr: &Expr, prev: Value) -> Resul
     }
 }
 
-/// If `value` is the self-rebind list-concat shape `name = name + ys`, return
-/// `Some(rhs_expr)`. Returns `None` for any other shape, including any case
-/// where the rhs references `name` (e.g. `s = s + s` self-concat), which
-/// would observe Nil after the fast path takes the binding.
+/// If `value` is the self-rebind list/text-concat shape `name = name + rhs`,
+/// return `Some(rhs_expr)`. Drives both the List and Text branches of
+/// `eval_self_rebind_concat`. Returns `None` for any other shape, including
+/// any case where the rhs references `name` (e.g. `s = s + s` self-concat),
+/// which would observe Nil after the fast path takes the binding.
 fn match_self_rebind_concat<'a>(name: &str, value: &'a Expr) -> Option<&'a Expr> {
     if let Expr::BinOp { op, left, right } = value
         && matches!(op, BinOp::Add)
@@ -4090,9 +4091,11 @@ fn match_self_rebind_concat<'a>(name: &str, value: &'a Expr) -> Option<&'a Expr>
 /// Fast-path executor for `xs = xs + ys`. Caller has taken the previous
 /// binding out of env. If both sides are lists, we use `Arc::make_mut` on the
 /// prev (which now has refcount=1) and `extend` from ys, again giving O(n)
-/// amortised behaviour for repeated concatenation. If the values aren't both
-/// lists (e.g. numeric add), we fall back to `apply_binop` so semantics match
-/// the general path exactly.
+/// amortised behaviour for repeated concatenation. If both sides are text,
+/// we do the same trick with `Arc::make_mut` and `push_str` to fold O(n^2)
+/// string-accumulator loops to O(n) amortised. If the values aren't both
+/// lists or both text (e.g. numeric add), we fall back to `apply_binop` so
+/// semantics match the general path exactly.
 fn eval_self_rebind_concat(env: &mut Env, rhs_expr: &Expr, prev: Value) -> Result<Value> {
     let rhs = eval_expr(env, rhs_expr)?;
     match (prev, rhs) {
@@ -4100,6 +4103,16 @@ fn eval_self_rebind_concat(env: &mut Env, rhs_expr: &Expr, prev: Value) -> Resul
             let inner = Arc::make_mut(&mut items);
             inner.extend(other.iter().cloned());
             Ok(Value::List(items))
+        }
+        (Value::Text(mut s), Value::Text(other)) => {
+            // `match_self_rebind_concat` already rejects RHSes that reference
+            // `name`, so `prev` and `other` cannot be the same Arc here. That
+            // means `Arc::make_mut(&mut s)` is free to mutate in place (the
+            // env's binding was taken to Nil, so refcount=1) and reading
+            // `other` after the mutation observes the unchanged source.
+            let inner = Arc::make_mut(&mut s);
+            inner.push_str(&other);
+            Ok(Value::Text(s))
         }
         (prev, rhs) => eval_binop(&BinOp::Add, &prev, &rhs),
     }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -50,7 +50,7 @@ impl MapKey {
     /// `at xs i`; non-finite numbers are rejected.
     pub fn from_value(v: &Value, op_name: &str) -> std::result::Result<Self, RuntimeError> {
         match v {
-            Value::Text(s) => Ok(MapKey::Text(s.clone())),
+            Value::Text(s) => Ok(MapKey::Text((**s).clone())),
             Value::Number(n) => {
                 if !n.is_finite() {
                     return Err(RuntimeError::new(
@@ -102,7 +102,7 @@ impl PartialOrd for MapKey {
 /// `mkeys`. Text → `Value::Text`, Int → `Value::Number(f64)`.
 pub fn map_key_to_value(k: &MapKey) -> Value {
     match k {
-        MapKey::Text(s) => Value::Text(s.clone()),
+        MapKey::Text(s) => Value::Text(Arc::new(s.clone())),
         MapKey::Int(n) => Value::Number(*n as f64),
     }
 }
@@ -110,7 +110,7 @@ pub fn map_key_to_value(k: &MapKey) -> Value {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value {
     Number(f64),
-    Text(String),
+    Text(Arc<String>),
     Bool(bool),
     Nil,
     List(Arc<Vec<Value>>),
@@ -449,7 +449,7 @@ fn parse_format(fmt: &str, content: &str) -> std::result::Result<Value, String> 
                 .map(|line| {
                     let fields: Vec<Value> = parse_csv_row(line, sep)
                         .into_iter()
-                        .map(Value::Text)
+                        .map(|s| Value::Text(Arc::new(s)))
                         .collect();
                     Value::List(Arc::new(fields))
                 })
@@ -459,7 +459,7 @@ fn parse_format(fmt: &str, content: &str) -> std::result::Result<Value, String> 
         "json" => serde_json::from_str::<serde_json::Value>(content)
             .map(serde_json_to_value)
             .map_err(|e| e.to_string()),
-        _ => Ok(Value::Text(content.to_string())),
+        _ => Ok(Value::Text(Arc::new(content.to_string()))),
     }
 }
 
@@ -565,7 +565,7 @@ fn vec_from_value(v: &Value, name: &str) -> Result<Vec<f64>> {
 /// Inner `"` are escaped as `""`.
 fn fmt_csv_field(v: &Value, sep: char) -> String {
     let raw = match v {
-        Value::Text(s) => s.clone(),
+        Value::Text(s) => (**s).clone(),
         Value::Number(n) => {
             if *n == (*n as i64) as f64 {
                 format!("{}", *n as i64)
@@ -627,7 +627,7 @@ pub(crate) fn write_csv_tsv(rows: &[Value], sep: char) -> Result<String> {
             if i > 0 {
                 out.push(sep);
             }
-            out.push_str(&fmt_csv_field(&Value::Text(k.clone()), sep));
+            out.push_str(&fmt_csv_field(&Value::Text(Arc::new(k.clone())), sep));
         }
         out.push('\n');
     }
@@ -986,7 +986,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 } else {
                     format!("{}", n)
                 };
-                Ok(Value::Text(s))
+                Ok(Value::Text(Arc::new(s)))
             }
             other => Err(RuntimeError::new(
                 "ILO-R009",
@@ -1187,24 +1187,24 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         return match (&args[0], &args[1]) {
             (Value::Number(epoch), Value::Text(fmt_str)) => {
                 if !epoch.is_finite() {
-                    return Ok(Value::Err(Box::new(Value::Text(format!(
+                    return Ok(Value::Err(Box::new(Value::Text(Arc::new(format!(
                         "dtfmt: epoch is not finite ({epoch})"
-                    )))));
+                    ))))));
                 }
                 if *epoch < i64::MIN as f64 || *epoch > i64::MAX as f64 {
-                    return Ok(Value::Err(Box::new(Value::Text(format!(
+                    return Ok(Value::Err(Box::new(Value::Text(Arc::new(format!(
                         "dtfmt: epoch out of range ({epoch})"
-                    )))));
+                    ))))));
                 }
                 let secs = *epoch as i64;
                 match chrono::DateTime::<chrono::Utc>::from_timestamp(secs, 0) {
                     Some(dt) => {
                         let formatted = dt.format(fmt_str.as_str()).to_string();
-                        Ok(Value::Ok(Box::new(Value::Text(formatted))))
+                        Ok(Value::Ok(Box::new(Value::Text(Arc::new(formatted)))))
                     }
-                    None => Ok(Value::Err(Box::new(Value::Text(format!(
+                    None => Ok(Value::Err(Box::new(Value::Text(Arc::new(format!(
                         "dtfmt: timestamp out of range ({secs})"
-                    ))))),
+                    )))))),
                 }
             }
             _ => Err(RuntimeError::new(
@@ -1224,7 +1224,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                     });
                 match parsed {
                     Ok(n) => Ok(Value::Ok(Box::new(Value::Number(n)))),
-                    Err(e) => Ok(Value::Err(Box::new(Value::Text(format!("dtparse: {e}"))))),
+                    Err(e) => Ok(Value::Err(Box::new(Value::Text(Arc::new(format!(
+                        "dtparse: {e}"
+                    )))))),
                 }
             }
             _ => Err(RuntimeError::new(
@@ -1262,7 +1264,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             (Value::Text(s), Value::Text(sep)) => {
                 let parts: Vec<Value> = s
                     .split(sep.as_str())
-                    .map(|p| Value::Text(p.to_string()))
+                    .map(|p| Value::Text(Arc::new(p.to_string())))
                     .collect();
                 Ok(Value::List(Arc::new(parts)))
             }
@@ -1275,10 +1277,10 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
     if builtin == Some(Builtin::Cat) && args.len() == 2 {
         return match (&args[0], &args[1]) {
             (Value::List(items), Value::Text(sep)) => {
-                let mut parts = Vec::new();
+                let mut parts: Vec<String> = Vec::new();
                 for item in items.iter() {
                     match item {
-                        Value::Text(s) => parts.push(s.clone()),
+                        Value::Text(s) => parts.push((**s).clone()),
                         other => {
                             return Err(RuntimeError::new(
                                 "ILO-R009",
@@ -1287,7 +1289,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                         }
                     }
                 }
-                Ok(Value::Text(parts.join(sep.as_str())))
+                Ok(Value::Text(Arc::new(parts.join(sep.as_str()))))
             }
             _ => Err(RuntimeError::new(
                 "ILO-R009",
@@ -1324,7 +1326,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 if s.is_empty() {
                     Err(RuntimeError::new("ILO-R009", "hd: empty text".to_string()))
                 } else {
-                    Ok(Value::Text(s.chars().next().unwrap().to_string()))
+                    Ok(Value::Text(Arc::new(s.chars().next().unwrap().to_string())))
                 }
             }
             other => Err(RuntimeError::new(
@@ -1368,7 +1370,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 }
             }
             Value::Text(s) => match char_at_signed(s, i) {
-                CharAtResult::Found(c) => Ok(Value::Text(c.to_string())),
+                CharAtResult::Found(c) => Ok(Value::Text(Arc::new(c.to_string()))),
                 CharAtResult::OutOfRange { len } => Err(RuntimeError::new(
                     "ILO-R009",
                     format!("at: index {i} out of range for text of length {len}"),
@@ -1690,7 +1692,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 } else {
                     let mut chars = s.chars();
                     chars.next();
-                    Ok(Value::Text(chars.collect()))
+                    Ok(Value::Text(Arc::new(chars.collect())))
                 }
             }
             other => Err(RuntimeError::new(
@@ -1706,7 +1708,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 reversed.reverse();
                 Ok(Value::List(Arc::new(reversed)))
             }
-            Value::Text(s) => Ok(Value::Text(s.chars().rev().collect())),
+            Value::Text(s) => Ok(Value::Text(Arc::new(s.chars().rev().collect()))),
             other => Err(RuntimeError::new(
                 "ILO-R009",
                 format!("rev requires a list or text, got {:?}", other),
@@ -1751,7 +1753,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             Value::Text(s) => {
                 let mut chars: Vec<char> = s.chars().collect();
                 chars.sort();
-                Ok(Value::Text(chars.into_iter().collect()))
+                Ok(Value::Text(Arc::new(chars.into_iter().collect())))
             }
             other => Err(RuntimeError::new(
                 "ILO-R009",
@@ -1849,7 +1851,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             Value::Text(s) => {
                 let mut chars: Vec<char> = s.chars().collect();
                 chars.sort_by(|a, b| b.cmp(a));
-                Ok(Value::Text(chars.into_iter().collect()))
+                Ok(Value::Text(Arc::new(chars.into_iter().collect())))
             }
             other => Err(RuntimeError::new(
                 "ILO-R009",
@@ -1907,7 +1909,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 let len = chars.len();
                 let end = crate::builtins::resolve_slice_bound(end_raw, len);
                 let start = crate::builtins::resolve_slice_bound(start_raw, len).min(end);
-                Ok(Value::Text(chars[start..end].iter().collect()))
+                Ok(Value::Text(Arc::new(chars[start..end].iter().collect())))
             }
             other => Err(RuntimeError::new(
                 "ILO-R009",
@@ -1943,7 +1945,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             Value::Text(s) => {
                 let chars: Vec<char> = s.chars().collect();
                 let end = crate::builtins::resolve_take_count(n, chars.len());
-                Ok(Value::Text(chars[..end].iter().collect()))
+                Ok(Value::Text(Arc::new(chars[..end].iter().collect())))
             }
             other => Err(RuntimeError::new(
                 "ILO-R009",
@@ -1979,7 +1981,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             Value::Text(s) => {
                 let chars: Vec<char> = s.chars().collect();
                 let start = crate::builtins::resolve_drop_count(n, chars.len());
-                Ok(Value::Text(chars[start..].iter().collect()))
+                Ok(Value::Text(Arc::new(chars[start..].iter().collect())))
             }
             other => Err(RuntimeError::new(
                 "ILO-R009",
@@ -2002,8 +2004,8 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 Value::Map(m) => m
                     .iter()
                     .map(|(k, v)| {
-                        let vs = match v {
-                            Value::Text(s) => s.clone(),
+                        let vs: String = match v {
+                            Value::Text(s) => (**s).clone(),
                             other => format!("{other:?}"),
                         };
                         (k.to_display_string(), vs)
@@ -2028,12 +2030,14 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 }
                 match req.send() {
                     Ok(resp) => match resp.as_str() {
-                        Ok(body) => Ok(Value::Ok(Box::new(Value::Text(body.to_string())))),
-                        Err(e) => Ok(Value::Err(Box::new(Value::Text(format!(
+                        Ok(body) => {
+                            Ok(Value::Ok(Box::new(Value::Text(Arc::new(body.to_string())))))
+                        }
+                        Err(e) => Ok(Value::Err(Box::new(Value::Text(Arc::new(format!(
                             "response is not valid UTF-8: {e}"
-                        ))))),
+                        )))))),
                     },
-                    Err(e) => Ok(Value::Err(Box::new(Value::Text(e.to_string())))),
+                    Err(e) => Ok(Value::Err(Box::new(Value::Text(Arc::new(e.to_string()))))),
                 }
             }
             #[cfg(not(feature = "http"))]
@@ -2046,12 +2050,12 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         };
     }
     if builtin == Some(Builtin::GetMany) && args.len() == 1 {
-        let urls = match &args[0] {
+        let urls: Vec<String> = match &args[0] {
             Value::List(items) => {
                 let mut out = Vec::with_capacity(items.len());
                 for (i, v) in items.iter().enumerate() {
                     match v {
-                        Value::Text(s) => out.push(s.clone()),
+                        Value::Text(s) => out.push((**s).clone()),
                         other => {
                             return Err(RuntimeError::new(
                                 "ILO-R009",
@@ -2089,8 +2093,8 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 Value::Map(m) => m
                     .iter()
                     .map(|(k, v)| {
-                        let vs = match v {
-                            Value::Text(s) => s.clone(),
+                        let vs: String = match v {
+                            Value::Text(s) => (**s).clone(),
                             other => format!("{other:?}"),
                         };
                         (k.to_display_string(), vs)
@@ -2115,12 +2119,12 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 }
                 match req.send() {
                     Ok(resp) => match resp.as_str() {
-                        Ok(b) => Ok(Value::Ok(Box::new(Value::Text(b.to_string())))),
-                        Err(e) => Ok(Value::Err(Box::new(Value::Text(format!(
+                        Ok(b) => Ok(Value::Ok(Box::new(Value::Text(Arc::new(b.to_string()))))),
+                        Err(e) => Ok(Value::Err(Box::new(Value::Text(Arc::new(format!(
                             "response is not valid UTF-8: {e}"
-                        ))))),
+                        )))))),
                     },
-                    Err(e) => Ok(Value::Err(Box::new(Value::Text(e.to_string())))),
+                    Err(e) => Ok(Value::Err(Box::new(Value::Text(Arc::new(e.to_string()))))),
                 }
             }
             #[cfg(not(feature = "http"))]
@@ -2134,7 +2138,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
     }
     if builtin == Some(Builtin::Trm) && args.len() == 1 {
         return match &args[0] {
-            Value::Text(s) => Ok(Value::Text(s.trim().to_string())),
+            Value::Text(s) => Ok(Value::Text(Arc::new(s.trim().to_string()))),
             other => Err(RuntimeError::new(
                 "ILO-R009",
                 format!("trm requires text, got {:?}", other),
@@ -2143,7 +2147,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
     }
     if builtin == Some(Builtin::Upr) && args.len() == 1 {
         return match &args[0] {
-            Value::Text(s) => Ok(Value::Text(s.to_uppercase())),
+            Value::Text(s) => Ok(Value::Text(Arc::new(s.to_uppercase()))),
             other => Err(RuntimeError::new(
                 "ILO-R009",
                 format!("upr requires text, got {:?}", other),
@@ -2152,7 +2156,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
     }
     if builtin == Some(Builtin::Lwr) && args.len() == 1 {
         return match &args[0] {
-            Value::Text(s) => Ok(Value::Text(s.to_lowercase())),
+            Value::Text(s) => Ok(Value::Text(Arc::new(s.to_lowercase()))),
             other => Err(RuntimeError::new(
                 "ILO-R009",
                 format!("lwr requires text, got {:?}", other),
@@ -2167,7 +2171,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                     Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
                     None => String::new(),
                 };
-                Ok(Value::Text(out))
+                Ok(Value::Text(Arc::new(out)))
             }
             other => Err(RuntimeError::new(
                 "ILO-R009",
@@ -2223,7 +2227,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         } else {
             format!("{s}{pad}")
         };
-        return Ok(Value::Text(out));
+        return Ok(Value::Text(Arc::new(out)));
     }
     if builtin == Some(Builtin::Ord) && args.len() == 1 {
         return match &args[0] {
@@ -2251,7 +2255,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 }
                 let cp = *n as u32;
                 match char::from_u32(cp) {
-                    Some(c) => Ok(Value::Text(c.to_string())),
+                    Some(c) => Ok(Value::Text(Arc::new(c.to_string()))),
                     None => Err(RuntimeError::new(
                         "ILO-R009",
                         format!("chr: {cp} is not a valid Unicode codepoint"),
@@ -2267,7 +2271,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
     if builtin == Some(Builtin::Chars) && args.len() == 1 {
         return match &args[0] {
             Value::Text(s) => Ok(Value::List(Arc::new(
-                s.chars().map(|c| Value::Text(c.to_string())).collect(),
+                s.chars()
+                    .map(|c| Value::Text(Arc::new(c.to_string())))
+                    .collect(),
             ))),
             other => Err(RuntimeError::new(
                 "ILO-R009",
@@ -2291,7 +2297,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             Value::Text(s) => {
                 let mut seen = std::collections::HashSet::new();
                 let deduped: String = s.chars().filter(|c| seen.insert(*c)).collect();
-                Ok(Value::Text(deduped))
+                Ok(Value::Text(Arc::new(deduped)))
             }
             other => Err(RuntimeError::new(
                 "ILO-R009",
@@ -2307,7 +2313,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 } else {
                     (*d as usize).min(20)
                 };
-                Ok(Value::Text(format!("{:.*}", digits, x)))
+                Ok(Value::Text(Arc::new(format!("{:.*}", digits, x))))
             }
             _ => Err(RuntimeError::new(
                 "ILO-R009",
@@ -2341,7 +2347,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 result.push(c);
             }
         }
-        return Ok(Value::Text(result));
+        return Ok(Value::Text(Arc::new(result)));
     }
     if builtin == Some(Builtin::Rd) && (args.len() == 1 || args.len() == 2) {
         let path = match &args[0] {
@@ -2365,17 +2371,17 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             }
         } else {
             // auto-detect from extension
-            std::path::Path::new(&path)
+            std::path::Path::new(path.as_str())
                 .extension()
                 .and_then(|e| e.to_str())
                 .unwrap_or("raw")
                 .to_lowercase()
         };
-        return match std::fs::read_to_string(&path) {
-            Err(e) => Ok(Value::Err(Box::new(Value::Text(e.to_string())))),
+        return match std::fs::read_to_string(path.as_str()) {
+            Err(e) => Ok(Value::Err(Box::new(Value::Text(Arc::new(e.to_string()))))),
             Ok(content) => match parse_format(&fmt, &content) {
                 Ok(v) => Ok(Value::Ok(Box::new(v))),
-                Err(e) => Ok(Value::Err(Box::new(Value::Text(e)))),
+                Err(e) => Ok(Value::Err(Box::new(Value::Text(Arc::new(e))))),
             },
         };
     }
@@ -2400,20 +2406,20 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         };
         return match parse_format(&fmt, &s) {
             Ok(v) => Ok(Value::Ok(Box::new(v))),
-            Err(e) => Ok(Value::Err(Box::new(Value::Text(e)))),
+            Err(e) => Ok(Value::Err(Box::new(Value::Text(Arc::new(e))))),
         };
     }
     if builtin == Some(Builtin::Rdl) && args.len() == 1 {
         return match &args[0] {
-            Value::Text(path) => match std::fs::read_to_string(path) {
+            Value::Text(path) => match std::fs::read_to_string(path.as_str()) {
                 Ok(content) => {
                     let lines: Vec<Value> = content
                         .lines()
-                        .map(|l| Value::Text(l.to_string()))
+                        .map(|l| Value::Text(Arc::new(l.to_string())))
                         .collect();
                     Ok(Value::Ok(Box::new(Value::List(Arc::new(lines)))))
                 }
-                Err(e) => Ok(Value::Err(Box::new(Value::Text(e.to_string())))),
+                Err(e) => Ok(Value::Err(Box::new(Value::Text(Arc::new(e.to_string()))))),
             },
             other => Err(RuntimeError::new(
                 "ILO-R009",
@@ -2443,7 +2449,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             };
             match fmt.as_str() {
                 "csv" | "tsv" => {
-                    let sep = if fmt == "csv" { ',' } else { '\t' };
+                    let sep = if fmt.as_str() == "csv" { ',' } else { '\t' };
                     let rows = match &args[1] {
                         Value::List(l) => l,
                         other => {
@@ -2490,7 +2496,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             }
         } else {
             match &args[1] {
-                Value::Text(s) => s.clone(),
+                Value::Text(s) => (**s).clone(),
                 other => {
                     return Err(RuntimeError::new(
                         "ILO-R009",
@@ -2499,9 +2505,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 }
             }
         };
-        return match std::fs::write(&path, &content) {
+        return match std::fs::write(path.as_str(), &content) {
             Ok(()) => Ok(Value::Ok(Box::new(Value::Text(path)))),
-            Err(e) => Ok(Value::Err(Box::new(Value::Text(e.to_string())))),
+            Err(e) => Ok(Value::Err(Box::new(Value::Text(Arc::new(e.to_string()))))),
         };
     }
     if builtin == Some(Builtin::Wrl) && args.len() == 2 {
@@ -2522,9 +2528,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                         }
                     }
                 }
-                match std::fs::write(path, &content) {
+                match std::fs::write(path.as_str(), &content) {
                     Ok(()) => Ok(Value::Ok(Box::new(Value::Text(path.clone())))),
-                    Err(e) => Ok(Value::Err(Box::new(Value::Text(e.to_string())))),
+                    Err(e) => Ok(Value::Err(Box::new(Value::Text(Arc::new(e.to_string()))))),
                 }
             }
             other => Err(RuntimeError::new(
@@ -2544,25 +2550,25 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                                 if let Some(v) = current.as_array().and_then(|a| a.get(idx)) {
                                     current = v;
                                 } else {
-                                    return Ok(Value::Err(Box::new(Value::Text(format!(
-                                        "key not found: {key}"
+                                    return Ok(Value::Err(Box::new(Value::Text(Arc::new(
+                                        format!("key not found: {key}"),
                                     )))));
                                 }
                             } else if let Some(v) = current.get(key) {
                                 current = v;
                             } else {
-                                return Ok(Value::Err(Box::new(Value::Text(format!(
+                                return Ok(Value::Err(Box::new(Value::Text(Arc::new(format!(
                                     "key not found: {key}"
-                                )))));
+                                ))))));
                             }
                         }
                         let result_str = match current {
                             serde_json::Value::String(s) => s.clone(),
                             other => other.to_string(),
                         };
-                        Ok(Value::Ok(Box::new(Value::Text(result_str))))
+                        Ok(Value::Ok(Box::new(Value::Text(Arc::new(result_str)))))
                     }
-                    Err(e) => Ok(Value::Err(Box::new(Value::Text(e.to_string())))),
+                    Err(e) => Ok(Value::Err(Box::new(Value::Text(Arc::new(e.to_string()))))),
                 }
             }
             _ => Err(RuntimeError::new(
@@ -2581,13 +2587,13 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
     }
     if builtin == Some(Builtin::Jdmp) && args.len() == 1 {
         let json_val = value_to_json(&args[0]);
-        return Ok(Value::Text(json_val.to_string()));
+        return Ok(Value::Text(Arc::new(json_val.to_string())));
     }
     if builtin == Some(Builtin::Jpar) && args.len() == 1 {
         return match &args[0] {
             Value::Text(s) => match serde_json::from_str::<serde_json::Value>(s) {
                 Ok(v) => Ok(Value::Ok(Box::new(serde_json_to_value(v)))),
-                Err(e) => Ok(Value::Err(Box::new(Value::Text(e.to_string())))),
+                Err(e) => Ok(Value::Err(Box::new(Value::Text(Arc::new(e.to_string()))))),
             },
             other => Err(RuntimeError::new(
                 "ILO-R009",
@@ -2597,7 +2603,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
     }
     if builtin == Some(Builtin::Rdjl) && args.len() == 1 {
         return match &args[0] {
-            Value::Text(path) => match std::fs::read_to_string(path) {
+            Value::Text(path) => match std::fs::read_to_string(path.as_str()) {
                 Ok(content) => {
                     let mut items: Vec<Value> = Vec::new();
                     for line in content.split('\n') {
@@ -2606,7 +2612,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                         }
                         let parsed = match serde_json::from_str::<serde_json::Value>(line) {
                             Ok(v) => Value::Ok(Box::new(serde_json_to_value(v))),
-                            Err(e) => Value::Err(Box::new(Value::Text(e.to_string()))),
+                            Err(e) => Value::Err(Box::new(Value::Text(Arc::new(e.to_string())))),
                         };
                         items.push(parsed);
                     }
@@ -2627,11 +2633,11 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
     if builtin == Some(Builtin::Env) && args.len() == 1 {
         return match &args[0] {
             Value::Text(key) => match std::env::var(key.as_str()) {
-                Ok(val) => Ok(Value::Ok(Box::new(Value::Text(val)))),
-                Err(_) => Ok(Value::Err(Box::new(Value::Text(format!(
+                Ok(val) => Ok(Value::Ok(Box::new(Value::Text(Arc::new(val))))),
+                Err(_) => Ok(Value::Err(Box::new(Value::Text(Arc::new(format!(
                     "env var '{}' not set",
                     key
-                ))))),
+                )))))),
             },
             other => Err(RuntimeError::new(
                 "ILO-R009",
@@ -2641,14 +2647,14 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
     }
 
     // Higher-order builtins: map, flt, fld
-    // A function reference can be Value::FnRef(name) or Value::Text(name) when the
+    // A function reference can be Value::FnRef(name) or Value::Text(Arc::new(name)) when the
     // function name was passed as a CLI string argument. Inline lambdas with
     // free-var capture produce Value::Closure, which carries the lifted fn
     // name plus by-value capture snapshots to append after the per-item args.
     fn resolve_fn_ref(val: &Value) -> Option<String> {
         match val {
             Value::FnRef(n) => Some(n.clone()),
-            Value::Text(n) => Some(n.clone()),
+            Value::Text(n) => Some((**n).clone()),
             Value::Closure { fn_name, .. } => Some(fn_name.clone()),
             _ => None,
         }
@@ -2944,7 +2950,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             call_args.extend(captures.iter().cloned());
             let key = call_function(env, &fn_name, call_args)?;
             let map_key = match &key {
-                Value::Text(s) => MapKey::Text(s.clone()),
+                Value::Text(s) => MapKey::Text((**s).clone()),
                 Value::Number(n) => {
                     if !n.is_finite() {
                         return Err(RuntimeError::new(
@@ -2991,7 +2997,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             // kept distinct — they were merged into a single key in the
             // pre-MapKey era.
             let map_key = match item {
-                Value::Text(s) => MapKey::Text(s.clone()),
+                Value::Text(s) => MapKey::Text((**s).clone()),
                 Value::Number(n) => {
                     if !n.is_finite() {
                         return Err(RuntimeError::new(
@@ -3537,14 +3543,17 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             re.captures(input)
                 .map(|caps| {
                     (1..caps.len())
-                        .filter_map(|i| caps.get(i).map(|m| Value::Text(m.as_str().to_string())))
+                        .filter_map(|i| {
+                            caps.get(i)
+                                .map(|m| Value::Text(Arc::new(m.as_str().to_string())))
+                        })
                         .collect()
                 })
                 .unwrap_or_default()
         } else {
             // No capture groups — return list of all matches
             re.find_iter(input)
-                .map(|m| Value::Text(m.as_str().to_string()))
+                .map(|m| Value::Text(Arc::new(m.as_str().to_string())))
                 .collect()
         };
         return Ok(Value::List(Arc::new(result)));
@@ -3590,14 +3599,21 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             re.captures_iter(input)
                 .map(|caps| {
                     let groups: Vec<Value> = (1..caps.len())
-                        .filter_map(|i| caps.get(i).map(|m| Value::Text(m.as_str().to_string())))
+                        .filter_map(|i| {
+                            caps.get(i)
+                                .map(|m| Value::Text(Arc::new(m.as_str().to_string())))
+                        })
                         .collect();
                     Value::List(Arc::new(groups))
                 })
                 .collect()
         } else {
             re.find_iter(input)
-                .map(|m| Value::List(Arc::new(vec![Value::Text(m.as_str().to_string())])))
+                .map(|m| {
+                    Value::List(Arc::new(vec![Value::Text(Arc::new(
+                        m.as_str().to_string(),
+                    ))]))
+                })
                 .collect()
         };
         return Ok(Value::List(Arc::new(result)));
@@ -3642,9 +3658,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         let re = regex::Regex::new(pattern).map_err(|e| {
             RuntimeError::new("ILO-R009", format!("rgxsub: invalid regex pattern: {e}"))
         })?;
-        return Ok(Value::Text(
+        return Ok(Value::Text(Arc::new(
             re.replace_all(subject, replacement).into_owned(),
-        ));
+        )));
     }
     if builtin == Some(Builtin::Flat) && args.len() == 1 {
         let items = match &args[0] {
@@ -3857,7 +3873,7 @@ fn value_to_json(val: &Value) -> serde_json::Value {
                     .unwrap_or(serde_json::Value::Null)
             }
         }
-        Value::Text(s) => serde_json::Value::String(s.clone()),
+        Value::Text(s) => serde_json::Value::String((**s).clone()),
         Value::Bool(b) => serde_json::Value::Bool(*b),
         Value::Nil => serde_json::Value::Null,
         Value::List(items) => serde_json::Value::Array(items.iter().map(value_to_json).collect()),
@@ -3899,7 +3915,7 @@ fn serde_json_to_value(v: serde_json::Value) -> Value {
         serde_json::Value::Array(arr) => {
             Value::List(Arc::new(arr.into_iter().map(serde_json_to_value).collect()))
         }
-        serde_json::Value::String(s) => Value::Text(s),
+        serde_json::Value::String(s) => Value::Text(Arc::new(s)),
         serde_json::Value::Number(n) => Value::Number(n.as_f64().unwrap_or(0.0)),
         serde_json::Value::Bool(b) => Value::Bool(b),
         serde_json::Value::Null => Value::Nil,
@@ -4419,7 +4435,9 @@ fn eval_expr(env: &mut Env, expr: &Expr) -> Result<Value> {
             // as the HOF call sites). FnRef/Text keep their original behaviour.
             let (callee, extra_captures) = match callee_from_scope {
                 Some(Value::FnRef(name)) => (name, Vec::new()),
-                Some(Value::Text(name)) if env.functions.contains_key(&name) => (name, Vec::new()),
+                Some(Value::Text(name)) if env.functions.contains_key(name.as_str()) => {
+                    ((*name).clone(), Vec::new())
+                }
                 Some(Value::Closure { fn_name, captures }) => (fn_name, captures),
                 _ => (function.clone(), Vec::new()),
             };
@@ -4591,7 +4609,7 @@ fn eval_expr(env: &mut Env, expr: &Expr) -> Result<Value> {
 fn eval_literal(lit: &Literal) -> Value {
     match lit {
         Literal::Number(n) => Value::Number(*n),
-        Literal::Text(s) => Value::Text(s.clone()),
+        Literal::Text(s) => Value::Text(Arc::new(s.clone())),
         Literal::Bool(b) => Value::Bool(*b),
         Literal::Nil => Value::Nil,
     }
@@ -4611,11 +4629,17 @@ fn eval_binop(op: &BinOp, left: &Value, right: &Value) -> Result<Value> {
             }
         }
         // String concatenation with +
+        //
+        // Slow path: `a` and `b` are borrowed (`&Arc<String>`), so we always
+        // allocate a fresh String here. The hot accumulator pattern
+        // `s = +s c` is short-circuited in eval_stmt via the self-rebind
+        // peephole, which owns the Arc and uses `Arc::make_mut` for O(1)
+        // amortised in-place push_str.
         (BinOp::Add, Value::Text(a), Value::Text(b)) => {
             let mut out = String::with_capacity(a.len() + b.len());
             out.push_str(a);
             out.push_str(b);
-            Ok(Value::Text(out))
+            Ok(Value::Text(Arc::new(out)))
         }
         // List concatenation with +
         (BinOp::Add, Value::List(a), Value::List(b)) => {
@@ -4837,17 +4861,21 @@ pub(crate) fn get_many_fetch(urls: &[String]) -> Vec<Value> {
                     let u = url.clone();
                     handles.push(s.spawn(move || match minreq::get(u.as_str()).send() {
                         Ok(resp) => match resp.as_str() {
-                            Ok(body) => Value::Ok(Box::new(Value::Text(body.to_string()))),
-                            Err(e) => Value::Err(Box::new(Value::Text(format!(
+                            Ok(body) => {
+                                Value::Ok(Box::new(Value::Text(Arc::new(body.to_string()))))
+                            }
+                            Err(e) => Value::Err(Box::new(Value::Text(Arc::new(format!(
                                 "response is not valid UTF-8: {e}"
-                            )))),
+                            ))))),
                         },
-                        Err(e) => Value::Err(Box::new(Value::Text(e.to_string()))),
+                        Err(e) => Value::Err(Box::new(Value::Text(Arc::new(e.to_string())))),
                     }));
                 }
                 for (i, h) in handles.into_iter().enumerate() {
                     let v = h.join().unwrap_or_else(|_| {
-                        Value::Err(Box::new(Value::Text("worker thread panicked".to_string())))
+                        Value::Err(Box::new(Value::Text(Arc::new(
+                            "worker thread panicked".to_string(),
+                        ))))
                     });
                     results[base + i] = v;
                 }
@@ -4931,36 +4959,48 @@ mod tests {
         // Braceless guards: early return
         let source = r#"cls sp:n>t;>=sp 1000 "gold";>=sp 500 "silver";"bronze""#;
         let result = run_str(source, Some("cls"), vec![Value::Number(1000.0)]);
-        assert_eq!(result, Value::Text("gold".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("gold".to_string())));
     }
 
     #[test]
     fn interpret_cls_silver() {
         let source = r#"cls sp:n>t;>=sp 1000 "gold";>=sp 500 "silver";"bronze""#;
         let result = run_str(source, Some("cls"), vec![Value::Number(500.0)]);
-        assert_eq!(result, Value::Text("silver".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("silver".to_string())));
     }
 
     #[test]
     fn interpret_cls_bronze() {
         let source = r#"cls sp:n>t;>=sp 1000 "gold";>=sp 500 "silver";"bronze""#;
         let result = run_str(source, Some("cls"), vec![Value::Number(100.0)]);
-        assert_eq!(result, Value::Text("bronze".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("bronze".to_string())));
     }
 
     #[test]
     fn interpret_match_stmt() {
         let source = r#"f x:t>n;?x{"a":1;"b":2;_:0}"#;
         assert_eq!(
-            run_str(source, Some("f"), vec![Value::Text("a".to_string())]),
+            run_str(
+                source,
+                Some("f"),
+                vec![Value::Text(Arc::new("a".to_string()))]
+            ),
             Value::Number(1.0)
         );
         assert_eq!(
-            run_str(source, Some("f"), vec![Value::Text("b".to_string())]),
+            run_str(
+                source,
+                Some("f"),
+                vec![Value::Text(Arc::new("b".to_string()))]
+            ),
             Value::Number(2.0)
         );
         assert_eq!(
-            run_str(source, Some("f"), vec![Value::Text("z".to_string())]),
+            run_str(
+                source,
+                Some("f"),
+                vec![Value::Text(Arc::new("z".to_string()))]
+            ),
             Value::Number(0.0)
         );
     }
@@ -4976,7 +5016,10 @@ mod tests {
     fn interpret_err_constructor() {
         let source = r#"f x:n>R n t;^"bad""#;
         let result = run_str(source, Some("f"), vec![Value::Number(0.0)]);
-        assert_eq!(result, Value::Err(Box::new(Value::Text("bad".to_string()))));
+        assert_eq!(
+            result,
+            Value::Err(Box::new(Value::Text(Arc::new("bad".to_string()))))
+        );
     }
 
     #[test]
@@ -4992,7 +5035,9 @@ mod tests {
         let err_result = run_str(
             source,
             Some("f"),
-            vec![Value::Err(Box::new(Value::Text("oops".to_string())))],
+            vec![Value::Err(Box::new(Value::Text(Arc::new(
+                "oops".to_string(),
+            ))))],
         );
         assert_eq!(err_result, Value::Number(0.0));
     }
@@ -5003,11 +5048,11 @@ mod tests {
         let source = r#"f x:b>t;!x{"nope"}{"yes"}"#;
         assert_eq!(
             run_str(source, Some("f"), vec![Value::Bool(false)]),
-            Value::Text("nope".to_string())
+            Value::Text(Arc::new("nope".to_string()))
         );
         assert_eq!(
             run_str(source, Some("f"), vec![Value::Bool(true)]),
-            Value::Text("yes".to_string())
+            Value::Text(Arc::new("yes".to_string()))
         );
     }
 
@@ -5045,11 +5090,11 @@ mod tests {
             source,
             Some("f"),
             vec![
-                Value::Text("hello ".to_string()),
-                Value::Text("world".to_string()),
+                Value::Text(Arc::new("hello ".to_string())),
+                Value::Text(Arc::new("world".to_string())),
             ],
         );
-        assert_eq!(result, Value::Text("hello world".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("hello world".to_string())));
     }
 
     #[test]
@@ -5059,7 +5104,10 @@ mod tests {
             run_str(
                 gt,
                 Some("f"),
-                vec![Value::Text("banana".into()), Value::Text("apple".into())]
+                vec![
+                    Value::Text(Arc::new("banana".to_string())),
+                    Value::Text(Arc::new("apple".to_string()))
+                ]
             ),
             Value::Bool(true)
         );
@@ -5067,7 +5115,10 @@ mod tests {
             run_str(
                 gt,
                 Some("f"),
-                vec![Value::Text("apple".into()), Value::Text("banana".into())]
+                vec![
+                    Value::Text(Arc::new("apple".to_string())),
+                    Value::Text(Arc::new("banana".to_string()))
+                ]
             ),
             Value::Bool(false)
         );
@@ -5077,7 +5128,10 @@ mod tests {
             run_str(
                 lt,
                 Some("f"),
-                vec![Value::Text("apple".into()), Value::Text("banana".into())]
+                vec![
+                    Value::Text(Arc::new("apple".to_string())),
+                    Value::Text(Arc::new("banana".to_string()))
+                ]
             ),
             Value::Bool(true)
         );
@@ -5087,7 +5141,10 @@ mod tests {
             run_str(
                 ge,
                 Some("f"),
-                vec![Value::Text("apple".into()), Value::Text("apple".into())]
+                vec![
+                    Value::Text(Arc::new("apple".to_string())),
+                    Value::Text(Arc::new("apple".to_string()))
+                ]
             ),
             Value::Bool(true)
         );
@@ -5097,7 +5154,10 @@ mod tests {
             run_str(
                 le,
                 Some("f"),
-                vec![Value::Text("zebra".into()), Value::Text("banana".into())]
+                vec![
+                    Value::Text(Arc::new("zebra".to_string())),
+                    Value::Text(Arc::new("banana".to_string()))
+                ]
             ),
             Value::Bool(false)
         );
@@ -5106,7 +5166,11 @@ mod tests {
     #[test]
     fn interpret_match_expr_in_let() {
         let source = r#"f x:t>n;y=?x{"a":1;"b":2;_:0};y"#;
-        let result = run_str(source, Some("f"), vec![Value::Text("b".to_string())]);
+        let result = run_str(
+            source,
+            Some("f"),
+            vec![Value::Text(Arc::new("b".to_string()))],
+        );
         assert_eq!(result, Value::Number(2.0));
     }
 
@@ -5133,7 +5197,12 @@ mod tests {
     fn interpret_sqrt_non_number_errors() {
         let source = "f x:t>n;sqrt x";
         let prog = parse_program(source);
-        let err = run(&prog, Some("f"), vec![Value::Text("nope".into())]).unwrap_err();
+        let err = run(
+            &prog,
+            Some("f"),
+            vec![Value::Text(Arc::new("nope".to_string()))],
+        )
+        .unwrap_err();
         assert!(
             err.to_string().contains("sqrt") && err.to_string().contains("requires a number"),
             "unexpected error: {err}"
@@ -5143,28 +5212,48 @@ mod tests {
     #[test]
     fn interpret_log_non_number_errors() {
         let prog = parse_program("f x:t>n;log x");
-        let err = run(&prog, Some("f"), vec![Value::Text("nope".into())]).unwrap_err();
+        let err = run(
+            &prog,
+            Some("f"),
+            vec![Value::Text(Arc::new("nope".to_string()))],
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("log"), "unexpected error: {err}");
     }
 
     #[test]
     fn interpret_exp_non_number_errors() {
         let prog = parse_program("f x:t>n;exp x");
-        let err = run(&prog, Some("f"), vec![Value::Text("nope".into())]).unwrap_err();
+        let err = run(
+            &prog,
+            Some("f"),
+            vec![Value::Text(Arc::new("nope".to_string()))],
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("exp"), "unexpected error: {err}");
     }
 
     #[test]
     fn interpret_sin_non_number_errors() {
         let prog = parse_program("f x:t>n;sin x");
-        let err = run(&prog, Some("f"), vec![Value::Text("nope".into())]).unwrap_err();
+        let err = run(
+            &prog,
+            Some("f"),
+            vec![Value::Text(Arc::new("nope".to_string()))],
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("sin"), "unexpected error: {err}");
     }
 
     #[test]
     fn interpret_cos_non_number_errors() {
         let prog = parse_program("f x:t>n;cos x");
-        let err = run(&prog, Some("f"), vec![Value::Text("nope".into())]).unwrap_err();
+        let err = run(
+            &prog,
+            Some("f"),
+            vec![Value::Text(Arc::new("nope".to_string()))],
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("cos"), "unexpected error: {err}");
     }
 
@@ -5174,7 +5263,10 @@ mod tests {
         let err = run(
             &prog,
             Some("f"),
-            vec![Value::Text("a".into()), Value::Text("b".into())],
+            vec![
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+            ],
         )
         .unwrap_err();
         assert!(
@@ -5245,11 +5337,19 @@ mod tests {
     fn interpret_len_string() {
         let source = r#"f s:t>n;len s"#;
         assert_eq!(
-            run_str(source, Some("f"), vec![Value::Text("hello".to_string())]),
+            run_str(
+                source,
+                Some("f"),
+                vec![Value::Text(Arc::new("hello".to_string()))]
+            ),
             Value::Number(5.0)
         );
         assert_eq!(
-            run_str(source, Some("f"), vec![Value::Text("".to_string())]),
+            run_str(
+                source,
+                Some("f"),
+                vec![Value::Text(Arc::new("".to_string()))]
+            ),
             Value::Number(0.0)
         );
     }
@@ -5299,7 +5399,10 @@ mod tests {
     #[test]
     fn interpret_str_integer() {
         let source = "f>t;str 42";
-        assert_eq!(run_str(source, Some("f"), vec![]), Value::Text("42".into()));
+        assert_eq!(
+            run_str(source, Some("f"), vec![]),
+            Value::Text(Arc::new("42".to_string()))
+        );
     }
 
     #[test]
@@ -5307,7 +5410,7 @@ mod tests {
         let source = "f>t;str 3.14";
         assert_eq!(
             run_str(source, Some("f"), vec![]),
-            Value::Text("3.14".into())
+            Value::Text(Arc::new("3.14".to_string()))
         );
     }
 
@@ -5325,7 +5428,7 @@ mod tests {
         let source = "f>R n t;num \"abc\"";
         assert_eq!(
             run_str(source, Some("f"), vec![]),
-            Value::Err(Box::new(Value::Text("abc".into())))
+            Value::Err(Box::new(Value::Text(Arc::new("abc".to_string()))))
         );
     }
 
@@ -5370,7 +5473,7 @@ mod tests {
         let source = "f>t;xs=[\"hello\", \"world\"];xs.0";
         assert_eq!(
             run_str(source, Some("f"), vec![]),
-            Value::Text("hello".into())
+            Value::Text(Arc::new("hello".to_string()))
         );
     }
 
@@ -5450,7 +5553,10 @@ mod tests {
 
     #[test]
     fn display_text() {
-        assert_eq!(format!("{}", Value::Text("hello".into())), "hello");
+        assert_eq!(
+            format!("{}", Value::Text(Arc::new("hello".to_string()))),
+            "hello"
+        );
     }
 
     #[test]
@@ -5517,7 +5623,10 @@ mod tests {
     #[test]
     fn display_err() {
         assert_eq!(
-            format!("{}", Value::Err(Box::new(Value::Text("bad".into())))),
+            format!(
+                "{}",
+                Value::Err(Box::new(Value::Text(Arc::new("bad".to_string()))))
+            ),
             "^bad"
         );
     }
@@ -5565,7 +5674,7 @@ mod tests {
         let err = run_str_err(
             r#"f x:t>t;str x"#,
             Some("f"),
-            vec![Value::Text("hi".into())],
+            vec![Value::Text(Arc::new("hi".to_string()))],
         );
         assert!(err.contains("str requires a number"));
     }
@@ -5593,7 +5702,7 @@ mod tests {
         let err = run_str_err(
             r#"f x:t>n;abs x"#,
             Some("f"),
-            vec![Value::Text("hi".into())],
+            vec![Value::Text(Arc::new("hi".to_string()))],
         );
         assert!(err.contains("abs requires a number"));
     }
@@ -5603,7 +5712,10 @@ mod tests {
         let err = run_str_err(
             r#"f a:t b:t>n;min a b"#,
             Some("f"),
-            vec![Value::Text("a".into()), Value::Text("b".into())],
+            vec![
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+            ],
         );
         assert!(err.contains("min requires two numbers"));
     }
@@ -5613,20 +5725,31 @@ mod tests {
         let err = run_str_err(
             r#"f a:t b:t>n;max a b"#,
             Some("f"),
-            vec![Value::Text("a".into()), Value::Text("b".into())],
+            vec![
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+            ],
         );
         assert!(err.contains("max requires two numbers"));
     }
 
     #[test]
     fn err_flr_non_number() {
-        let err = run_str_err(r#"f x:t>n;flr x"#, Some("f"), vec![Value::Text("a".into())]);
+        let err = run_str_err(
+            r#"f x:t>n;flr x"#,
+            Some("f"),
+            vec![Value::Text(Arc::new("a".to_string()))],
+        );
         assert!(err.contains("flr requires a number"));
     }
 
     #[test]
     fn err_cel_non_number() {
-        let err = run_str_err(r#"f x:t>n;cel x"#, Some("f"), vec![Value::Text("a".into())]);
+        let err = run_str_err(
+            r#"f x:t>n;cel x"#,
+            Some("f"),
+            vec![Value::Text(Arc::new("a".to_string()))],
+        );
         assert!(err.contains("cel requires a number"));
     }
 
@@ -5768,7 +5891,10 @@ mod tests {
 
     #[test]
     fn values_equal_mismatched() {
-        assert!(!values_equal(&Value::Number(1.0), &Value::Text("1".into())));
+        assert!(!values_equal(
+            &Value::Number(1.0),
+            &Value::Text(Arc::new("1".to_string()))
+        ));
         assert!(!values_equal(&Value::Nil, &Value::Bool(false)));
     }
 
@@ -5790,8 +5916,8 @@ mod tests {
 
     #[test]
     fn is_truthy_text() {
-        assert!(!is_truthy(&Value::Text("".into())));
-        assert!(is_truthy(&Value::Text("hello".into())));
+        assert!(!is_truthy(&Value::Text(Arc::new("".to_string()))));
+        assert!(is_truthy(&Value::Text(Arc::new("hello".to_string()))));
     }
 
     #[test]
@@ -5969,14 +6095,14 @@ mod tests {
     fn interpret_match_expr_no_subject() {
         let source = r#"f>t;x=?{_:"always"};x"#;
         let result = run_str(source, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("always".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("always".to_string())));
     }
 
     #[test]
     fn interpret_pattern_ok_no_match() {
         let source = r#"f>t;x=^"err";?x{~v:v;_:"default"}"#;
         let result = run_str(source, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("default".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("default".to_string())));
     }
 
     #[test]
@@ -6097,7 +6223,7 @@ mod tests {
         let result = run(&prog, Some("outer"), vec![Value::Number(42.0)]).unwrap();
         assert_eq!(
             result,
-            Value::Err(Box::new(Value::Text("fail".to_string())))
+            Value::Err(Box::new(Value::Text(Arc::new("fail".to_string()))))
         );
     }
 
@@ -6158,7 +6284,7 @@ mod tests {
         let result = run(&prog, Some("a"), vec![Value::Number(1.0)]).unwrap();
         assert_eq!(
             result,
-            Value::Err(Box::new(Value::Text("deep".to_string())))
+            Value::Err(Box::new(Value::Text(Arc::new("deep".to_string()))))
         );
     }
 
@@ -6169,15 +6295,15 @@ mod tests {
         let source = r#"cls sp:n>t;>=sp 1000 "gold";>=sp 500 "silver";"bronze""#;
         assert_eq!(
             run_str(source, Some("cls"), vec![Value::Number(1500.0)]),
-            Value::Text("gold".to_string())
+            Value::Text(Arc::new("gold".to_string()))
         );
         assert_eq!(
             run_str(source, Some("cls"), vec![Value::Number(750.0)]),
-            Value::Text("silver".to_string())
+            Value::Text(Arc::new("silver".to_string()))
         );
         assert_eq!(
             run_str(source, Some("cls"), vec![Value::Number(100.0)]),
-            Value::Text("bronze".to_string())
+            Value::Text(Arc::new("bronze".to_string()))
         );
     }
 
@@ -6205,9 +6331,9 @@ mod tests {
         assert_eq!(
             run_str(source, Some("f"), vec![]),
             Value::List(Arc::new(vec![
-                Value::Text("a".to_string()),
-                Value::Text("b".to_string()),
-                Value::Text("c".to_string()),
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+                Value::Text(Arc::new("c".to_string())),
             ]))
         );
     }
@@ -6217,7 +6343,7 @@ mod tests {
         let source = r#"f>L t;spl "" ",""#;
         assert_eq!(
             run_str(source, Some("f"), vec![]),
-            Value::List(Arc::new(vec![Value::Text("".to_string())]))
+            Value::List(Arc::new(vec![Value::Text(Arc::new("".to_string()))]))
         );
     }
 
@@ -6229,12 +6355,12 @@ mod tests {
                 source,
                 Some("f"),
                 vec![Value::List(Arc::new(vec![
-                    Value::Text("a".into()),
-                    Value::Text("b".into()),
-                    Value::Text("c".into()),
+                    Value::Text(Arc::new("a".to_string())),
+                    Value::Text(Arc::new("b".to_string())),
+                    Value::Text(Arc::new("c".to_string())),
                 ]))]
             ),
-            Value::Text("a,b,c".into())
+            Value::Text(Arc::new("a,b,c".to_string()))
         );
     }
 
@@ -6243,7 +6369,7 @@ mod tests {
         let source = "f items:L t>t;cat items \"-\"";
         assert_eq!(
             run_str(source, Some("f"), vec![Value::List(Arc::new(vec![]))]),
-            Value::Text("".into())
+            Value::Text(Arc::new("".to_string()))
         );
     }
 
@@ -6282,8 +6408,8 @@ mod tests {
                 source,
                 Some("f"),
                 vec![
-                    Value::Text("hello world".into()),
-                    Value::Text("world".into())
+                    Value::Text(Arc::new("hello world".to_string())),
+                    Value::Text(Arc::new("world".to_string()))
                 ]
             ),
             Value::Bool(true)
@@ -6309,8 +6435,12 @@ mod tests {
     fn interpret_hd_text() {
         let source = r#"f s:t>t;hd s"#;
         assert_eq!(
-            run_str(source, Some("f"), vec![Value::Text("hello".into())]),
-            Value::Text("h".into())
+            run_str(
+                source,
+                Some("f"),
+                vec![Value::Text(Arc::new("hello".to_string()))]
+            ),
+            Value::Text(Arc::new("h".to_string()))
         );
     }
 
@@ -6318,8 +6448,12 @@ mod tests {
     fn interpret_tl_text() {
         let source = r#"f s:t>t;tl s"#;
         assert_eq!(
-            run_str(source, Some("f"), vec![Value::Text("hello".into())]),
-            Value::Text("ello".into())
+            run_str(
+                source,
+                Some("f"),
+                vec![Value::Text(Arc::new("hello".to_string()))]
+            ),
+            Value::Text(Arc::new("ello".to_string()))
         );
     }
 
@@ -6341,7 +6475,7 @@ mod tests {
         let source = r#"f>t;rev "abc""#;
         assert_eq!(
             run_str(source, Some("f"), vec![]),
-            Value::Text("cba".into())
+            Value::Text(Arc::new("cba".to_string()))
         );
     }
 
@@ -6364,9 +6498,9 @@ mod tests {
         assert_eq!(
             run_str(source, Some("f"), vec![]),
             Value::List(Arc::new(vec![
-                Value::Text("a".into()),
-                Value::Text("b".into()),
-                Value::Text("c".into())
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+                Value::Text(Arc::new("c".to_string()))
             ]))
         );
     }
@@ -6376,7 +6510,7 @@ mod tests {
         let source = r#"f>t;srt "cab""#;
         assert_eq!(
             run_str(source, Some("f"), vec![]),
-            Value::Text("abc".into())
+            Value::Text(Arc::new("abc".to_string()))
         );
     }
 
@@ -6394,7 +6528,7 @@ mod tests {
         let source = r#"f>t;slc "hello" 1 4"#;
         assert_eq!(
             run_str(source, Some("f"), vec![]),
-            Value::Text("ell".into())
+            Value::Text(Arc::new("ell".to_string()))
         );
     }
 
@@ -6412,7 +6546,7 @@ mod tests {
         let source = r#"f x:n>t;=x 1{"yes"}{"no"}"#;
         assert_eq!(
             run_str(source, Some("f"), vec![Value::Number(1.0)]),
-            Value::Text("yes".into())
+            Value::Text(Arc::new("yes".to_string()))
         );
     }
 
@@ -6421,7 +6555,7 @@ mod tests {
         let source = r#"f x:n>t;=x 1{"yes"}{"no"}"#;
         assert_eq!(
             run_str(source, Some("f"), vec![Value::Number(2.0)]),
-            Value::Text("no".into())
+            Value::Text(Arc::new("no".to_string()))
         );
     }
 
@@ -6512,11 +6646,11 @@ mod tests {
         let source = r#"f x:n>t;!=x 1{"not one"}{"one"}"#;
         assert_eq!(
             run_str(source, Some("f"), vec![Value::Number(1.0)]),
-            Value::Text("one".into())
+            Value::Text(Arc::new("one".to_string()))
         );
         assert_eq!(
             run_str(source, Some("f"), vec![Value::Number(2.0)]),
-            Value::Text("not one".into())
+            Value::Text(Arc::new("not one".to_string()))
         );
     }
 
@@ -6728,8 +6862,15 @@ mod tests {
             std::env::set_var("ILO_TEST_VAR", "hello");
         }
         let source = r#"f k:t>R t t;env k"#;
-        let result = run_str(source, Some("f"), vec![Value::Text("ILO_TEST_VAR".into())]);
-        assert_eq!(result, Value::Ok(Box::new(Value::Text("hello".into()))));
+        let result = run_str(
+            source,
+            Some("f"),
+            vec![Value::Text(Arc::new("ILO_TEST_VAR".to_string()))],
+        );
+        assert_eq!(
+            result,
+            Value::Ok(Box::new(Value::Text(Arc::new("hello".to_string()))))
+        );
         unsafe {
             std::env::remove_var("ILO_TEST_VAR");
         }
@@ -6742,7 +6883,7 @@ mod tests {
         let result = run_str(
             source,
             Some("f"),
-            vec![Value::Text("ILO_NONEXISTENT_12345".into())],
+            vec![Value::Text(Arc::new("ILO_NONEXISTENT_12345".to_string()))],
         );
         let Value::Err(inner) = result else {
             panic!("expected Err")
@@ -6763,9 +6904,12 @@ mod tests {
         let result = run_str(
             source,
             Some("f"),
-            vec![Value::Text("ILO_TEST_UNWRAP".into())],
+            vec![Value::Text(Arc::new("ILO_TEST_UNWRAP".to_string()))],
         );
-        assert_eq!(result, Value::Ok(Box::new(Value::Text("world".into()))));
+        assert_eq!(
+            result,
+            Value::Ok(Box::new(Value::Text(Arc::new("world".to_string()))))
+        );
         unsafe {
             std::env::remove_var("ILO_TEST_UNWRAP");
         }
@@ -6840,7 +6984,7 @@ mod tests {
         let err = run_str_err(
             "f x:n y:t>L t;spl x y",
             Some("f"),
-            vec![Value::Number(1.0), Value::Text("a".into())],
+            vec![Value::Number(1.0), Value::Text(Arc::new("a".to_string()))],
         );
         assert!(err.contains("spl requires two text args"), "got: {err}");
     }
@@ -6850,7 +6994,7 @@ mod tests {
         let err = run_str_err(
             "f x:t y:n>L t;spl x y",
             Some("f"),
-            vec![Value::Text("a-b".into()), Value::Number(1.0)],
+            vec![Value::Text(Arc::new("a-b".to_string())), Value::Number(1.0)],
         );
         assert!(err.contains("spl requires two text args"), "got: {err}");
     }
@@ -6879,7 +7023,10 @@ mod tests {
         let err = run_str_err(
             "f x:t y:n>b;has x y",
             Some("f"),
-            vec![Value::Text("hello".into()), Value::Number(1.0)],
+            vec![
+                Value::Text(Arc::new("hello".to_string())),
+                Value::Number(1.0),
+            ],
         );
         assert!(
             err.contains("text search requires text needle"),
@@ -6965,7 +7112,10 @@ mod tests {
         let err = run_str_err(
             "f x:t y:t>t;slc x y 1",
             Some("f"),
-            vec![Value::Text("hi".into()), Value::Text("a".into())],
+            vec![
+                Value::Text(Arc::new("hi".to_string())),
+                Value::Text(Arc::new("a".to_string())),
+            ],
         );
         assert!(
             err.contains("slc: start index must be a number"),
@@ -6978,7 +7128,10 @@ mod tests {
         let err = run_str_err(
             "f x:t y:t>t;slc x 0 y",
             Some("f"),
-            vec![Value::Text("hi".into()), Value::Text("a".into())],
+            vec![
+                Value::Text(Arc::new("hi".to_string())),
+                Value::Text(Arc::new("a".to_string())),
+            ],
         );
         assert!(
             err.contains("slc: end index must be a number"),
@@ -6998,7 +7151,10 @@ mod tests {
         let err = run_str_err(
             "f x:t y:t>n;rnd x y",
             Some("f"),
-            vec![Value::Text("a".into()), Value::Text("b".into())],
+            vec![
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+            ],
         );
         assert!(err.contains("rnd requires two numbers"), "got: {err}");
     }
@@ -7038,7 +7194,7 @@ mod tests {
             "type usr{name:t;email:t} f>t;u=usr name:\"alice\" email:\"a@b\";{name;email}=u;name";
         assert_eq!(
             run_str(source, Some("f"), vec![]),
-            Value::Text("alice".to_string())
+            Value::Text(Arc::new("alice".to_string()))
         );
     }
 
@@ -7075,13 +7231,13 @@ mod tests {
             source,
             Some("f"),
             vec![
-                Value::Text(r#"{"name":"alice"}"#.to_string()),
-                Value::Text("name".to_string()),
+                Value::Text(Arc::new(r#"{"name":"alice"}"#.to_string())),
+                Value::Text(Arc::new("name".to_string())),
             ],
         );
         assert_eq!(
             result,
-            Value::Ok(Box::new(Value::Text("alice".to_string())))
+            Value::Ok(Box::new(Value::Text(Arc::new("alice".to_string()))))
         );
     }
 
@@ -7092,11 +7248,14 @@ mod tests {
             source,
             Some("f"),
             vec![
-                Value::Text(r#"{"user":{"name":"bob"}}"#.to_string()),
-                Value::Text("user.name".to_string()),
+                Value::Text(Arc::new(r#"{"user":{"name":"bob"}}"#.to_string())),
+                Value::Text(Arc::new("user.name".to_string())),
             ],
         );
-        assert_eq!(result, Value::Ok(Box::new(Value::Text("bob".to_string()))));
+        assert_eq!(
+            result,
+            Value::Ok(Box::new(Value::Text(Arc::new("bob".to_string()))))
+        );
     }
 
     #[test]
@@ -7106,11 +7265,14 @@ mod tests {
             source,
             Some("f"),
             vec![
-                Value::Text(r#"{"items":[10,20,30]}"#.to_string()),
-                Value::Text("items.1".to_string()),
+                Value::Text(Arc::new(r#"{"items":[10,20,30]}"#.to_string())),
+                Value::Text(Arc::new("items.1".to_string())),
             ],
         );
-        assert_eq!(result, Value::Ok(Box::new(Value::Text("20".to_string()))));
+        assert_eq!(
+            result,
+            Value::Ok(Box::new(Value::Text(Arc::new("20".to_string()))))
+        );
     }
 
     #[test]
@@ -7120,8 +7282,8 @@ mod tests {
             source,
             Some("f"),
             vec![
-                Value::Text(r#"{"a":1}"#.to_string()),
-                Value::Text("b".to_string()),
+                Value::Text(Arc::new(r#"{"a":1}"#.to_string())),
+                Value::Text(Arc::new("b".to_string())),
             ],
         );
         let Value::Err(e) = result else {
@@ -7137,8 +7299,8 @@ mod tests {
             source,
             Some("f"),
             vec![
-                Value::Text("not json".to_string()),
-                Value::Text("x".to_string()),
+                Value::Text(Arc::new("not json".to_string())),
+                Value::Text(Arc::new("x".to_string())),
             ],
         );
         assert!(matches!(result, Value::Err(_)));
@@ -7151,32 +7313,36 @@ mod tests {
             source,
             Some("f"),
             vec![
-                Value::Text(r#"{"x":"hello"}"#.to_string()),
-                Value::Text("x".to_string()),
+                Value::Text(Arc::new(r#"{"x":"hello"}"#.to_string())),
+                Value::Text(Arc::new("x".to_string())),
             ],
         );
-        assert_eq!(result, Value::Text("hello".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("hello".to_string())));
     }
 
     #[test]
     fn interp_jd_number() {
         let source = "f x:n>t;jdmp x";
         let result = run_str(source, Some("f"), vec![Value::Number(42.0)]);
-        assert_eq!(result, Value::Text("42".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("42".to_string())));
     }
 
     #[test]
     fn interp_jd_text() {
         let source = r#"f x:t>t;jdmp x"#;
-        let result = run_str(source, Some("f"), vec![Value::Text("hello".to_string())]);
-        assert_eq!(result, Value::Text(r#""hello""#.to_string()));
+        let result = run_str(
+            source,
+            Some("f"),
+            vec![Value::Text(Arc::new("hello".to_string()))],
+        );
+        assert_eq!(result, Value::Text(Arc::new(r#""hello""#.to_string())));
     }
 
     #[test]
     fn interp_jd_list() {
         let source = "f>t;xs=[1, 2, 3];jdmp xs";
         let result = run_str(source, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("[1,2,3]".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("[1,2,3]".to_string())));
     }
 
     #[test]
@@ -7198,7 +7364,7 @@ mod tests {
         let result = run_str(
             source,
             Some("f"),
-            vec![Value::Text(r#"{"a":1,"b":"two"}"#.to_string())],
+            vec![Value::Text(Arc::new(r#"{"a":1,"b":"two"}"#.to_string()))],
         );
         let Value::Ok(inner) = result else {
             panic!("expected Ok")
@@ -7208,13 +7374,20 @@ mod tests {
         };
         assert_eq!(type_name, "json");
         assert_eq!(fields.get("a"), Some(&Value::Number(1.0)));
-        assert_eq!(fields.get("b"), Some(&Value::Text("two".to_string())));
+        assert_eq!(
+            fields.get("b"),
+            Some(&Value::Text(Arc::new("two".to_string())))
+        );
     }
 
     #[test]
     fn interp_jparse_array() {
         let source = r#"f j:t>R t t;jpar j"#;
-        let result = run_str(source, Some("f"), vec![Value::Text("[1,2,3]".to_string())]);
+        let result = run_str(
+            source,
+            Some("f"),
+            vec![Value::Text(Arc::new("[1,2,3]".to_string()))],
+        );
         let Value::Ok(inner) = result else {
             panic!("expected Ok")
         };
@@ -7232,15 +7405,27 @@ mod tests {
     fn interp_jparse_scalar() {
         let source = r#"f j:t>R t t;jpar j"#;
         assert_eq!(
-            run_str(source, Some("f"), vec![Value::Text("42".to_string())]),
+            run_str(
+                source,
+                Some("f"),
+                vec![Value::Text(Arc::new("42".to_string()))]
+            ),
             Value::Ok(Box::new(Value::Number(42.0)))
         );
         assert_eq!(
-            run_str(source, Some("f"), vec![Value::Text("true".to_string())]),
+            run_str(
+                source,
+                Some("f"),
+                vec![Value::Text(Arc::new("true".to_string()))]
+            ),
             Value::Ok(Box::new(Value::Bool(true)))
         );
         assert_eq!(
-            run_str(source, Some("f"), vec![Value::Text("null".to_string())]),
+            run_str(
+                source,
+                Some("f"),
+                vec![Value::Text(Arc::new("null".to_string()))]
+            ),
             Value::Ok(Box::new(Value::Nil))
         );
     }
@@ -7248,7 +7433,11 @@ mod tests {
     #[test]
     fn interp_jparse_invalid() {
         let source = r#"f j:t>R t t;jpar j"#;
-        let result = run_str(source, Some("f"), vec![Value::Text("not json".to_string())]);
+        let result = run_str(
+            source,
+            Some("f"),
+            vec![Value::Text(Arc::new("not json".to_string()))],
+        );
         assert!(matches!(result, Value::Err(_)));
     }
 
@@ -7258,7 +7447,7 @@ mod tests {
         let result = run_str(
             source,
             Some("f"),
-            vec![Value::Text(r#"{"x":1}"#.to_string())],
+            vec![Value::Text(Arc::new(r#"{"x":1}"#.to_string()))],
         );
         let Value::Record { type_name, fields } = result else {
             panic!("expected record")
@@ -7273,7 +7462,7 @@ mod tests {
         let result = run_str(
             source,
             Some("f"),
-            vec![Value::Text(r#"{"x":42}"#.to_string())],
+            vec![Value::Text(Arc::new(r#"{"x":42}"#.to_string()))],
         );
         assert_eq!(result, Value::Number(42.0));
     }
@@ -7552,13 +7741,13 @@ mod tests {
         let result = run_str(
             source,
             Some("f"),
-            vec![Value::Text("abc 123 def 456".into())],
+            vec![Value::Text(Arc::new("abc 123 def 456".to_string()))],
         );
         assert_eq!(
             result,
             Value::List(Arc::new(vec![
-                Value::Text("123".into()),
-                Value::Text("456".into()),
+                Value::Text(Arc::new("123".to_string())),
+                Value::Text(Arc::new("456".to_string())),
             ]))
         );
     }
@@ -7570,14 +7759,14 @@ mod tests {
         let result = run_str(
             source,
             Some("f"),
-            vec![Value::Text("name=alice age=30".into())],
+            vec![Value::Text(Arc::new("name=alice age=30".to_string()))],
         );
         // Returns first match's groups
         assert_eq!(
             result,
             Value::List(Arc::new(vec![
-                Value::Text("name".into()),
-                Value::Text("alice".into()),
+                Value::Text(Arc::new("name".to_string())),
+                Value::Text(Arc::new("alice".to_string())),
             ]))
         );
     }
@@ -7588,7 +7777,7 @@ mod tests {
         let result = run_str(
             source,
             Some("f"),
-            vec![Value::Text("no numbers here".into())],
+            vec![Value::Text(Arc::new("no numbers here".to_string()))],
         );
         assert_eq!(result, Value::List(Arc::new(vec![])));
     }
@@ -7674,21 +7863,29 @@ mod tests {
         let result = run_str(
             "f s:t>t;trm s",
             Some("f"),
-            vec![Value::Text("  hello  ".into())],
+            vec![Value::Text(Arc::new("  hello  ".to_string()))],
         );
-        assert_eq!(result, Value::Text("hello".into()));
+        assert_eq!(result, Value::Text(Arc::new("hello".to_string())));
     }
 
     #[test]
     fn interpret_trm_no_whitespace() {
-        let result = run_str("f s:t>t;trm s", Some("f"), vec![Value::Text("hi".into())]);
-        assert_eq!(result, Value::Text("hi".into()));
+        let result = run_str(
+            "f s:t>t;trm s",
+            Some("f"),
+            vec![Value::Text(Arc::new("hi".to_string()))],
+        );
+        assert_eq!(result, Value::Text(Arc::new("hi".to_string())));
     }
 
     #[test]
     fn interpret_trm_only_whitespace() {
-        let result = run_str("f s:t>t;trm s", Some("f"), vec![Value::Text("   ".into())]);
-        assert_eq!(result, Value::Text("".into()));
+        let result = run_str(
+            "f s:t>t;trm s",
+            Some("f"),
+            vec![Value::Text(Arc::new("   ".to_string()))],
+        );
+        assert_eq!(result, Value::Text(Arc::new("".to_string())));
     }
 
     #[test]
@@ -7731,16 +7928,16 @@ mod tests {
             "f xs:L t>L t;unq xs",
             Some("f"),
             vec![Value::List(Arc::new(vec![
-                Value::Text("a".into()),
-                Value::Text("b".into()),
-                Value::Text("a".into()),
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+                Value::Text(Arc::new("a".to_string())),
             ]))],
         );
         assert_eq!(
             result,
             Value::List(Arc::new(vec![
-                Value::Text("a".into()),
-                Value::Text("b".into())
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string()))
             ]))
         );
     }
@@ -7750,9 +7947,9 @@ mod tests {
         let result = run_str(
             "f s:t>t;unq s",
             Some("f"),
-            vec![Value::Text("aabbc".into())],
+            vec![Value::Text(Arc::new("aabbc".to_string()))],
         );
-        assert_eq!(result, Value::Text("abc".into()));
+        assert_eq!(result, Value::Text(Arc::new("abc".to_string())));
     }
 
     #[test]
@@ -7795,15 +7992,18 @@ mod tests {
         let result = run_str(
             r#"f a:t b:t>t;fmt "{} + {}" a b"#,
             Some("f"),
-            vec![Value::Text("1".into()), Value::Text("2".into())],
+            vec![
+                Value::Text(Arc::new("1".to_string())),
+                Value::Text(Arc::new("2".to_string())),
+            ],
         );
-        assert_eq!(result, Value::Text("1 + 2".into()));
+        assert_eq!(result, Value::Text(Arc::new("1 + 2".to_string())));
     }
 
     #[test]
     fn interpret_fmt_template_only() {
         let result = run_str(r#"f>t;fmt "hello""#, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("hello".into()));
+        assert_eq!(result, Value::Text(Arc::new("hello".to_string())));
     }
 
     #[test]
@@ -7811,9 +8011,9 @@ mod tests {
         let result = run_str(
             r#"f a:t>t;fmt "{} and {}" a"#,
             Some("f"),
-            vec![Value::Text("x".into())],
+            vec![Value::Text(Arc::new("x".to_string()))],
         );
-        assert_eq!(result, Value::Text("x and {}".into()));
+        assert_eq!(result, Value::Text(Arc::new("x and {}".to_string())));
     }
 
     #[test]
@@ -7823,7 +8023,7 @@ mod tests {
             Some("f"),
             vec![Value::Number(42.0)],
         );
-        assert_eq!(result, Value::Text("value: 42".into()));
+        assert_eq!(result, Value::Text(Arc::new("value: 42".to_string())));
     }
 
     // --- srt fn xs ---
@@ -7835,17 +8035,17 @@ mod tests {
             source,
             Some("main"),
             vec![Value::List(Arc::new(vec![
-                Value::Text("banana".into()),
-                Value::Text("a".into()),
-                Value::Text("cc".into()),
+                Value::Text(Arc::new("banana".to_string())),
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("cc".to_string())),
             ]))],
         );
         assert_eq!(
             result,
             Value::List(Arc::new(vec![
-                Value::Text("a".into()),
-                Value::Text("cc".into()),
-                Value::Text("banana".into()),
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("cc".to_string())),
+                Value::Text(Arc::new("banana".to_string())),
             ]))
         );
     }
@@ -7883,8 +8083,12 @@ mod tests {
 
     #[test]
     fn interpret_prnt_text_passthrough() {
-        let result = run_str("f s:t>t;prnt s", Some("f"), vec![Value::Text("hi".into())]);
-        assert_eq!(result, Value::Text("hi".into()));
+        let result = run_str(
+            "f s:t>t;prnt s",
+            Some("f"),
+            vec![Value::Text(Arc::new("hi".to_string()))],
+        );
+        assert_eq!(result, Value::Text(Arc::new("hi".to_string())));
     }
 
     // --- rdb ---
@@ -7894,7 +8098,7 @@ mod tests {
         let result = run_str(
             r#"f s:t>t;rdb s "csv""#,
             Some("f"),
-            vec![Value::Text("a,b\n1,2".into())],
+            vec![Value::Text(Arc::new("a,b\n1,2".to_string()))],
         );
         let Value::Ok(inner) = result else {
             panic!("expected Ok")
@@ -7911,7 +8115,7 @@ mod tests {
         let result = run_str(
             r#"f s:t>t;rdb s "json""#,
             Some("f"),
-            vec![Value::Text(r#"{"x":1}"#.into())],
+            vec![Value::Text(Arc::new(r#"{"x":1}"#.to_string()))],
         );
         assert!(
             matches!(result, Value::Ok(_)),
@@ -7925,7 +8129,7 @@ mod tests {
         let result = run_str(
             r#"f s:t>t;rdb s "json""#,
             Some("f"),
-            vec![Value::Text("not json".into())],
+            vec![Value::Text(Arc::new("not json".to_string()))],
         );
         assert!(
             matches!(result, Value::Err(_)),
@@ -7939,9 +8143,12 @@ mod tests {
         let result = run_str(
             r#"f s:t>t;rdb s "raw""#,
             Some("f"),
-            vec![Value::Text("hello".into())],
+            vec![Value::Text(Arc::new("hello".to_string()))],
         );
-        assert_eq!(result, Value::Ok(Box::new(Value::Text("hello".into()))));
+        assert_eq!(
+            result,
+            Value::Ok(Box::new(Value::Text(Arc::new("hello".to_string()))))
+        );
     }
 
     // --- rd (error paths not needing a real file) ---
@@ -7951,7 +8158,9 @@ mod tests {
         let result = run_str(
             "f p:t>t;rd p",
             Some("f"),
-            vec![Value::Text("/nonexistent/ilo_test_file.txt".into())],
+            vec![Value::Text(Arc::new(
+                "/nonexistent/ilo_test_file.txt".to_string(),
+            ))],
         );
         assert!(
             matches!(result, Value::Err(_)),
@@ -7970,7 +8179,7 @@ mod tests {
             Some("f"),
             vec![Value::Number(42.0)],
         );
-        assert_eq!(result, Value::Text("num".into()));
+        assert_eq!(result, Value::Text(Arc::new("num".to_string())));
     }
 
     #[test]
@@ -7979,9 +8188,9 @@ mod tests {
         let result = run_str(
             r#"f x:t>t;?x{t v:v;_:"other"}"#,
             Some("f"),
-            vec![Value::Text("hello".into())],
+            vec![Value::Text(Arc::new("hello".to_string()))],
         );
-        assert_eq!(result, Value::Text("hello".into()));
+        assert_eq!(result, Value::Text(Arc::new("hello".to_string())));
     }
 
     #[test]
@@ -7992,7 +8201,7 @@ mod tests {
             Some("f"),
             vec![Value::Bool(true)],
         );
-        assert_eq!(result, Value::Text("bool".into()));
+        assert_eq!(result, Value::Text(Arc::new("bool".to_string())));
     }
 
     #[test]
@@ -8003,7 +8212,7 @@ mod tests {
             Some("f"),
             vec![Value::Number(1.0)],
         );
-        assert_eq!(result, Value::Text("other".into()));
+        assert_eq!(result, Value::Text(Arc::new("other".to_string())));
     }
 
     #[test]
@@ -8014,7 +8223,7 @@ mod tests {
             Some("f"),
             vec![Value::Number(5.0)],
         );
-        assert_eq!(result, Value::Text("matched".into()));
+        assert_eq!(result, Value::Text(Arc::new("matched".to_string())));
     }
 
     // --- Text comparison operators ---
@@ -8024,7 +8233,10 @@ mod tests {
         let result = run_str(
             "f a:t b:t>b;>a b",
             Some("f"),
-            vec![Value::Text("b".into()), Value::Text("a".into())],
+            vec![
+                Value::Text(Arc::new("b".to_string())),
+                Value::Text(Arc::new("a".to_string())),
+            ],
         );
         assert_eq!(result, Value::Bool(true));
     }
@@ -8034,7 +8246,10 @@ mod tests {
         let result = run_str(
             "f a:t b:t>b;<a b",
             Some("f"),
-            vec![Value::Text("a".into()), Value::Text("b".into())],
+            vec![
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+            ],
         );
         assert_eq!(result, Value::Bool(true));
     }
@@ -8044,7 +8259,10 @@ mod tests {
         let result = run_str(
             "f a:t b:t>b;>=a b",
             Some("f"),
-            vec![Value::Text("a".into()), Value::Text("a".into())],
+            vec![
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("a".to_string())),
+            ],
         );
         assert_eq!(result, Value::Bool(true));
     }
@@ -8054,7 +8272,10 @@ mod tests {
         let result = run_str(
             "f a:t b:t>b;<=a b",
             Some("f"),
-            vec![Value::Text("a".into()), Value::Text("b".into())],
+            vec![
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+            ],
         );
         assert_eq!(result, Value::Bool(true));
     }
@@ -8093,12 +8314,12 @@ mod tests {
     #[test]
     fn values_equal_texts() {
         assert!(values_equal(
-            &Value::Text("a".into()),
-            &Value::Text("a".into())
+            &Value::Text(Arc::new("a".to_string())),
+            &Value::Text(Arc::new("a".to_string()))
         ));
         assert!(!values_equal(
-            &Value::Text("a".into()),
-            &Value::Text("b".into())
+            &Value::Text(Arc::new("a".to_string())),
+            &Value::Text(Arc::new("b".to_string()))
         ));
     }
 
@@ -8204,17 +8425,17 @@ mod tests {
             source,
             Some("main"),
             vec![Value::List(Arc::new(vec![
-                Value::Text("banana".into()),
-                Value::Text("apple".into()),
-                Value::Text("cherry".into()),
+                Value::Text(Arc::new("banana".to_string())),
+                Value::Text(Arc::new("apple".to_string())),
+                Value::Text(Arc::new("cherry".to_string())),
             ]))],
         );
         assert_eq!(
             result,
             Value::List(Arc::new(vec![
-                Value::Text("apple".into()),
-                Value::Text("banana".into()),
-                Value::Text("cherry".into()),
+                Value::Text(Arc::new("apple".to_string())),
+                Value::Text(Arc::new("banana".to_string())),
+                Value::Text(Arc::new("cherry".to_string())),
             ]))
         );
     }
@@ -8295,7 +8516,11 @@ mod tests {
         path.push("ilo_interp_rdl_test.txt");
         std::fs::write(&path, "line1\nline2\nline3").unwrap();
         let path_str = path.to_str().unwrap().to_string();
-        let result = run_str("f p:t>t;rdl p", Some("f"), vec![Value::Text(path_str)]);
+        let result = run_str(
+            "f p:t>t;rdl p",
+            Some("f"),
+            vec![Value::Text(Arc::new(path_str))],
+        );
         std::fs::remove_file(&path).ok();
         let Value::Ok(inner) = result else {
             panic!("expected Ok")
@@ -8304,7 +8529,7 @@ mod tests {
             panic!("expected list")
         };
         assert_eq!(lines.len(), 3);
-        assert_eq!(lines[0], Value::Text("line1".into()));
+        assert_eq!(lines[0], Value::Text(Arc::new("line1".to_string())));
     }
 
     // L779: rdl file not found
@@ -8313,7 +8538,9 @@ mod tests {
         let result = run_str(
             "f p:t>t;rdl p",
             Some("f"),
-            vec![Value::Text("/nonexistent/ilo_rdl_test.txt".into())],
+            vec![Value::Text(Arc::new(
+                "/nonexistent/ilo_rdl_test.txt".to_string(),
+            ))],
         );
         assert!(
             matches!(result, Value::Err(_)),
@@ -8338,7 +8565,7 @@ mod tests {
         let result = run_str(
             "f p:t>t;wr p \"hello\"",
             Some("f"),
-            vec![Value::Text(path_str.clone())],
+            vec![Value::Text(Arc::new(path_str.clone()))],
         );
         std::fs::remove_file(&path).ok();
         assert!(
@@ -8364,7 +8591,7 @@ mod tests {
         let result = run_str(
             "f p:t>t;wrl p [\"a\", \"b\", \"c\"]",
             Some("f"),
-            vec![Value::Text(path_str.clone())],
+            vec![Value::Text(Arc::new(path_str.clone()))],
         );
         std::fs::remove_file(&path).ok();
         assert!(
@@ -8385,9 +8612,9 @@ mod tests {
             &mut env,
             "wrl",
             vec![
-                Value::Text(path_str.clone()),
+                Value::Text(Arc::new(path_str.clone())),
                 Value::List(Arc::new(vec![
-                    Value::Text("ok".into()),
+                    Value::Text(Arc::new("ok".to_string())),
                     Value::Number(99.0),
                 ])),
             ],
@@ -8413,11 +8640,14 @@ mod tests {
             source,
             Some("f"),
             vec![
-                Value::Text(r#"[10,20,30]"#.to_string()),
-                Value::Text("1".to_string()),
+                Value::Text(Arc::new(r#"[10,20,30]"#.to_string())),
+                Value::Text(Arc::new("1".to_string())),
             ],
         );
-        assert_eq!(result, Value::Ok(Box::new(Value::Text("20".into()))));
+        assert_eq!(
+            result,
+            Value::Ok(Box::new(Value::Text(Arc::new("20".to_string()))))
+        );
     }
 
     // L839: jpth non-text/non-map args
@@ -8431,7 +8661,7 @@ mod tests {
     #[test]
     fn interp_jdmp_ok_value() {
         let result = run_str("f>t;jdmp ~42", Some("f"), vec![]);
-        assert_eq!(result, Value::Text("42".into()));
+        assert_eq!(result, Value::Text(Arc::new("42".to_string())));
     }
 
     // L869: jdmp on FnRef (goes through value_to_json FnRef branch)
@@ -8660,7 +8890,7 @@ mod tests {
     #[test]
     fn interp_jdmp_err_value() {
         let result = run_str("f>t;jdmp ^42", Some("f"), vec![]);
-        assert_eq!(result, Value::Text("42".into()));
+        assert_eq!(result, Value::Text(Arc::new("42".to_string())));
     }
 
     // L1379: value_to_json Map variant
@@ -8682,7 +8912,7 @@ mod tests {
             Some("f"),
             vec![Value::List(Arc::new(vec![Value::Number(1.0)]))],
         );
-        assert_eq!(result, Value::Text("list".into()));
+        assert_eq!(result, Value::Text(Arc::new("list".to_string())));
     }
 
     // L2376: Decl::TypeDef is not callable error (duplicate name avoided — already tested above)
@@ -8694,7 +8924,7 @@ mod tests {
         let result = run_str(
             r#"f s:t>t;rdb s "csv""#,
             Some("f"),
-            vec![Value::Text("a,b,c".into())],
+            vec![Value::Text(Arc::new("a,b,c".to_string()))],
         );
         let Value::Ok(inner) = result else {
             panic!("expected Ok")
@@ -8731,8 +8961,8 @@ mod tests {
         assert_eq!(
             result,
             Value::List(Arc::new(vec![
-                Value::Text("a".into()),
-                Value::Text("b".into())
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string()))
             ]))
         );
     }
@@ -8797,7 +9027,7 @@ mod tests {
             source,
             Some("f"),
             vec![
-                Value::Text("sq".into()),
+                Value::Text(Arc::new("sq".to_string())),
                 Value::List(Arc::new(vec![Value::Number(3.0)])),
             ],
         );
@@ -8816,7 +9046,7 @@ mod tests {
         let Value::Ok(inner) = result else {
             panic!("expected Ok")
         };
-        assert_eq!(*inner, Value::Text("hello".into()));
+        assert_eq!(*inner, Value::Text(Arc::new("hello".to_string())));
     }
 
     #[test]
@@ -8921,7 +9151,9 @@ mod tests {
         let err = run_str_err(
             "f xs:L n>n;avg xs",
             Some("f"),
-            vec![Value::List(Arc::new(vec![Value::Text("x".into())]))],
+            vec![Value::List(Arc::new(vec![Value::Text(Arc::new(
+                "x".to_string(),
+            ))]))],
         );
         assert!(err.contains("avg"), "got: {err}");
     }
@@ -8940,14 +9172,14 @@ mod tests {
     fn interpret_jdmp_bool_value() {
         // value_to_json Bool branch (line 1179)
         let result = run_str("f>t;jdmp true", Some("f"), vec![]);
-        assert_eq!(result, Value::Text("true".into()));
+        assert_eq!(result, Value::Text(Arc::new("true".to_string())));
     }
 
     #[test]
     fn interpret_jdmp_nil_value() {
         // value_to_json Nil branch (line 1180) — mget on empty map returns Nil
         let result = run_str(r#"f>t;jdmp (mget mmap "k")"#, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("null".into()));
+        assert_eq!(result, Value::Text(Arc::new("null".to_string())));
     }
 
     // ── wr json — text/bool/map/nil value types (lines 835-843) ───────────────
@@ -9187,7 +9419,7 @@ mod tests {
         let err = run_str_err(
             "f s:t>n;@i s..3{i}",
             Some("f"),
-            vec![Value::Text("a".into())],
+            vec![Value::Text(Arc::new("a".to_string()))],
         );
         assert!(
             err.contains("range") || err.contains("number") || err.contains("start"),
@@ -9201,7 +9433,7 @@ mod tests {
         let err = run_str_err(
             "f e:t>n;@i 0..e{i}",
             Some("f"),
-            vec![Value::Text("b".into())],
+            vec![Value::Text(Arc::new("b".to_string()))],
         );
         assert!(
             err.contains("range") || err.contains("number") || err.contains("end"),
@@ -9268,7 +9500,11 @@ mod tests {
     fn interpret_text_callee_from_scope() {
         // When a variable holds a Text naming a known function, it is used as the callee (L1470)
         let source = "sq x:n>n;*x x f cb:z>n;cb 3";
-        let result = run_str(source, Some("f"), vec![Value::Text("sq".into())]);
+        let result = run_str(
+            source,
+            Some("f"),
+            vec![Value::Text(Arc::new("sq".to_string()))],
+        );
         assert_eq!(result, Value::Number(9.0));
     }
 
@@ -9383,7 +9619,10 @@ mod tests {
         let err = run(
             &prog,
             Some("f"),
-            vec![Value::Text("a".into()), Value::Text("b".into())],
+            vec![
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+            ],
         )
         .unwrap_err();
         assert!(
@@ -9435,7 +9674,7 @@ mod tests {
             Some("f"),
             vec![Value::Number(42.0)],
         );
-        assert_eq!(result, Value::Text("other".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("other".to_string())));
     }
 
     // ── Tool call with provider but no async runtime (L1160-1162) ───────────
@@ -9448,7 +9687,7 @@ mod tests {
         let result = run_with_tools(
             &prog,
             Some("greet"),
-            vec![Value::Text("world".into())],
+            vec![Value::Text(Arc::new("world".to_string()))],
             provider,
         )
         .unwrap();
@@ -9475,7 +9714,7 @@ mod tests {
             None,
             vec![Value::Number(5.0)],
         );
-        assert_eq!(result, Value::Text("num".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("num".to_string())));
     }
 
     #[test]
@@ -9483,9 +9722,9 @@ mod tests {
         let result = run_str(
             r#"f x:t>t;?x{t v:v;_:"other"}"#,
             None,
-            vec![Value::Text("hi".to_string())],
+            vec![Value::Text(Arc::new("hi".to_string()))],
         );
-        assert_eq!(result, Value::Text("hi".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("hi".to_string())));
     }
 
     #[test]
@@ -9495,7 +9734,7 @@ mod tests {
             None,
             vec![Value::Bool(true)],
         );
-        assert_eq!(result, Value::Text("matched".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("matched".to_string())));
     }
 
     // ── Coverage round 2: TypeIs pattern matching for less common types ──────
@@ -9514,7 +9753,7 @@ mod tests {
                 Value::Number(2.0),
             ]))],
         );
-        assert_eq!(result, Value::Text("list".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("list".to_string())));
     }
 
     #[test]
@@ -9522,7 +9761,7 @@ mod tests {
         // TypeIs List pattern tested against a non-list value — falls through to wildcard
         let source = r#"f x:n>t;?x{l _:"list";_:"other"}"#;
         let result = run_str(source, Some("f"), vec![Value::Number(42.0)]);
-        assert_eq!(result, Value::Text("other".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("other".to_string())));
     }
 
     // ── TypeIs with Map type → _ => false (L1727) ───────────────────────────
@@ -9540,7 +9779,7 @@ mod tests {
                 Value::Number(1.0),
             )])))],
         );
-        assert_eq!(result, Value::Text("other".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("other".to_string())));
     }
 
     // ── TypeIs with Nil value → no match on any typed pattern (L1727) ───────
@@ -9550,7 +9789,7 @@ mod tests {
         // Nil value doesn't match n/t/b/l patterns — exercises _ => false (L1727)
         let source = r#"f x:O n>t;?x{n _:"num";_:"nil"}"#;
         let result = run_str(source, Some("f"), vec![Value::Nil]);
-        assert_eq!(result, Value::Text("nil".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("nil".to_string())));
     }
 
     #[test]
@@ -9558,7 +9797,7 @@ mod tests {
         // Nil tested against text TypeIs pattern → falls through
         let source = r#"f x:O t>t;?x{t v:v;_:"none"}"#;
         let result = run_str(source, Some("f"), vec![Value::Nil]);
-        assert_eq!(result, Value::Text("none".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("none".to_string())));
     }
 
     // ── `!` auto-unwrap on Optional: nil propagates as the function's return ──
@@ -9599,7 +9838,7 @@ mod tests {
     fn interp_at_text_negative_last() {
         let source = r#"f>t;at "abc" -1"#;
         let result = run_str(source, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("c".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("c".to_string())));
     }
 
     #[test]
@@ -9686,7 +9925,7 @@ mod tests {
         let result = call_function(
             &mut env,
             "fmt2",
-            vec![Value::Text("hi".to_string()), Value::Number(2.0)],
+            vec![Value::Text(Arc::new("hi".to_string())), Value::Number(2.0)],
         );
         let err = result.unwrap_err();
         assert_eq!(err.code, "ILO-R009");

--- a/src/main.rs
+++ b/src/main.rs
@@ -3574,7 +3574,7 @@ fn parse_cli_arg(s: &str) -> interpreter::Value {
     // This preserves the raw contents (no escape decoding) which mirrors how
     // the rest of the CLI passes bare text.
     if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
-        return interpreter::Value::Text(s[1..s.len() - 1].to_string());
+        return interpreter::Value::Text(std::sync::Arc::new(s[1..s.len() - 1].to_string()));
     }
     // Bare comma list: 1,2,3
     if s.contains(',') {
@@ -3597,7 +3597,7 @@ fn parse_cli_arg(s: &str) -> interpreter::Value {
     } else if s == "false" {
         interpreter::Value::Bool(false)
     } else {
-        interpreter::Value::Text(s.to_string())
+        interpreter::Value::Text(std::sync::Arc::new(s.to_string()))
     }
 }
 
@@ -3625,7 +3625,7 @@ fn parse_cli_arg_for_param(s: &str, expected: Option<&ast::Type>) -> interpreter
         } else {
             s
         };
-        return interpreter::Value::Text(stripped.to_string());
+        return interpreter::Value::Text(std::sync::Arc::new(stripped.to_string()));
     }
     parse_cli_arg(s)
 }
@@ -3795,7 +3795,7 @@ mod tests {
     fn cli_arg_text() {
         assert_eq!(
             parse_cli_arg("hello"),
-            interpreter::Value::Text("hello".into())
+            interpreter::Value::Text(Arc::new("hello".to_string()))
         );
     }
 
@@ -3837,7 +3837,7 @@ mod tests {
             parse_cli_arg("1,hello,true"),
             interpreter::Value::List(Arc::new(vec![
                 interpreter::Value::Number(1.0),
-                interpreter::Value::Text("hello".into()),
+                interpreter::Value::Text(Arc::new("hello".to_string())),
                 interpreter::Value::Bool(true),
             ]))
         );
@@ -3846,7 +3846,10 @@ mod tests {
     #[test]
     fn cli_arg_infinity_is_text() {
         // inf is not finite so it should fall through to text
-        assert_eq!(parse_cli_arg("inf"), interpreter::Value::Text("inf".into()));
+        assert_eq!(
+            parse_cli_arg("inf"),
+            interpreter::Value::Text(Arc::new("inf".to_string()))
+        );
     }
 
     // ── detect_output_mode ────────────────────────────────────────────────────
@@ -4530,7 +4533,7 @@ mod tests {
         run_default(
             &program,
             Some("greet"),
-            vec![interpreter::Value::Text("world".into())],
+            vec![interpreter::Value::Text(Arc::new("world".to_string()))],
             "greet name:t>t;cat \"hi \" name",
             OutputMode::Text,
             false,
@@ -4621,19 +4624,27 @@ mod tests {
 
     #[test]
     fn print_value_err_as_json() {
-        let val = interpreter::Value::Err(Box::new(interpreter::Value::Text("oops".into())));
+        let val = interpreter::Value::Err(Box::new(interpreter::Value::Text(Arc::new(
+            "oops".to_string(),
+        ))));
         print_value(&val, true, false);
     }
 
     #[test]
     fn print_value_err_no_json() {
-        let val = interpreter::Value::Err(Box::new(interpreter::Value::Text("fail".into())));
+        let val = interpreter::Value::Err(Box::new(interpreter::Value::Text(Arc::new(
+            "fail".to_string(),
+        ))));
         print_value(&val, false, false);
     }
 
     #[test]
     fn print_value_text_as_json() {
-        print_value(&interpreter::Value::Text("hello".into()), true, false);
+        print_value(
+            &interpreter::Value::Text(Arc::new("hello".to_string())),
+            true,
+            false,
+        );
     }
 
     #[test]
@@ -4831,7 +4842,10 @@ mod tests {
     #[test]
     fn cli_arg_nan_is_text() {
         // NaN is not finite, so it should fall through to text
-        assert_eq!(parse_cli_arg("NaN"), interpreter::Value::Text("NaN".into()));
+        assert_eq!(
+            parse_cli_arg("NaN"),
+            interpreter::Value::Text(Arc::new("NaN".to_string()))
+        );
     }
 
     #[test]
@@ -4847,7 +4861,10 @@ mod tests {
     #[test]
     fn cli_arg_nil_not_text() {
         // "nil" should parse as Nil, not Text("nil")
-        assert_ne!(parse_cli_arg("nil"), interpreter::Value::Text("nil".into()));
+        assert_ne!(
+            parse_cli_arg("nil"),
+            interpreter::Value::Text(Arc::new("nil".to_string()))
+        );
     }
 
     // ── coerce_cli_args ──────────────────────────────────────────────────────
@@ -4969,7 +4986,10 @@ mod tests {
         let program = make_program("f arg:t>t;arg");
         let raw = vec!["2".to_string()];
         let parsed = parse_cli_args_typed(&program, Some("f"), &raw);
-        assert_eq!(parsed, vec![interpreter::Value::Text("2".into())]);
+        assert_eq!(
+            parsed,
+            vec![interpreter::Value::Text(Arc::new("2".to_string()))]
+        );
     }
 
     #[test]
@@ -4977,7 +4997,10 @@ mod tests {
         let program = make_program("f arg:t>t;arg");
         let raw = vec!["true".to_string()];
         let parsed = parse_cli_args_typed(&program, Some("f"), &raw);
-        assert_eq!(parsed, vec![interpreter::Value::Text("true".into())]);
+        assert_eq!(
+            parsed,
+            vec![interpreter::Value::Text(Arc::new("true".to_string()))]
+        );
     }
 
     #[test]
@@ -4985,7 +5008,10 @@ mod tests {
         let program = make_program("f arg:t>t;arg");
         let raw = vec!["nil".to_string()];
         let parsed = parse_cli_args_typed(&program, Some("f"), &raw);
-        assert_eq!(parsed, vec![interpreter::Value::Text("nil".into())]);
+        assert_eq!(
+            parsed,
+            vec![interpreter::Value::Text(Arc::new("nil".to_string()))]
+        );
     }
 
     #[test]
@@ -4994,7 +5020,10 @@ mod tests {
         let program = make_program("f arg:t>t;arg");
         let raw = vec!["[1,2]".to_string()];
         let parsed = parse_cli_args_typed(&program, Some("f"), &raw);
-        assert_eq!(parsed, vec![interpreter::Value::Text("[1,2]".into())]);
+        assert_eq!(
+            parsed,
+            vec![interpreter::Value::Text(Arc::new("[1,2]".to_string()))]
+        );
     }
 
     #[test]
@@ -5030,7 +5059,7 @@ mod tests {
         assert_eq!(
             parsed,
             vec![
-                interpreter::Value::Text("2".into()),
+                interpreter::Value::Text(Arc::new("2".to_string())),
                 interpreter::Value::Number(3.0),
             ]
         );
@@ -5197,7 +5226,7 @@ mod tests {
     fn print_value_list_plain_not_json() {
         let val = interpreter::Value::List(Arc::new(vec![
             interpreter::Value::Number(1.0),
-            interpreter::Value::Text("x".into()),
+            interpreter::Value::Text(Arc::new("x".to_string())),
         ]));
         print_value(&val, false, false);
     }

--- a/src/tools/http_provider.rs
+++ b/src/tools/http_provider.rs
@@ -131,6 +131,7 @@ impl ToolProvider for HttpProvider {
 mod tests {
     use super::*;
     use crate::tools::ToolProvider;
+    use std::sync::Arc;
 
     #[test]
     fn from_file_missing_file() {
@@ -192,7 +193,10 @@ mod tests {
         let provider = HttpProvider::new(ToolsConfig {
             tools: HashMap::new(),
         });
-        let args = vec![Value::Text("ignored".into()), Value::Number(42.0)];
+        let args = vec![
+            Value::Text(Arc::new("ignored".to_string())),
+            Value::Number(42.0),
+        ];
         let result = provider.call("tool", args).await;
         assert_eq!(result.unwrap(), Value::Ok(Box::new(Value::Nil)));
     }

--- a/src/tools/mcp_provider.rs
+++ b/src/tools/mcp_provider.rs
@@ -226,11 +226,11 @@ impl ToolProvider for McpProvider {
                 .unwrap_or(false)
             {
                 let err_text = extract_text_content(&result);
-                return Ok(Value::Err(Box::new(Value::Text(err_text))));
+                return Ok(Value::Err(Box::new(Value::Text(Arc::new(err_text)))));
             }
 
             let text = extract_text_content(&result);
-            Ok(Value::Ok(Box::new(Value::Text(text))))
+            Ok(Value::Ok(Box::new(Value::Text(Arc::new(text)))))
         })
     }
 }

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -4556,15 +4556,21 @@ mod tests {
         let result = jit_run(
             r#"f a:t b:t>t;+ a b"#,
             "f",
-            &[Value::Text("hello".into()), Value::Text(" world".into())],
+            &[
+                Value::Text(Arc::new("hello".to_string())),
+                Value::Text(Arc::new(" world".to_string())),
+            ],
         );
-        assert_eq!(result, Some(Value::Text("hello world".into())));
+        assert_eq!(
+            result,
+            Some(Value::Text(Arc::new("hello world".to_string())))
+        );
     }
 
     #[test]
     fn cranelift_string_constant() {
         let result = jit_run(r#"f>t;"hello""#, "f", &[]);
-        assert_eq!(result, Some(Value::Text("hello".into())));
+        assert_eq!(result, Some(Value::Text(Arc::new("hello".to_string()))));
     }
 
     #[test]
@@ -4615,16 +4621,26 @@ mod tests {
 
     #[test]
     fn cranelift_wraperr() {
-        let result = jit_run(r#"f x:t>R n t;^"bad""#, "f", &[Value::Text("bad".into())]);
+        let result = jit_run(
+            r#"f x:t>R n t;^"bad""#,
+            "f",
+            &[Value::Text(Arc::new("bad".to_string()))],
+        );
         assert_eq!(
             result,
-            Some(Value::Err(Box::new(Value::Text("bad".into()))))
+            Some(Value::Err(Box::new(Value::Text(Arc::new(
+                "bad".to_string()
+            )))))
         );
     }
 
     #[test]
     fn cranelift_len_string() {
-        let result = jit_run(r#"f s:t>n;len s"#, "f", &[Value::Text("hello".into())]);
+        let result = jit_run(
+            r#"f s:t>n;len s"#,
+            "f",
+            &[Value::Text(Arc::new("hello".to_string()))],
+        );
         assert_eq!(result, Some(Value::Number(5.0)));
     }
 
@@ -4682,7 +4698,7 @@ mod tests {
     #[test]
     fn cranelift_str_builtin() {
         let result = jit_run("f x:n>t;str x", "f", &[Value::Number(42.0)]);
-        assert_eq!(result, Some(Value::Text("42".into())));
+        assert_eq!(result, Some(Value::Text(Arc::new("42".to_string()))));
     }
 
     #[test]
@@ -4709,7 +4725,7 @@ mod tests {
         let result = jit_run(
             r#"f s:t>n;r=num s;?r{~v:v;^_:0}"#,
             "f",
-            &[Value::Text("3.14".into())],
+            &[Value::Text(Arc::new("3.14".to_string()))],
         );
         assert_eq!(result, Some(Value::Number(3.14)));
     }
@@ -4769,11 +4785,13 @@ mod tests {
         let result = jit_run(
             r#"f k:t>R t t;env k"#,
             "f",
-            &[Value::Text("ILO_JIT_TEST_VAR".into())],
+            &[Value::Text(Arc::new("ILO_JIT_TEST_VAR".to_string()))],
         );
         assert_eq!(
             result,
-            Some(Value::Ok(Box::new(Value::Text("hello".into()))))
+            Some(Value::Ok(Box::new(Value::Text(Arc::new(
+                "hello".to_string()
+            )))))
         );
     }
 
@@ -4784,14 +4802,17 @@ mod tests {
         let result = jit_run(
             r#"f s:t sep:t>L t;spl s sep"#,
             "f",
-            &[Value::Text("a,b,c".into()), Value::Text(",".into())],
+            &[
+                Value::Text(Arc::new("a,b,c".to_string())),
+                Value::Text(Arc::new(",".to_string())),
+            ],
         );
         assert_eq!(
             result,
             Some(Value::List(std::sync::Arc::new(vec![
-                Value::Text("a".into()),
-                Value::Text("b".into()),
-                Value::Text("c".into()),
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+                Value::Text(Arc::new("c".to_string())),
             ])))
         );
     }
@@ -4803,13 +4824,13 @@ mod tests {
             "f",
             &[
                 Value::List(std::sync::Arc::new(vec![
-                    Value::Text("x".into()),
-                    Value::Text("y".into()),
+                    Value::Text(Arc::new("x".to_string())),
+                    Value::Text(Arc::new("y".to_string())),
                 ])),
-                Value::Text("-".into()),
+                Value::Text(Arc::new("-".to_string())),
             ],
         );
-        assert_eq!(result, Some(Value::Text("x-y".into())));
+        assert_eq!(result, Some(Value::Text(Arc::new("x-y".to_string()))));
     }
 
     // ── has / hd / tl / rev / srt / slc ──────────────────────────────────────
@@ -5013,7 +5034,7 @@ mod tests {
     fn cranelift_jdmp_number() {
         // jdmp serialises numbers without trailing .0 (matches interpreter behaviour)
         let result = jit_run("f x:n>t;jdmp x", "f", &[Value::Number(42.0)]);
-        assert_eq!(result, Some(Value::Text("42".into())));
+        assert_eq!(result, Some(Value::Text(Arc::new("42".to_string()))));
     }
 
     #[test]
@@ -5021,7 +5042,7 @@ mod tests {
         let result = jit_run(
             r#"f s:t>R t t;jpar s"#,
             "f",
-            &[Value::Text(r#"{"k":"v"}"#.into())],
+            &[Value::Text(Arc::new(r#"{"k":"v"}"#.to_string()))],
         );
         assert!(matches!(result, Some(Value::Ok(_))));
     }
@@ -5032,13 +5053,15 @@ mod tests {
             r#"f j:t p:t>R t t;jpth j p"#,
             "f",
             &[
-                Value::Text(r#"{"name":"alice"}"#.into()),
-                Value::Text("name".into()),
+                Value::Text(Arc::new(r#"{"name":"alice"}"#.to_string())),
+                Value::Text(Arc::new("name".to_string())),
             ],
         );
         assert_eq!(
             result,
-            Some(Value::Ok(Box::new(Value::Text("alice".into()))))
+            Some(Value::Ok(Box::new(Value::Text(Arc::new(
+                "alice".to_string()
+            )))))
         );
     }
 
@@ -5061,7 +5084,9 @@ mod tests {
         let result = jit_run(
             r#"f x:R n t>n;?x{~_:1;^_:99}"#,
             "f",
-            &[Value::Err(Box::new(Value::Text("bad".into())))],
+            &[Value::Err(Box::new(Value::Text(Arc::new(
+                "bad".to_string(),
+            ))))],
         );
         assert_eq!(result, Some(Value::Number(99.0)));
     }
@@ -5142,7 +5167,7 @@ mod tests {
         let idx = compiled.func_names.iter().position(|n| n == "f").unwrap();
         let chunk = &compiled.chunks[idx];
         let nan_consts = &compiled.nan_constants[idx];
-        let nan_args: Vec<u64> = [Value::Text(r#"{"score":42}"#.to_string())]
+        let nan_args: Vec<u64> = [Value::Text(Arc::new(r#"{"score":42}"#.to_string()))]
             .iter()
             .map(|v| NanVal::from_value(v).0)
             .collect();
@@ -5273,9 +5298,9 @@ mod tests {
             "f xs:L n>n;s=0;@x xs{s=+s 1};s",
             "f",
             &[Value::List(std::sync::Arc::new(vec![
-                Value::Text("a".to_string()),
-                Value::Text("b".to_string()),
-                Value::Text("c".to_string()),
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+                Value::Text(Arc::new("c".to_string())),
             ]))],
         );
         assert_eq!(result, Some(Value::Number(3.0)));
@@ -5467,9 +5492,15 @@ mod tests {
         let result = jit_run(
             "strjoin a:t b:t>t;+a b\nf a:t b:t>t;strjoin a b",
             "f",
-            &[Value::Text("hello".into()), Value::Text(" world".into())],
+            &[
+                Value::Text(Arc::new("hello".to_string())),
+                Value::Text(Arc::new(" world".to_string())),
+            ],
         );
-        assert_eq!(result, Some(Value::Text("hello world".into())));
+        assert_eq!(
+            result,
+            Some(Value::Text(Arc::new("hello world".to_string())))
+        );
     }
 
     #[test]
@@ -5481,9 +5512,9 @@ mod tests {
         let result = jit_run(
             "greet x:t>t;+\"hi \" x\nf name:t>t;greet name",
             "f",
-            &[Value::Text("alice".into())],
+            &[Value::Text(Arc::new("alice".to_string()))],
         );
-        assert_eq!(result, Some(Value::Text("hi alice".into())));
+        assert_eq!(result, Some(Value::Text(Arc::new("hi alice".to_string()))));
     }
 
     // ── Type predicate ops ────────────────────────────────────────────────────
@@ -5505,7 +5536,7 @@ mod tests {
         let result = jit_run(
             r#"f x:t>b;?x{t _:true;_:false}"#,
             "f",
-            &[Value::Text("hi".into())],
+            &[Value::Text(Arc::new("hi".to_string()))],
         );
         assert_eq!(result, Some(Value::Bool(true)));
     }
@@ -5582,7 +5613,7 @@ mod tests {
             "f",
             &[],
         );
-        assert_eq!(result, Some(Value::Text("miss".into())));
+        assert_eq!(result, Some(Value::Text(Arc::new("miss".to_string()))));
     }
 
     #[test]
@@ -5595,7 +5626,7 @@ mod tests {
             "f",
             &[],
         );
-        assert_eq!(result, Some(Value::Text("second".into())));
+        assert_eq!(result, Some(Value::Text(Arc::new("second".to_string()))));
     }
 
     #[test]
@@ -5619,8 +5650,12 @@ mod tests {
 
     #[test]
     fn cranelift_trm_builtin() {
-        let result = jit_run(r#"f s:t>t;trm s"#, "f", &[Value::Text("  hello  ".into())]);
-        assert_eq!(result, Some(Value::Text("hello".into())));
+        let result = jit_run(
+            r#"f s:t>t;trm s"#,
+            "f",
+            &[Value::Text(Arc::new("  hello  ".to_string()))],
+        );
+        assert_eq!(result, Some(Value::Text(Arc::new("hello".to_string()))));
     }
 
     #[test]
@@ -5647,7 +5682,10 @@ mod tests {
         let result = jit_run(
             r#"f x:t y:t>b;= x y"#,
             "f",
-            &[Value::Text("hello".into()), Value::Text("hello".into())],
+            &[
+                Value::Text(Arc::new("hello".to_string())),
+                Value::Text(Arc::new("hello".to_string())),
+            ],
         );
         assert_eq!(result, Some(Value::Bool(true)));
     }
@@ -5658,7 +5696,10 @@ mod tests {
         let result = jit_run(
             r#"f x:t y:t>b;< x y"#,
             "f",
-            &[Value::Text("a".into()), Value::Text("b".into())],
+            &[
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+            ],
         );
         // String comparison: "a" < "b" is true
         assert_eq!(result, Some(Value::Bool(true)));
@@ -5693,7 +5734,10 @@ mod tests {
         let result = jit_run(
             "f p:t c:t>t;wr p c",
             "f",
-            &[Value::Text(path_str), Value::Text("hello jit\n".into())],
+            &[
+                Value::Text(Arc::new(path_str)),
+                Value::Text(Arc::new("hello jit\n".to_string())),
+            ],
         );
         // wr returns ok/err result; we just check it doesn't panic
         let _ = std::fs::remove_file(&path);
@@ -5799,7 +5843,11 @@ mod tests {
     #[test]
     fn cranelift_num_text_to_number() {
         // num converts a text to a number (returns Result)
-        let result = jit_run(r#"f s:t>R n t;num s"#, "f", &[Value::Text("3.14".into())]);
+        let result = jit_run(
+            r#"f s:t>R n t;num s"#,
+            "f",
+            &[Value::Text(Arc::new("3.14".to_string()))],
+        );
         assert_eq!(result, Some(Value::Ok(Box::new(Value::Number(3.14)))));
     }
 
@@ -5809,8 +5857,8 @@ mod tests {
     fn cranelift_map_set_and_get_string_value() {
         let result = jit_run(r#"f>t;m=mset mmap "key" "val";mget m "key""#, "f", &[]);
         match result {
-            Some(Value::Text(s)) => assert_eq!(s, "val"),
-            Some(Value::Ok(v)) => assert_eq!(*v, Value::Text("val".into())),
+            Some(Value::Text(s)) => assert_eq!(s.as_str(), "val"),
+            Some(Value::Ok(v)) => assert_eq!(*v, Value::Text(Arc::new("val".to_string()))),
             other => panic!("expected 'val', got {:?}", other),
         }
     }
@@ -5861,8 +5909,12 @@ mod tests {
     fn cranelift_move_string_value() {
         // When the source register holds a string (not proven always-numeric),
         // the MOVE handler takes the general is_heap-check path.
-        let result = jit_run(r#"f s:t>t;t=s;t"#, "f", &[Value::Text("hello".into())]);
-        assert_eq!(result, Some(Value::Text("hello".into())));
+        let result = jit_run(
+            r#"f s:t>t;t=s;t"#,
+            "f",
+            &[Value::Text(Arc::new("hello".to_string()))],
+        );
+        assert_eq!(result, Some(Value::Text(Arc::new("hello".to_string()))));
     }
 
     // ── NEG on non-numeric operand (helper slow path) ─────────────────────────
@@ -6033,7 +6085,10 @@ mod tests {
         let result = jit_run(
             "f x:n y:t>n;-x x",
             "f",
-            &[Value::Number(8.0), Value::Text("dummy".into())],
+            &[
+                Value::Number(8.0),
+                Value::Text(Arc::new("dummy".to_string())),
+            ],
         );
         assert_eq!(result, Some(Value::Number(0.0)));
     }
@@ -6043,7 +6098,10 @@ mod tests {
         let result = jit_run(
             "f x:n y:t>n;*x x",
             "f",
-            &[Value::Number(3.0), Value::Text("dummy".into())],
+            &[
+                Value::Number(3.0),
+                Value::Text(Arc::new("dummy".to_string())),
+            ],
         );
         assert_eq!(result, Some(Value::Number(9.0)));
     }
@@ -6053,7 +6111,10 @@ mod tests {
         let result = jit_run(
             "f x:n y:t>n;/x x",
             "f",
-            &[Value::Number(6.0), Value::Text("dummy".into())],
+            &[
+                Value::Number(6.0),
+                Value::Text(Arc::new("dummy".to_string())),
+            ],
         );
         assert_eq!(result, Some(Value::Number(1.0)));
     }
@@ -6099,7 +6160,10 @@ mod tests {
         let result = jit_run(
             "f x:n y:t>n;+x 1",
             "f",
-            &[Value::Number(5.0), Value::Text("dummy".into())],
+            &[
+                Value::Number(5.0),
+                Value::Text(Arc::new("dummy".to_string())),
+            ],
         );
         assert_eq!(result, Some(Value::Number(6.0)));
     }
@@ -6109,7 +6173,10 @@ mod tests {
         let result = jit_run(
             "f x:n y:t>n;-x 1",
             "f",
-            &[Value::Number(8.0), Value::Text("dummy".into())],
+            &[
+                Value::Number(8.0),
+                Value::Text(Arc::new("dummy".to_string())),
+            ],
         );
         assert_eq!(result, Some(Value::Number(7.0)));
     }
@@ -6119,7 +6186,10 @@ mod tests {
         let result = jit_run(
             "f x:n y:t>n;*x 3",
             "f",
-            &[Value::Number(4.0), Value::Text("dummy".into())],
+            &[
+                Value::Number(4.0),
+                Value::Text(Arc::new("dummy".to_string())),
+            ],
         );
         assert_eq!(result, Some(Value::Number(12.0)));
     }
@@ -6129,7 +6199,10 @@ mod tests {
         let result = jit_run(
             "f x:n y:t>n;/x 2",
             "f",
-            &[Value::Number(10.0), Value::Text("dummy".into())],
+            &[
+                Value::Number(10.0),
+                Value::Text(Arc::new("dummy".to_string())),
+            ],
         );
         assert_eq!(result, Some(Value::Number(5.0)));
     }
@@ -6178,7 +6251,10 @@ mod tests {
         let result = jit_run(
             "f x:n y:t>n;>x 5 1;0",
             "f",
-            &[Value::Number(10.0), Value::Text("dummy".into())],
+            &[
+                Value::Number(10.0),
+                Value::Text(Arc::new("dummy".to_string())),
+            ],
         );
         assert_eq!(result, Some(Value::Number(1.0)));
     }
@@ -6188,7 +6264,10 @@ mod tests {
         let result = jit_run(
             "f x:n y:t>n;<x 5 1;0",
             "f",
-            &[Value::Number(3.0), Value::Text("dummy".into())],
+            &[
+                Value::Number(3.0),
+                Value::Text(Arc::new("dummy".to_string())),
+            ],
         );
         assert_eq!(result, Some(Value::Number(1.0)));
     }
@@ -6198,7 +6277,10 @@ mod tests {
         let result = jit_run(
             "f x:n y:t>n;<=x 5 1;0",
             "f",
-            &[Value::Number(5.0), Value::Text("dummy".into())],
+            &[
+                Value::Number(5.0),
+                Value::Text(Arc::new("dummy".to_string())),
+            ],
         );
         assert_eq!(result, Some(Value::Number(1.0)));
     }
@@ -6208,7 +6290,10 @@ mod tests {
         let result = jit_run(
             "f x:n y:t>n;>=x 5 1;0",
             "f",
-            &[Value::Number(5.0), Value::Text("dummy".into())],
+            &[
+                Value::Number(5.0),
+                Value::Text(Arc::new("dummy".to_string())),
+            ],
         );
         assert_eq!(result, Some(Value::Number(1.0)));
     }
@@ -6218,7 +6303,10 @@ mod tests {
         let result = jit_run(
             "f x:n y:t>n;==x 5 1;0",
             "f",
-            &[Value::Number(5.0), Value::Text("dummy".into())],
+            &[
+                Value::Number(5.0),
+                Value::Text(Arc::new("dummy".to_string())),
+            ],
         );
         assert_eq!(result, Some(Value::Number(1.0)));
     }
@@ -6228,7 +6316,10 @@ mod tests {
         let result = jit_run(
             "f x:n y:t>n;!=x 5 1;0",
             "f",
-            &[Value::Number(3.0), Value::Text("dummy".into())],
+            &[
+                Value::Number(3.0),
+                Value::Text(Arc::new("dummy".to_string())),
+            ],
         );
         assert_eq!(result, Some(Value::Number(1.0)));
     }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -3,6 +3,7 @@ use crate::builtins::{Builtin, CharAtResult, char_at_signed};
 use crate::interpreter::{MapKey, Value};
 use std::collections::HashMap;
 use std::rc::Rc;
+use std::sync::Arc;
 
 #[derive(Debug, thiserror::Error)]
 pub enum VmError {
@@ -1171,7 +1172,9 @@ impl RegCompiler {
                             }
                         }
                         None => {
-                            let ki = self.current.add_const(Value::Text(binding.clone()));
+                            let ki = self
+                                .current
+                                .add_const(Value::Text(Arc::new(binding.clone())));
                             assert!(
                                 ki <= 255,
                                 "constant pool overflow for dynamic destructure field"
@@ -1624,7 +1627,7 @@ impl RegCompiler {
                 Pattern::Literal(lit) => {
                     let val = match lit {
                         Literal::Number(n) => Value::Number(*n),
-                        Literal::Text(s) => Value::Text(s.clone()),
+                        Literal::Text(s) => Value::Text(Arc::new(s.clone())),
                         Literal::Bool(b) => Value::Bool(*b),
                         Literal::Nil => Value::Nil,
                     };
@@ -1689,7 +1692,7 @@ impl RegCompiler {
         match expr {
             Expr::Literal(lit) => Some(match lit {
                 Literal::Number(n) => Value::Number(*n),
-                Literal::Text(s) => Value::Text(s.clone()),
+                Literal::Text(s) => Value::Text(Arc::new(s.clone())),
                 Literal::Bool(b) => Value::Bool(*b),
                 Literal::Nil => Value::Nil,
             }),
@@ -1715,7 +1718,7 @@ impl RegCompiler {
                             let mut out = String::with_capacity(a.len() + b.len());
                             out.push_str(a);
                             out.push_str(b);
-                            Some(Value::Text(out))
+                            Some(Value::Text(Arc::new(out)))
                         }
                         _ => None,
                     },
@@ -1762,7 +1765,7 @@ impl RegCompiler {
                 let is_str = matches!(lit, Literal::Text(_));
                 let val = match lit {
                     Literal::Number(n) => Value::Number(*n),
-                    Literal::Text(s) => Value::Text(s.clone()),
+                    Literal::Text(s) => Value::Text(Arc::new(s.clone())),
                     Literal::Bool(b) => Value::Bool(*b),
                     Literal::Nil => Value::Nil,
                 };
@@ -1851,7 +1854,7 @@ impl RegCompiler {
                     }
                     None => {
                         // Dynamic path: store field name, runtime linear scan
-                        let ki = self.current.add_const(Value::Text(field.clone()));
+                        let ki = self.current.add_const(Value::Text(Arc::new(field.clone())));
                         assert!(ki <= 255, "constant pool overflow for dynamic field name");
                         if *safe {
                             let ra = self.alloc_reg();
@@ -3152,7 +3155,7 @@ impl RegCompiler {
                         Value::List(std::sync::Arc::new(
                             updates
                                 .iter()
-                                .map(|(n, _)| Value::Text(n.clone()))
+                                .map(|(n, _)| Value::Text(Arc::new(n.clone())))
                                 .collect(),
                         ))
                     };
@@ -3962,7 +3965,7 @@ impl NanVal {
             Value::Number(n) => NanVal::number(*n),
             Value::Bool(b) => NanVal::boolean(*b),
             Value::Nil => NanVal::nil(),
-            Value::Text(s) => NanVal::heap_string(s.clone()),
+            Value::Text(s) => NanVal::heap_string((**s).clone()),
             Value::List(items) => NanVal::heap_list(items.iter().map(NanVal::from_value).collect()),
             Value::Map(m) => {
                 let nan_map: HashMap<MapKey, NanVal> = m
@@ -4130,7 +4133,7 @@ impl NanVal {
                     self.0
                 );
                 match self.as_heap_ref() {
-                    HeapObj::Str(s) => Value::Text(s.clone()),
+                    HeapObj::Str(s) => Value::Text(Arc::new(s.clone())),
                     HeapObj::List(items) => Value::List(std::sync::Arc::new(
                         items.iter().map(|v| v.to_value()).collect(),
                     )),
@@ -6294,7 +6297,7 @@ impl<'a> VM<'a> {
                                                 Value::Text(name) => type_info
                                                     .fields
                                                     .iter()
-                                                    .position(|f| f == name)
+                                                    .position(|f| f == name.as_str())
                                                     .unwrap_or(0),
                                                 _ => 0,
                                             })
@@ -13546,36 +13549,48 @@ mod tests {
         // Braceless guards: early return
         let source = r#"cls sp:n>t;>=sp 1000 "gold";>=sp 500 "silver";"bronze""#;
         let result = vm_run(source, Some("cls"), vec![Value::Number(1000.0)]);
-        assert_eq!(result, Value::Text("gold".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("gold".to_string())));
     }
 
     #[test]
     fn vm_cls_silver() {
         let source = r#"cls sp:n>t;>=sp 1000 "gold";>=sp 500 "silver";"bronze""#;
         let result = vm_run(source, Some("cls"), vec![Value::Number(500.0)]);
-        assert_eq!(result, Value::Text("silver".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("silver".to_string())));
     }
 
     #[test]
     fn vm_cls_bronze() {
         let source = r#"cls sp:n>t;>=sp 1000 "gold";>=sp 500 "silver";"bronze""#;
         let result = vm_run(source, Some("cls"), vec![Value::Number(100.0)]);
-        assert_eq!(result, Value::Text("bronze".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("bronze".to_string())));
     }
 
     #[test]
     fn vm_match_stmt() {
         let source = r#"f x:t>n;?x{"a":1;"b":2;_:0}"#;
         assert_eq!(
-            vm_run(source, Some("f"), vec![Value::Text("a".to_string())]),
+            vm_run(
+                source,
+                Some("f"),
+                vec![Value::Text(Arc::new("a".to_string()))]
+            ),
             Value::Number(1.0)
         );
         assert_eq!(
-            vm_run(source, Some("f"), vec![Value::Text("b".to_string())]),
+            vm_run(
+                source,
+                Some("f"),
+                vec![Value::Text(Arc::new("b".to_string()))]
+            ),
             Value::Number(2.0)
         );
         assert_eq!(
-            vm_run(source, Some("f"), vec![Value::Text("z".to_string())]),
+            vm_run(
+                source,
+                Some("f"),
+                vec![Value::Text(Arc::new("z".to_string()))]
+            ),
             Value::Number(0.0)
         );
     }
@@ -13617,7 +13632,7 @@ mod tests {
         let source =
             "tool fetch\"get\" url:t>R _ t\nf>t;r=fetch \"http://x\";?r{~v:\"ok\";^e:\"err\"}";
         let result = vm_run(source, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("ok".into()));
+        assert_eq!(result, Value::Text(Arc::new("ok".to_string())));
     }
 
     #[test]
@@ -13640,7 +13655,10 @@ mod tests {
     fn vm_err_constructor() {
         let source = r#"f x:n>R n t;^"bad""#;
         let result = vm_run(source, Some("f"), vec![Value::Number(0.0)]);
-        assert_eq!(result, Value::Err(Box::new(Value::Text("bad".to_string()))));
+        assert_eq!(
+            result,
+            Value::Err(Box::new(Value::Text(Arc::new("bad".to_string()))))
+        );
     }
 
     #[test]
@@ -13656,7 +13674,9 @@ mod tests {
         let err_result = vm_run(
             source,
             Some("f"),
-            vec![Value::Err(Box::new(Value::Text("oops".to_string())))],
+            vec![Value::Err(Box::new(Value::Text(Arc::new(
+                "oops".to_string(),
+            ))))],
         );
         assert_eq!(err_result, Value::Number(0.0));
     }
@@ -13667,11 +13687,11 @@ mod tests {
         let source = r#"f x:b>t;!x{"nope"}{"yes"}"#;
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Bool(false)]),
-            Value::Text("nope".to_string())
+            Value::Text(Arc::new("nope".to_string()))
         );
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Bool(true)]),
-            Value::Text("yes".to_string())
+            Value::Text(Arc::new("yes".to_string()))
         );
     }
 
@@ -13734,11 +13754,11 @@ mod tests {
             source,
             Some("f"),
             vec![
-                Value::Text("foo".to_string()),
-                Value::Text("bar".to_string()),
+                Value::Text(Arc::new("foo".to_string())),
+                Value::Text(Arc::new("bar".to_string())),
             ],
         );
-        assert_eq!(result, Value::Text("foobar".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("foobar".to_string())));
     }
 
     #[test]
@@ -13749,9 +13769,12 @@ mod tests {
         let result = vm_run(
             source,
             Some("f"),
-            vec![Value::Text("val=".to_string()), Value::Number(42.0)],
+            vec![
+                Value::Text(Arc::new("val=".to_string())),
+                Value::Number(42.0),
+            ],
         );
-        assert_eq!(result, Value::Text("val=42".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("val=42".to_string())));
     }
 
     #[test]
@@ -13759,7 +13782,7 @@ mod tests {
         // Both sides are text literals → OP_ADD_SS
         let source = r#"f>t;+"hello " "world""#;
         let result = vm_run(source, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("hello world".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("hello world".to_string())));
     }
 
     #[test]
@@ -13769,11 +13792,11 @@ mod tests {
             source,
             Some("f"),
             vec![
-                Value::Text("hello ".to_string()),
-                Value::Text("world".to_string()),
+                Value::Text(Arc::new("hello ".to_string())),
+                Value::Text(Arc::new("world".to_string())),
             ],
         );
-        assert_eq!(result, Value::Text("hello world".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("hello world".to_string())));
     }
 
     #[test]
@@ -13812,7 +13835,10 @@ mod tests {
             vm_run(
                 source,
                 Some("f"),
-                vec![Value::Text("banana".into()), Value::Text("apple".into())]
+                vec![
+                    Value::Text(Arc::new("banana".to_string())),
+                    Value::Text(Arc::new("apple".to_string()))
+                ]
             ),
             Value::Bool(true)
         );
@@ -13820,7 +13846,10 @@ mod tests {
             vm_run(
                 source,
                 Some("f"),
-                vec![Value::Text("apple".into()), Value::Text("banana".into())]
+                vec![
+                    Value::Text(Arc::new("apple".to_string())),
+                    Value::Text(Arc::new("banana".to_string()))
+                ]
             ),
             Value::Bool(false)
         );
@@ -13831,7 +13860,10 @@ mod tests {
             vm_run(
                 source,
                 Some("f"),
-                vec![Value::Text("apple".into()), Value::Text("banana".into())]
+                vec![
+                    Value::Text(Arc::new("apple".to_string())),
+                    Value::Text(Arc::new("banana".to_string()))
+                ]
             ),
             Value::Bool(true)
         );
@@ -13842,7 +13874,10 @@ mod tests {
             vm_run(
                 source,
                 Some("f"),
-                vec![Value::Text("apple".into()), Value::Text("apple".into())]
+                vec![
+                    Value::Text(Arc::new("apple".to_string())),
+                    Value::Text(Arc::new("apple".to_string()))
+                ]
             ),
             Value::Bool(true)
         );
@@ -13850,7 +13885,10 @@ mod tests {
             vm_run(
                 source,
                 Some("f"),
-                vec![Value::Text("apple".into()), Value::Text("banana".into())]
+                vec![
+                    Value::Text(Arc::new("apple".to_string())),
+                    Value::Text(Arc::new("banana".to_string()))
+                ]
             ),
             Value::Bool(false)
         );
@@ -13861,7 +13899,10 @@ mod tests {
             vm_run(
                 source,
                 Some("f"),
-                vec![Value::Text("banana".into()), Value::Text("banana".into())]
+                vec![
+                    Value::Text(Arc::new("banana".to_string())),
+                    Value::Text(Arc::new("banana".to_string()))
+                ]
             ),
             Value::Bool(true)
         );
@@ -13869,7 +13910,10 @@ mod tests {
             vm_run(
                 source,
                 Some("f"),
-                vec![Value::Text("zebra".into()), Value::Text("banana".into())]
+                vec![
+                    Value::Text(Arc::new("zebra".to_string())),
+                    Value::Text(Arc::new("banana".to_string()))
+                ]
             ),
             Value::Bool(false)
         );
@@ -13885,7 +13929,11 @@ mod tests {
     #[test]
     fn vm_match_expr_in_let() {
         let source = r#"f x:t>n;y=?x{"a":1;"b":2;_:0};y"#;
-        let result = vm_run(source, Some("f"), vec![Value::Text("b".to_string())]);
+        let result = vm_run(
+            source,
+            Some("f"),
+            vec![Value::Text(Arc::new("b".to_string()))],
+        );
         assert_eq!(result, Value::Number(2.0));
     }
 
@@ -13986,19 +14034,19 @@ mod tests {
         let source = r#"f n:n>t;a=flr /n 3;b=flr /n 5;c=*a 3;d=*b 5;e= =c n;f= =d n;&e f{ret "FizzBuzz"};e{ret "Fizz"};f{ret "Buzz"};str n"#;
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Number(3.0)]),
-            Value::Text("Fizz".to_string())
+            Value::Text(Arc::new("Fizz".to_string()))
         );
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Number(5.0)]),
-            Value::Text("Buzz".to_string())
+            Value::Text(Arc::new("Buzz".to_string()))
         );
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Number(15.0)]),
-            Value::Text("FizzBuzz".to_string())
+            Value::Text(Arc::new("FizzBuzz".to_string()))
         );
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Number(7.0)]),
-            Value::Text("7".to_string())
+            Value::Text(Arc::new("7".to_string()))
         );
     }
 
@@ -14009,7 +14057,7 @@ mod tests {
         let source = r#"f>t;a=true;b=false;r= |a b;a{"a is still true"}{"nope"}"#;
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
-            Value::Text("a is still true".to_string())
+            Value::Text(Arc::new("a is still true".to_string()))
         );
     }
 
@@ -14017,11 +14065,19 @@ mod tests {
     fn vm_len_string() {
         let source = r#"f s:t>n;len s"#;
         assert_eq!(
-            vm_run(source, Some("f"), vec![Value::Text("hello".to_string())]),
+            vm_run(
+                source,
+                Some("f"),
+                vec![Value::Text(Arc::new("hello".to_string()))]
+            ),
             Value::Number(5.0)
         );
         assert_eq!(
-            vm_run(source, Some("f"), vec![Value::Text("".to_string())]),
+            vm_run(
+                source,
+                Some("f"),
+                vec![Value::Text(Arc::new("".to_string()))]
+            ),
             Value::Number(0.0)
         );
     }
@@ -14098,7 +14154,10 @@ mod tests {
     #[test]
     fn vm_str_integer() {
         let source = "f>t;str 42";
-        assert_eq!(vm_run(source, Some("f"), vec![]), Value::Text("42".into()));
+        assert_eq!(
+            vm_run(source, Some("f"), vec![]),
+            Value::Text(Arc::new("42".to_string()))
+        );
     }
 
     #[test]
@@ -14106,7 +14165,7 @@ mod tests {
         let source = "f>t;str 3.14";
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
-            Value::Text("3.14".into())
+            Value::Text(Arc::new("3.14".to_string()))
         );
     }
 
@@ -14133,7 +14192,7 @@ mod tests {
         let source = "f>R n t;num \"abc\"";
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
-            Value::Err(Box::new(Value::Text("abc".into())))
+            Value::Err(Box::new(Value::Text(Arc::new("abc".to_string()))))
         );
     }
 
@@ -14218,7 +14277,10 @@ mod tests {
     #[test]
     fn vm_index_access_string_list() {
         let source = "f>t;xs=[\"a\", \"b\"];xs.1";
-        assert_eq!(vm_run(source, Some("f"), vec![]), Value::Text("b".into()));
+        assert_eq!(
+            vm_run(source, Some("f"), vec![]),
+            Value::Text(Arc::new("b".to_string()))
+        );
     }
 
     #[test]
@@ -14310,7 +14372,7 @@ mod tests {
         assert_eq!(nv.to_value(), v);
 
         // Text
-        let v = Value::Text("hello".to_string());
+        let v = Value::Text(Arc::new("hello".to_string()));
         let nv = NanVal::from_value(&v);
         assert_eq!(nv.to_value(), v);
         nv.drop_rc();
@@ -14322,7 +14384,7 @@ mod tests {
         nv.drop_rc();
 
         // Err wrapping text
-        let v = Value::Err(Box::new(Value::Text("bad".to_string())));
+        let v = Value::Err(Box::new(Value::Text(Arc::new("bad".to_string()))));
         let nv = NanVal::from_value(&v);
         assert_eq!(nv.to_value(), v);
         nv.drop_rc();
@@ -14446,11 +14508,11 @@ mod tests {
         let source = "f x:n>t;==x 3 \"match\";\"nope\"";
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Number(3.0)]),
-            Value::Text("match".to_string())
+            Value::Text(Arc::new("match".to_string()))
         );
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Number(5.0)]),
-            Value::Text("nope".to_string())
+            Value::Text(Arc::new("nope".to_string()))
         );
     }
 
@@ -14461,11 +14523,11 @@ mod tests {
         let source = "f x:n>t;e= ==x 3;e{\"match\"}{\"nope\"}";
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Number(3.0)]),
-            Value::Text("match".to_string())
+            Value::Text(Arc::new("match".to_string()))
         );
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Number(5.0)]),
-            Value::Text("nope".to_string())
+            Value::Text(Arc::new("nope".to_string()))
         );
     }
 
@@ -14542,7 +14604,7 @@ mod tests {
         let source = r#"f>t;x=+"hello " "world";x"#;
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
-            Value::Text("hello world".into())
+            Value::Text(Arc::new("hello world".to_string()))
         );
     }
 
@@ -14588,11 +14650,11 @@ mod tests {
         let source = r#"f x:b>t;?x{true:"yes";_:"no"}"#;
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Bool(true)]),
-            Value::Text("yes".into())
+            Value::Text(Arc::new("yes".to_string()))
         );
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Bool(false)]),
-            Value::Text("no".into())
+            Value::Text(Arc::new("no".to_string()))
         );
     }
 
@@ -14602,15 +14664,15 @@ mod tests {
         let source = r#"f x:n>t;?x{0:"zero";1:"one";_:"other"}"#;
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Number(0.0)]),
-            Value::Text("zero".into())
+            Value::Text(Arc::new("zero".to_string()))
         );
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Number(1.0)]),
-            Value::Text("one".into())
+            Value::Text(Arc::new("one".to_string()))
         );
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Number(42.0)]),
-            Value::Text("other".into())
+            Value::Text(Arc::new("other".to_string()))
         );
     }
 
@@ -14620,7 +14682,7 @@ mod tests {
         let source = r#"f>t;?{_:"always"}"#;
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
-            Value::Text("always".into())
+            Value::Text(Arc::new("always".to_string()))
         );
     }
 
@@ -14689,7 +14751,10 @@ mod tests {
             vm_run(
                 source,
                 Some("f"),
-                vec![Value::Text("hi".into()), Value::Text("hi".into())]
+                vec![
+                    Value::Text(Arc::new("hi".to_string())),
+                    Value::Text(Arc::new("hi".to_string()))
+                ]
             ),
             Value::Bool(true)
         );
@@ -14697,7 +14762,10 @@ mod tests {
             vm_run(
                 source,
                 Some("f"),
-                vec![Value::Text("hi".into()), Value::Text("bye".into())]
+                vec![
+                    Value::Text(Arc::new("hi".to_string())),
+                    Value::Text(Arc::new("bye".to_string()))
+                ]
             ),
             Value::Bool(false)
         );
@@ -14796,17 +14864,23 @@ mod tests {
             vm_run(
                 source,
                 Some("f"),
-                vec![Value::Text("hi".into()), Value::Text("there".into())]
+                vec![
+                    Value::Text(Arc::new("hi".to_string())),
+                    Value::Text(Arc::new("there".to_string()))
+                ]
             ),
-            Value::Text("there".into())
+            Value::Text(Arc::new("there".to_string()))
         );
         assert_eq!(
             vm_run(
                 source,
                 Some("f"),
-                vec![Value::Text("".into()), Value::Text("there".into())]
+                vec![
+                    Value::Text(Arc::new("".to_string())),
+                    Value::Text(Arc::new("there".to_string()))
+                ]
             ),
-            Value::Text("".into())
+            Value::Text(Arc::new("".to_string()))
         );
     }
 
@@ -14943,7 +15017,7 @@ mod tests {
         let source = r#"f x:n>t;y=?{_:"default"};y"#;
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Number(1.0)]),
-            Value::Text("default".into())
+            Value::Text(Arc::new("default".to_string()))
         );
     }
 
@@ -15030,10 +15104,14 @@ mod tests {
         let prog = parse_program(source);
         let compiled = compile(&prog).unwrap();
         let mut state = VmState::new(&compiled);
-        let r1 = state.call("f", vec![Value::Text("hello".into())]).unwrap();
-        assert_eq!(r1, Value::Text("hello".into()));
-        let r2 = state.call("f", vec![Value::Text("world".into())]).unwrap();
-        assert_eq!(r2, Value::Text("world".into()));
+        let r1 = state
+            .call("f", vec![Value::Text(Arc::new("hello".to_string()))])
+            .unwrap();
+        assert_eq!(r1, Value::Text(Arc::new("hello".to_string())));
+        let r2 = state
+            .call("f", vec![Value::Text(Arc::new("world".to_string()))])
+            .unwrap();
+        assert_eq!(r2, Value::Text(Arc::new("world".to_string())));
     }
 
     // ---- Constant dedup: Bool and Nil ----
@@ -15371,7 +15449,7 @@ mod tests {
         let err = vm_run_err(
             source,
             Some("f"),
-            vec![Value::Number(1.0), Value::Text("hi".to_string())],
+            vec![Value::Number(1.0), Value::Text(Arc::new("hi".to_string()))],
         );
         assert!(err.contains("cannot add"), "got: {err}");
     }
@@ -15394,7 +15472,7 @@ mod tests {
         let err = vm_run_err(
             source,
             Some("f"),
-            vec![Value::Text("hi".to_string()), Value::Number(2.0)],
+            vec![Value::Text(Arc::new("hi".to_string())), Value::Number(2.0)],
         );
         assert!(err.contains("multiply"), "got: {err}");
     }
@@ -15406,7 +15484,7 @@ mod tests {
         let err = vm_run_err(
             source,
             Some("f"),
-            vec![Value::Number(1.0), Value::Text("hi".to_string())],
+            vec![Value::Number(1.0), Value::Text(Arc::new("hi".to_string()))],
         );
         assert!(err.contains("compare"), "got: {err}");
     }
@@ -15418,7 +15496,7 @@ mod tests {
         let err = vm_run_err(
             source,
             Some("f"),
-            vec![Value::Number(1.0), Value::Text("hi".to_string())],
+            vec![Value::Number(1.0), Value::Text(Arc::new("hi".to_string()))],
         );
         assert!(err.contains("compare"), "got: {err}");
     }
@@ -15430,7 +15508,7 @@ mod tests {
         let err = vm_run_err(
             source,
             Some("f"),
-            vec![Value::Number(1.0), Value::Text("hi".to_string())],
+            vec![Value::Number(1.0), Value::Text(Arc::new("hi".to_string()))],
         );
         assert!(err.contains("compare"), "got: {err}");
     }
@@ -15442,7 +15520,7 @@ mod tests {
         let err = vm_run_err(
             source,
             Some("f"),
-            vec![Value::Number(1.0), Value::Text("hi".to_string())],
+            vec![Value::Number(1.0), Value::Text(Arc::new("hi".to_string()))],
         );
         assert!(err.contains("compare"), "got: {err}");
     }
@@ -15451,7 +15529,11 @@ mod tests {
     fn vm_neg_type_error() {
         // OP_NEG on text (unary negate) → L1514
         let source = "f x:t>n;-x";
-        let err = vm_run_err(source, Some("f"), vec![Value::Text("hi".to_string())]);
+        let err = vm_run_err(
+            source,
+            Some("f"),
+            vec![Value::Text(Arc::new("hi".to_string()))],
+        );
         assert!(err.contains("negate"), "got: {err}");
     }
 
@@ -15459,7 +15541,11 @@ mod tests {
     fn vm_str_non_number_type_error() {
         // OP_STR on text → L1903 ("str requires a number")
         let source = "f x:t>t;str x";
-        let err = vm_run_err(source, Some("f"), vec![Value::Text("hi".to_string())]);
+        let err = vm_run_err(
+            source,
+            Some("f"),
+            vec![Value::Text(Arc::new("hi".to_string()))],
+        );
         assert!(err.contains("str"), "got: {err}");
     }
 
@@ -15475,7 +15561,11 @@ mod tests {
     fn vm_abs_non_number_type_error() {
         // OP_ABS on text → L1936 ("abs requires a number")
         let source = "f x:t>n;abs x";
-        let err = vm_run_err(source, Some("f"), vec![Value::Text("hi".to_string())]);
+        let err = vm_run_err(
+            source,
+            Some("f"),
+            vec![Value::Text(Arc::new("hi".to_string()))],
+        );
         assert!(err.contains("abs"), "got: {err}");
     }
 
@@ -15486,7 +15576,7 @@ mod tests {
         let err = vm_run_err(
             source,
             Some("f"),
-            vec![Value::Text("hi".to_string()), Value::Number(2.0)],
+            vec![Value::Text(Arc::new("hi".to_string())), Value::Number(2.0)],
         );
         assert!(
             err.contains("min") || err.contains("max") || err.contains("number"),
@@ -15498,7 +15588,11 @@ mod tests {
     fn vm_flr_non_number_type_error() {
         // OP_FLR on text → L1959 ("flr/cel requires a number")
         let source = "f x:t>n;flr x";
-        let err = vm_run_err(source, Some("f"), vec![Value::Text("hi".to_string())]);
+        let err = vm_run_err(
+            source,
+            Some("f"),
+            vec![Value::Text(Arc::new("hi".to_string()))],
+        );
         assert!(err.contains("flr") || err.contains("number"), "got: {err}");
     }
 
@@ -15535,7 +15629,10 @@ mod tests {
         let err = vm_run_err(
             source,
             Some("f"),
-            vec![Value::Text("hi".into()), Value::Text("lo".into())],
+            vec![
+                Value::Text(Arc::new("hi".to_string())),
+                Value::Text(Arc::new("lo".to_string())),
+            ],
         );
         assert!(err.contains("divide"), "got: {err}");
     }
@@ -15555,7 +15652,11 @@ mod tests {
     fn vm_index_on_non_list() {
         // OP_INDEX: index access on a string (heap but not list) → L1612
         let source = "f x:t>t;x.0";
-        let err = vm_run_err(source, Some("f"), vec![Value::Text("hi".into())]);
+        let err = vm_run_err(
+            source,
+            Some("f"),
+            vec![Value::Text(Arc::new("hi".to_string()))],
+        );
         assert!(err.contains("index") || err.contains("list"), "got: {err}");
     }
 
@@ -15574,7 +15675,11 @@ mod tests {
     fn vm_foreach_on_heap_non_list() {
         // OP_LISTGET: foreach over a string (heap but not list) → L1643
         let source = "f x:t>t;@elem x{elem}";
-        let err = vm_run_err(source, Some("f"), vec![Value::Text("hi".into())]);
+        let err = vm_run_err(
+            source,
+            Some("f"),
+            vec![Value::Text(Arc::new("hi".to_string()))],
+        );
         assert!(
             err.contains("list") || err.contains("foreach"),
             "got: {err}"
@@ -15634,7 +15739,7 @@ mod tests {
         let err = vm_run_err(
             source,
             Some("f"),
-            vec![Value::Text("hi".into()), Value::Number(1.0)],
+            vec![Value::Text(Arc::new("hi".to_string())), Value::Number(1.0)],
         );
         assert!(err.contains("list") || err.contains("+="), "got: {err}");
     }
@@ -15765,13 +15870,13 @@ mod tests {
         let mut headers = std::collections::HashMap::new();
         headers.insert(
             crate::interpreter::MapKey::Text("x-api-key".to_string()),
-            Value::Text("tok".to_string()),
+            Value::Text(Arc::new("tok".to_string())),
         );
         let result = vm_run(
             src,
             Some("f"),
             vec![
-                Value::Text("http://127.0.0.1:1".to_string()),
+                Value::Text(Arc::new("http://127.0.0.1:1".to_string())),
                 Value::Map(std::sync::Arc::new(headers)),
             ],
         );
@@ -15787,14 +15892,14 @@ mod tests {
         let mut headers = std::collections::HashMap::new();
         headers.insert(
             crate::interpreter::MapKey::Text("x-api-key".to_string()),
-            Value::Text("tok".to_string()),
+            Value::Text(Arc::new("tok".to_string())),
         );
         let result = vm_run(
             src,
             Some("f"),
             vec![
-                Value::Text("http://127.0.0.1:1".to_string()),
-                Value::Text("body".to_string()),
+                Value::Text(Arc::new("http://127.0.0.1:1".to_string())),
+                Value::Text(Arc::new("body".to_string())),
                 Value::Map(std::sync::Arc::new(headers)),
             ],
         );
@@ -15810,15 +15915,15 @@ mod tests {
         let source = r#"cls sp:n>t;>=sp 1000 "gold";>=sp 500 "silver";"bronze""#;
         assert_eq!(
             vm_run(source, Some("cls"), vec![Value::Number(1500.0)]),
-            Value::Text("gold".to_string())
+            Value::Text(Arc::new("gold".to_string()))
         );
         assert_eq!(
             vm_run(source, Some("cls"), vec![Value::Number(750.0)]),
-            Value::Text("silver".to_string())
+            Value::Text(Arc::new("silver".to_string()))
         );
         assert_eq!(
             vm_run(source, Some("cls"), vec![Value::Number(100.0)]),
-            Value::Text("bronze".to_string())
+            Value::Text(Arc::new("bronze".to_string()))
         );
     }
 
@@ -15846,9 +15951,9 @@ mod tests {
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
             Value::List(Arc::new(vec![
-                Value::Text("a".to_string()),
-                Value::Text("b".to_string()),
-                Value::Text("c".to_string()),
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+                Value::Text(Arc::new("c".to_string())),
             ]))
         );
     }
@@ -15858,7 +15963,7 @@ mod tests {
         let source = r#"f>L t;spl "" ",""#;
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
-            Value::List(Arc::new(vec![Value::Text("".to_string())]))
+            Value::List(Arc::new(vec![Value::Text(Arc::new("".to_string()))]))
         );
     }
 
@@ -15870,12 +15975,12 @@ mod tests {
                 source,
                 Some("f"),
                 vec![Value::List(Arc::new(vec![
-                    Value::Text("a".into()),
-                    Value::Text("b".into()),
-                    Value::Text("c".into()),
+                    Value::Text(Arc::new("a".to_string())),
+                    Value::Text(Arc::new("b".to_string())),
+                    Value::Text(Arc::new("c".to_string())),
                 ]))]
             ),
-            Value::Text("a,b,c".into())
+            Value::Text(Arc::new("a,b,c".to_string()))
         );
     }
 
@@ -15884,7 +15989,7 @@ mod tests {
         let source = "f items:L t>t;cat items \"-\"";
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::List(Arc::new(vec![]))]),
-            Value::Text("".into())
+            Value::Text(Arc::new("".to_string()))
         );
     }
 
@@ -15927,8 +16032,8 @@ mod tests {
                 source,
                 Some("f"),
                 vec![
-                    Value::Text("hello world".into()),
-                    Value::Text("world".into())
+                    Value::Text(Arc::new("hello world".to_string())),
+                    Value::Text(Arc::new("world".to_string()))
                 ]
             ),
             Value::Bool(true)
@@ -15954,8 +16059,12 @@ mod tests {
     fn vm_hd_text() {
         let source = r#"f s:t>t;hd s"#;
         assert_eq!(
-            vm_run(source, Some("f"), vec![Value::Text("hello".into())]),
-            Value::Text("h".into())
+            vm_run(
+                source,
+                Some("f"),
+                vec![Value::Text(Arc::new("hello".to_string()))]
+            ),
+            Value::Text(Arc::new("h".to_string()))
         );
     }
 
@@ -15963,8 +16072,12 @@ mod tests {
     fn vm_tl_text() {
         let source = r#"f s:t>t;tl s"#;
         assert_eq!(
-            vm_run(source, Some("f"), vec![Value::Text("hello".into())]),
-            Value::Text("ello".into())
+            vm_run(
+                source,
+                Some("f"),
+                vec![Value::Text(Arc::new("hello".to_string()))]
+            ),
+            Value::Text(Arc::new("ello".to_string()))
         );
     }
 
@@ -15984,7 +16097,10 @@ mod tests {
     #[test]
     fn vm_rev_text() {
         let source = r#"f>t;rev "abc""#;
-        assert_eq!(vm_run(source, Some("f"), vec![]), Value::Text("cba".into()));
+        assert_eq!(
+            vm_run(source, Some("f"), vec![]),
+            Value::Text(Arc::new("cba".to_string()))
+        );
     }
 
     #[test]
@@ -16006,9 +16122,9 @@ mod tests {
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
             Value::List(Arc::new(vec![
-                Value::Text("a".into()),
-                Value::Text("b".into()),
-                Value::Text("c".into())
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+                Value::Text(Arc::new("c".to_string()))
             ]))
         );
     }
@@ -16025,7 +16141,10 @@ mod tests {
     #[test]
     fn vm_slc_text() {
         let source = r#"f>t;slc "hello" 1 4"#;
-        assert_eq!(vm_run(source, Some("f"), vec![]), Value::Text("ell".into()));
+        assert_eq!(
+            vm_run(source, Some("f"), vec![]),
+            Value::Text(Arc::new("ell".to_string()))
+        );
     }
 
     #[test]
@@ -16033,7 +16152,7 @@ mod tests {
         let source = r#"f x:n>t;=x 1{"yes"}{"no"}"#;
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Number(1.0)]),
-            Value::Text("yes".into())
+            Value::Text(Arc::new("yes".to_string()))
         );
     }
 
@@ -16042,7 +16161,7 @@ mod tests {
         let source = r#"f x:n>t;=x 1{"yes"}{"no"}"#;
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Number(2.0)]),
-            Value::Text("no".into())
+            Value::Text(Arc::new("no".to_string()))
         );
     }
 
@@ -16257,8 +16376,15 @@ mod tests {
             std::env::set_var("ILO_VM_TEST", "vmval");
         }
         let source = r#"f k:t>R t t;env k"#;
-        let result = vm_run(source, Some("f"), vec![Value::Text("ILO_VM_TEST".into())]);
-        assert_eq!(result, Value::Ok(Box::new(Value::Text("vmval".into()))));
+        let result = vm_run(
+            source,
+            Some("f"),
+            vec![Value::Text(Arc::new("ILO_VM_TEST".to_string()))],
+        );
+        assert_eq!(
+            result,
+            Value::Ok(Box::new(Value::Text(Arc::new("vmval".to_string()))))
+        );
         unsafe {
             std::env::remove_var("ILO_VM_TEST");
         }
@@ -16271,7 +16397,7 @@ mod tests {
         let result = vm_run(
             source,
             Some("f"),
-            vec![Value::Text("ILO_VM_NONEXIST_999".into())],
+            vec![Value::Text(Arc::new("ILO_VM_NONEXIST_999".to_string()))],
         );
         let Value::Err(inner) = result else {
             panic!("expected Err")
@@ -16385,13 +16511,13 @@ mod tests {
             source,
             Some("f"),
             vec![
-                Value::Text(r#"{"name":"alice"}"#.to_string()),
-                Value::Text("name".to_string()),
+                Value::Text(Arc::new(r#"{"name":"alice"}"#.to_string())),
+                Value::Text(Arc::new("name".to_string())),
             ],
         );
         assert_eq!(
             result,
-            Value::Ok(Box::new(Value::Text("alice".to_string())))
+            Value::Ok(Box::new(Value::Text(Arc::new("alice".to_string()))))
         );
     }
 
@@ -16402,11 +16528,14 @@ mod tests {
             source,
             Some("f"),
             vec![
-                Value::Text(r#"{"user":{"name":"bob"}}"#.to_string()),
-                Value::Text("user.name".to_string()),
+                Value::Text(Arc::new(r#"{"user":{"name":"bob"}}"#.to_string())),
+                Value::Text(Arc::new("user.name".to_string())),
             ],
         );
-        assert_eq!(result, Value::Ok(Box::new(Value::Text("bob".to_string()))));
+        assert_eq!(
+            result,
+            Value::Ok(Box::new(Value::Text(Arc::new("bob".to_string()))))
+        );
     }
 
     #[test]
@@ -16416,11 +16545,14 @@ mod tests {
             source,
             Some("f"),
             vec![
-                Value::Text(r#"[10,20,30]"#.to_string()),
-                Value::Text("1".to_string()),
+                Value::Text(Arc::new(r#"[10,20,30]"#.to_string())),
+                Value::Text(Arc::new("1".to_string())),
             ],
         );
-        assert_eq!(result, Value::Ok(Box::new(Value::Text("20".to_string()))));
+        assert_eq!(
+            result,
+            Value::Ok(Box::new(Value::Text(Arc::new("20".to_string()))))
+        );
     }
 
     #[test]
@@ -16430,8 +16562,8 @@ mod tests {
             source,
             Some("f"),
             vec![
-                Value::Text(r#"{"a":1}"#.to_string()),
-                Value::Text("b".to_string()),
+                Value::Text(Arc::new(r#"{"a":1}"#.to_string())),
+                Value::Text(Arc::new("b".to_string())),
             ],
         );
         let Value::Err(e) = result else {
@@ -16447,11 +16579,11 @@ mod tests {
             source,
             Some("f"),
             vec![
-                Value::Text(r#"{"x":"hello"}"#.to_string()),
-                Value::Text("x".to_string()),
+                Value::Text(Arc::new(r#"{"x":"hello"}"#.to_string())),
+                Value::Text(Arc::new("x".to_string())),
             ],
         );
-        assert_eq!(result, Value::Text("hello".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("hello".to_string())));
     }
 
     #[test]
@@ -16467,21 +16599,25 @@ mod tests {
     fn vm_jd_number() {
         let source = "f x:n>t;jdmp x";
         let result = vm_run(source, Some("f"), vec![Value::Number(42.0)]);
-        assert_eq!(result, Value::Text("42".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("42".to_string())));
     }
 
     #[test]
     fn vm_jd_text() {
         let source = r#"f x:t>t;jdmp x"#;
-        let result = vm_run(source, Some("f"), vec![Value::Text("hello".to_string())]);
-        assert_eq!(result, Value::Text(r#""hello""#.to_string()));
+        let result = vm_run(
+            source,
+            Some("f"),
+            vec![Value::Text(Arc::new("hello".to_string()))],
+        );
+        assert_eq!(result, Value::Text(Arc::new(r#""hello""#.to_string())));
     }
 
     #[test]
     fn vm_jd_list() {
         let source = "f>t;xs=[1, 2, 3];jdmp xs";
         let result = vm_run(source, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("[1,2,3]".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("[1,2,3]".to_string())));
     }
 
     #[test]
@@ -16512,7 +16648,7 @@ mod tests {
         let result = vm_run(
             source,
             Some("f"),
-            vec![Value::Text(r#"{"a":1,"b":"two"}"#.to_string())],
+            vec![Value::Text(Arc::new(r#"{"a":1,"b":"two"}"#.to_string()))],
         );
         let Value::Ok(inner) = result else {
             panic!("expected Ok")
@@ -16522,13 +16658,20 @@ mod tests {
         };
         assert_eq!(type_name, "json");
         assert_eq!(fields.get("a"), Some(&Value::Number(1.0)));
-        assert_eq!(fields.get("b"), Some(&Value::Text("two".to_string())));
+        assert_eq!(
+            fields.get("b"),
+            Some(&Value::Text(Arc::new("two".to_string())))
+        );
     }
 
     #[test]
     fn vm_jparse_array() {
         let source = r#"f j:t>R t t;jpar j"#;
-        let result = vm_run(source, Some("f"), vec![Value::Text("[1,2,3]".to_string())]);
+        let result = vm_run(
+            source,
+            Some("f"),
+            vec![Value::Text(Arc::new("[1,2,3]".to_string()))],
+        );
         let Value::Ok(inner) = result else {
             panic!("expected Ok")
         };
@@ -16545,7 +16688,11 @@ mod tests {
     #[test]
     fn vm_jparse_invalid() {
         let source = r#"f j:t>R t t;jpar j"#;
-        let result = vm_run(source, Some("f"), vec![Value::Text("not json".to_string())]);
+        let result = vm_run(
+            source,
+            Some("f"),
+            vec![Value::Text(Arc::new("not json".to_string()))],
+        );
         assert!(matches!(result, Value::Err(_)));
     }
 
@@ -16555,7 +16702,7 @@ mod tests {
         let result = vm_run(
             source,
             Some("f"),
-            vec![Value::Text(r#"{"x":1}"#.to_string())],
+            vec![Value::Text(Arc::new(r#"{"x":1}"#.to_string()))],
         );
         let Value::Record { type_name, fields } = result else {
             panic!("expected record")
@@ -16579,7 +16726,7 @@ mod tests {
         let result = vm_run(
             source,
             Some("f"),
-            vec![Value::Text(r#"{"x":42}"#.to_string())],
+            vec![Value::Text(Arc::new(r#"{"x":42}"#.to_string()))],
         );
         assert_eq!(result, Value::Number(42.0));
     }
@@ -16591,21 +16738,29 @@ mod tests {
         let result = vm_run(
             "f s:t>t;trm s",
             Some("f"),
-            vec![Value::Text("  hello  ".into())],
+            vec![Value::Text(Arc::new("  hello  ".to_string()))],
         );
-        assert_eq!(result, Value::Text("hello".into()));
+        assert_eq!(result, Value::Text(Arc::new("hello".to_string())));
     }
 
     #[test]
     fn vm_trm_no_whitespace() {
-        let result = vm_run("f s:t>t;trm s", Some("f"), vec![Value::Text("hi".into())]);
-        assert_eq!(result, Value::Text("hi".into()));
+        let result = vm_run(
+            "f s:t>t;trm s",
+            Some("f"),
+            vec![Value::Text(Arc::new("hi".to_string()))],
+        );
+        assert_eq!(result, Value::Text(Arc::new("hi".to_string())));
     }
 
     #[test]
     fn vm_trm_only_whitespace() {
-        let result = vm_run("f s:t>t;trm s", Some("f"), vec![Value::Text("   ".into())]);
-        assert_eq!(result, Value::Text("".into()));
+        let result = vm_run(
+            "f s:t>t;trm s",
+            Some("f"),
+            vec![Value::Text(Arc::new("   ".to_string()))],
+        );
+        assert_eq!(result, Value::Text(Arc::new("".to_string())));
     }
 
     #[test]
@@ -16626,9 +16781,9 @@ mod tests {
         let result = vm_run(
             "f s:t>t;unq s",
             Some("f"),
-            vec![Value::Text("aabbc".into())],
+            vec![Value::Text(Arc::new("aabbc".to_string()))],
         );
-        assert_eq!(result, Value::Text("abc".into()));
+        assert_eq!(result, Value::Text(Arc::new("abc".to_string())));
     }
 
     #[test]
@@ -16661,19 +16816,19 @@ mod tests {
             "f xs:L t>L t;unq xs",
             Some("f"),
             vec![Value::List(Arc::new(vec![
-                Value::Text("a".into()),
-                Value::Text("b".into()),
-                Value::Text("a".into()),
-                Value::Text("c".into()),
-                Value::Text("b".into()),
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("c".to_string())),
+                Value::Text(Arc::new("b".to_string())),
             ]))],
         );
         assert_eq!(
             result,
             Value::List(Arc::new(vec![
-                Value::Text("a".into()),
-                Value::Text("b".into()),
-                Value::Text("c".into()),
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+                Value::Text(Arc::new("c".to_string())),
             ]))
         );
     }
@@ -16737,7 +16892,9 @@ mod tests {
         let result = vm_run(
             "f p:t>t;rd p",
             Some("f"),
-            vec![Value::Text("/nonexistent/ilo_test.txt".into())],
+            vec![Value::Text(Arc::new(
+                "/nonexistent/ilo_test.txt".to_string(),
+            ))],
         );
         assert!(
             matches!(result, Value::Err(_)),
@@ -16808,9 +16965,9 @@ mod tests {
         assert_eq!(
             result,
             Value::List(Arc::new(vec![
-                Value::Text("a".into()),
-                Value::Text("b".into()),
-                Value::Text("c".into()),
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+                Value::Text(Arc::new("c".to_string())),
             ]))
         );
     }
@@ -16888,7 +17045,7 @@ mod tests {
             Some("f"),
             vec![],
         );
-        assert_eq!(result, Value::Text("third".into()));
+        assert_eq!(result, Value::Text(Arc::new("third".to_string())));
     }
 
     #[test]
@@ -16902,7 +17059,7 @@ mod tests {
             Some("f"),
             vec![],
         );
-        assert_eq!(result, Value::Text("one".into()));
+        assert_eq!(result, Value::Text(Arc::new("one".to_string())));
     }
 
     #[test]
@@ -16914,7 +17071,7 @@ mod tests {
             Some("f"),
             vec![],
         );
-        assert_eq!(result, Value::Text("miss".into()));
+        assert_eq!(result, Value::Text(Arc::new("miss".to_string())));
     }
 
     #[test]
@@ -16959,7 +17116,11 @@ mod tests {
 
     #[test]
     fn vm_hd_empty_text_is_error() {
-        let err = vm_run_err("f s:t>t;hd s", Some("f"), vec![Value::Text(String::new())]);
+        let err = vm_run_err(
+            "f s:t>t;hd s",
+            Some("f"),
+            vec![Value::Text(Arc::new(String::new()))],
+        );
         assert!(err.contains("hd"), "expected hd error, got: {err}");
     }
 
@@ -16975,7 +17136,11 @@ mod tests {
 
     #[test]
     fn vm_tl_empty_text_is_error() {
-        let err = vm_run_err("f s:t>t;tl s", Some("f"), vec![Value::Text(String::new())]);
+        let err = vm_run_err(
+            "f s:t>t;tl s",
+            Some("f"),
+            vec![Value::Text(Arc::new(String::new()))],
+        );
         assert!(err.contains("tl"), "expected tl error, got: {err}");
     }
 
@@ -16986,7 +17151,7 @@ mod tests {
             Some("f"),
             vec![Value::List(Arc::new(vec![
                 Value::Number(1.0),
-                Value::Text("a".into()),
+                Value::Text(Arc::new("a".to_string())),
             ]))],
         );
         assert!(err.contains("srt"), "expected srt error, got: {err}");
@@ -16998,12 +17163,12 @@ mod tests {
             "f items:L t>t;cat items \"\"",
             Some("f"),
             vec![Value::List(Arc::new(vec![
-                Value::Text("a".into()),
-                Value::Text("b".into()),
-                Value::Text("c".into()),
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+                Value::Text(Arc::new("c".to_string())),
             ]))],
         );
-        assert_eq!(result, Value::Text("abc".into()));
+        assert_eq!(result, Value::Text(Arc::new("abc".to_string())));
     }
 
     #[test]
@@ -17085,7 +17250,7 @@ mod tests {
     #[test]
     fn vm_srt_text_chars() {
         let result = vm_run(r#"f>t;srt "bac""#, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("abc".into()));
+        assert_eq!(result, Value::Text(Arc::new("abc".to_string())));
     }
 
     // ── RDL / WR ──
@@ -17095,7 +17260,9 @@ mod tests {
         let result = vm_run(
             "f p:t>t;rdl p",
             Some("f"),
-            vec![Value::Text("/nonexistent/ilo_rdl_test.txt".into())],
+            vec![Value::Text(Arc::new(
+                "/nonexistent/ilo_rdl_test.txt".to_string(),
+            ))],
         );
         assert!(
             matches!(result, Value::Err(_)),
@@ -17107,7 +17274,11 @@ mod tests {
     fn vm_wr_and_rdl_roundtrip() {
         let path = "/tmp/ilo_vm_rdl_test.txt";
         std::fs::write(path, "line1\nline2\n").unwrap();
-        let result = vm_run("f p:t>t;rdl p", Some("f"), vec![Value::Text(path.into())]);
+        let result = vm_run(
+            "f p:t>t;rdl p",
+            Some("f"),
+            vec![Value::Text(Arc::new(path.into()))],
+        );
         let Value::Ok(inner) = result else {
             panic!("expected Ok")
         };
@@ -17115,7 +17286,7 @@ mod tests {
             panic!("expected List inside Ok")
         };
         assert_eq!(lines.len(), 2);
-        assert_eq!(lines[0], Value::Text("line1".into()));
+        assert_eq!(lines[0], Value::Text(Arc::new("line1".to_string())));
         let _ = std::fs::remove_file(path);
     }
 
@@ -17129,7 +17300,11 @@ mod tests {
             Value::Bool(true)
         );
         assert_eq!(
-            vm_run(src, Some("f"), vec![Value::Text("hi".into())]),
+            vm_run(
+                src,
+                Some("f"),
+                vec![Value::Text(Arc::new("hi".to_string()))]
+            ),
             Value::Bool(false)
         );
     }
@@ -17138,7 +17313,11 @@ mod tests {
     fn vm_type_check_istext_match() {
         let src = r#"f x:n>b;?x{t _:true;_:false}"#;
         assert_eq!(
-            vm_run(src, Some("f"), vec![Value::Text("hello".into())]),
+            vm_run(
+                src,
+                Some("f"),
+                vec![Value::Text(Arc::new("hello".to_string()))]
+            ),
             Value::Bool(true)
         );
         assert_eq!(
@@ -17186,7 +17365,7 @@ mod tests {
             Value::Number(99.0)
         );
         assert_eq!(
-            vm_run(src, Some("f"), vec![Value::Text("x".into())]),
+            vm_run(src, Some("f"), vec![Value::Text(Arc::new("x".to_string()))]),
             Value::Number(0.0)
         );
     }
@@ -17196,12 +17375,16 @@ mod tests {
         // t v: binds the value if it's text
         let src = r#"f x:n>t;?x{t v:v;_:"nope"}"#;
         assert_eq!(
-            vm_run(src, Some("f"), vec![Value::Text("yes".into())]),
-            Value::Text("yes".into())
+            vm_run(
+                src,
+                Some("f"),
+                vec![Value::Text(Arc::new("yes".to_string()))]
+            ),
+            Value::Text(Arc::new("yes".to_string()))
         );
         assert_eq!(
             vm_run(src, Some("f"), vec![Value::Number(1.0)]),
-            Value::Text("nope".into())
+            Value::Text(Arc::new("nope".to_string()))
         );
     }
 
@@ -17251,7 +17434,10 @@ mod tests {
         let err = vm_run_err(
             "f j:n p:t>R t t;jpth j p",
             Some("f"),
-            vec![Value::Number(42.0), Value::Text("key".into())],
+            vec![
+                Value::Number(42.0),
+                Value::Text(Arc::new("key".to_string())),
+            ],
         );
         assert!(err.contains("jpth") || err.contains("string"), "got: {err}");
     }
@@ -17261,7 +17447,7 @@ mod tests {
         let err = vm_run_err(
             r#"f j:t p:n>R t t;jpth j p"#,
             Some("f"),
-            vec![Value::Text("{}".into()), Value::Number(1.0)],
+            vec![Value::Text(Arc::new("{}".to_string())), Value::Number(1.0)],
         );
         assert!(err.contains("jpth") || err.contains("string"), "got: {err}");
     }
@@ -17304,7 +17490,10 @@ mod tests {
         let err = vm_run_err(
             "f x:n c:t>R t t;wr x c",
             Some("f"),
-            vec![Value::Number(42.0), Value::Text("content".into())],
+            vec![
+                Value::Number(42.0),
+                Value::Text(Arc::new("content".to_string())),
+            ],
         );
         assert!(
             err.contains("wr") || err.contains("text") || err.contains("string"),
@@ -17317,7 +17506,10 @@ mod tests {
         let err = vm_run_err(
             "f p:t x:n>R t t;wr p x",
             Some("f"),
-            vec![Value::Text("/tmp/test".into()), Value::Number(42.0)],
+            vec![
+                Value::Text(Arc::new("/tmp/test".to_string())),
+                Value::Number(42.0),
+            ],
         );
         assert!(
             err.contains("wr") || err.contains("text") || err.contains("string"),
@@ -17332,7 +17524,7 @@ mod tests {
             Some("f"),
             vec![
                 Value::Number(42.0),
-                Value::List(Arc::new(vec![Value::Text("a".into())])),
+                Value::List(Arc::new(vec![Value::Text(Arc::new("a".to_string()))])),
             ],
         );
         assert!(
@@ -17349,8 +17541,8 @@ mod tests {
             "f p:t c:t>R t t;wr p c",
             Some("f"),
             vec![
-                Value::Text(path_str.into()),
-                Value::Text("hello from ilo".into()),
+                Value::Text(Arc::new(path_str.into())),
+                Value::Text(Arc::new("hello from ilo".to_string())),
             ],
         );
         assert!(
@@ -17370,10 +17562,10 @@ mod tests {
             "f p:t xs:L t>R t t;wrl p xs",
             Some("f"),
             vec![
-                Value::Text(path_str.into()),
+                Value::Text(Arc::new(path_str.into())),
                 Value::List(Arc::new(vec![
-                    Value::Text("line1".into()),
-                    Value::Text("line2".into()),
+                    Value::Text(Arc::new("line1".to_string())),
+                    Value::Text(Arc::new("line2".to_string())),
                 ])),
             ],
         );
@@ -17419,7 +17611,7 @@ mod tests {
         let result = vm_run(
             "f p:t>R t t;rd p",
             Some("f"),
-            vec![Value::Text(path.into())],
+            vec![Value::Text(Arc::new(path.into()))],
         );
         assert!(
             matches!(result, Value::Ok(_)),
@@ -17435,7 +17627,7 @@ mod tests {
         let result = vm_run(
             "f p:t>R t t;rd p",
             Some("f"),
-            vec![Value::Text(path.into())],
+            vec![Value::Text(Arc::new(path.into()))],
         );
         assert!(
             matches!(result, Value::Ok(_)),
@@ -17469,7 +17661,10 @@ mod tests {
         let result = vm_run(
             "f a:t b:t>b;>a b",
             Some("f"),
-            vec![Value::Text("b".into()), Value::Text("a".into())],
+            vec![
+                Value::Text(Arc::new("b".to_string())),
+                Value::Text(Arc::new("a".to_string())),
+            ],
         );
         assert_eq!(result, Value::Bool(true));
     }
@@ -17479,7 +17674,10 @@ mod tests {
         let result = vm_run(
             "f a:t b:t>b;<a b",
             Some("f"),
-            vec![Value::Text("a".into()), Value::Text("b".into())],
+            vec![
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+            ],
         );
         assert_eq!(result, Value::Bool(true));
     }
@@ -17489,7 +17687,10 @@ mod tests {
         let result = vm_run(
             "f a:t b:t>b;>=a b",
             Some("f"),
-            vec![Value::Text("a".into()), Value::Text("a".into())],
+            vec![
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("a".to_string())),
+            ],
         );
         assert_eq!(result, Value::Bool(true));
     }
@@ -17499,7 +17700,10 @@ mod tests {
         let result = vm_run(
             "f a:t b:t>b;<=a b",
             Some("f"),
-            vec![Value::Text("a".into()), Value::Text("b".into())],
+            vec![
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+            ],
         );
         assert_eq!(result, Value::Bool(true));
     }
@@ -17544,7 +17748,7 @@ mod tests {
             Some("f"),
             vec![
                 Value::List(Arc::new(vec![Value::Number(1.0)])),
-                Value::Text(",".into()),
+                Value::Text(Arc::new(",".to_string())),
             ],
         );
         assert!(err.contains("cat") || err.contains("text"), "got: {err}");
@@ -17555,7 +17759,7 @@ mod tests {
         let err = vm_run_err(
             "f x:n sep:t>L t;spl x sep",
             Some("f"),
-            vec![Value::Number(42.0), Value::Text(",".into())],
+            vec![Value::Number(42.0), Value::Text(Arc::new(",".to_string()))],
         );
         assert!(err.contains("spl") || err.contains("text"), "got: {err}");
     }
@@ -17601,7 +17805,10 @@ mod tests {
         let err = vm_run_err(
             "f s:t x:n>b;has s x",
             Some("f"),
-            vec![Value::Text("hello".into()), Value::Number(42.0)],
+            vec![
+                Value::Text(Arc::new("hello".to_string())),
+                Value::Number(42.0),
+            ],
         );
         assert!(err.contains("has") || err.contains("text"), "got: {err}");
     }
@@ -17648,7 +17855,10 @@ mod tests {
         let err = vm_run_err(
             r#"f s:t sep:t>t;cat s sep"#,
             Some("f"),
-            vec![Value::Text("hello".into()), Value::Text(",".into())],
+            vec![
+                Value::Text(Arc::new("hello".to_string())),
+                Value::Text(Arc::new(",".to_string())),
+            ],
         );
         assert!(err.contains("cat") || err.contains("list"), "got: {err}");
     }
@@ -17658,7 +17868,11 @@ mod tests {
     #[test]
     fn vm_not_on_non_empty_text_is_false() {
         // !"hello" → truthy, so !truthy = false
-        let result = vm_run(r#"f s:t>b;!s"#, Some("f"), vec![Value::Text("hi".into())]);
+        let result = vm_run(
+            r#"f s:t>b;!s"#,
+            Some("f"),
+            vec![Value::Text(Arc::new("hi".to_string()))],
+        );
         assert_eq!(result, Value::Bool(false));
     }
 
@@ -17680,7 +17894,7 @@ mod tests {
         let err = vm_run_err(
             r#"f x:t>n;neg x"#,
             Some("f"),
-            vec![Value::Text("hi".into())],
+            vec![Value::Text(Arc::new("hi".to_string()))],
         );
         assert!(
             err.contains("neg") || err.contains("number") || err.contains("n"),
@@ -17707,7 +17921,7 @@ mod tests {
             Some("f"),
             vec![Value::Number(5.0)],
         );
-        assert_eq!(result, Value::Text("default".into()));
+        assert_eq!(result, Value::Text(Arc::new("default".to_string())));
     }
 
     // --- OP_ABS error path ---
@@ -17717,7 +17931,7 @@ mod tests {
         let err = vm_run_err(
             r#"f x:t>n;abs x"#,
             Some("f"),
-            vec![Value::Text("hi".into())],
+            vec![Value::Text(Arc::new("hi".to_string()))],
         );
         assert!(err.contains("abs") || err.contains("number"), "got: {err}");
     }
@@ -17729,7 +17943,7 @@ mod tests {
         let err = vm_run_err(
             r#"f x:t>n;flr x"#,
             Some("f"),
-            vec![Value::Text("hi".into())],
+            vec![Value::Text(Arc::new("hi".to_string()))],
         );
         assert!(err.contains("flr") || err.contains("number"), "got: {err}");
     }
@@ -17739,7 +17953,7 @@ mod tests {
         let err = vm_run_err(
             r#"f x:t>n;cel x"#,
             Some("f"),
-            vec![Value::Text("hi".into())],
+            vec![Value::Text(Arc::new("hi".to_string()))],
         );
         assert!(err.contains("cel") || err.contains("number"), "got: {err}");
     }
@@ -17751,7 +17965,10 @@ mod tests {
         let err = vm_run_err(
             r#"f x:t y:t>n;min x y"#,
             Some("f"),
-            vec![Value::Text("a".into()), Value::Text("b".into())],
+            vec![
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+            ],
         );
         assert!(err.contains("min") || err.contains("number"), "got: {err}");
     }
@@ -17779,7 +17996,7 @@ mod tests {
         let src = r#"f x:n>t;?x{42:"found";_:"other"}"#;
         assert_eq!(
             vm_run(src, Some("f"), vec![Value::Number(42.0)]),
-            Value::Text("found".into())
+            Value::Text(Arc::new("found".to_string()))
         );
     }
 
@@ -17789,7 +18006,7 @@ mod tests {
         let src = r#"f x:n>t;?x{42:"found";_:"other"}"#;
         assert_eq!(
             vm_run(src, Some("f"), vec![Value::Number(7.0)]),
-            Value::Text("other".into())
+            Value::Text(Arc::new("other".to_string()))
         );
     }
 
@@ -17799,11 +18016,11 @@ mod tests {
         let src = r#"f x:n>t;?x{1:"one";2:"two";3:"three";_:"many"}"#;
         assert_eq!(
             vm_run(src, Some("f"), vec![Value::Number(2.0)]),
-            Value::Text("two".into())
+            Value::Text(Arc::new("two".to_string()))
         );
         assert_eq!(
             vm_run(src, Some("f"), vec![Value::Number(99.0)]),
-            Value::Text("many".into())
+            Value::Text(Arc::new("many".to_string()))
         );
     }
 
@@ -17814,7 +18031,7 @@ mod tests {
         let src = r#"f x:b>t;?x{true:"yes";false:"no"}"#;
         assert_eq!(
             vm_run(src, Some("f"), vec![Value::Bool(true)]),
-            Value::Text("yes".into())
+            Value::Text(Arc::new("yes".to_string()))
         );
     }
 
@@ -17823,7 +18040,7 @@ mod tests {
         let src = r#"f x:b>t;?x{true:"yes";false:"no"}"#;
         assert_eq!(
             vm_run(src, Some("f"), vec![Value::Bool(false)]),
-            Value::Text("no".into())
+            Value::Text(Arc::new("no".to_string()))
         );
     }
 
@@ -17833,7 +18050,10 @@ mod tests {
     fn vm_safe_field_on_record_non_nil_returns_value() {
         // type decl after function (known VM chunk ordering)
         let src = "f>t;p=rec name:\"alice\";p.?name\ntype rec{name:t}";
-        assert_eq!(vm_run(src, Some("f"), vec![]), Value::Text("alice".into()));
+        assert_eq!(
+            vm_run(src, Some("f"), vec![]),
+            Value::Text(Arc::new("alice".to_string()))
+        );
     }
 
     #[test]
@@ -17842,7 +18062,7 @@ mod tests {
         let src = "mk x:n>n;>=x 1{x}\nf>t;v=mk 0;v.?a.?b??\"default\"";
         assert_eq!(
             vm_run(src, Some("f"), vec![]),
-            Value::Text("default".into())
+            Value::Text(Arc::new("default".to_string()))
         );
     }
 
@@ -17862,14 +18082,17 @@ mod tests {
         let src = "mk x:n>n;>=x 1{x}\nf>t;v=mk 0;v??\"fallback\"";
         assert_eq!(
             vm_run(src, Some("f"), vec![]),
-            Value::Text("fallback".into())
+            Value::Text(Arc::new("fallback".to_string()))
         );
     }
 
     #[test]
     fn vm_nil_coalesce_text_non_nil_passes_through() {
         let src = "f>t;v=\"hello\";v??\"fallback\"";
-        assert_eq!(vm_run(src, Some("f"), vec![]), Value::Text("hello".into()));
+        assert_eq!(
+            vm_run(src, Some("f"), vec![]),
+            Value::Text(Arc::new("hello".to_string()))
+        );
     }
 
     // --- Break without expr in foreach ---
@@ -17900,8 +18123,10 @@ mod tests {
             src,
             Some("f"),
             vec![
-                Value::Text("http://ilo-lang-test-nonexistent.invalid/endpoint".into()),
-                Value::Text("{}".into()),
+                Value::Text(Arc::new(
+                    "http://ilo-lang-test-nonexistent.invalid/endpoint".to_string(),
+                )),
+                Value::Text(Arc::new("{}".to_string())),
             ],
         );
         assert!(
@@ -17935,7 +18160,9 @@ mod tests {
             vm_run(
                 src,
                 Some("f"),
-                vec![Value::Err(Box::new(Value::Text("oops".into())))]
+                vec![Value::Err(Box::new(Value::Text(Arc::new(
+                    "oops".to_string()
+                ))))]
             ),
             Value::Number(0.0)
         );
@@ -18005,7 +18232,7 @@ mod tests {
         // jdmp on a number parameter (not inline literal — exercises arg path)
         let source = "f x:n>t;jdmp x";
         let result = vm_run(source, Some("f"), vec![Value::Number(42.0)]);
-        assert_eq!(result, Value::Text("42".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("42".to_string())));
     }
 
     #[test]
@@ -18020,7 +18247,7 @@ mod tests {
                 Value::Number(2.0),
             ]))],
         );
-        assert_eq!(result, Value::Text("[1,2]".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("[1,2]".to_string())));
     }
 
     #[test]
@@ -18029,7 +18256,7 @@ mod tests {
         // nil is obtained via mget on a missing key (mget returns nil for missing keys)
         let source = "f>t;m=mmap;v=mget m \"missing\";jdmp v";
         let result = vm_run(source, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("null".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("null".to_string())));
     }
 
     // --- OP_HAS with map heap object returns error ---
@@ -18060,11 +18287,11 @@ mod tests {
                     let mut m = std::collections::HashMap::new();
                     m.insert(
                         crate::interpreter::MapKey::Text("x".to_string()),
-                        Value::Text("1".to_string()),
+                        Value::Text(Arc::new("1".to_string())),
                     );
                     m
                 })),
-                Value::Text("x".to_string()),
+                Value::Text(Arc::new("x".to_string())),
             ],
         );
         assert!(
@@ -18083,7 +18310,7 @@ mod tests {
             Some("f"),
             vec![
                 Value::List(Arc::new(vec![Value::Number(1.0), Value::Number(2.0)])),
-                Value::Text(" ".to_string()),
+                Value::Text(Arc::new(" ".to_string())),
             ],
         );
         // cat requires all elements to be text strings
@@ -18104,7 +18331,7 @@ mod tests {
             src,
             Some("f"),
             vec![
-                Value::Text("http://127.0.0.1:1".to_string()),
+                Value::Text(Arc::new("http://127.0.0.1:1".to_string())),
                 Value::Map(std::sync::Arc::new(std::collections::HashMap::new())),
             ],
         );
@@ -18125,8 +18352,8 @@ mod tests {
             src,
             Some("f"),
             vec![
-                Value::Text("http://127.0.0.1:1".to_string()),
-                Value::Text("{}".to_string()),
+                Value::Text(Arc::new("http://127.0.0.1:1".to_string())),
+                Value::Text(Arc::new("{}".to_string())),
                 Value::Map(std::sync::Arc::new(std::collections::HashMap::new())),
             ],
         );
@@ -18562,7 +18789,9 @@ mod tests {
 
         #[test]
         fn jit_iserr_on_err_value() {
-            let err_val = NanVal::from_value(&Value::Err(Box::new(Value::Text("oops".into()))));
+            let err_val = NanVal::from_value(&Value::Err(Box::new(Value::Text(Arc::new(
+                "oops".to_string(),
+            )))));
             let r = jit_iserr(err_val.0);
             assert!(as_bool(r));
         }
@@ -19340,7 +19569,7 @@ mod tests {
             Some("f"),
             vec![Value::List(Arc::new(vec![Value::Number(1.0)]))],
         );
-        assert_eq!(result, Value::Text("got list".into()));
+        assert_eq!(result, Value::Text(Arc::new("got list".to_string())));
     }
 
     // L1566: DIVK_N constant on right side
@@ -19463,7 +19692,7 @@ mod tests {
             Some("f"),
             vec![Value::Bool(true)],
         );
-        assert_eq!(result, Value::Text("bool".into()));
+        assert_eq!(result, Value::Text(Arc::new("bool".to_string())));
     }
 
     #[test]
@@ -19474,7 +19703,7 @@ mod tests {
             Some("f"),
             vec![Value::List(Arc::new(vec![]))],
         );
-        assert_eq!(result, Value::Text("list".into()));
+        assert_eq!(result, Value::Text(Arc::new("list".to_string())));
     }
 
     #[test]
@@ -19746,7 +19975,7 @@ mod tests {
             Some("f"),
             vec![],
         );
-        assert_eq!(result, Value::Text("alice".into()));
+        assert_eq!(result, Value::Text(Arc::new("alice".to_string())));
     }
 
     #[test]
@@ -19810,7 +20039,7 @@ mod tests {
         let result = vm_run(
             source,
             Some("f"),
-            vec![Value::Text(r#"{"x": 10, "y": 20}"#.to_string())],
+            vec![Value::Text(Arc::new(r#"{"x": 10, "y": 20}"#.to_string()))],
         );
         assert_eq!(result, Value::Number(20.0));
     }
@@ -19846,7 +20075,7 @@ mod tests {
             Some("f"),
             vec![],
         );
-        assert_eq!(result, Value::Text("widget".into()));
+        assert_eq!(result, Value::Text(Arc::new("widget".to_string())));
     }
 
     // Match with TypeIs pattern — "other" type branch fallback (L970)
@@ -19861,13 +20090,21 @@ mod tests {
             Value::Bool(true)
         );
         assert_eq!(
-            vm_run(num_src, Some("f"), vec![Value::Text("a".into())]),
+            vm_run(
+                num_src,
+                Some("f"),
+                vec![Value::Text(Arc::new("a".to_string()))]
+            ),
             Value::Bool(false)
         );
 
         let text_src = r#"f x:n>b;?x{t _:true;_:false}"#;
         assert_eq!(
-            vm_run(text_src, Some("f"), vec![Value::Text("x".into())]),
+            vm_run(
+                text_src,
+                Some("f"),
+                vec![Value::Text(Arc::new("x".to_string()))]
+            ),
             Value::Bool(true)
         );
         assert_eq!(
@@ -19923,7 +20160,7 @@ mod tests {
             Some("f"),
             vec![],
         );
-        assert_eq!(result, Value::Text("hello world".into()));
+        assert_eq!(result, Value::Text(Arc::new("hello world".to_string())));
     }
 
     // Guard ternary where both branches produce values via chained computations
@@ -19933,15 +20170,15 @@ mod tests {
         let src = r#"f x:n>t;>=x 10{"large"}{"small"}"#;
         assert_eq!(
             vm_run(src, Some("f"), vec![Value::Number(10.0)]),
-            Value::Text("large".into())
+            Value::Text(Arc::new("large".to_string()))
         );
         assert_eq!(
             vm_run(src, Some("f"), vec![Value::Number(5.0)]),
-            Value::Text("small".into())
+            Value::Text(Arc::new("small".to_string()))
         );
         assert_eq!(
             vm_run(src, Some("f"), vec![Value::Number(15.0)]),
-            Value::Text("large".into())
+            Value::Text(Arc::new("large".to_string()))
         );
     }
 
@@ -20217,7 +20454,7 @@ mod tests {
             Some("f"),
             vec![
                 Value::List(Arc::new(vec![Value::Number(1.0)])),
-                Value::Text("key".into()),
+                Value::Text(Arc::new("key".to_string())),
             ],
         );
         assert!(err.contains("mget") || err.contains("map"), "got: {err}");
@@ -20232,7 +20469,7 @@ mod tests {
             vec![
                 Value::Map(std::sync::Arc::new(std::collections::HashMap::new())),
                 Value::List(Arc::new(vec![Value::Number(1.0)])),
-                Value::Text("val".into()),
+                Value::Text(Arc::new("val".to_string())),
             ],
         );
         assert!(
@@ -20249,9 +20486,9 @@ mod tests {
             "f x:z k:t v:t>n;mset x k v",
             Some("f"),
             vec![
-                Value::Text("not-a-map".into()),
-                Value::Text("key".into()),
-                Value::Text("val".into()),
+                Value::Text(Arc::new("not-a-map".to_string())),
+                Value::Text(Arc::new("key".to_string())),
+                Value::Text(Arc::new("val".to_string())),
             ],
         );
         assert!(err.contains("mset") || err.contains("map"), "got: {err}");
@@ -20283,7 +20520,7 @@ mod tests {
             Some("f"),
             vec![
                 Value::List(Arc::new(vec![Value::Number(1.0)])),
-                Value::Text("k".into()),
+                Value::Text(Arc::new("k".to_string())),
             ],
         );
         assert!(err.contains("mhas") || err.contains("map"), "got: {err}");
@@ -20295,7 +20532,9 @@ mod tests {
         let err = vm_run_err(
             "f x:z>n;mkeys x",
             Some("f"),
-            vec![Value::List(Arc::new(vec![Value::Text("a".into())]))],
+            vec![Value::List(Arc::new(vec![Value::Text(Arc::new(
+                "a".to_string(),
+            ))]))],
         );
         assert!(err.contains("mkeys") || err.contains("map"), "got: {err}");
     }
@@ -20306,7 +20545,7 @@ mod tests {
         let err = vm_run_err(
             "f x:z>n;mvals x",
             Some("f"),
-            vec![Value::Text("not-a-map".into())],
+            vec![Value::Text(Arc::new("not-a-map".to_string()))],
         );
         assert!(err.contains("mvals") || err.contains("map"), "got: {err}");
     }
@@ -20336,7 +20575,7 @@ mod tests {
             Some("f"),
             vec![
                 Value::List(Arc::new(vec![Value::Number(1.0)])),
-                Value::Text("k".into()),
+                Value::Text(Arc::new("k".to_string())),
             ],
         );
         assert!(err.contains("mdel") || err.contains("map"), "got: {err}");
@@ -20352,7 +20591,7 @@ mod tests {
         let result = vm_run(
             "f p:t>R t t;rd p",
             Some("f"),
-            vec![Value::Text(path.into())],
+            vec![Value::Text(Arc::new(path.into()))],
         );
         assert!(
             matches!(result, Value::Err(_)),
@@ -20369,8 +20608,8 @@ mod tests {
             "f p:t c:t>R t t;wr p c",
             Some("f"),
             vec![
-                Value::Text("/nonexistent_dir_ilo/output.txt".into()),
-                Value::Text("hello".into()),
+                Value::Text(Arc::new("/nonexistent_dir_ilo/output.txt".to_string())),
+                Value::Text(Arc::new("hello".to_string())),
             ],
         );
         assert!(
@@ -20386,8 +20625,8 @@ mod tests {
             "f p:t xs:L t>R t t;wrl p xs",
             Some("f"),
             vec![
-                Value::Text("/nonexistent_dir_ilo/lines.txt".into()),
-                Value::List(Arc::new(vec![Value::Text("line1".into())])),
+                Value::Text(Arc::new("/nonexistent_dir_ilo/lines.txt".to_string())),
+                Value::List(Arc::new(vec![Value::Text(Arc::new("line1".to_string()))])),
             ],
         );
         assert!(
@@ -20403,8 +20642,8 @@ mod tests {
             "f p:t x:z>R t t;wrl p x",
             Some("f"),
             vec![
-                Value::Text("/tmp/ilo_wrl_nonlist.txt".into()),
-                Value::Text("not-a-list".into()),
+                Value::Text(Arc::new("/tmp/ilo_wrl_nonlist.txt".to_string())),
+                Value::Text(Arc::new("not-a-list".to_string())),
             ],
         );
         assert!(err.contains("wrl") || err.contains("list"), "got: {err}");
@@ -20464,7 +20703,7 @@ mod tests {
         let err = vm_run_err(
             "type pt{x:n} f r:z>n;r.x",
             Some("f"),
-            vec![Value::Text("not-a-record".into())],
+            vec![Value::Text(Arc::new("not-a-record".to_string()))],
         );
         assert!(
             err.contains("field")
@@ -20511,7 +20750,7 @@ mod tests {
         let err = vm_run_err(
             "f xs:z>n;@x xs{x};0",
             Some("f"),
-            vec![Value::Text("not-a-list".into())],
+            vec![Value::Text(Arc::new("not-a-list".to_string()))],
         );
         assert!(
             err.contains("list") || err.contains("foreach"),
@@ -20586,7 +20825,7 @@ mod tests {
             "f p:t xs:L n>R t t;wrl p xs",
             Some("f"),
             vec![
-                Value::Text("/tmp/ilo_wrl_elem.txt".into()),
+                Value::Text(Arc::new("/tmp/ilo_wrl_elem.txt".to_string())),
                 Value::List(Arc::new(vec![Value::Number(42.0)])),
             ],
         );
@@ -20611,7 +20850,7 @@ mod tests {
         let err = vm_run_err(
             "type pt{x:n;y:n} f r:z>n;q=r with x:5;q.x",
             Some("f"),
-            vec![Value::Text("not-a-record".into())],
+            vec![Value::Text(Arc::new("not-a-record".to_string()))],
         );
         assert!(
             err.contains("record") || err.contains("with") || err.contains("field"),
@@ -20627,7 +20866,7 @@ mod tests {
         let result = vm_run(
             r#"f s:t>R t t;jpth s "a""#,
             Some("f"),
-            vec![Value::Text("not json at all".into())],
+            vec![Value::Text(Arc::new("not json at all".to_string()))],
         );
         let Value::Err(_) = result else {
             panic!("expected Err")
@@ -20640,7 +20879,7 @@ mod tests {
         let result = vm_run(
             r#"f s:t>R t t;jpth s "a.5""#,
             Some("f"),
-            vec![Value::Text(r#"{"a":[1,2]}"#.into())],
+            vec![Value::Text(Arc::new(r#"{"a":[1,2]}"#.to_string()))],
         );
         let Value::Err(_) = result else {
             panic!("expected Err")
@@ -20655,7 +20894,9 @@ mod tests {
         let err = vm_run_err(
             r#"f xs:L t>t;cat xs 42"#,
             Some("f"),
-            vec![Value::List(Arc::new(vec![Value::Text("a".into())]))],
+            vec![Value::List(Arc::new(vec![Value::Text(Arc::new(
+                "a".to_string(),
+            ))]))],
         );
         assert!(err.contains("cat") || err.contains("text"), "got: {err}");
     }
@@ -20742,8 +20983,8 @@ mod tests {
             Some("f"),
             vec![
                 Value::List(Arc::new(vec![Value::Number(1.0), Value::Number(2.0)])),
-                Value::Text("a".into()),
-                Value::Text("b".into()),
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
             ],
         );
         assert!(
@@ -20771,7 +21012,7 @@ mod tests {
     #[test]
     fn vm_jdmp_float_number() {
         let result = vm_run("f>t;jdmp 3.14", Some("f"), vec![]);
-        assert_eq!(result, Value::Text("3.14".into()));
+        assert_eq!(result, Value::Text(Arc::new("3.14".to_string())));
     }
 
     // ── nanval_to_json heap record (lines 4216-4221) ─────────────────────────
@@ -20783,7 +21024,7 @@ mod tests {
         let result = vm_run(
             r#"f s:t>t;r=jpar! s;jdmp r"#,
             Some("f"),
-            vec![Value::Text(r#"{"x":10}"#.into())],
+            vec![Value::Text(Arc::new(r#"{"x":10}"#.to_string()))],
         );
         let Value::Text(s) = result else {
             panic!("expected Text")
@@ -20800,7 +21041,7 @@ mod tests {
         let result = vm_run(
             r#"f s:t>t;r=jpar s;jdmp r"#,
             Some("f"),
-            vec![Value::Text(r#"{"v":5}"#.into())],
+            vec![Value::Text(Arc::new(r#"{"v":5}"#.to_string()))],
         );
         let Value::Text(s) = result else {
             panic!("expected Text")
@@ -20826,14 +21067,14 @@ mod tests {
     #[test]
     fn vm_jdmp_bool_true() {
         let result = vm_run("f>t;jdmp true", Some("f"), vec![]);
-        assert_eq!(result, Value::Text("true".into()));
+        assert_eq!(result, Value::Text(Arc::new("true".to_string())));
     }
 
     // line 4207: jdmp on Bool false → "false"
     #[test]
     fn vm_jdmp_bool_false() {
         let result = vm_run("f>t;jdmp false", Some("f"), vec![]);
-        assert_eq!(result, Value::Text("false".into()));
+        assert_eq!(result, Value::Text(Arc::new("false".to_string())));
     }
 
     // ── nanval_to_json ErrVal (line 4224) ────────────────────────────────────
@@ -20845,7 +21086,7 @@ mod tests {
         let result = vm_run(
             r#"f s:t>t;e=jpar s;jdmp e"#,
             Some("f"),
-            vec![Value::Text("not json".into())],
+            vec![Value::Text(Arc::new("not json".to_string()))],
         );
         let Value::Text(_) = result else {
             panic!("expected Text")
@@ -20882,7 +21123,7 @@ mod tests {
         let Value::Ok(inner) = result else {
             panic!("expected Ok")
         };
-        assert_eq!(*inner, Value::Text("hello raw".into()));
+        assert_eq!(*inner, Value::Text(Arc::new("hello raw".to_string())));
     }
 
     // ── vm_parse_csv_row quoted fields (lines 4295-4306) ─────────────────────
@@ -21013,7 +21254,10 @@ mod tests {
         let err = vm_run_err(
             "f u:z b:z>R t t;post u b",
             Some("f"),
-            vec![Value::Number(1.0), Value::Text("body".into())],
+            vec![
+                Value::Number(1.0),
+                Value::Text(Arc::new("body".to_string())),
+            ],
         );
         assert!(
             err.contains("post") || err.contains("string") || err.contains("type"),
@@ -21046,7 +21290,7 @@ mod tests {
             Some("f"),
             vec![
                 Value::Number(1.0),
-                Value::Text("body".into()),
+                Value::Text(Arc::new("body".to_string())),
                 Value::Map(std::sync::Arc::new(std::collections::HashMap::new())),
             ],
         );
@@ -21374,11 +21618,11 @@ mod tests {
         let source = r#"f x:n>t;!=x 1{"not one"}{"one"}"#;
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Number(1.0)]),
-            Value::Text("one".into())
+            Value::Text(Arc::new("one".to_string()))
         );
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Number(2.0)]),
-            Value::Text("not one".into())
+            Value::Text(Arc::new("not one".to_string()))
         );
     }
 
@@ -21484,7 +21728,7 @@ mod tests {
         let source = r#"f>t;x=^"err";?x{~v:v;_:"default"}"#;
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
-            Value::Text("default".to_string())
+            Value::Text(Arc::new("default".to_string()))
         );
     }
 
@@ -21497,7 +21741,7 @@ mod tests {
             Some("f"),
             vec![Value::Number(42.0)],
         );
-        assert_eq!(result, Value::Text("num".into()));
+        assert_eq!(result, Value::Text(Arc::new("num".to_string())));
     }
 
     #[test]
@@ -21505,9 +21749,9 @@ mod tests {
         let result = vm_run(
             r#"f x:t>t;?x{t v:v;_:"other"}"#,
             Some("f"),
-            vec![Value::Text("hello".into())],
+            vec![Value::Text(Arc::new("hello".to_string()))],
         );
-        assert_eq!(result, Value::Text("hello".into()));
+        assert_eq!(result, Value::Text(Arc::new("hello".to_string())));
     }
 
     #[test]
@@ -21517,7 +21761,7 @@ mod tests {
             Some("f"),
             vec![Value::Bool(true)],
         );
-        assert_eq!(result, Value::Text("bool".into()));
+        assert_eq!(result, Value::Text(Arc::new("bool".to_string())));
     }
 
     #[test]
@@ -21527,7 +21771,7 @@ mod tests {
             Some("f"),
             vec![Value::List(Arc::new(vec![Value::Number(1.0)]))],
         );
-        assert_eq!(result, Value::Text("list".into()));
+        assert_eq!(result, Value::Text(Arc::new("list".to_string())));
     }
 
     #[test]
@@ -21537,7 +21781,7 @@ mod tests {
             Some("f"),
             vec![Value::Number(1.0)],
         );
-        assert_eq!(result, Value::Text("other".into()));
+        assert_eq!(result, Value::Text(Arc::new("other".to_string())));
     }
 
     #[test]
@@ -21547,7 +21791,7 @@ mod tests {
             Some("f"),
             vec![Value::Number(5.0)],
         );
-        assert_eq!(result, Value::Text("matched".into()));
+        assert_eq!(result, Value::Text(Arc::new("matched".to_string())));
     }
 
     #[test]
@@ -21571,7 +21815,7 @@ mod tests {
         let source = "f>t;xs=[\"hello\", \"world\"];xs.0";
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
-            Value::Text("hello".into())
+            Value::Text(Arc::new("hello".to_string()))
         );
     }
 
@@ -21616,7 +21860,7 @@ mod tests {
             "type usr{name:t;email:t} f>t;u=usr name:\"alice\" email:\"a@b\";{name;email}=u;name";
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
-            Value::Text("alice".to_string())
+            Value::Text(Arc::new("alice".to_string()))
         );
     }
 
@@ -21651,7 +21895,7 @@ mod tests {
         let source = "f>t;xs=[\"hello\", \"world\"];xs.1";
         assert_eq!(
             vm_run(source, Some("f"), vec![]),
-            Value::Text("world".into())
+            Value::Text(Arc::new("world".to_string()))
         );
     }
 
@@ -21667,9 +21911,12 @@ mod tests {
         let result = vm_run(
             source,
             Some("f"),
-            vec![Value::Text("ILO_TEST_UNWRAP_VM".into())],
+            vec![Value::Text(Arc::new("ILO_TEST_UNWRAP_VM".to_string()))],
         );
-        assert_eq!(result, Value::Ok(Box::new(Value::Text("world".into()))));
+        assert_eq!(
+            result,
+            Value::Ok(Box::new(Value::Text(Arc::new("world".to_string()))))
+        );
         unsafe {
             std::env::remove_var("ILO_TEST_UNWRAP_VM");
         }
@@ -21717,7 +21964,7 @@ mod tests {
         let err = vm_run_err(
             "f s:t>n;@i s..3{i}",
             Some("f"),
-            vec![Value::Text("a".into())],
+            vec![Value::Text(Arc::new("a".to_string()))],
         );
         assert!(
             err.contains("range")
@@ -21733,7 +21980,7 @@ mod tests {
         let err = vm_run_err(
             "f e:t>n;@i 0..e{i}",
             Some("f"),
-            vec![Value::Text("b".into())],
+            vec![Value::Text(Arc::new("b".to_string()))],
         );
         assert!(
             err.contains("range")
@@ -21760,7 +22007,7 @@ mod tests {
         let err = vm_run_err(
             r#"f x:t>n;abs x"#,
             Some("f"),
-            vec![Value::Text("hi".into())],
+            vec![Value::Text(Arc::new("hi".to_string()))],
         );
         assert!(
             err.contains("abs") || err.contains("number") || err.contains("type"),
@@ -21789,7 +22036,11 @@ mod tests {
 
     #[test]
     fn vm_err_cel_non_number() {
-        let err = vm_run_err(r#"f x:t>n;cel x"#, Some("f"), vec![Value::Text("a".into())]);
+        let err = vm_run_err(
+            r#"f x:t>n;cel x"#,
+            Some("f"),
+            vec![Value::Text(Arc::new("a".to_string()))],
+        );
         assert!(
             err.contains("cel") || err.contains("number") || err.contains("type"),
             "got: {err}"
@@ -21817,7 +22068,11 @@ mod tests {
 
     #[test]
     fn vm_err_flr_non_number() {
-        let err = vm_run_err(r#"f x:t>n;flr x"#, Some("f"), vec![Value::Text("a".into())]);
+        let err = vm_run_err(
+            r#"f x:t>n;flr x"#,
+            Some("f"),
+            vec![Value::Text(Arc::new("a".to_string()))],
+        );
         assert!(
             err.contains("flr") || err.contains("number") || err.contains("type"),
             "got: {err}"
@@ -21838,7 +22093,10 @@ mod tests {
         let err = vm_run_err(
             "f x:t y:n>b;has x y",
             Some("f"),
-            vec![Value::Text("hello".into()), Value::Number(1.0)],
+            vec![
+                Value::Text(Arc::new("hello".to_string())),
+                Value::Number(1.0),
+            ],
         );
         assert!(
             err.contains("has") || err.contains("text") || err.contains("needle"),
@@ -21932,7 +22190,10 @@ mod tests {
         let err = vm_run_err(
             r#"f a:t b:t>n;max a b"#,
             Some("f"),
-            vec![Value::Text("a".into()), Value::Text("b".into())],
+            vec![
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+            ],
         );
         assert!(
             err.contains("max") || err.contains("number") || err.contains("type"),
@@ -21945,7 +22206,10 @@ mod tests {
         let err = vm_run_err(
             r#"f a:t b:t>n;min a b"#,
             Some("f"),
-            vec![Value::Text("a".into()), Value::Text("b".into())],
+            vec![
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+            ],
         );
         assert!(
             err.contains("min") || err.contains("number") || err.contains("type"),
@@ -21994,7 +22258,10 @@ mod tests {
         let err = vm_run_err(
             "f x:t y:t>n;rnd x y",
             Some("f"),
-            vec![Value::Text("a".into()), Value::Text("b".into())],
+            vec![
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+            ],
         );
         assert!(
             err.contains("rnd") || err.contains("number") || err.contains("type"),
@@ -22008,7 +22275,10 @@ mod tests {
         let err = vm_run_err(
             "f x:t y:t>t;slc x 0 y",
             Some("f"),
-            vec![Value::Text("hi".into()), Value::Text("a".into())],
+            vec![
+                Value::Text(Arc::new("hi".to_string())),
+                Value::Text(Arc::new("a".to_string())),
+            ],
         );
         assert!(
             err.contains("slc")
@@ -22024,7 +22294,10 @@ mod tests {
         let err = vm_run_err(
             "f x:t y:t>t;slc x y 1",
             Some("f"),
-            vec![Value::Text("hi".into()), Value::Text("a".into())],
+            vec![
+                Value::Text(Arc::new("hi".to_string())),
+                Value::Text(Arc::new("a".to_string())),
+            ],
         );
         assert!(
             err.contains("slc")
@@ -22052,7 +22325,7 @@ mod tests {
         let err = vm_run_err(
             "f x:n y:t>L t;spl x y",
             Some("f"),
-            vec![Value::Number(1.0), Value::Text("a".into())],
+            vec![Value::Number(1.0), Value::Text(Arc::new("a".to_string()))],
         );
         assert!(
             err.contains("spl") || err.contains("text") || err.contains("type"),
@@ -22065,7 +22338,7 @@ mod tests {
         let err = vm_run_err(
             "f x:t y:n>L t;spl x y",
             Some("f"),
-            vec![Value::Text("a-b".into()), Value::Number(1.0)],
+            vec![Value::Text(Arc::new("a-b".to_string())), Value::Number(1.0)],
         );
         assert!(
             err.contains("spl") || err.contains("text") || err.contains("type"),
@@ -22108,7 +22381,7 @@ mod tests {
         let err = vm_run_err(
             r#"f x:t>t;str x"#,
             Some("f"),
-            vec![Value::Text("hi".into())],
+            vec![Value::Text(Arc::new("hi".to_string()))],
         );
         assert!(
             err.contains("str") || err.contains("number") || err.contains("type"),
@@ -22221,7 +22494,7 @@ mod tests {
             source,
             Some("f"),
             vec![
-                Value::Text("sq".into()),
+                Value::Text(Arc::new("sq".to_string())),
                 Value::List(Arc::new(vec![Value::Number(3.0)])),
             ],
         );
@@ -22567,7 +22840,9 @@ mod tests {
         let err = vm_run_err(
             "f xs:L n>n;avg xs",
             Some("f"),
-            vec![Value::List(Arc::new(vec![Value::Text("x".into())]))],
+            vec![Value::List(Arc::new(vec![Value::Text(Arc::new(
+                "x".to_string(),
+            ))]))],
         );
         assert!(err.contains("avg") || err.contains("number"), "got: {err}");
     }
@@ -22628,17 +22903,17 @@ mod tests {
             source,
             Some("main"),
             vec![Value::List(Arc::new(vec![
-                Value::Text("banana".into()),
-                Value::Text("a".into()),
-                Value::Text("cc".into()),
+                Value::Text(Arc::new("banana".to_string())),
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("cc".to_string())),
             ]))],
         );
         assert_eq!(
             result,
             Value::List(Arc::new(vec![
-                Value::Text("a".into()),
-                Value::Text("cc".into()),
-                Value::Text("banana".into()),
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("cc".to_string())),
+                Value::Text(Arc::new("banana".to_string())),
             ]))
         );
     }
@@ -22674,17 +22949,17 @@ mod tests {
             source,
             Some("main"),
             vec![Value::List(Arc::new(vec![
-                Value::Text("banana".into()),
-                Value::Text("apple".into()),
-                Value::Text("cherry".into()),
+                Value::Text(Arc::new("banana".to_string())),
+                Value::Text(Arc::new("apple".to_string())),
+                Value::Text(Arc::new("cherry".to_string())),
             ]))],
         );
         assert_eq!(
             result,
             Value::List(Arc::new(vec![
-                Value::Text("apple".into()),
-                Value::Text("banana".into()),
-                Value::Text("cherry".into()),
+                Value::Text(Arc::new("apple".to_string())),
+                Value::Text(Arc::new("banana".to_string())),
+                Value::Text(Arc::new("cherry".to_string())),
             ]))
         );
     }
@@ -22714,7 +22989,7 @@ mod tests {
     fn vm_srt_text_string() {
         assert_eq!(
             vm_run(r#"f>t;srt "cab""#, Some("f"), vec![]),
-            Value::Text("abc".into())
+            Value::Text(Arc::new("abc".to_string()))
         );
     }
 
@@ -22756,16 +23031,16 @@ mod tests {
             "f xs:L t>L t;unq xs",
             Some("f"),
             vec![Value::List(Arc::new(vec![
-                Value::Text("a".into()),
-                Value::Text("b".into()),
-                Value::Text("a".into()),
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+                Value::Text(Arc::new("a".to_string())),
             ]))],
         );
         assert_eq!(
             result,
             Value::List(Arc::new(vec![
-                Value::Text("a".into()),
-                Value::Text("b".into())
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string()))
             ]))
         );
     }
@@ -22776,9 +23051,9 @@ mod tests {
             vm_run(
                 "f s:t>t;unq s",
                 Some("f"),
-                vec![Value::Text("aabbc".into())]
+                vec![Value::Text(Arc::new("aabbc".to_string()))]
             ),
-            Value::Text("abc".into())
+            Value::Text(Arc::new("abc".to_string()))
         );
     }
 
@@ -22802,9 +23077,12 @@ mod tests {
         let result = vm_run(
             r#"f a:t b:t>t;fmt "{} + {}" a b"#,
             Some("f"),
-            vec![Value::Text("1".into()), Value::Text("2".into())],
+            vec![
+                Value::Text(Arc::new("1".to_string())),
+                Value::Text(Arc::new("2".to_string())),
+            ],
         );
-        assert_eq!(result, Value::Text("1 + 2".into()));
+        assert_eq!(result, Value::Text(Arc::new("1 + 2".to_string())));
     }
 
     #[test]
@@ -22812,7 +23090,7 @@ mod tests {
     fn vm_fmt_template_only() {
         assert_eq!(
             vm_run(r#"f>t;fmt "hello""#, Some("f"), vec![]),
-            Value::Text("hello".into())
+            Value::Text(Arc::new("hello".to_string()))
         );
     }
 
@@ -22822,9 +23100,9 @@ mod tests {
         let result = vm_run(
             r#"f a:t>t;fmt "{} and {}" a"#,
             Some("f"),
-            vec![Value::Text("x".into())],
+            vec![Value::Text(Arc::new("x".to_string()))],
         );
-        assert_eq!(result, Value::Text("x and {}".into()));
+        assert_eq!(result, Value::Text(Arc::new("x and {}".to_string())));
     }
 
     #[test]
@@ -22835,7 +23113,7 @@ mod tests {
             Some("f"),
             vec![Value::Number(42.0)],
         );
-        assert_eq!(result, Value::Text("value: 42".into()));
+        assert_eq!(result, Value::Text(Arc::new("value: 42".to_string())));
     }
 
     #[test]
@@ -22853,8 +23131,12 @@ mod tests {
     #[ignore] // VM missing builtin implementation
     fn vm_prnt_text_passthrough() {
         assert_eq!(
-            vm_run("f s:t>t;prnt s", Some("f"), vec![Value::Text("hi".into())]),
-            Value::Text("hi".into())
+            vm_run(
+                "f s:t>t;prnt s",
+                Some("f"),
+                vec![Value::Text(Arc::new("hi".to_string()))]
+            ),
+            Value::Text(Arc::new("hi".to_string()))
         );
     }
 
@@ -22867,13 +23149,13 @@ mod tests {
         let result = vm_run(
             source,
             Some("f"),
-            vec![Value::Text("abc 123 def 456".into())],
+            vec![Value::Text(Arc::new("abc 123 def 456".to_string()))],
         );
         assert_eq!(
             result,
             Value::List(Arc::new(vec![
-                Value::Text("123".into()),
-                Value::Text("456".into()),
+                Value::Text(Arc::new("123".to_string())),
+                Value::Text(Arc::new("456".to_string())),
             ]))
         );
     }
@@ -22885,13 +23167,13 @@ mod tests {
         let result = vm_run(
             source,
             Some("f"),
-            vec![Value::Text("name=alice age=30".into())],
+            vec![Value::Text(Arc::new("name=alice age=30".to_string()))],
         );
         assert_eq!(
             result,
             Value::List(Arc::new(vec![
-                Value::Text("name".into()),
-                Value::Text("alice".into()),
+                Value::Text(Arc::new("name".to_string())),
+                Value::Text(Arc::new("alice".to_string())),
             ]))
         );
     }
@@ -22903,7 +23185,7 @@ mod tests {
         let result = vm_run(
             source,
             Some("f"),
-            vec![Value::Text("no numbers here".into())],
+            vec![Value::Text(Arc::new("no numbers here".to_string()))],
         );
         assert_eq!(result, Value::List(Arc::new(vec![])));
     }
@@ -22944,13 +23226,13 @@ mod tests {
             source,
             Some("f"),
             vec![
-                Value::Text(r#"{"name":"alice"}"#.to_string()),
-                Value::Text("name".to_string()),
+                Value::Text(Arc::new(r#"{"name":"alice"}"#.to_string())),
+                Value::Text(Arc::new("name".to_string())),
             ],
         );
         assert_eq!(
             result,
-            Value::Ok(Box::new(Value::Text("alice".to_string())))
+            Value::Ok(Box::new(Value::Text(Arc::new("alice".to_string()))))
         );
     }
 
@@ -22961,8 +23243,8 @@ mod tests {
             source,
             Some("f"),
             vec![
-                Value::Text("not json".to_string()),
-                Value::Text("x".to_string()),
+                Value::Text(Arc::new("not json".to_string())),
+                Value::Text(Arc::new("x".to_string())),
             ],
         );
         assert!(matches!(result, Value::Err(_)));
@@ -22972,15 +23254,27 @@ mod tests {
     fn vm_jparse_scalar() {
         let source = r#"f j:t>R t t;jpar j"#;
         assert_eq!(
-            vm_run(source, Some("f"), vec![Value::Text("42".to_string())]),
+            vm_run(
+                source,
+                Some("f"),
+                vec![Value::Text(Arc::new("42".to_string()))]
+            ),
             Value::Ok(Box::new(Value::Number(42.0)))
         );
         assert_eq!(
-            vm_run(source, Some("f"), vec![Value::Text("true".to_string())]),
+            vm_run(
+                source,
+                Some("f"),
+                vec![Value::Text(Arc::new("true".to_string()))]
+            ),
             Value::Ok(Box::new(Value::Bool(true)))
         );
         assert_eq!(
-            vm_run(source, Some("f"), vec![Value::Text("null".to_string())]),
+            vm_run(
+                source,
+                Some("f"),
+                vec![Value::Text(Arc::new("null".to_string()))]
+            ),
             Value::Ok(Box::new(Value::Nil))
         );
     }
@@ -23001,11 +23295,14 @@ mod tests {
             source,
             Some("f"),
             vec![
-                Value::Text(r#"[10,20,30]"#.to_string()),
-                Value::Text("1".to_string()),
+                Value::Text(Arc::new(r#"[10,20,30]"#.to_string())),
+                Value::Text(Arc::new("1".to_string())),
             ],
         );
-        assert_eq!(result, Value::Ok(Box::new(Value::Text("20".into()))));
+        assert_eq!(
+            result,
+            Value::Ok(Box::new(Value::Text(Arc::new("20".to_string()))))
+        );
     }
 
     #[test]
@@ -23035,14 +23332,14 @@ mod tests {
     fn vm_jdmp_bool_value() {
         assert_eq!(
             vm_run("f>t;jdmp true", Some("f"), vec![]),
-            Value::Text("true".into())
+            Value::Text(Arc::new("true".to_string()))
         );
     }
 
     #[test]
     fn vm_jdmp_nil_value() {
         let result = vm_run(r#"f>t;jdmp (mget mmap "k")"#, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("null".into()));
+        assert_eq!(result, Value::Text(Arc::new("null".to_string())));
     }
 
     #[test]
@@ -23096,8 +23393,8 @@ mod tests {
         assert_eq!(
             result,
             Value::List(Arc::new(vec![
-                Value::Text("a".into()),
-                Value::Text("b".into())
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string()))
             ]))
         );
     }
@@ -23206,7 +23503,11 @@ mod tests {
     #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
     fn vm_text_callee_from_scope() {
         let source = "sq x:n>n;*x x f cb:z>n;cb 3";
-        let result = vm_run(source, Some("f"), vec![Value::Text("sq".into())]);
+        let result = vm_run(
+            source,
+            Some("f"),
+            vec![Value::Text(Arc::new("sq".to_string()))],
+        );
         assert_eq!(result, Value::Number(9.0));
     }
 
@@ -23283,7 +23584,7 @@ mod tests {
         let result = vm_run(
             r#"f s:t>t;rdb s "csv""#,
             Some("f"),
-            vec![Value::Text("a,b\n1,2".into())],
+            vec![Value::Text(Arc::new("a,b\n1,2".to_string()))],
         );
         let Value::Ok(inner) = result else {
             panic!("expected Ok")
@@ -23300,7 +23601,7 @@ mod tests {
         let result = vm_run(
             r#"f s:t>t;rdb s "csv""#,
             Some("f"),
-            vec![Value::Text("a,b,c".into())],
+            vec![Value::Text(Arc::new("a,b,c".to_string()))],
         );
         let Value::Ok(inner) = result else {
             panic!("expected Ok")
@@ -23317,7 +23618,7 @@ mod tests {
         let result = vm_run(
             r#"f s:t>t;rdb s "json""#,
             Some("f"),
-            vec![Value::Text(r#"{"x":1}"#.into())],
+            vec![Value::Text(Arc::new(r#"{"x":1}"#.to_string()))],
         );
         assert!(
             matches!(result, Value::Ok(_)),
@@ -23332,7 +23633,7 @@ mod tests {
         let result = vm_run(
             r#"f s:t>t;rdb s "json""#,
             Some("f"),
-            vec![Value::Text("not json".into())],
+            vec![Value::Text(Arc::new("not json".to_string()))],
         );
         assert!(
             matches!(result, Value::Err(_)),
@@ -23347,9 +23648,12 @@ mod tests {
         let result = vm_run(
             r#"f s:t>t;rdb s "raw""#,
             Some("f"),
-            vec![Value::Text("hello".into())],
+            vec![Value::Text(Arc::new("hello".to_string()))],
         );
-        assert_eq!(result, Value::Ok(Box::new(Value::Text("hello".into()))));
+        assert_eq!(
+            result,
+            Value::Ok(Box::new(Value::Text(Arc::new("hello".to_string()))))
+        );
     }
 
     #[test]
@@ -23400,7 +23704,7 @@ mod tests {
         let Value::Ok(inner) = result else {
             panic!("expected Ok")
         };
-        assert_eq!(*inner, Value::Text("hello".into()));
+        assert_eq!(*inner, Value::Text(Arc::new("hello".to_string())));
     }
 
     #[test]
@@ -23421,7 +23725,11 @@ mod tests {
         path.push("ilo_vm_rdl_test.txt");
         std::fs::write(&path, "line1\nline2\nline3").unwrap();
         let path_str = path.to_str().unwrap().to_string();
-        let result = vm_run("f p:t>t;rdl p", Some("f"), vec![Value::Text(path_str)]);
+        let result = vm_run(
+            "f p:t>t;rdl p",
+            Some("f"),
+            vec![Value::Text(Arc::new(path_str))],
+        );
         std::fs::remove_file(&path).ok();
         let Value::Ok(inner) = result else {
             panic!("expected Ok")
@@ -23430,7 +23738,7 @@ mod tests {
             panic!("expected list")
         };
         assert_eq!(lines.len(), 3);
-        assert_eq!(lines[0], Value::Text("line1".into()));
+        assert_eq!(lines[0], Value::Text(Arc::new("line1".to_string())));
     }
 
     #[test]
@@ -23438,7 +23746,9 @@ mod tests {
         let result = vm_run(
             "f p:t>t;rdl p",
             Some("f"),
-            vec![Value::Text("/nonexistent/ilo_rdl_test.txt".into())],
+            vec![Value::Text(Arc::new(
+                "/nonexistent/ilo_rdl_test.txt".to_string(),
+            ))],
         );
         assert!(
             matches!(result, Value::Err(_)),
@@ -23466,7 +23776,7 @@ mod tests {
         let result = vm_run(
             "f p:t>t;wr p \"hello\"",
             Some("f"),
-            vec![Value::Text(path_str.clone())],
+            vec![Value::Text(Arc::new(path_str.clone()))],
         );
         std::fs::remove_file(&path).ok();
         assert!(
@@ -23722,7 +24032,7 @@ mod tests {
         let result = vm_run(
             "f p:t>t;wrl p [\"a\", \"b\", \"c\"]",
             Some("f"),
-            vec![Value::Text(path_str.clone())],
+            vec![Value::Text(Arc::new(path_str.clone()))],
         );
         std::fs::remove_file(&path).ok();
         assert!(
@@ -23832,7 +24142,7 @@ mod tests {
         // Arena overflow during recwith with string field in old record (L3555-3567).
         let src = r#"type msg{text:t;val:n} f>t;r=msg text:"hello" val:0;i=0;wh <i 3000{r=r with val:i;i=+i 1};r.text"#;
         let result = vm_run(src, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("hello".into()));
+        assert_eq!(result, Value::Text(Arc::new("hello".to_string())));
     }
 
     #[test]
@@ -23972,7 +24282,7 @@ mod tests {
         let src = r#"f x:O n>t;?x{~v:"val";_:"nil"}"#;
         assert_eq!(
             vm_run(src, Some("f"), vec![Value::Nil]),
-            Value::Text("nil".to_string())
+            Value::Text(Arc::new("nil".to_string()))
         );
         assert_eq!(
             vm_run(
@@ -23980,7 +24290,7 @@ mod tests {
                 Some("f"),
                 vec![Value::Ok(Box::new(Value::Number(1.0)))]
             ),
-            Value::Text("val".to_string())
+            Value::Text(Arc::new("val".to_string()))
         );
     }
 
@@ -24018,7 +24328,7 @@ mod tests {
         // JSON parse returns a record accessible by field name
         let src = r#"f>t;j=jpar! "{\"name\":\"alice\",\"age\":30}";j.name"#;
         let result = vm_run(src, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("alice".to_string()));
+        assert_eq!(result, Value::Text(Arc::new("alice".to_string())));
     }
 
     // ── Coverage: heap record with text field names (L3585-3589) ────────────
@@ -24144,7 +24454,7 @@ f>n;r=mk 10 20;+r.x r.y";
         let src = r#"f x:b>t;?x{b v:"matched";_:"other"}"#;
         assert_eq!(
             vm_run(src, Some("f"), vec![Value::Bool(true)]),
-            Value::Text("matched".to_string())
+            Value::Text(Arc::new("matched".to_string()))
         );
     }
 
@@ -24167,10 +24477,14 @@ f>n;r=mk 10 20;+r.x r.y";
     fn vm_list_with_variable() {
         let src = r#"f w:t>L t;["hi" w]"#;
         assert_eq!(
-            vm_run(src, Some("f"), vec![Value::Text("world".to_string())]),
+            vm_run(
+                src,
+                Some("f"),
+                vec![Value::Text(Arc::new("world".to_string()))]
+            ),
             Value::List(Arc::new(vec![
-                Value::Text("hi".to_string()),
-                Value::Text("world".to_string())
+                Value::Text(Arc::new("hi".to_string())),
+                Value::Text(Arc::new("world".to_string()))
             ]))
         );
     }
@@ -24181,7 +24495,7 @@ f>n;r=mk 10 20;+r.x r.y";
         assert_eq!(
             vm_run(src, Some("f"), vec![]),
             Value::List(Arc::new(vec![
-                Value::Text("search".to_string()),
+                Value::Text(Arc::new("search".to_string())),
                 Value::Number(10.0),
                 Value::Bool(true),
             ]))
@@ -24230,7 +24544,10 @@ f>n;r=mk 10 20;+r.x r.y";
         match result {
             Value::Record { type_name, fields } => {
                 assert_eq!(type_name, "named");
-                assert_eq!(fields.get("name"), Some(&Value::Text("alice".to_string())));
+                assert_eq!(
+                    fields.get("name"),
+                    Some(&Value::Text(Arc::new("alice".to_string())))
+                );
                 assert_eq!(fields.get("age"), Some(&Value::Number(30.0)));
             }
             other => panic!("expected Record, got {:?}", other),
@@ -24268,7 +24585,10 @@ f>n;r=mk 10 20;+r.x r.y";
         let err = compile_and_run(
             &prog,
             Some("f"),
-            vec![Value::Text("a".into()), Value::Text("b".into())],
+            vec![
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+            ],
         )
         .unwrap_err();
         assert!(
@@ -24335,8 +24655,12 @@ f>n;r=mk 10 20;+r.x r.y";
         // Multi-frame return where inner function returns text (heap value)
         // exercises stack cleanup across frames (L2622-2639 area)
         let src = "inner x:t>t;+x \"!\"\nouter x:t>t;inner x\nf x:t>t;outer x";
-        let result = vm_run(src, Some("f"), vec![Value::Text("hi".to_string())]);
-        assert_eq!(result, Value::Text("hi!".to_string()));
+        let result = vm_run(
+            src,
+            Some("f"),
+            vec![Value::Text(Arc::new("hi".to_string()))],
+        );
+        assert_eq!(result, Value::Text(Arc::new("hi!".to_string())));
     }
 
     #[test]
@@ -24455,9 +24779,12 @@ f>n;r=mk 10 20;+r.x r.y";
         let result = vm_run(
             "f a:t b:t>t;+a b",
             Some("f"),
-            vec![Value::Text("hello ".into()), Value::Text("world".into())],
+            vec![
+                Value::Text(Arc::new("hello ".to_string())),
+                Value::Text(Arc::new("world".to_string())),
+            ],
         );
-        assert_eq!(result, Value::Text("hello world".into()));
+        assert_eq!(result, Value::Text(Arc::new("hello world".to_string())));
     }
 
     // Guard true/false paths
@@ -24475,7 +24802,7 @@ f>n;r=mk 10 20;+r.x r.y";
             Some("f"),
             vec![Value::Bool(true)],
         );
-        assert_eq!(result, Value::Text("yes".into()));
+        assert_eq!(result, Value::Text(Arc::new("yes".to_string())));
     }
 
     // Match with text pattern (L1230-1251)
@@ -24484,7 +24811,7 @@ f>n;r=mk 10 20;+r.x r.y";
         let result = vm_run(
             r#"f x:t>n;?x{"a":1;"b":2;_:0}"#,
             Some("f"),
-            vec![Value::Text("b".into())],
+            vec![Value::Text(Arc::new("b".to_string()))],
         );
         assert_eq!(result, Value::Number(2.0));
     }
@@ -24507,9 +24834,9 @@ f>n;r=mk 10 20;+r.x r.y";
         let result = vm_run(
             r#"f x:t>t;?x{n v:"num";t v:v;b v:"bool"}"#,
             Some("f"),
-            vec![Value::Text("hello".into())],
+            vec![Value::Text(Arc::new("hello".to_string()))],
         );
-        assert_eq!(result, Value::Text("hello".into()));
+        assert_eq!(result, Value::Text(Arc::new("hello".to_string())));
     }
 
     // Nested record creation and field access
@@ -24534,7 +24861,10 @@ f>n;r=mk 10 20;+r.x r.y";
     #[test]
     fn vm_cov_result_err() {
         let result = vm_run(r#"f>R n t;^"oops""#, Some("f"), vec![]);
-        assert_eq!(result, Value::Err(Box::new(Value::Text("oops".into()))));
+        assert_eq!(
+            result,
+            Value::Err(Box::new(Value::Text(Arc::new("oops".to_string()))))
+        );
     }
 
     // Map set/get
@@ -24545,7 +24875,7 @@ f>n;r=mk 10 20;+r.x r.y";
             Some("f"),
             vec![],
         );
-        assert_eq!(result, Value::Text("val".into()));
+        assert_eq!(result, Value::Text(Arc::new("val".to_string())));
     }
 
     // Map has
@@ -24670,7 +25000,7 @@ f>n;r=mk 10 20;+r.x r.y";
     #[test]
     fn vm_cov_slice_text() {
         let result = vm_run(r#"f>t;slc "hello" 1 4"#, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("ell".into()));
+        assert_eq!(result, Value::Text(Arc::new("ell".to_string())));
     }
 
     // Multi-guard cascading
@@ -24681,7 +25011,7 @@ f>n;r=mk 10 20;+r.x r.y";
             Some("cls"),
             vec![Value::Number(750.0)],
         );
-        assert_eq!(result, Value::Text("silver".into()));
+        assert_eq!(result, Value::Text(Arc::new("silver".to_string())));
     }
 
     // Comparison operators
@@ -24721,7 +25051,7 @@ f>n;r=mk 10 20;+r.x r.y";
         let result = vm_run(
             r#"f s:t>n;len s"#,
             Some("f"),
-            vec![Value::Text("hello".into())],
+            vec![Value::Text(Arc::new("hello".to_string()))],
         );
         assert_eq!(result, Value::Number(5.0));
     }
@@ -24763,7 +25093,7 @@ f>n;r=mk 10 20;+r.x r.y";
             Some("f"),
             vec![Value::Number(1.0)],
         );
-        assert_eq!(result, Value::Text("yes".into()));
+        assert_eq!(result, Value::Text(Arc::new("yes".to_string())));
     }
 
     #[test]
@@ -24773,7 +25103,7 @@ f>n;r=mk 10 20;+r.x r.y";
             Some("f"),
             vec![Value::Number(0.0)],
         );
-        assert_eq!(result, Value::Text("no".into()));
+        assert_eq!(result, Value::Text(Arc::new("no".to_string())));
     }
 
     // Fibonacci (exercises deep recursion)
@@ -24837,7 +25167,7 @@ f>n;r=mk 10 20;+r.x r.y";
             Some("f"),
             vec![Value::Number(3.0)],
         );
-        assert_eq!(result, Value::Text("small".into()));
+        assert_eq!(result, Value::Text(Arc::new("small".to_string())));
     }
 
     // ── rou (round) opcode ────────────────────────────────────────────────
@@ -24911,7 +25241,10 @@ f>n;r=mk 10 20;+r.x r.y";
         unsafe {
             std::env::remove_var("ILO_TEST_ENV_COV");
         }
-        assert_eq!(result, Value::Ok(Box::new(Value::Text("hello".into()))));
+        assert_eq!(
+            result,
+            Value::Ok(Box::new(Value::Text(Arc::new("hello".to_string()))))
+        );
     }
 
     #[test]
@@ -24967,33 +25300,33 @@ f>n;r=mk 10 20;+r.x r.y";
     #[test]
     fn vm_cov_jdmp_list() {
         let result = vm_run("f>t;jdmp [1, 2, 3]", Some("f"), vec![]);
-        assert_eq!(result, Value::Text("[1,2,3]".into()));
+        assert_eq!(result, Value::Text(Arc::new("[1,2,3]".to_string())));
     }
 
     #[test]
     fn vm_cov_jdmp_nested_list() {
         // list inside list exercises the nanval_to_json array branch
         let result = vm_run("f>t;xs=[1,2];jdmp xs", Some("f"), vec![]);
-        assert_eq!(result, Value::Text("[1,2]".into()));
+        assert_eq!(result, Value::Text(Arc::new("[1,2]".to_string())));
     }
 
     // ── OP_CAT (join list with separator) ─────────────────────────────────
     #[test]
     fn vm_cov_cat_join() {
         let result = vm_run(r#"f>t;cat ["a","b","c"] ",""#, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("a,b,c".into()));
+        assert_eq!(result, Value::Text(Arc::new("a,b,c".to_string())));
     }
 
     #[test]
     fn vm_cov_cat_single() {
         let result = vm_run(r#"f>t;cat ["hello"] ",""#, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("hello".into()));
+        assert_eq!(result, Value::Text(Arc::new("hello".to_string())));
     }
 
     #[test]
     fn vm_cov_cat_empty_list() {
         let result = vm_run(r#"f>t;cat [] ",""#, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("".into()));
+        assert_eq!(result, Value::Text(Arc::new("".to_string())));
     }
 
     // ── OP_HAS — string contains ───────────────────────────────────────────
@@ -25025,20 +25358,20 @@ f>n;r=mk 10 20;+r.x r.y";
     #[test]
     fn vm_cov_hd_string() {
         let result = vm_run(r#"f>t;hd "hello""#, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("h".into()));
+        assert_eq!(result, Value::Text(Arc::new("h".to_string())));
     }
 
     // ── OP_TL — tail of string ─────────────────────────────────────────────
     #[test]
     fn vm_cov_tl_string() {
         let result = vm_run(r#"f>t;tl "hello""#, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("ello".into()));
+        assert_eq!(result, Value::Text(Arc::new("ello".to_string())));
     }
 
     #[test]
     fn vm_cov_tl_single_char_string() {
         let result = vm_run(r#"f>t;tl "x""#, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("".into()));
+        assert_eq!(result, Value::Text(Arc::new("".to_string())));
     }
 
     // ── OP_REV — reverse list ──────────────────────────────────────────────
@@ -25058,7 +25391,7 @@ f>n;r=mk 10 20;+r.x r.y";
     #[test]
     fn vm_cov_rev_string() {
         let result = vm_run(r#"f>t;rev "abc""#, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("cba".into()));
+        assert_eq!(result, Value::Text(Arc::new("cba".to_string())));
     }
 
     // ── OP_SRT — sort list of strings ─────────────────────────────────────
@@ -25072,9 +25405,9 @@ f>n;r=mk 10 20;+r.x r.y";
         assert_eq!(
             result,
             Value::List(Arc::new(vec![
-                Value::Text("apple".into()),
-                Value::Text("banana".into()),
-                Value::Text("cherry".into()),
+                Value::Text(Arc::new("apple".to_string())),
+                Value::Text(Arc::new("banana".to_string())),
+                Value::Text(Arc::new("cherry".to_string())),
             ]))
         );
     }
@@ -25102,13 +25435,13 @@ f>n;r=mk 10 20;+r.x r.y";
     #[test]
     fn vm_cov_slc_string() {
         let result = vm_run(r#"f>t;slc "hello" 1 3"#, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("el".into()));
+        assert_eq!(result, Value::Text(Arc::new("el".to_string())));
     }
 
     #[test]
     fn vm_cov_slc_string_full() {
         let result = vm_run(r#"f>t;slc "hello" 0 5"#, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("hello".into()));
+        assert_eq!(result, Value::Text(Arc::new("hello".to_string())));
     }
 
     // ── OP_SPL — split string ──────────────────────────────────────────────
@@ -25118,9 +25451,9 @@ f>n;r=mk 10 20;+r.x r.y";
         assert_eq!(
             result,
             Value::List(Arc::new(vec![
-                Value::Text("a".into()),
-                Value::Text("b".into()),
-                Value::Text("c".into()),
+                Value::Text(Arc::new("a".to_string())),
+                Value::Text(Arc::new("b".to_string())),
+                Value::Text(Arc::new("c".to_string())),
             ]))
         );
     }
@@ -25130,7 +25463,7 @@ f>n;r=mk 10 20;+r.x r.y";
         let result = vm_run(r#"f>L t;spl "abc" ",""#, Some("f"), vec![]);
         assert_eq!(
             result,
-            Value::List(Arc::new(vec![Value::Text("abc".into())]))
+            Value::List(Arc::new(vec![Value::Text(Arc::new("abc".to_string()))]))
         );
     }
 
@@ -25138,20 +25471,20 @@ f>n;r=mk 10 20;+r.x r.y";
     #[test]
     fn vm_cov_unq_string() {
         let result = vm_run(r#"f>t;unq "aabbcc""#, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("abc".into()));
+        assert_eq!(result, Value::Text(Arc::new("abc".to_string())));
     }
 
     #[test]
     fn vm_cov_unq_string_no_dups() {
         let result = vm_run(r#"f>t;unq "abc""#, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("abc".into()));
+        assert_eq!(result, Value::Text(Arc::new("abc".to_string())));
     }
 
     // ── OP_TRM — trim string ───────────────────────────────────────────────
     #[test]
     fn vm_cov_trm_spaces() {
         let result = vm_run(r#"f>t;trm "  hello  ""#, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("hello".into()));
+        assert_eq!(result, Value::Text(Arc::new("hello".to_string())));
     }
 
     // ── OP_LISTAPPEND RC > 1 path (shared list must copy) ─────────────────
@@ -25215,7 +25548,7 @@ f>n;r=mk 10 20;+r.x r.y";
         // nil inside a record/list exercises the _ => Null branch in nanval_to_json
         let src = "f>t;jdmp false";
         let result = vm_run(src, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("false".into()));
+        assert_eq!(result, Value::Text(Arc::new("false".to_string())));
     }
 
     // ── to_value_with_registry on non-arena value falls through ───────────
@@ -25469,7 +25802,7 @@ f>n;r=mk 10 20;+r.x r.y";
     #[test]
     fn vm_cov_jdmp_bool_true() {
         let result = vm_run("f>t;jdmp true", Some("f"), vec![]);
-        assert_eq!(result, Value::Text("true".into()));
+        assert_eq!(result, Value::Text(Arc::new("true".to_string())));
     }
 
     // ── OP_UNWRAP on Err ──────────────────────────────────────────────────
@@ -25478,7 +25811,7 @@ f>n;r=mk 10 20;+r.x r.y";
         // Unwrapping an Err via match pattern extracts the inner value
         let src = r#"f>t;r=^"oops";?r{^e:e;~v:"ok"}"#;
         let result = vm_run(src, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("oops".into()));
+        assert_eq!(result, Value::Text(Arc::new("oops".to_string())));
     }
 
     // ── OP_ISOK / OP_ISERR ────────────────────────────────────────────────
@@ -25503,11 +25836,11 @@ f>n;r=mk 10 20;+r.x r.y";
         let src = r#"f x:O n>t;?x{n v:"num";_:"other"}"#;
         assert_eq!(
             vm_run(src, Some("f"), vec![Value::Number(5.0)]),
-            Value::Text("num".into())
+            Value::Text(Arc::new("num".to_string()))
         );
         assert_eq!(
             vm_run(src, Some("f"), vec![Value::Bool(true)]),
-            Value::Text("other".into())
+            Value::Text(Arc::new("other".to_string()))
         );
     }
 
@@ -25542,7 +25875,7 @@ f>n;r=mk 10 20;+r.x r.y";
         // When a string is referenced multiple times (shared RC), concat must copy
         let src = r#"f>t;a="hello";b=a;+a " world""#;
         let result = vm_run(src, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("hello world".into()));
+        assert_eq!(result, Value::Text(Arc::new("hello world".to_string())));
     }
 
     // ── OP_FOREACHPREP / OP_FOREACHNEXT empty list path ───────────────────
@@ -25611,8 +25944,12 @@ f>n;r=mk 10 20;+r.x r.y";
     fn vm_string_accumulation_peephole() {
         // s starts as text param; s = +s " world" triggers the string-accumulation peephole
         let src = r#"f s:t>t;s=+s " world";s"#;
-        let result = vm_run(src, Some("f"), vec![Value::Text("hello".into())]);
-        assert_eq!(result, Value::Text("hello world".into()));
+        let result = vm_run(
+            src,
+            Some("f"),
+            vec![Value::Text(Arc::new("hello".to_string()))],
+        );
+        assert_eq!(result, Value::Text(Arc::new("hello world".to_string())));
     }
 
     #[test]
@@ -25620,7 +25957,7 @@ f>n;r=mk 10 20;+r.x r.y";
         // Multiple string accumulations
         let src = r#"f>t;s="a";s=+s "b";s=+s "c";s"#;
         let result = vm_run(src, Some("f"), vec![]);
-        assert_eq!(result, Value::Text("abc".into()));
+        assert_eq!(result, Value::Text(Arc::new("abc".to_string())));
     }
 
     // ── OP_RECFLD_NAME on arena record (field found) ─────────────────────
@@ -26060,7 +26397,7 @@ f>n;r=mk 10 20;+r.x r.y";
 
     // ── OP_RECWITH heap record with text field names (lines 4499-4507) ────
     // When the compiler can't resolve field indices (ambiguous types), it stores
-    // `Value::Text(name)` in the const pool. At runtime, OP_RECWITH on a heap record
+    // `Value::Text(Arc::new(name))` in the const pool. At runtime, OP_RECWITH on a heap record
     // with text field names looks up the index by name (lines 4499-4507).
     #[test]
     fn vm_recwith_heap_record_text_field_names() {
@@ -26125,7 +26462,11 @@ f>n;r=mk 10 20;+r.x r.y";
         };
 
         // Pass a string as the collection → is_heap()=true but not a list → error
-        let result = run(&program, Some("f"), vec![Value::Text("hello".into())]);
+        let result = run(
+            &program,
+            Some("f"),
+            vec![Value::Text(Arc::new("hello".to_string()))],
+        );
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -4188,7 +4188,7 @@ impl NanVal {
                 unsafe {
                     debug_assert!(self.is_heap());
                     match self.as_heap_ref() {
-                        HeapObj::Str(s) => Value::Text(s.clone()),
+                        HeapObj::Str(s) => Value::Text(Arc::new(s.clone())),
                         HeapObj::List(items) => Value::List(std::sync::Arc::new(
                             items
                                 .iter()

--- a/tests/regression_string_accumulator_tree.rs
+++ b/tests/regression_string_accumulator_tree.rs
@@ -1,0 +1,171 @@
+// Regression tests for the tree-walker RC-aware string-concat fast path.
+//
+// Background: Phase 2b.1 (PR #261, Map) and Phase 2b.2 (PR #273, List) made
+// `Value::Map` / `Value::List` RC-aware via `Arc<HashMap>` / `Arc<Vec>` and
+// added eval_stmt peepholes for self-rebind accumulator shapes. Phase 2b.3
+// (this PR) does the same for `Value::Text`:
+//
+//   1. `Value::Text(String)` becomes `Value::Text(Arc<String>)`, so cloning a
+//      string is a refcount bump rather than a full byte copy.
+//   2. The existing `xs = xs + ys` eval_stmt peephole gains a Text branch
+//      alongside its List branch. When prev and rhs are both Text, it calls
+//      `Arc::make_mut(&mut prev).push_str(&rhs)` and returns the same Arc.
+//      With the env's binding taken to Nil before evaluating the rhs the Arc
+//      arrives at refcount=1, so the mutation is in place and the
+//      string-accumulator loop runs in O(n) instead of O(n²).
+//
+// Mirror of the VM `OP_ADD_SS` rebind-shape guard (PR #260) and the
+// Cranelift `jit_concat` non-rebind split (PR #250) — same alias trap, same
+// fix shape.
+//
+// On a 5k-iteration accumulator the tree wall-clock drops from 10+s to
+// milliseconds. This file pins:
+//   1. Correctness for `s = s + suffix` with literal and variable suffixes
+//      on the tree engine.
+//   2. The non-rebind shape (`b = +a c`) leaves `a` untouched (alias
+//      contract).
+//   3. Aliased rhs (`s = s + s` self-concat) still works correctly because
+//      the peephole bails out when the rhs references the same binding.
+//   4. Numeric `n = n + 1` is unaffected (falls through to apply_binop).
+//   5. Scaling: a 5k-iteration accumulator finishes well under a second.
+
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_tree(src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, "--run-tree", entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo --run-tree failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+// ── Self-rebind: text-literal suffix ──────────────────────────────────────
+
+#[test]
+fn tree_text_concat_self_rebind_literal() {
+    // Three concats via the self-rebind shape. Exercises the eval_stmt
+    // Text branch on every assignment.
+    let src = r#"f>t;s="";s=+s "a";s=+s "b";s=+s "c";s"#;
+    assert_eq!(run_tree(src, "f"), "abc");
+}
+
+#[test]
+fn tree_text_concat_self_rebind_starts_nonempty() {
+    let src = r#"f>t;s="x";s=+s "y";s=+s "z";s"#;
+    assert_eq!(run_tree(src, "f"), "xyz");
+}
+
+// ── Self-rebind: variable suffix ──────────────────────────────────────────
+
+#[test]
+fn tree_text_concat_self_rebind_variable() {
+    let src = r#"f>t;s="hello ";name="world";s=+s name;s"#;
+    assert_eq!(run_tree(src, "f"), "hello world");
+}
+
+// ── Self-rebind: concat inside foreach (the hot accumulator shape) ─────────
+
+#[test]
+fn tree_text_concat_self_rebind_in_foreach() {
+    // Classic accumulator shape inside a loop. This is the pattern Phase
+    // 2b.3 targets: every iteration goes through the peephole, so the loop
+    // runs in O(n) instead of O(n²).
+    let src = r#"f>n;s="";@i 0..5{s=+s "x"};len s"#;
+    assert_eq!(run_tree(src, "f"), "5");
+}
+
+// ── Non-rebind: caller's text is preserved (alias contract) ────────────────
+
+#[test]
+fn tree_text_concat_non_rebind_preserves_source() {
+    // `b = +a c` is the non-rebind shape: the peephole's name-match fails
+    // and we go through apply_binop, which allocates a fresh String. `a`
+    // must still observe its original value.
+    let src = r#"f>t;a="k1";b=+a "_x";a"#;
+    assert_eq!(run_tree(src, "f"), "k1");
+}
+
+#[test]
+fn tree_text_concat_non_rebind_both_visible() {
+    // Both source and dest visible in one return. Pins the aliasing
+    // contract: `a` must be untouched, `b` must have the concat.
+    let src = r#"f>t;a="k1";b=+a "_x";fmt "{}|{}" a b"#;
+    assert_eq!(run_tree(src, "f"), "k1|k1_x");
+}
+
+// ── Self-rebind: RHS is a Call returning Text ─────────────────────────────
+
+#[test]
+fn tree_text_concat_self_rebind_rhs_is_call() {
+    // `s = +s (fmt "...")` — the rhs is a Call expression, not a literal or
+    // Ref. The peephole's expr_refers_to walks into Call args, sees no Ref
+    // to `s`, and fires. eval_self_rebind_concat evaluates the Call, gets a
+    // Value::Text back, and goes through the Arc::make_mut + push_str path.
+    let src = r#"f>t;s="k";s=+s (fmt "_{}" 1);s"#;
+    assert_eq!(run_tree(src, "f"), "k_1");
+}
+
+// ── Aliasing: rhs references same binding ──────────────────────────────────
+
+#[test]
+fn tree_text_concat_self_alias_doubles() {
+    // `s = s + s` — the peephole MUST bail out because evaluating the rhs
+    // after `env.take("s")` would observe Nil. The expr_refers_to guard in
+    // match_self_rebind_concat is what catches this. Same trap that bit
+    // OP_ADD_SS in #260.
+    let src = r#"f>t;s="ab";s=+s s;s"#;
+    assert_eq!(run_tree(src, "f"), "abab");
+}
+
+// ── Numeric add still works under the same operator ───────────────────────
+
+#[test]
+fn tree_numeric_add_self_rebind_distinct_rhs() {
+    // `n = n + 1` — peephole fires because rhs is a literal (no self-ref).
+    // eval_self_rebind_concat falls back to eval_binop because values
+    // aren't both Text or both List. Result must be 4.
+    let src = r#"f>n;n=3;n=+n 1;n"#;
+    assert_eq!(run_tree(src, "f"), "4");
+}
+
+// ── Scale: 5k-iteration accumulator under 5s ──────────────────────────────
+//
+// The pre-Phase-2b.3 tree path was O(n²) — every `+s c` cloned the whole
+// String. 5k iterations of "x" appended took 10+s on a recent MacBook. With
+// Arc + the peephole it's a millisecond or two. The 5s ceiling catches an
+// accidental regression to the quadratic path while being lenient on slow
+// CI runners.
+
+#[test]
+fn tree_text_concat_scale_5k_under_5s() {
+    let src = r#"build n:n>n;s="";@i 0..n{s=+s "x"};len s
+demo>n;build 5000"#;
+    let start = Instant::now();
+    let out = ilo()
+        .args([src, "--run-tree", "demo"])
+        .output()
+        .expect("failed to run ilo");
+    let elapsed = start.elapsed();
+    assert!(
+        out.status.success(),
+        "ilo --run-tree demo failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(stdout.trim(), "5000", "wrong string length: {stdout}");
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "tree text-concat 5k took {elapsed:?} - expected <5s; the O(n^2) \
+         path used to take 10+s. The eval_stmt Text peephole may have regressed."
+    );
+}


### PR DESCRIPTION
## Summary

Third (and last) step of the tree-walker RC-aware mutation rollout. Mirror of Phase 2b.1 (Map, PR #261) and Phase 2b.2 (List, PR #273):

- `Value::Text(String)` becomes `Value::Text(Arc<String>)` so cloning a string is a refcount bump rather than a full byte copy.
- The existing self-rebind concat peephole in `eval_self_rebind_concat` (added for Lists in #273) gains a Text branch. When prev and rhs are both `Value::Text`, `Arc::make_mut` runs on the refcount=1 Arc and `push_str` mutates the inner String in place.

The classic string-accumulator loop folds from O(n^2) to O(n) amortised on the tree engine. 5k iterations of `s=+s "x"` go from 10+ seconds to milliseconds.

## Repro

```ilo
build n:n>n;s="";@i 0..n{s=+s "x"};len s
demo>n;build 5000
```

- Before: 10+ seconds, every iteration clones the whole `String`.
- After: a millisecond or two, every iteration uses `Arc::make_mut` + `push_str`.

The alias guard inherited from `match_self_rebind_concat` (which calls `expr_refers_to` to reject `s = s + s`) carries over unchanged. Non-rebind shapes (`b = +a c`) still go through `apply_binop` so the caller's `a` is preserved, same as the VM `OP_ADD_SS` split landed in #260 and the Cranelift `jit_concat` split landed in #250.

## What's in the diff

- **`interpreter: switch Value::Text to Arc<String> with RC=1 in-place concat`** (8a05a30) - mechanical rewrite. Every `Value::Text(String)` construction becomes `Value::Text(Arc::new(...))` across the interpreter, VM, Cranelift JIT, json bridge, http/mcp tool providers, and the CLI arg-parser. Every `Value::Text(s)` read that needs an owned `String` (MapKey::Text, serde_json::Value::String, parts: Vec<String>, etc.) becomes `(**s).clone()`. No behavioural change on its own.
- **`interpreter: eval_stmt peephole for self-rebind text concat`** (daab1c1) - adds the `(Value::Text, Value::Text)` branch to `eval_self_rebind_concat` and updates the `match_self_rebind_concat` docstring.
- **`test + example: tree-walker string accumulator regression coverage`** (0974b0d) - 10 regression tests covering literal / variable / Call-returning-Text rhs / foreach / non-rebind / self-alias / numeric fallthrough / 5k scale, plus `examples/string-accumulator-tree.ilo` so the engine harness runs the same shapes across tree, VM, and Cranelift.

## Test plan

- [x] `cargo build --release --features cranelift` clean
- [x] `cargo test --release --features cranelift` - all 112 suites green
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --release --features cranelift --all-targets -- -D warnings` clean
- [x] New regression file: 10/10 pass
- [x] Engine harness picks up `examples/string-accumulator-tree.ilo` across tree, VM, Cranelift
- [x] 5k-iteration scale check completes well under the 5s ceiling

## Follow-ups

None. This closes Phase 2b. Map (#261), List (#273), and Text (this PR) all use the same Arc + self-rebind peephole shape on the tree engine, matching the VM `OP_*` rebind splits and the Cranelift `jit_*` rebind splits that landed earlier.

No README / SPEC updates: this is a runtime-internal perf fix with no user-observable semantic change beyond the formerly O(n^2) accumulator going O(n).