### PR TITLE
vm + cranelift: native map HOF dispatch (PR 2 of 4)

### DIFF
--- a/examples/map-fnref.ilo
+++ b/examples/map-fnref.ilo
@@ -1,0 +1,11 @@
+-- map fn xs: apply a function to every element of a list. The fn
+-- argument is a function reference (user-defined like `sq` or a pure
+-- builtin like `abs`). The result is a fresh list of the same length.
+-- Signature: map fn:F a b xs:L a > L b
+
+sq x:n>n;*x x
+
+main xs:L n>L n;map sq xs
+
+-- run: main [1,2,3,4,5]
+-- out: [1, 4, 9, 16, 25]

--- a/examples/window.ilo
+++ b/examples/window.ilo
@@ -15,11 +15,10 @@ singles>L (L n);window 1 [1, 2, 3]
 toobig>L (L n);window 5 [1, 2, 3]
 
 -- 3-element moving sum: window then map sum.
--- Tree only — vm/cranelift don't dispatch builtins-as-HOF yet.
+-- Cross-engine: map with a builtin HOF callback now works on every engine
+-- (FnRef NaN-tagging + native `map` lift; see #274 and the PR 2 follow-up).
 sums>L n;map sum (window 3 [1, 2, 3, 4, 5])
 
--- engine-skip: vm
--- engine-skip: cranelift
 -- run: basic
 -- out: [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
 -- run: pairs

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -165,6 +165,8 @@ struct HelperFuncs {
     dtparse: FuncId,
     // Tree-bridge for tree-only builtins
     call_builtin_tree: FuncId,
+    // Dynamic-dispatch bridge for OP_CALL_DYN (HOF callbacks: `map`, ...)
+    call_dyn: FuncId,
     // AOT-specific helpers
     get_arena_ptr: FuncId,
     get_registry_ptr: FuncId,
@@ -339,6 +341,7 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         dtfmt: declare_helper(module, "jit_dtfmt", 2, 1),
         dtparse: declare_helper(module, "jit_dtparse", 2, 1),
         call_builtin_tree: declare_helper(module, "jit_call_builtin_tree", 3, 1),
+        call_dyn: declare_helper(module, "jit_call_dyn", 3, 1),
         // AOT-specific helpers
         get_arena_ptr: declare_helper(module, "jit_get_arena_ptr", 0, 1),
         get_registry_ptr: declare_helper(module, "jit_get_registry_ptr", 0, 1),
@@ -1707,14 +1710,45 @@ fn compile_function_body(
                 let kval = builder.ins().iconst(I64, bits as i64);
                 builder.def_var(vars[a_idx], kval);
             }
-            // OP_CALL_DYN is not emitted by the compiler in PR 1 (HOF
-            // dispatch hasn't been lifted yet). Cranelift translation
-            // arrives in PR 2 alongside the first native HOF lowering.
+            // ── Dynamic call by function reference ──
+            // ABC: A = result_reg, B = fnref_reg, C = argc.
+            // Args live contiguously in R[A+1..=A+argc] (mirrors OP_CALL
+            // and OP_CALL_BUILTIN_TREE). The JIT side has no re-entrant
+            // function-pointer table for arbitrary FnRef dispatch, so we
+            // route through the `jit_call_dyn` helper which:
+            //   - for a Builtin FnRef: round-trips through the tree-bridge,
+            //     same as OP_CALL_BUILTIN_TREE
+            //   - for a User FnRef: re-enters the bytecode VM on the same
+            //     program via `VM::new(active_program).call(idx, args)`
+            // Both paths use the FnRef NaN-tagging plumbing from PR 1
+            // (#274) so FnRef args survive the boxing round-trip.
             OP_CALL_DYN => {
-                return Err(format!(
-                    "OP_CALL_DYN not yet supported by cranelift codegen at instruction {}",
-                    ip
-                ));
+                let argc = c_idx;
+                let callee_val = builder.use_var(vars[b_idx]);
+                let argc_val = builder.ins().iconst(I64, argc as i64);
+
+                // Spill args into a contiguous stack slot, mirroring the
+                // OP_CALL_BUILTIN_TREE lowering above.
+                let regs_ptr = if argc == 0 {
+                    builder.ins().iconst(I64, 0)
+                } else {
+                    let slot =
+                        builder.create_sized_stack_slot(cranelift_codegen::ir::StackSlotData::new(
+                            cranelift_codegen::ir::StackSlotKind::ExplicitSlot,
+                            (argc * 8) as u32,
+                            0,
+                        ));
+                    for i in 0..argc {
+                        let src = builder.use_var(vars[a_idx + 1 + i]);
+                        builder.ins().stack_store(src, slot, (i * 8) as i32);
+                    }
+                    builder.ins().stack_addr(I64, slot, 0)
+                };
+
+                let fref = get_func_ref(&mut builder, module, helpers.call_dyn);
+                let call_inst = builder.ins().call(fref, &[callee_val, argc_val, regs_ptr]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
             }
             // ── Control flow ──
             OP_JMP => {

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -180,6 +180,8 @@ struct HelperFuncs {
     dtparse: FuncId,
     // Tree-bridge for tree-only builtins (rgx, rgxall, fmt-variadic, etc.)
     call_builtin_tree: FuncId,
+    // Dynamic-dispatch bridge for OP_CALL_DYN (HOF callbacks: `map`, ...)
+    call_dyn: FuncId,
 }
 
 /// Pack a `Span { start, end }` into a single i64 immediate for passing to
@@ -365,6 +367,7 @@ fn register_helpers(builder: &mut JITBuilder) {
         ("jit_dtfmt", jit_dtfmt as *const u8),
         ("jit_dtparse", jit_dtparse as *const u8),
         ("jit_call_builtin_tree", jit_call_builtin_tree as *const u8),
+        ("jit_call_dyn", jit_call_dyn as *const u8),
     ];
     for &(name, ptr) in helpers {
         builder.symbol(name, ptr);
@@ -527,6 +530,7 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         dtfmt: declare_helper(module, "jit_dtfmt", 2, 1),
         dtparse: declare_helper(module, "jit_dtparse", 2, 1),
         call_builtin_tree: declare_helper(module, "jit_call_builtin_tree", 3, 1),
+        call_dyn: declare_helper(module, "jit_call_dyn", 3, 1),
     }
 }
 
@@ -1798,12 +1802,43 @@ fn compile_function_body(
                 let kval = builder.ins().iconst(I64, bits as i64);
                 builder.def_var(vars[a_idx], kval);
             }
-            // OP_CALL_DYN: JIT translation arrives in PR 2 with the first
-            // native HOF lowering. PR 1 leaves the compiler unable to emit
-            // OP_CALL_DYN, so this arm is unreachable from PR-1 bytecode.
-            // Defensive: bail out of JIT compilation (None) so callers can
-            // fall back to the interpreter VM, which has the dispatcher.
-            OP_CALL_DYN => return None,
+            // ── Dynamic call by function reference ──
+            // ABC: A = result_reg, B = fnref_reg, C = argc.
+            // Args live contiguously in R[A+1..=A+argc] (mirrors OP_CALL
+            // and OP_CALL_BUILTIN_TREE). Cranelift cannot resolve the
+            // callee statically (FnRef id is only known at runtime), so we
+            // delegate to the `jit_call_dyn` helper which handles both
+            // FnRef kinds:
+            //   - Builtin → tree-bridge (same path as OP_CALL_BUILTIN_TREE)
+            //   - User    → fresh `VM::new(active_program).call(idx, args)`
+            // Both paths rely on the FnRef NaN-tagging plumbing from PR 1
+            // (#274) so FnRef args survive the boxing round-trip.
+            OP_CALL_DYN => {
+                let argc = c_idx;
+                let callee_val = builder.use_var(vars[b_idx]);
+                let argc_val = builder.ins().iconst(I64, argc as i64);
+
+                let regs_ptr = if argc == 0 {
+                    builder.ins().iconst(I64, 0)
+                } else {
+                    let slot =
+                        builder.create_sized_stack_slot(cranelift_codegen::ir::StackSlotData::new(
+                            cranelift_codegen::ir::StackSlotKind::ExplicitSlot,
+                            (argc * 8) as u32,
+                            0,
+                        ));
+                    for i in 0..argc {
+                        let src = builder.use_var(vars[a_idx + 1 + i]);
+                        builder.ins().stack_store(src, slot, (i * 8) as i32);
+                    }
+                    builder.ins().stack_addr(I64, slot, 0)
+                };
+
+                let fref = get_func_ref(&mut builder, module, helpers.call_dyn);
+                let call_inst = builder.ins().call(fref, &[callee_val, argc_val, regs_ptr]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
             OP_JMP => {
                 let sbx = (inst & 0xFFFF) as i16;
                 let target = (ip as isize + 1 + sbx as isize) as usize;

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -22382,7 +22382,6 @@ mod tests {
     // ── HOF builtins: map, flt, fld, grp ────────────────────────────────
 
     #[test]
-    #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
     fn vm_map_squares() {
         let source = "sq x:n>n;*x x main xs:L n>L n;map sq xs";
         let result = vm_run(
@@ -22416,7 +22415,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
     fn vm_map_wrong_list_arg() {
         let source = "sq x:n>n;*x x f>t;map sq 42";
         let err = vm_run_err(source, Some("f"), vec![]);

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -3476,6 +3476,15 @@ thread_local! {
     /// pointer to a `[String]`, paired with a length stored separately.
     static ACTIVE_FUNC_NAMES: std::cell::Cell<*const Vec<String>> =
         const { std::cell::Cell::new(std::ptr::null()) };
+    /// Active `CompiledProgram` pointer, set by `with_active_registry`
+    /// during a Cranelift JIT invocation. Used by `jit_call_dyn` to
+    /// re-enter the VM for a user-fn callback inside a HOF (`map`, etc.).
+    /// The JIT itself has no re-entrant function pointer table for
+    /// dynamic dispatch, so the FnRef → user-fn path routes through a
+    /// fresh `VM::new(compiled).call(func_idx, args)` on the same
+    /// bytecode program. Cleared by `with_active_registry`'s drop guard.
+    static ACTIVE_PROGRAM: std::cell::Cell<*const CompiledProgram> =
+        const { std::cell::Cell::new(std::ptr::null()) };
 }
 
 /// Look up a user-fn name by index in the currently active `func_names`
@@ -3515,11 +3524,13 @@ pub fn with_active_registry<R>(program: &CompiledProgram, f: impl FnOnce() -> R)
         fn drop(&mut self) {
             ACTIVE_REGISTRY.with(|r| r.set(std::ptr::null()));
             ACTIVE_FUNC_NAMES.with(|r| r.set(std::ptr::null()));
+            ACTIVE_PROGRAM.with(|r| r.set(std::ptr::null()));
         }
     }
 
     ACTIVE_REGISTRY.with(|r| r.set(&program.type_registry as *const TypeRegistry));
     ACTIVE_FUNC_NAMES.with(|r| r.set(&program.func_names as *const Vec<String>));
+    ACTIVE_PROGRAM.with(|r| r.set(program as *const CompiledProgram));
     let _guard = ClearGuard;
     f()
 }
@@ -11269,6 +11280,114 @@ pub(crate) extern "C" fn jit_call_builtin_tree(tag: u64, argc: u64, regs_ptr: u6
     match crate::interpreter::call_builtin_for_bridge(builtin.name(), value_args) {
         Ok(v) => NanVal::from_value(&v).0,
         Err(_) => TAG_NIL,
+    }
+}
+
+/// Dynamic call helper for the Cranelift JIT's OP_CALL_DYN lowering.
+///
+/// Args:
+///   callee_bits: NanVal bits of a FnRef (kind + id encoded by `NanVal::fnref`)
+///   argc:        number of args (callable via this helper today is 1; the
+///                signature uses an arg slice for forward-compat)
+///   regs_ptr:    pointer to `argc` contiguous NanVal slots holding the args
+///
+/// Dispatch:
+///   - Builtin FnRef → route through the tree-bridge (`call_builtin_for_bridge`),
+///     the same path `jit_call_builtin_tree` uses. This handles every builtin
+///     uniformly; HOFs receive `Value::FnRef` arg(s) since FnRef NaN-tagging
+///     round-trips losslessly through `to_value`/`from_value` (PR 1).
+///   - User-fn FnRef → spin up a fresh `VM::new(active_program).call(idx, args)`.
+///     Cranelift JIT has no re-entrant function pointer table for dynamic
+///     dispatch, so we re-enter the VM on the same bytecode program. The
+///     active program is published by `with_active_registry` via the
+///     `ACTIVE_PROGRAM` TLS slot, which is also responsible for clearing it.
+///
+/// Returns NanVal bits of the result, or `TAG_NIL` on any error path. The
+/// "swallow errors as nil" behaviour mirrors `jit_call_builtin_tree`; a
+/// follow-up can promote these to typed runtime errors once OP_CALL_DYN's
+/// in-band error signalling is wired (today the VM uses panics via `vm_err!`).
+///
+/// SAFETY: `regs_ptr` must point to at least `argc` valid `NanVal`s in
+/// readable memory for the duration of the call. The compiler emits a sized
+/// stack slot immediately before the call, mirroring `jit_call_builtin_tree`.
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_call_dyn(callee_bits: u64, argc: u64, regs_ptr: u64) -> u64 {
+    let callee = NanVal(callee_bits);
+    if !callee.is_fnref() {
+        return TAG_NIL;
+    }
+    let (kind, id) = callee.fnref_parts();
+    let argc = argc as usize;
+
+    // SAFETY: caller guarantees `regs_ptr` points to `argc` valid NanVals.
+    let regs: &[NanVal] = unsafe {
+        if argc == 0 {
+            &[]
+        } else {
+            std::slice::from_raw_parts(regs_ptr as *const NanVal, argc)
+        }
+    };
+
+    match kind {
+        FnRefKind::Builtin => {
+            let builtin = match crate::builtins::Builtin::from_tag(id as u8) {
+                Some(b) => b,
+                None => return TAG_NIL,
+            };
+            let mut value_args: Vec<Value> = Vec::with_capacity(argc);
+            for nv in regs {
+                // Use the program-aware bridge so FnRef args render with
+                // their source name rather than `<user_fn:N>`. Falls back
+                // gracefully if no program is active.
+                let v = ACTIVE_FUNC_NAMES.with(|cell| {
+                    let ptr = cell.get();
+                    if ptr.is_null() {
+                        nv.to_value()
+                    } else {
+                        // SAFETY: pointer is non-null; lifetime is bounded by
+                        // `with_active_registry`'s drop guard, which clears
+                        // this TLS before the borrow ends.
+                        let names: &Vec<String> = unsafe { &*ptr };
+                        nv.to_value_with_program(names)
+                    }
+                });
+                value_args.push(v);
+            }
+            match crate::interpreter::call_builtin_for_bridge(builtin.name(), value_args) {
+                Ok(v) => NanVal::from_value(&v).0,
+                Err(_) => TAG_NIL,
+            }
+        }
+        FnRefKind::User => {
+            // Re-enter the VM on the same bytecode program. ACTIVE_PROGRAM
+            // is published by `with_active_registry`, which the Cranelift
+            // entry path (`compile_and_call`) wraps around every JIT
+            // invocation.
+            let prog_ptr = ACTIVE_PROGRAM.with(|cell| cell.get());
+            if prog_ptr.is_null() {
+                return TAG_NIL;
+            }
+            // SAFETY: pointer was set by `with_active_registry` to a live
+            // borrow that outlives this helper's invocation (cleared by
+            // the drop guard at the end of `with_active_registry`'s scope).
+            let program: &CompiledProgram = unsafe { &*prog_ptr };
+            let func_idx = id as u16;
+            if (func_idx as usize) >= program.chunks.len() {
+                return TAG_NIL;
+            }
+            let mut value_args: Vec<Value> = Vec::with_capacity(argc);
+            for nv in regs {
+                value_args.push(nv.to_value_with_program(&program.func_names));
+            }
+            // Fresh VM on the same program. `call(func_idx, ...)` mirrors
+            // OP_CALL_DYN's User arm in the bytecode interpreter.
+            let mut sub_vm = VM::new(program);
+            match sub_vm.call(func_idx, value_args) {
+                Ok(v) => NanVal::from_value_with_program(&v, &program.func_names).0,
+                Err(_) => TAG_NIL,
+            }
+        }
     }
 }
 

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -377,9 +377,10 @@ pub(crate) const OP_PANIC_UNWRAP: u8 = 164;
 /// round-tripping is lossless. Adding a new entry here makes the builtin
 /// callable from `--run-vm` and `--run-cranelift` for free.
 ///
-/// HOFs (`map`, `flt`, `fld`, `grp`, `flatmap`, `uniqby`, `partition`,
-/// 2-arg `srt`, dynamic-fmt `wr`) are NOT eligible: their function-reference
-/// argument can't survive the round-trip until FnRef nan-tagging lands.
+/// HOFs (`flt`, `fld`, `grp`, `flatmap`, `uniqby`, `partition`,
+/// 2-arg `srt`, dynamic-fmt `wr`) are NOT eligible: they get native VM
+/// lifts in the HOF dispatch chain (PR 2+). `map` is already lifted —
+/// see the `(Builtin::Map, 2)` arm in the compiler.
 pub(crate) fn is_tree_bridge_eligible(b: crate::builtins::Builtin, argc: usize) -> bool {
     use crate::builtins::Builtin;
     match (b, argc) {
@@ -2652,12 +2653,102 @@ impl RegCompiler {
                             self.emit_abc(OP_MDEL, ra, rb, rc);
                             return ra;
                         }
+                        // map fn xs → native HOF loop using OP_CALL_DYN.
+                        // The FnRef plumbing from #274 means we can keep the
+                        // callee in a register (NanVal-tagged) and invoke it
+                        // per element without ever leaving bytecode land.
+                        // Emits, schematically:
+                        //   fn_reg    = compile(fn)         ; OP_LOADFN if Ref to user/builtin name
+                        //   xs_reg    = compile(xs)
+                        //   acc_reg   = OP_LISTNEW 0        ; empty result list
+                        //   idx_reg   = OP_LOADK 0.0
+                        //   item_reg  = OP_LOADK nil        ; loop binding (allocated)
+                        //   res_reg   = OP_LOADK nil        ; per-iteration call result
+                        //   arg_reg   = OP_LOADK nil        ; contiguous arg slot for OP_CALL_DYN
+                        //                                    (must be at res_reg + 1)
+                        //   loop_top: OP_FOREACHPREP item_reg, xs_reg, idx_reg
+                        //             JMP end                 (empty list)
+                        //   body:     OP_MOVE arg_reg, item_reg
+                        //             OP_CALL_DYN res_reg, fn_reg, 1
+                        //             OP_LISTAPPEND acc_reg, acc_reg, res_reg
+                        //             OP_FOREACHNEXT item_reg, xs_reg, idx_reg
+                        //             JMP end                 (out of bounds)
+                        //             JMP body
+                        //   end:
+                        //   ra = acc_reg
+                        (Builtin::Map, 2) => {
+                            let fn_reg = self.compile_expr(&args[0]);
+                            let xs_reg = self.compile_expr(&args[1]);
+
+                            // Result list — start empty, OP_LISTAPPEND grows it
+                            // in-place when acc == acc + item.
+                            let acc_reg = self.alloc_reg();
+                            self.emit_abx(OP_LISTNEW, acc_reg, 0);
+
+                            // Loop index (number, fits the FOREACHNEXT contract).
+                            let idx_reg = self.alloc_reg();
+                            let zero_ki = self.current.add_const(Value::Number(0.0));
+                            self.emit_abx(OP_LOADK, idx_reg, zero_ki);
+                            self.reg_is_num[idx_reg as usize] = true;
+
+                            // Loop binding — receives R[xs_reg][i].
+                            let item_reg = self.alloc_reg();
+                            let nil_ki = self.current.add_const(Value::Nil);
+                            self.emit_abx(OP_LOADK, item_reg, nil_ki);
+
+                            // OP_CALL_DYN reads args from R[result+1..=result+argc].
+                            // Reserve two contiguous regs (result, then arg) so the
+                            // single-arg callback layout is correct.
+                            let res_reg = self.alloc_reg();
+                            self.emit_abx(OP_LOADK, res_reg, nil_ki);
+                            let arg_reg = self.alloc_reg();
+                            assert!(
+                                arg_reg == res_reg + 1,
+                                "map HOF: arg reg must follow result reg contiguously"
+                            );
+                            self.emit_abx(OP_LOADK, arg_reg, nil_ki);
+
+                            // OP_FOREACHPREP validates xs is a list and loads xs[0]
+                            // into item_reg; on empty it falls through to the exit JMP.
+                            let _loop_top = self.current.code.len();
+                            self.emit_abc(OP_FOREACHPREP, item_reg, xs_reg, idx_reg);
+                            let exit_jump_a = self.emit_jmp_placeholder();
+
+                            // Body
+                            let body_top = self.current.code.len();
+                            self.emit_abc(OP_MOVE, arg_reg, item_reg, 0);
+                            self.emit_abc(OP_CALL_DYN, res_reg, fn_reg, 1);
+                            // acc_reg = acc_reg ++ [res_reg]. dst == src1 hits the
+                            // in-place RC=1 fast path in the dispatcher / cranelift.
+                            self.emit_abc(OP_LISTAPPEND, acc_reg, acc_reg, res_reg);
+
+                            // Advance and re-test
+                            self.emit_abc(OP_FOREACHNEXT, item_reg, xs_reg, idx_reg);
+                            let exit_jump_b = self.emit_jmp_placeholder();
+                            self.emit_jump_to(body_top);
+
+                            // Exit — patch both empty-list and end-of-list jumps
+                            self.current.patch_jump(exit_jump_a);
+                            self.current.patch_jump(exit_jump_b);
+
+                            // The bridge-style result fully boxes a list; reset the
+                            // numeric-tracking on the result register so downstream
+                            // arithmetic doesn't assume it's a raw f64.
+                            self.current_all_regs_numeric = false;
+                            self.reg_is_num[acc_reg as usize] = false;
+
+                            // Free the scratch regs above acc_reg so subsequent
+                            // expressions can reuse them. acc_reg stays live as
+                            // the call site's result.
+                            self.next_reg = acc_reg + 1;
+                            return acc_reg;
+                        }
                         // Builtins that fall through:
                         //   - tree-bridge eligible (rgx, rgxall, fmt-variadic, rd 2-arg, rdb)
                         //     → routed to OP_CALL_BUILTIN_TREE below
-                        //   - HOFs (map/flt/fld/grp/flatmap/uniqby/partition/srt 2-arg/wr 3-arg
-                        //     with dynamic fmt) → still error; FnRef args can't round-trip
-                        //     through the bridge until FnRef NaN-tagging lands
+                        //   - HOFs (flt/fld/grp/flatmap/uniqby/partition/srt 2-arg/wr 3-arg
+                        //     with dynamic fmt) → still error; their native lift lands
+                        //     in PR 3 of the HOF dispatch chain (PR 2 = `map` only)
                         _ => {}
                     }
                 }

--- a/tests/regression_hof_map.rs
+++ b/tests/regression_hof_map.rs
@@ -1,0 +1,127 @@
+// Regression tests for native `map` HOF dispatch on every engine
+// (PR 2 of the VM/Cranelift HOF dispatch chain).
+//
+// Background: PR 1 (#274) landed FnRef NaN-tagging so a function
+// reference could survive the NanVal round-trip on VM and Cranelift.
+// PR 2 puts that plumbing to work: the compiler emits a native bytecode
+// loop for `map fn xs` that calls back into the FnRef via OP_CALL_DYN,
+// and Cranelift lowers OP_CALL_DYN to a `jit_call_dyn` helper which
+// dispatches user-fns by re-entering the VM and builtins by routing
+// through the tree-bridge. Every engine now runs `map` end-to-end.
+//
+// The tests below pin the value-level behaviour across `--run-tree`,
+// `--run-vm` and `--run-cranelift`. They cover the common shapes that
+// were previously gated with `engine-skip: vm / cranelift`:
+//   - user-function callback (`map sq xs`)
+//   - builtin callback (`map abs xs`)
+//   - empty list (early-exit before the first OP_CALL_DYN)
+//   - single-element list (one trip through the loop body)
+//   - composition with the result of another `map` (chained HOFs)
+//   - tail-call shape where `map` is the function's return value
+//
+// Any divergence between engines should fail one of these tests rather
+// than silently producing different output.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn write_src(name: &str, src: &str) -> std::path::PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut path = std::env::temp_dir();
+    path.push(format!("ilo_hof_map_{name}_{}_{n}.ilo", std::process::id()));
+    std::fs::write(&path, src).expect("write src");
+    path
+}
+
+fn run_ok(engine: &str, src: &str, entry: &str, args: &[&str]) -> String {
+    let path = write_src(entry, src);
+    let mut cmd = ilo();
+    cmd.arg(&path).arg(engine).arg(entry);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn run_all(src: &str, entry: &str, args: &[&str], expected: &str) {
+    for engine in ["--run-tree", "--run-vm", "--run-cranelift"] {
+        let actual = run_ok(engine, src, entry, args);
+        assert_eq!(
+            actual, expected,
+            "engine {engine} produced {actual:?}, expected {expected:?} for src `{src}`"
+        );
+    }
+}
+
+// ── User-fn callback ────────────────────────────────────────────────────
+
+const MAP_USER_SQ: &str = "sq x:n>n;*x x\nmain xs:L n>L n;map sq xs";
+
+#[test]
+fn map_user_fn_squares_tree_vm_cranelift() {
+    run_all(MAP_USER_SQ, "main", &["[1,2,3,4,5]"], "[1, 4, 9, 16, 25]");
+}
+
+#[test]
+fn map_user_fn_empty_list() {
+    // Empty list short-circuits at OP_FOREACHPREP: the first JMP exits
+    // before any OP_CALL_DYN fires. Pins the dispatcher's "no callback
+    // for empty input" path on every engine.
+    run_all(MAP_USER_SQ, "main", &["[]"], "[]");
+}
+
+#[test]
+fn map_user_fn_single_element() {
+    // One iteration only. Worth pinning separately because it exercises
+    // OP_FOREACHPREP-stay-in-loop, then exactly one OP_CALL_DYN, then
+    // FOREACHNEXT-fallthrough-to-exit. Past HOF stubs failed here
+    // because the OP_LISTAPPEND in the body left acc_reg in a bad state.
+    run_all(MAP_USER_SQ, "main", &["[7]"], "[49]");
+}
+
+// ── Builtin callback ────────────────────────────────────────────────────
+
+// `abs` is a pure builtin promoted to F by the verifier (#165); the
+// Cranelift path goes through `jit_call_dyn` → tree-bridge for builtins.
+const MAP_BUILTIN_ABS: &str = "main xs:L n>L n;map abs xs";
+
+#[test]
+fn map_builtin_abs_round_trip() {
+    run_all(MAP_BUILTIN_ABS, "main", &["[-3, 0, 4, -7]"], "[3, 0, 4, 7]");
+}
+
+// ── Chained map (composition) ───────────────────────────────────────────
+
+// Two HOF calls in series: the result of the first feeds the second.
+// This pins that `map`'s result is a valid List value (not a smuggled
+// FnRef or stale heap pointer) when it flows back into another HOF.
+const MAP_CHAINED: &str = "sq x:n>n;*x x\nadd1 x:n>n;+x 1\nmain xs:L n>L n;map add1 (map sq xs)";
+
+#[test]
+fn map_chained_user_fns() {
+    run_all(MAP_CHAINED, "main", &["[1,2,3]"], "[2, 5, 10]");
+}
+
+// ── Tail-position map (result is the function's return) ─────────────────
+
+// Most function bodies in ilo return the last expression. With `map` as
+// the tail, the result register must survive OP_RET's RC accounting on
+// every engine. Pins that we don't drop the result list early.
+const MAP_TAIL: &str = "dbl x:n>n;*x 2\nmain xs:L n>L n;map dbl xs";
+
+#[test]
+fn map_tail_position_user_fn() {
+    run_all(MAP_TAIL, "main", &["[5, 10, 15]"], "[10, 20, 30]");
+}


### PR DESCRIPTION
## Summary

PR 2 of the HOF dispatch chain. PR 1 (#274) wired FnRef NaN-tagging so a function reference could survive a NanVal round-trip on VM and Cranelift. This PR puts that plumbing to work for the first HOF.

`map fn xs` now runs natively on every engine. The compiler emits a real bytecode loop using the OP_CALL_DYN opcode that PR 1 reserved, and Cranelift lowers OP_CALL_DYN through a new `jit_call_dyn` helper that re-enters the VM for user-fn callbacks and routes builtin callbacks through the tree-bridge.

Token-cost framing: the manifesto bet is that each engine should agree with the others on whatever ilo prints, so an agent never has to second-guess which engine its `-- run-vm` example ran under. `engine-skip: vm` lines and "tree-only" hedges in HOF examples were a tax on that promise. This PR cashes in the first slice of that for `map`.

## Repro before / after

```
sq x:n>n;*x x
main xs:L n>L n;map sq xs
```

Before:

```
$ ilo file.ilo --run-vm main [1,2,3,4,5]
Compile error: undefined function: map   # the HOF arm errored out

$ ilo file.ilo --run-cranelift main [1,2,3,4,5]
Compile error: ...                       # same
```

After:

```
$ ilo file.ilo --run-tree main [1,2,3,4,5]
[1, 4, 9, 16, 25]
$ ilo file.ilo --run-vm main [1,2,3,4,5]
[1, 4, 9, 16, 25]
$ ilo file.ilo --run-cranelift main [1,2,3,4,5]
[1, 4, 9, 16, 25]
```

## What's in the diff (per commit)

- **vm: thread-local active program + jit_call_dyn helper for OP_CALL_DYN** — adds the runtime plumbing Cranelift needs. New `ACTIVE_PROGRAM` TLS slot published by `with_active_registry` (cleared by the same drop guard as the existing FUNC_NAMES / REGISTRY TLS). New `jit_call_dyn(callee_bits, argc, regs_ptr) -> u64` extern "C" helper: Builtin FnRef → tree-bridge (same path as `jit_call_builtin_tree`), User FnRef → fresh `VM::new(active_program).call(idx, args)`. The TLS-plus-helper combo is the minimum surface that lets Cranelift dispatch a FnRef whose target id is only known at runtime.

- **cranelift: lower OP_CALL_DYN through the jit_call_dyn helper** — replaces the PR-1 placeholders in both Cranelift backends (compile_cranelift returned an error, jit_cranelift bailed JIT compilation with None). Mirrors the OP_CALL_BUILTIN_TREE pattern: spill arg slots into a sized stack slot and pass `(callee_bits, argc, regs_ptr)` to the helper. Both backends register the helper FuncId.

- **vm: native map HOF loop using OP_CALL_DYN** — `(Builtin::Map, 2)` arm in the bytecode compiler. Emits OP_LISTNEW for the accumulator, allocates contiguous result + arg scratch regs (so OP_CALL_DYN's R[A+1..=A+argc] layout is correct), drives the iteration with OP_FOREACHPREP / OP_FOREACHNEXT (the same pair `@i xs` uses), and grows the accumulator with OP_LISTAPPEND on the in-place RC=1 fast path. `is_tree_bridge_eligible` doc-comment loses `map` from the not-yet list. Also drops `#[ignore]` from `vm_map_squares` and `vm_map_wrong_list_arg`.

- **test + example: cross-engine coverage for native map HOF** — six cross-engine tests in `tests/regression_hof_map.rs` covering user-fn / builtin / empty / single-element / chained / tail-position shapes. `examples/map-fnref.ilo` doubles as an agent-facing learning sample and runs through `tests/examples_engines.rs` on every engine.

- **example: lift vm/cranelift skip from window.ilo** — `sums>L n;map sum (window 3 [1,2,3,4,5])` now runs on every engine and no longer needs the skip annotation.

## Test plan

- [x] `cargo build --release --features cranelift` clean
- [x] `cargo test --release --features cranelift` — all 4803 tests pass, 0 failures across 113 suites (includes the new `regression_hof_map` and the cross-engine `examples_engines` harness which exercises the updated `window.ilo`)
- [x] `cargo clippy --release --features cranelift --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Manual cross-engine smoke: `map sq [1,2,3,4,5]` and `map abs [-3,0,4,-7]` return identical output on `--run-tree`, `--run-vm`, `--run-cranelift`

## Follow-ups (PR 3, not in this diff)

- `flt`, `fld`, `grp`, `flatmap`, `uniqby`, `partition`, 2-arg `srt`, dynamic-fmt `wr` — same native-loop pattern, each with its own emitter arm
- The 23+ tests still gated with `#[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.` for the other HOFs
- 3-arg closure-bind `map fn ctx xs` (verifier accepts it; the emitter currently only handles 2-arg)
- `Value::Text`-as-callable dispatch (the `vm_map_with_text_fn_name` shape) — needs OP_CALL_DYN to accept a Text fallback alongside FnRef