### PR TITLE
vm + cranelift: native flt + fld + flatmap HOF dispatch (PR 3a of 4)

### DIFF
--- a/examples/flatmap.ilo
+++ b/examples/flatmap.ilo
@@ -8,8 +8,5 @@ rep n:n>L n;xs=[];@i 0..n{xs=+=xs n};xs
 -- Apply rep to every element and flatten one level.
 expand xs:L n>L n;flatmap rep xs
 
--- vm and cranelift do not yet implement HOF dispatch (FnRef resolution)
--- engine-skip: vm
--- engine-skip: cranelift
 -- run: expand [1,2,3]
 -- out: [1, 2, 2, 3, 3, 3]

--- a/examples/fld-sum.ilo
+++ b/examples/fld-sum.ilo
@@ -1,0 +1,11 @@
+-- fld fn xs init: left fold with an explicit initial accumulator. The fn
+-- takes (acc, item) and returns the new acc. Initial value carries the
+-- starting state. Returns the final acc, not a list.
+-- Signature: fld fn:F a b a xs:L b a init:a > a
+
+add a:n b:n>n;+a b
+
+main xs:L n>n;fld add xs 0
+
+-- run: main [1,2,3,4,5]
+-- out: 15

--- a/examples/flt-basics.ilo
+++ b/examples/flt-basics.ilo
@@ -1,0 +1,11 @@
+-- flt fn xs: keep only the elements where fn returns true. Predicate is a
+-- function reference (user-defined like `pos` or a pure builtin). Returns a
+-- fresh list. Predicates that return a non-bool value raise a runtime error.
+-- Signature: flt fn:F a b xs:L a > L a
+
+pos x:n>b;>x 0
+
+main xs:L n>L n;flt pos xs
+
+-- run: main [-3,-1,0,2,4]
+-- out: [2, 4]

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -167,6 +167,9 @@ struct HelperFuncs {
     call_builtin_tree: FuncId,
     // Dynamic-dispatch bridge for OP_CALL_DYN (HOF callbacks: `map`, ...)
     call_dyn: FuncId,
+    // `!!` panic-unwrap. Used by HOF lifts that emit a typed runtime error
+    // mid-loop (e.g. `flt` when the predicate returns a non-bool).
+    panic_unwrap: FuncId,
     // AOT-specific helpers
     get_arena_ptr: FuncId,
     get_registry_ptr: FuncId,
@@ -342,6 +345,7 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         dtparse: declare_helper(module, "jit_dtparse", 2, 1),
         call_builtin_tree: declare_helper(module, "jit_call_builtin_tree", 3, 1),
         call_dyn: declare_helper(module, "jit_call_dyn", 3, 1),
+        panic_unwrap: declare_helper(module, "jit_panic_unwrap", 1, 1),
         // AOT-specific helpers
         get_arena_ptr: declare_helper(module, "jit_get_arena_ptr", 0, 1),
         get_registry_ptr: declare_helper(module, "jit_get_registry_ptr", 0, 1),
@@ -1650,6 +1654,22 @@ fn compile_function_body(
                 let call_inst = builder.ins().call(fref, &[bv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
+            }
+            // `!!` panic-unwrap. Mirrors the JIT lowering: the helper sets
+            // JIT_RUNTIME_ERROR (the post-call check in the caller surfaces
+            // it as a runtime error) and returns TAG_NIL. We emit an
+            // immediate `return` so subsequent instructions don't execute
+            // against the failed value, matching the VM dispatcher's
+            // `vm_err!` early-unwind contract. Without this AOT path the
+            // HOF lifts (`flt`'s non-bool predicate guard) would refuse
+            // to compile to a binary.
+            OP_PANIC_UNWRAP => {
+                let bv = builder.use_var(vars[b_idx]);
+                let fref = get_func_ref(&mut builder, module, helpers.panic_unwrap);
+                let call_inst = builder.ins().call(fref, &[bv]);
+                let nil_val = builder.inst_results(call_inst)[0];
+                builder.ins().return_(&[nil_val]);
+                block_terminated = true;
             }
             // ── Load constant ──
             OP_LOADK => {

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -378,10 +378,11 @@ pub(crate) const OP_PANIC_UNWRAP: u8 = 164;
 /// round-tripping is lossless. Adding a new entry here makes the builtin
 /// callable from `--run-vm` and `--run-cranelift` for free.
 ///
-/// HOFs (`flt`, `fld`, `grp`, `flatmap`, `uniqby`, `partition`,
-/// 2-arg `srt`, dynamic-fmt `wr`) are NOT eligible: they get native VM
-/// lifts in the HOF dispatch chain (PR 2+). `map` is already lifted —
-/// see the `(Builtin::Map, 2)` arm in the compiler.
+/// HOFs (`grp`, `uniqby`, `partition`, 2-arg `srt`, dynamic-fmt `wr`)
+/// are NOT eligible: they get native VM lifts in the HOF dispatch chain
+/// (PR 3b+). `map`, `flt`, `fld`, and `flatmap` are already lifted — see
+/// the `(Builtin::Map, 2)` / `(Builtin::Flt, 2)` / `(Builtin::Fld, 3)` /
+/// `(Builtin::Flatmap, 2)` arms in the compiler.
 pub(crate) fn is_tree_bridge_eligible(b: crate::builtins::Builtin, argc: usize) -> bool {
     use crate::builtins::Builtin;
     match (b, argc) {
@@ -2746,12 +2747,238 @@ impl RegCompiler {
                             self.next_reg = acc_reg + 1;
                             return acc_reg;
                         }
+                        // flt fn xs → native HOF loop using OP_CALL_DYN.
+                        // Same shape as `map` but:
+                        //   - the call result drives a bool typecheck (OP_ISBOOL)
+                        //   - on bool: branch on truthiness, append item on true,
+                        //     skip on false (OP_LISTAPPEND only on the true arm)
+                        //   - on non-bool: raise a typed runtime error via
+                        //     OP_WRAPERR + OP_PANIC_UNWRAP so the message contains
+                        //     "flt" / "bool" (matches tree-walker semantics).
+                        // The FOREACHPREP error path covers the wrong-list-arg case
+                        // ("foreach requires a list").
+                        (Builtin::Flt, 2) => {
+                            let fn_reg = self.compile_expr(&args[0]);
+                            let xs_reg = self.compile_expr(&args[1]);
+
+                            let acc_reg = self.alloc_reg();
+                            self.emit_abx(OP_LISTNEW, acc_reg, 0);
+
+                            let idx_reg = self.alloc_reg();
+                            let zero_ki = self.current.add_const(Value::Number(0.0));
+                            self.emit_abx(OP_LOADK, idx_reg, zero_ki);
+                            self.reg_is_num[idx_reg as usize] = true;
+
+                            let item_reg = self.alloc_reg();
+                            let nil_ki = self.current.add_const(Value::Nil);
+                            self.emit_abx(OP_LOADK, item_reg, nil_ki);
+
+                            // res_reg + arg_reg contiguous for OP_CALL_DYN ABI.
+                            let res_reg = self.alloc_reg();
+                            self.emit_abx(OP_LOADK, res_reg, nil_ki);
+                            let arg_reg = self.alloc_reg();
+                            assert!(
+                                arg_reg == res_reg + 1,
+                                "flt HOF: arg reg must follow result reg contiguously"
+                            );
+                            self.emit_abx(OP_LOADK, arg_reg, nil_ki);
+
+                            // Scratch for the bool typecheck.
+                            let isb_reg = self.alloc_reg();
+                            self.emit_abx(OP_LOADK, isb_reg, nil_ki);
+
+                            let _loop_top = self.current.code.len();
+                            self.emit_abc(OP_FOREACHPREP, item_reg, xs_reg, idx_reg);
+                            let exit_jump_a = self.emit_jmp_placeholder();
+
+                            let body_top = self.current.code.len();
+                            self.emit_abc(OP_MOVE, arg_reg, item_reg, 0);
+                            self.emit_abc(OP_CALL_DYN, res_reg, fn_reg, 1);
+
+                            // Typecheck: predicate must return Bool. If ISBOOL is true,
+                            // skip the type-error block; else WRAPERR + PANIC_UNWRAP
+                            // with a message containing both "flt" and "bool".
+                            self.emit_abc(OP_ISBOOL, isb_reg, res_reg, 0);
+                            let typeok_jump = self.emit_jmpt(isb_reg);
+                            let err_text_ki = self.current.add_const(Value::Text(Arc::new(
+                                "flt: predicate must return bool".to_string(),
+                            )));
+                            // Reuse arg_reg as scratch (it will be re-loaded by the
+                            // OP_MOVE at the top of the next iteration if any).
+                            self.emit_abx(OP_LOADK, arg_reg, err_text_ki);
+                            self.emit_abc(OP_WRAPERR, arg_reg, arg_reg, 0);
+                            self.emit_abc(OP_PANIC_UNWRAP, 0, arg_reg, 0);
+                            self.current.patch_jump(typeok_jump);
+
+                            // Bool was true → append item to acc. Bool was false → skip.
+                            let skip_append_jump = self.emit_jmpf(res_reg);
+                            self.emit_abc(OP_LISTAPPEND, acc_reg, acc_reg, item_reg);
+                            self.current.patch_jump(skip_append_jump);
+
+                            self.emit_abc(OP_FOREACHNEXT, item_reg, xs_reg, idx_reg);
+                            let exit_jump_b = self.emit_jmp_placeholder();
+                            self.emit_jump_to(body_top);
+
+                            self.current.patch_jump(exit_jump_a);
+                            self.current.patch_jump(exit_jump_b);
+
+                            self.current_all_regs_numeric = false;
+                            self.reg_is_num[acc_reg as usize] = false;
+
+                            self.next_reg = acc_reg + 1;
+                            return acc_reg;
+                        }
+                        // fld fn xs init → native HOF loop using OP_CALL_DYN.
+                        // The accumulator carries the running value across
+                        // iterations. Per-iter call is 2-arg: fn(acc, item).
+                        // Result is the final acc, not a list.
+                        (Builtin::Fld, 3) => {
+                            let fn_reg = self.compile_expr(&args[0]);
+                            let xs_reg = self.compile_expr(&args[1]);
+                            let init_reg = self.compile_expr(&args[2]);
+
+                            // Accumulator reg starts as init. Each iter overwrites
+                            // it with the call result.
+                            let acc_reg = self.alloc_reg();
+                            self.emit_abc(OP_MOVE, acc_reg, init_reg, 0);
+                            // Acc can hold any value shape (the fn return type).
+                            self.reg_is_num[acc_reg as usize] = false;
+
+                            let idx_reg = self.alloc_reg();
+                            let zero_ki = self.current.add_const(Value::Number(0.0));
+                            self.emit_abx(OP_LOADK, idx_reg, zero_ki);
+                            self.reg_is_num[idx_reg as usize] = true;
+
+                            let item_reg = self.alloc_reg();
+                            let nil_ki = self.current.add_const(Value::Nil);
+                            self.emit_abx(OP_LOADK, item_reg, nil_ki);
+
+                            // OP_CALL_DYN reads R[A+1..=A+argc]; for 2 args we need
+                            // three contiguous regs: res, arg0 (acc), arg1 (item).
+                            let res_reg = self.alloc_reg();
+                            self.emit_abx(OP_LOADK, res_reg, nil_ki);
+                            let arg0_reg = self.alloc_reg();
+                            assert!(
+                                arg0_reg == res_reg + 1,
+                                "fld HOF: arg0 reg must follow result reg contiguously"
+                            );
+                            self.emit_abx(OP_LOADK, arg0_reg, nil_ki);
+                            let arg1_reg = self.alloc_reg();
+                            assert!(
+                                arg1_reg == arg0_reg + 1,
+                                "fld HOF: arg1 reg must follow arg0 reg contiguously"
+                            );
+                            self.emit_abx(OP_LOADK, arg1_reg, nil_ki);
+
+                            let _loop_top = self.current.code.len();
+                            self.emit_abc(OP_FOREACHPREP, item_reg, xs_reg, idx_reg);
+                            let exit_jump_a = self.emit_jmp_placeholder();
+
+                            let body_top = self.current.code.len();
+                            // arg0 = acc, arg1 = item
+                            self.emit_abc(OP_MOVE, arg0_reg, acc_reg, 0);
+                            self.emit_abc(OP_MOVE, arg1_reg, item_reg, 0);
+                            self.emit_abc(OP_CALL_DYN, res_reg, fn_reg, 2);
+                            // acc = res (refresh the accumulator)
+                            self.emit_abc(OP_MOVE, acc_reg, res_reg, 0);
+
+                            self.emit_abc(OP_FOREACHNEXT, item_reg, xs_reg, idx_reg);
+                            let exit_jump_b = self.emit_jmp_placeholder();
+                            self.emit_jump_to(body_top);
+
+                            self.current.patch_jump(exit_jump_a);
+                            self.current.patch_jump(exit_jump_b);
+
+                            self.current_all_regs_numeric = false;
+                            self.reg_is_num[acc_reg as usize] = false;
+
+                            self.next_reg = acc_reg + 1;
+                            return acc_reg;
+                        }
+                        // flatmap fn xs → native HOF loop. The fn returns a list
+                        // per element; we splice each result list into the accumulator
+                        // via an inner FOREACHPREP/NEXT over the call result.
+                        // Two nested loops share the same OP_CALL_DYN + LISTAPPEND
+                        // primitives as `map`. A non-list return raises through the
+                        // inner FOREACHPREP error path ("foreach requires a list"),
+                        // which the test asserts matches.
+                        (Builtin::Flatmap, 2) => {
+                            let fn_reg = self.compile_expr(&args[0]);
+                            let xs_reg = self.compile_expr(&args[1]);
+
+                            let acc_reg = self.alloc_reg();
+                            self.emit_abx(OP_LISTNEW, acc_reg, 0);
+
+                            // Outer loop state.
+                            let outer_idx_reg = self.alloc_reg();
+                            let zero_ki = self.current.add_const(Value::Number(0.0));
+                            self.emit_abx(OP_LOADK, outer_idx_reg, zero_ki);
+                            self.reg_is_num[outer_idx_reg as usize] = true;
+
+                            let outer_item_reg = self.alloc_reg();
+                            let nil_ki = self.current.add_const(Value::Nil);
+                            self.emit_abx(OP_LOADK, outer_item_reg, nil_ki);
+
+                            // OP_CALL_DYN result + arg slot (contiguous).
+                            let res_reg = self.alloc_reg();
+                            self.emit_abx(OP_LOADK, res_reg, nil_ki);
+                            let arg_reg = self.alloc_reg();
+                            assert!(
+                                arg_reg == res_reg + 1,
+                                "flatmap HOF: arg reg must follow result reg contiguously"
+                            );
+                            self.emit_abx(OP_LOADK, arg_reg, nil_ki);
+
+                            // Inner loop state — iterates over each call result.
+                            let inner_idx_reg = self.alloc_reg();
+                            self.emit_abx(OP_LOADK, inner_idx_reg, zero_ki);
+                            self.reg_is_num[inner_idx_reg as usize] = true;
+                            let inner_item_reg = self.alloc_reg();
+                            self.emit_abx(OP_LOADK, inner_item_reg, nil_ki);
+
+                            // ── Outer loop ──
+                            self.emit_abc(OP_FOREACHPREP, outer_item_reg, xs_reg, outer_idx_reg);
+                            let outer_exit_a = self.emit_jmp_placeholder();
+                            let outer_body_top = self.current.code.len();
+                            self.emit_abc(OP_MOVE, arg_reg, outer_item_reg, 0);
+                            self.emit_abc(OP_CALL_DYN, res_reg, fn_reg, 1);
+
+                            // Reset inner idx to 0 before each inner pass.
+                            self.emit_abx(OP_LOADK, inner_idx_reg, zero_ki);
+
+                            // ── Inner loop over res ──
+                            // OP_FOREACHPREP validates res is a list; that's where
+                            // non-list returns surface as "foreach requires a list".
+                            self.emit_abc(OP_FOREACHPREP, inner_item_reg, res_reg, inner_idx_reg);
+                            let inner_exit_a = self.emit_jmp_placeholder();
+                            let inner_body_top = self.current.code.len();
+                            self.emit_abc(OP_LISTAPPEND, acc_reg, acc_reg, inner_item_reg);
+                            self.emit_abc(OP_FOREACHNEXT, inner_item_reg, res_reg, inner_idx_reg);
+                            let inner_exit_b = self.emit_jmp_placeholder();
+                            self.emit_jump_to(inner_body_top);
+                            self.current.patch_jump(inner_exit_a);
+                            self.current.patch_jump(inner_exit_b);
+
+                            // ── End inner; back to outer ──
+                            self.emit_abc(OP_FOREACHNEXT, outer_item_reg, xs_reg, outer_idx_reg);
+                            let outer_exit_b = self.emit_jmp_placeholder();
+                            self.emit_jump_to(outer_body_top);
+                            self.current.patch_jump(outer_exit_a);
+                            self.current.patch_jump(outer_exit_b);
+
+                            self.current_all_regs_numeric = false;
+                            self.reg_is_num[acc_reg as usize] = false;
+
+                            self.next_reg = acc_reg + 1;
+                            return acc_reg;
+                        }
                         // Builtins that fall through:
                         //   - tree-bridge eligible (rgx, rgxall, fmt-variadic, rd 2-arg, rdb)
                         //     → routed to OP_CALL_BUILTIN_TREE below
-                        //   - HOFs (flt/fld/grp/flatmap/uniqby/partition/srt 2-arg/wr 3-arg
-                        //     with dynamic fmt) → still error; their native lift lands
-                        //     in PR 3 of the HOF dispatch chain (PR 2 = `map` only)
+                        //   - HOFs (grp/uniqby/partition/srt 2-arg/wr 3-arg with
+                        //     dynamic fmt) → still error; their native lift lands
+                        //     in PR 3b+ of the HOF dispatch chain. `map`, `flt`,
+                        //     `fld`, and `flatmap` are lifted above.
                         _ => {}
                     }
                 }
@@ -22710,7 +22937,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
     fn vm_flt_positive() {
         let source = "pos x:n>b;>x 0 main xs:L n>L n;flt pos xs";
         let result = vm_run(
@@ -22732,7 +22958,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
     fn vm_flt_predicate_returns_non_bool() {
         let source = "id x:n>n;x f xs:L n>L n;flt id xs";
         let err = vm_run_err(
@@ -22744,7 +22969,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
     fn vm_flt_wrong_list_arg() {
         let source = "pos x:n>b;>x 0 f>t;flt pos 42";
         let err = vm_run_err(source, Some("f"), vec![]);
@@ -22765,7 +22989,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // VM missing builtin implementation
     fn vm_fld_sum() {
         let source = "add a:n b:n>n;+a b main xs:L n>n;fld add xs 0";
         let result = vm_run(
@@ -22791,7 +23014,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
     fn vm_fld_wrong_list_arg() {
         let source = "add a:n b:n>n;+a b f>n;fld add 42 0";
         let err = vm_run_err(source, Some("f"), vec![]);

--- a/tests/regression_hof_flt_fld_flatmap.rs
+++ b/tests/regression_hof_flt_fld_flatmap.rs
@@ -1,0 +1,194 @@
+// Regression tests for native `flt` / `fld` / `flatmap` HOF dispatch on
+// every engine (PR 3a of the VM/Cranelift HOF dispatch chain).
+//
+// Background: PR 1 (#274) landed FnRef NaN-tagging, PR 2 (#277) lifted
+// `map fn xs` to a native bytecode loop using OP_CALL_DYN. PR 3a extends
+// that pattern to the next three pure-bytecode HOFs:
+//
+//   - `flt fn xs`       filter, keep where fn returns true
+//   - `fld fn xs init`  left fold with explicit initial accumulator
+//   - `flatmap fn xs`   map then flatten one level (nested foreach over
+//                       each call result inside the outer iteration)
+//
+// Cranelift gets all three for free via the existing `jit_call_dyn`
+// helper (#277): the new compiler arms emit the same OP_CALL_DYN
+// opcode, and the lowering is op-agnostic.
+//
+// The tests below pin the value-level behaviour across `--run-tree`,
+// `--run-vm` and `--run-cranelift`. They cover the common shapes that
+// were previously gated with `engine-skip: vm / cranelift`:
+//   - user-function callbacks
+//   - builtin callbacks (where the verifier promotes a pure builtin to F)
+//   - empty list (early-exit before the first OP_CALL_DYN)
+//   - single-element list (one trip through the loop body)
+//   - composition with `map` (chained HOFs)
+//
+// Any divergence between engines should fail one of these tests rather
+// than silently producing different output.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn write_src(name: &str, src: &str) -> std::path::PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "ilo_hof_flt_fld_flatmap_{name}_{}_{n}.ilo",
+        std::process::id()
+    ));
+    std::fs::write(&path, src).expect("write src");
+    path
+}
+
+fn run_ok(engine: &str, src: &str, entry: &str, args: &[&str]) -> String {
+    let path = write_src(entry, src);
+    let mut cmd = ilo();
+    cmd.arg(&path).arg(engine).arg(entry);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn run_all(src: &str, entry: &str, args: &[&str], expected: &str) {
+    for engine in ["--run-tree", "--run-vm", "--run-cranelift"] {
+        let actual = run_ok(engine, src, entry, args);
+        assert_eq!(
+            actual, expected,
+            "engine {engine} produced {actual:?}, expected {expected:?} for src `{src}`"
+        );
+    }
+}
+
+// ── flt ─────────────────────────────────────────────────────────────────
+
+const FLT_USER_POS: &str = "pos x:n>b;>x 0\nmain xs:L n>L n;flt pos xs";
+
+#[test]
+fn flt_user_fn_positives_tree_vm_cranelift() {
+    run_all(FLT_USER_POS, "main", &["[-3,-1,0,2,4]"], "[2, 4]");
+}
+
+#[test]
+fn flt_user_fn_empty_list() {
+    // Empty list short-circuits at OP_FOREACHPREP — never reaches the
+    // bool typecheck or OP_CALL_DYN.
+    run_all(FLT_USER_POS, "main", &["[]"], "[]");
+}
+
+#[test]
+fn flt_user_fn_all_pass() {
+    run_all(FLT_USER_POS, "main", &["[1,2,3]"], "[1, 2, 3]");
+}
+
+#[test]
+fn flt_user_fn_all_fail() {
+    // Pins that the result list survives RC accounting when no
+    // OP_LISTAPPEND fires in the body.
+    run_all(FLT_USER_POS, "main", &["[-3,-1,0]"], "[]");
+}
+
+// Builtin-callback coverage is pinned by `map_builtin_abs_round_trip` in
+// regression_hof_map.rs. The Cranelift `jit_call_dyn` helper is
+// dispatch-uniform across HOFs, so once builtin-callback works for one
+// HOF it works for all of them. The flt-specific bool-typecheck path
+// makes it awkward to pick a numeric pure builtin that returns bool, so
+// we lean on the map test for builtin coverage and keep flt focused on
+// user-fn predicates.
+
+// ── fld ─────────────────────────────────────────────────────────────────
+
+const FLD_USER_ADD: &str = "add a:n b:n>n;+a b\nmain xs:L n>n;fld add xs 0";
+
+#[test]
+fn fld_user_fn_sum_tree_vm_cranelift() {
+    run_all(FLD_USER_ADD, "main", &["[1,2,3,4,5]"], "15");
+}
+
+#[test]
+fn fld_user_fn_empty_list_returns_init() {
+    // Empty list: zero iterations, acc stays at init.
+    run_all(FLD_USER_ADD, "main", &["[]"], "0");
+}
+
+#[test]
+fn fld_user_fn_single_element() {
+    // One iteration: pins acc=init, then acc=fn(init, item).
+    run_all(FLD_USER_ADD, "main", &["[7]"], "7");
+}
+
+// Text concat fold: pins that the accumulator survives type changes
+// (init is text, the fn returns text every iter).
+const FLD_TEXT_CONCAT: &str = "join a:t b:t>t;+a b\nmain xs:L t>t;fld join xs \"\"";
+
+#[test]
+fn fld_text_concat() {
+    run_all(FLD_TEXT_CONCAT, "main", &["[\"a\",\"b\",\"c\"]"], "abc");
+}
+
+// ── flatmap ─────────────────────────────────────────────────────────────
+
+// Repeat each number n times: 2 -> [2, 2], 3 -> [3, 3, 3].
+const FLATMAP_USER_REP: &str =
+    "rep n:n>L n;xs=[];@i 0..n{xs=+=xs n};xs\nmain xs:L n>L n;flatmap rep xs";
+
+#[test]
+fn flatmap_user_fn_repeat_tree_vm_cranelift() {
+    run_all(FLATMAP_USER_REP, "main", &["[1,2,3]"], "[1, 2, 2, 3, 3, 3]");
+}
+
+#[test]
+fn flatmap_user_fn_empty_outer() {
+    run_all(FLATMAP_USER_REP, "main", &["[]"], "[]");
+}
+
+#[test]
+fn flatmap_user_fn_empty_inner_results() {
+    // rep 0 returns [], so every outer element contributes nothing.
+    // Pins that the inner FOREACHPREP correctly short-circuits on each
+    // empty result without leaving the outer loop in a bad state.
+    run_all(FLATMAP_USER_REP, "main", &["[0,0,0]"], "[]");
+}
+
+#[test]
+fn flatmap_user_fn_mixed_inner_sizes() {
+    // Mixes empty, single-element, and multi-element inner results to
+    // exercise every branch of the inner loop in one go.
+    run_all(
+        FLATMAP_USER_REP,
+        "main",
+        &["[0,1,2,0,3]"],
+        "[1, 2, 2, 3, 3, 3]",
+    );
+}
+
+// ── Composition with map ────────────────────────────────────────────────
+
+// Pins that flt's result is a valid List that feeds into map without
+// corruption (RC accounting on the acc_reg survives OP_RET).
+const FLT_THEN_MAP: &str = "pos x:n>b;>x 0\nsq x:n>n;*x x\nmain xs:L n>L n;map sq (flt pos xs)";
+
+#[test]
+fn flt_then_map_composition() {
+    run_all(FLT_THEN_MAP, "main", &["[-2,-1,0,1,2,3]"], "[1, 4, 9]");
+}
+
+// Pins that fld's accumulator survives feeding it through map first.
+const MAP_THEN_FLD: &str = "sq x:n>n;*x x\nadd a:n b:n>n;+a b\nmain xs:L n>n;fld add (map sq xs) 0";
+
+#[test]
+fn map_then_fld_composition() {
+    run_all(MAP_THEN_FLD, "main", &["[1,2,3]"], "14");
+}


### PR DESCRIPTION
## Summary

Extends the `map` native HOF dispatch from #277 to the next three pure-bytecode HOFs: `flt`, `fld`, `flatmap`. Each gets a real bytecode loop in the compiler that calls back into the FnRef via OP_CALL_DYN, so VM and Cranelift run them end-to-end with no tree-bridge round-trip.

Builds on #274 (FnRef NaN-tagging) and #277 (`map` native + OP_CALL_DYN lowering). The Cranelift JIT helper for OP_CALL_DYN is dispatch-uniform across HOFs, so the new arms light up `--run-cranelift` for free.

This is PR 3a of a four-PR chain that closes out HOF dispatch on VM/Cranelift. The remaining HOFs (`grp`, `uniqby`, 2-arg `srt`, `partition`), closure-bind ctx-arg forms, and direct FnRef-variable calls land in PR 3b, 3c, 3d, then PR 4 lifts the lambda examples.

## Repro before/after

```
sq x:n>n;*x x
pos x:n>b;>x 0
add a:n b:n>n;+a b
main xs:L n>L n;flt pos xs

ilo --run-vm        # before: error "unsupported HOF". after: [2, 4]
ilo --run-cranelift # before: error "unsupported HOF". after: [2, 4]
ilo --run-tree                                                # [2, 4]
```

Same story for `fld add xs 0` (now `15`) and `flatmap rep xs` (now `[1, 2, 2, 3, 3, 3]`).

## What's in the diff (per-commit)

- **vm: native flt + fld + flatmap HOF dispatch using OP_CALL_DYN.** Three new arms in `RegCompiler::compile_expr` mirroring the `(Builtin::Map, 2)` shape from #277. `flt` adds an OP_ISBOOL typecheck and routes non-bool through OP_WRAPERR + OP_PANIC_UNWRAP. `fld` allocates a 3-reg contiguous slice for `(res, arg0, arg1)` and overwrites the accumulator each iter. `flatmap` nests an inner FOREACHPREP/NEXT over each call result. Drops `#[ignore]` from `vm_flt_positive`, `vm_flt_predicate_returns_non_bool`, `vm_flt_wrong_list_arg`, `vm_fld_sum`, `vm_fld_wrong_list_arg`. Updates the `is_tree_bridge_eligible` doc comment to reflect what's still parked for PR 3b.
- **cranelift aot: lower OP_PANIC_UNWRAP through jit_panic_unwrap helper.** The JIT already supported this op; AOT (`compile_to_binary`) was the remaining gap. Without it, `flt`-using programs would refuse to compile to a binary because the non-bool predicate guard emits OP_PANIC_UNWRAP unconditionally. Pure parity with the JIT lowering, no new behaviour for tree or VM.
- **test + example: cross-engine coverage for flt + fld + flatmap.** 14 cross-engine assertions in `tests/regression_hof_flt_fld_flatmap.rs` covering happy paths, empty lists, single-element, all-pass / all-fail, mixed inner sizes (flatmap), text accumulator (fld), and composition with `map`. Adds `examples/flt-basics.ilo` and `examples/fld-sum.ilo` with `-- run` / `-- out` directives so `tests/examples_engines.rs` exercises them across every engine.
- **example: lift vm/cranelift skip from flatmap.ilo.** Drops the two engine-skip lines and the explanatory comment.

## Test plan

- [x] `cargo build --release --features cranelift` clean
- [x] `cargo test --release --features cranelift` — 4847 passed, 0 failed, 66 ignored (down from 71)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --release --features cranelift --all-targets -- -D warnings` clean
- [x] `tests/regression_hof_flt_fld_flatmap.rs` passes on tree + VM + Cranelift (14/14)
- [x] `tests/examples_engines.rs` passes (includes new `flt-basics.ilo`, `fld-sum.ilo`, and lifted `flatmap.ilo`)
- [x] The 5 previously-ignored HOF tests pass

## Follow-ups

- PR 3b: `grp`, `uniqby`, 2-arg `srt`, `partition`. These need either new opcodes (Map ops, Set ops, sort) or a tree-bridge variant that takes the active AST `Program` for user-fn callback resolution. Approx 17 more `Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.` tests get unignored.
- PR 3c: closure-bind 3-arg ctx forms (`map fn ctx xs`, etc.) across all HOFs. Lifts `engine-skip` from `closure-bind.ilo`.
- PR 3d: direct FnRef-variable calls (`f=dbl; f 10`). Unignores `vm_fnref_callee_from_scope`, `vm_fn_ref_via_ref_expr`, `vm_text_callee_from_scope`, `vm_user_hof_fn_type`.
- PR 4: inline lambda Phase 1 cross-engine lift.