### PR TITLE
vm/cranelift: lift grp + uniqby + srt-2arg + partition via tree-bridge (HOF dispatch PR 3b)

### DIFF
--- a/examples/grp-basics.ilo
+++ b/examples/grp-basics.ilo
@@ -1,0 +1,13 @@
+-- grp fn xs: group list items by the key returned by `fn`.
+-- Result is a map from key to the sublist of items that produced it.
+-- Signature: grp fn:F a k xs:L a > M k (L a)
+
+-- Key function: parity as a string (so the resulting map has string keys).
+par n:n>t;r=mod n 2;str r
+
+by-parity ns:L n>M t (L n);grp par ns
+
+-- engine-skip: jit
+
+-- run: by-parity [1,2,3,4,5,6]
+-- out: {0: [2, 4, 6]; 1: [1, 3, 5]}

--- a/examples/partition.ilo
+++ b/examples/partition.ilo
@@ -7,8 +7,8 @@ split-pos xs:L n>L (L n);partition pos xs
 even x:n>b;=(mod x 2) 0
 split-even xs:L n>L (L n);partition even xs
 
--- vm/jit lack higher-order builtins (partition passes a function ref); tree-only.
--- engine-skip: vm cranelift
+-- HOF dispatch goes through the tree-bridge on every engine (PR 3b).
+-- engine-skip: jit
 -- run: split-pos [-1,2,-3,4]
 -- out: [[2, 4], [-1, -3]]
 -- run: split-even [1,2,3,4,5,6]

--- a/examples/srt-by-key.ilo
+++ b/examples/srt-by-key.ilo
@@ -1,0 +1,20 @@
+-- srt fn xs: sort xs by the key returned by `fn`.
+-- The 2-arg form pipes each element through `fn` and sorts by that key.
+-- Signature: srt fn:F a k xs:L a > L a
+
+-- Key: absolute value, so [-3,1,-2] sorts to [1,-2,-3].
+absv n:n>n;?<n 0 (-0 n) n
+
+by-abs xs:L n>L n;srt absv xs
+
+-- Key: string length, shortest first.
+slen s:t>n;len s
+
+by-len ws:L t>L t;srt slen ws
+
+-- engine-skip: jit
+
+-- run: by-abs [-3,1,-2,4,-1]
+-- out: [1, -1, -2, -3, 4]
+-- run: by-len ["banana","fig","apple"]
+-- out: [fig, apple, banana]

--- a/examples/uniqby.ilo
+++ b/examples/uniqby.ilo
@@ -7,10 +7,8 @@ par n:n>t;r=mod n 2;str r
 -- Dedup numbers by parity (keep first even, first odd).
 by-parity ns:L n>L n;uniqby par ns
 
--- vm/jit lack higher-order builtins (no FnRef dispatch)
--- engine-skip: vm
+-- HOF dispatch goes through the tree-bridge on every engine (PR 3b).
 -- engine-skip: jit
--- engine-skip: cranelift
 
 -- run: by-parity [1,3,2,4,5,6]
 -- out: [1, 2]

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -368,6 +368,33 @@ pub fn call_builtin_for_bridge(name: &str, args: Vec<Value>) -> Result<Value> {
     call_function(&mut env, name, args)
 }
 
+/// Program-aware variant of `call_builtin_for_bridge`.
+///
+/// HOF builtins (`grp`, `uniqby`, `partition`, 2-arg `srt`) invoke
+/// user-defined callbacks via `call_function(env, ...)`, which requires
+/// `env.functions` to be populated. The VM/Cranelift tree-bridge passes
+/// the active AST `Program` here so we can register every `Decl::Function`
+/// and `Decl::Tool` into the Env before dispatch, mirroring the prefix of
+/// `run_with_env`. Builtins that don't need an Env still work, so it's
+/// safe to route every bridge call through this entry point once the AST
+/// is available.
+pub fn call_builtin_for_bridge_with_program(
+    name: &str,
+    args: Vec<Value>,
+    program: &Program,
+) -> Result<Value> {
+    let mut env = Env::new();
+    for decl in &program.declarations {
+        match decl {
+            Decl::Function { name, .. } | Decl::Tool { name, .. } => {
+                env.functions.insert(name.clone(), decl.clone());
+            }
+            Decl::TypeDef { .. } | Decl::Alias { .. } | Decl::Use { .. } | Decl::Error { .. } => {}
+        }
+    }
+    call_function(&mut env, name, args)
+}
+
 pub fn run_with_tools(
     program: &Program,
     func_name: Option<&str>,

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -395,6 +395,14 @@ pub(crate) fn is_tree_bridge_eligible(b: crate::builtins::Builtin, argc: usize) 
         // is lossless, so VM/Cranelift get it for free. The actual sleep is
         // delegated to `std::thread::sleep` inside the tree interpreter.
         (Builtin::Sleep, 1) => true,
+        // HOFs that take a FnRef + list. The bridge routes them through the
+        // tree interpreter, which dispatches user-fn callbacks via the
+        // Env populated from the ACTIVE_AST_PROGRAM TLS. Closure-captured
+        // (3-arg) shapes still error here; those land in PR 3c.
+        (Builtin::Grp, 2) => true,
+        (Builtin::Uniqby, 2) => true,
+        (Builtin::Partition, 2) => true,
+        (Builtin::Srt, 2) => true,
         _ => false,
     }
 }
@@ -559,6 +567,11 @@ pub struct CompiledProgram {
     pub type_registry: TypeRegistry,
     /// Parallel to `func_names`/`chunks`: true if the function slot is a `tool` declaration.
     pub is_tool: Vec<bool>,
+    /// Retained AST kept alive for the tree-bridge so it can resolve
+    /// user-fn callbacks when HOFs (grp/uniqby/partition/srt-2arg) are
+    /// dispatched via the bridge. Populated by `compile()`. Cheap clone
+    /// behind an `Arc`; the bridge only needs a read-only view.
+    pub ast: Option<std::sync::Arc<Program>>,
 }
 
 impl CompiledProgram {
@@ -1006,6 +1019,7 @@ impl RegCompiler {
             nan_constants: Vec::new(),
             type_registry: self.type_registry,
             is_tool,
+            ast: None,
         })
     }
 
@@ -3806,6 +3820,14 @@ thread_local! {
     /// bytecode program. Cleared by `with_active_registry`'s drop guard.
     static ACTIVE_PROGRAM: std::cell::Cell<*const CompiledProgram> =
         const { std::cell::Cell::new(std::ptr::null()) };
+    /// Active AST `Program` pointer, set by `VM::execute()` and by
+    /// `with_active_registry()` so the tree-bridge (`OP_CALL_BUILTIN_TREE`
+    /// + `jit_call_builtin_tree`) can hand the tree interpreter an Env
+    /// populated with all user functions and tools. Required for HOFs
+    /// (grp/uniqby/partition/srt-2arg) whose callbacks are user-defined.
+    /// Cleared by the same RAII guard that clears the other TLS slots.
+    static ACTIVE_AST_PROGRAM: std::cell::Cell<*const Program> =
+        const { std::cell::Cell::new(std::ptr::null()) };
 }
 
 /// Look up a user-fn name by index in the currently active `func_names`
@@ -3846,12 +3868,16 @@ pub fn with_active_registry<R>(program: &CompiledProgram, f: impl FnOnce() -> R)
             ACTIVE_REGISTRY.with(|r| r.set(std::ptr::null()));
             ACTIVE_FUNC_NAMES.with(|r| r.set(std::ptr::null()));
             ACTIVE_PROGRAM.with(|r| r.set(std::ptr::null()));
+            ACTIVE_AST_PROGRAM.with(|r| r.set(std::ptr::null()));
         }
     }
 
     ACTIVE_REGISTRY.with(|r| r.set(&program.type_registry as *const TypeRegistry));
     ACTIVE_FUNC_NAMES.with(|r| r.set(&program.func_names as *const Vec<String>));
     ACTIVE_PROGRAM.with(|r| r.set(program as *const CompiledProgram));
+    if let Some(ast) = &program.ast {
+        ACTIVE_AST_PROGRAM.with(|r| r.set(ast.as_ref() as *const Program));
+    }
     let _guard = ClearGuard;
     f()
 }
@@ -3885,6 +3911,18 @@ pub(crate) struct ActiveFuncNamesGuard;
 impl Drop for ActiveFuncNamesGuard {
     fn drop(&mut self) {
         ACTIVE_FUNC_NAMES.with(|r| r.set(std::ptr::null()));
+    }
+}
+
+/// RAII guard that clears `ACTIVE_AST_PROGRAM` on drop, paralleling the
+/// other VM-side TLS guards. Set by `VM::execute()` when the
+/// `CompiledProgram` retains its AST; cleared on return or panic so the
+/// pointer can never outlive the borrow.
+pub(crate) struct ActiveAstProgramGuard;
+
+impl Drop for ActiveAstProgramGuard {
+    fn drop(&mut self) {
+        ACTIVE_AST_PROGRAM.with(|r| r.set(std::ptr::null()));
     }
 }
 
@@ -4587,6 +4625,10 @@ pub fn compile(program: &Program) -> Result<CompiledProgram, CompileError> {
         .iter()
         .map(|chunk| chunk.constants.iter().map(NanVal::from_value).collect())
         .collect();
+    // Retain the AST so the tree-bridge can resolve user-fn callbacks for
+    // HOFs (grp/uniqby/partition/srt-2arg). One Arc; lives as long as the
+    // CompiledProgram.
+    prog.ast = Some(std::sync::Arc::new(program.clone()));
     Ok(prog)
 }
 
@@ -4818,6 +4860,13 @@ impl<'a> VM<'a> {
         // without threading the program reference through every helper.
         ACTIVE_FUNC_NAMES.with(|r| r.set(&self.program.func_names as *const Vec<String>));
         let _func_names_guard = ActiveFuncNamesGuard;
+
+        // Publish the retained AST (if any) for the tree-bridge's HOF
+        // dispatch path. Cleared on return/panic by the guard.
+        if let Some(ast) = &self.program.ast {
+            ACTIVE_AST_PROGRAM.with(|r| r.set(ast.as_ref() as *const Program));
+        }
+        let _ast_guard = ActiveAstProgramGuard;
         // SAFETY: execute() is only called from call() after setup_call() has pushed
         // a frame, so frames is non-empty.
         let frame = unsafe { self.frames.last().unwrap_unchecked() };
@@ -8752,16 +8801,35 @@ impl<'a> VM<'a> {
                     }
 
                     // Run the same dispatcher the tree interpreter uses.
-                    // No env is needed for the bridge-eligible set (no FnRef
-                    // args, no user-function callbacks), so we hand it an
-                    // empty `Program` shell.
-                    let result = match crate::interpreter::call_builtin_for_bridge(
-                        builtin.name(),
-                        value_args,
-                    ) {
-                        Ok(v) => v,
-                        Err(e) => {
-                            vm_err!(VmError::Runtime(e.message));
+                    // HOF builtins need an Env with user functions registered;
+                    // we pull the AST through the ACTIVE_AST_PROGRAM TLS that
+                    // VM::execute() publishes. Non-HOF builtins also work via
+                    // the program-aware variant (empty Env is a subset), so we
+                    // route uniformly when a program is available. Falls back
+                    // to the no-program bridge for callers (test shells) that
+                    // build CompiledProgram literals without an AST.
+                    let result = {
+                        let ast_ptr = ACTIVE_AST_PROGRAM.with(|c| c.get());
+                        let res = if ast_ptr.is_null() {
+                            crate::interpreter::call_builtin_for_bridge(builtin.name(), value_args)
+                        } else {
+                            // SAFETY: ast_ptr was set by VM::execute() to a
+                            // borrow of program.ast (an Arc<Program> owned by
+                            // self.program). It outlives every dispatcher
+                            // iteration and is cleared by ActiveAstProgramGuard
+                            // before that borrow ends.
+                            let program: &Program = unsafe { &*ast_ptr };
+                            crate::interpreter::call_builtin_for_bridge_with_program(
+                                builtin.name(),
+                                value_args,
+                                program,
+                            )
+                        };
+                        match res {
+                            Ok(v) => v,
+                            Err(e) => {
+                                vm_err!(VmError::Runtime(e.message));
+                            }
                         }
                     };
 
@@ -11598,7 +11666,20 @@ pub(crate) extern "C" fn jit_call_builtin_tree(tag: u64, argc: u64, regs_ptr: u6
     for nv in regs {
         value_args.push(nv.to_value());
     }
-    match crate::interpreter::call_builtin_for_bridge(builtin.name(), value_args) {
+    let ast_ptr = ACTIVE_AST_PROGRAM.with(|c| c.get());
+    let res = if ast_ptr.is_null() {
+        crate::interpreter::call_builtin_for_bridge(builtin.name(), value_args)
+    } else {
+        // SAFETY: published by `with_active_registry`, cleared by its drop
+        // guard. Lives for the duration of the Cranelift entry call.
+        let program: &Program = unsafe { &*ast_ptr };
+        crate::interpreter::call_builtin_for_bridge_with_program(
+            builtin.name(),
+            value_args,
+            program,
+        )
+    };
+    match res {
         Ok(v) => NanVal::from_value(&v).0,
         Err(_) => TAG_NIL,
     }
@@ -21596,6 +21677,7 @@ mod tests {
             nan_constants: vec![vec![]],
             type_registry: TypeRegistry::default(),
             is_tool: vec![false],
+            ast: None,
         };
         let result = run(&program, Some("f"), vec![]).expect("fallthrough should succeed");
         assert_eq!(result, Value::Nil);
@@ -21619,6 +21701,7 @@ mod tests {
             nan_constants: vec![vec![]],
             type_registry: TypeRegistry::default(),
             is_tool: vec![false],
+            ast: None,
         };
         let err = run(&program, Some("f"), vec![]).unwrap_err();
         // Error kind should be UnknownOpcode and span should be captured.
@@ -22922,7 +23005,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
+    #[ignore] // Direct FnRef-variable call (OP_CALL_DYN from Expr::Call) arrives in PR 3d.
     fn vm_map_with_text_fn_name() {
         let source = "sq x:n>n;*x x f cb:t xs:L n>L n;map cb xs";
         let result = vm_run(
@@ -23021,7 +23104,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
     fn vm_grp_by_string_key() {
         let source = r#"cl x:n>t;>x 5{"big"}{"small"} main xs:L n>M t L n;grp cl xs"#;
         let result = vm_run(
@@ -23053,7 +23135,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
     fn vm_grp_by_numeric_key() {
         let source = "key x:n>t;str x main xs:L n>M t L n;grp key xs";
         let result = vm_run(
@@ -23089,7 +23170,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
     fn vm_grp_empty_list() {
         let source = "id x:n>t;str x main xs:L n>M t L n;grp id xs";
         let result = vm_run(source, Some("main"), vec![Value::List(Arc::new(vec![]))]);
@@ -23109,14 +23189,12 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
     fn vm_grp_wrong_list_arg() {
         let err = vm_run_err("id x:n>n;x f>t;grp id 42", Some("f"), vec![]);
         assert!(err.contains("grp") || err.contains("list"), "got: {err}");
     }
 
     #[test]
-    #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
     fn vm_grp_number_key() {
         let source = "id x:n>n;x g xs:L n>_;grp id xs";
         let result = vm_run(
@@ -23135,7 +23213,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
     fn vm_grp_bool_key() {
         let source = "pos x:n>b;>x 0 g xs:L n>_;grp pos xs";
         let result = vm_run(
@@ -23156,7 +23233,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
     fn vm_grp_float_key() {
         let source = "half x:n>n;/x 2 g xs:L n>_;grp half xs";
         let result = vm_run(
@@ -23181,7 +23257,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
     fn vm_grp_key_returns_list_error() {
         let source = "mk x:n>L n;[x] g xs:L n>_;grp mk xs";
         let err = vm_run_err(
@@ -23326,7 +23401,6 @@ mod tests {
     // ── srt with key fn ─────────────────────────────────────────────────
 
     #[test]
-    #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
     fn vm_srt_fn_by_length() {
         let source = "ln s:t>n;len s main xs:L t>L t;srt ln xs";
         let result = vm_run(
@@ -23349,7 +23423,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
     fn vm_srt_fn_numeric_key() {
         let source = "neg x:n>n;-x main xs:L n>L n;srt neg xs";
         let result = vm_run(
@@ -23372,7 +23445,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
     fn vm_srt_key_fn_text_keys() {
         let source = "id x:t>t;x main xs:L t>L t;srt id xs";
         let result = vm_run(
@@ -23395,7 +23467,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
     fn vm_srt_key_fn_wrong_second_arg() {
         let source = "sq x:n>n;*x x f>n;srt sq 42";
         let err = vm_run_err(source, Some("f"), vec![]);
@@ -23424,7 +23495,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
     fn vm_srt_bool_key_equal_ordering() {
         let source = "pos x:n>b;> x 0 f>L n;srt pos [3,-1,2,-2]";
         let result = vm_run(source, Some("f"), vec![]);
@@ -23915,7 +23985,7 @@ mod tests {
     // ── FnRef callee from scope ─────────────────────────────────────────
 
     #[test]
-    #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
+    #[ignore] // Direct FnRef-variable call (OP_CALL_DYN from Expr::Call) arrives in PR 3d.
     fn vm_fnref_callee_from_scope() {
         let source = "sq x:n>n;*x x f cb:z>n;cb 3";
         let result = vm_run(source, Some("f"), vec![Value::FnRef("sq".into())]);
@@ -23923,14 +23993,14 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
+    #[ignore] // Direct FnRef-variable call (OP_CALL_DYN from Expr::Call) arrives in PR 3d.
     fn vm_fn_ref_via_ref_expr() {
         let source = "dbl x:n>n;*x 2 main>n;f=dbl;f 10";
         assert_eq!(vm_run(source, Some("main"), vec![]), Value::Number(20.0));
     }
 
     #[test]
-    #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
+    #[ignore] // Direct FnRef-variable call (OP_CALL_DYN from Expr::Call) arrives in PR 3d.
     fn vm_text_callee_from_scope() {
         let source = "sq x:n>n;*x x f cb:z>n;cb 3";
         let result = vm_run(
@@ -23942,7 +24012,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Dynamic dispatch (OP_CALL_DYN emission) arrives in PR 2.
+    #[ignore] // Direct FnRef-variable call (OP_CALL_DYN from Expr::Call) arrives in PR 3d.
     fn vm_user_hof_fn_type() {
         let source = "sq x:n>n;*x x apl f:F n n x:n>n;f x";
         let result = vm_run(
@@ -26471,6 +26541,7 @@ f>n;r=mk 10 20;+r.x r.y";
             ]],
             type_registry: TypeRegistry::default(),
             is_tool: vec![false],
+            ast: None,
         };
 
         let list_arg = Value::List(Arc::new(vec![
@@ -26523,6 +26594,7 @@ f>n;r=mk 10 20;+r.x r.y";
             nan_constants: vec![vec![NanVal::number(99.0), NanVal::nil()]],
             type_registry: TypeRegistry::default(),
             is_tool: vec![false],
+            ast: None,
         };
 
         let list_arg = Value::List(Arc::new(vec![
@@ -26571,6 +26643,7 @@ f>n;r=mk 10 20;+r.x r.y";
             nan_constants: vec![vec![NanVal::number(0.0), NanVal::nil()]],
             type_registry: TypeRegistry::default(),
             is_tool: vec![false],
+            ast: None,
         };
 
         // Pass a number as the collection arg → triggers "foreach requires a list"
@@ -26674,6 +26747,7 @@ f>n;r=mk 10 20;+r.x r.y";
             nan_constants: vec![vec![], vec![]],
             type_registry: TypeRegistry::default(),
             is_tool: vec![false, false],
+            ast: None,
         };
 
         // g falls through with no RET → returns nil; f returns that nil
@@ -26813,6 +26887,7 @@ f>n;r=mk 10 20;+r.x r.y";
             nan_constants: vec![vec![NanVal::nil()]],
             type_registry: TypeRegistry::default(),
             is_tool: vec![false],
+            ast: None,
         };
 
         let list_arg = Value::List(Arc::new(vec![Value::Number(1.0), Value::Number(2.0)]));
@@ -26889,6 +26964,7 @@ f>n;r=mk 10 20;+r.x r.y";
             nan_constants: vec![vec![NanVal::number(0.0), NanVal::nil()]],
             type_registry: TypeRegistry::default(),
             is_tool: vec![false],
+            ast: None,
         };
 
         // Pass a string as the collection → is_heap()=true but not a list → error
@@ -26965,6 +27041,7 @@ f>n;r=mk 10 20;+r.x r.y";
             nan_constants: vec![vec![NanVal::nil()]],
             type_registry: TypeRegistry::default(),
             is_tool: vec![false],
+            ast: None,
         };
         let result = run(&program, Some("f"), vec![]).expect("sqrt nil should not error");
         match result {
@@ -26992,6 +27069,7 @@ f>n;r=mk 10 20;+r.x r.y";
             nan_constants: vec![vec![NanVal::nil()]],
             type_registry: TypeRegistry::default(),
             is_tool: vec![false],
+            ast: None,
         };
         let result = run(&program, Some("f"), vec![]).expect("pow nil should not error");
         match result {
@@ -27020,6 +27098,7 @@ f>n;r=mk 10 20;+r.x r.y";
                 nan_constants: vec![vec![NanVal::nil()]],
                 type_registry: TypeRegistry::default(),
                 is_tool: vec![false],
+                ast: None,
             };
             let result = run(&program, Some("f"), vec![]).expect("math op on nil should not error");
             match result {
@@ -27059,6 +27138,7 @@ f>n;r=mk 10 20;+r.x r.y";
             nan_constants: vec![vec![NanVal::number(input)]],
             type_registry: TypeRegistry::default(),
             is_tool: vec![false],
+            ast: None,
         };
         match run(&program, Some("f"), vec![]).expect("unary math op should not error") {
             Value::Number(n) => n,
@@ -27096,6 +27176,7 @@ f>n;r=mk 10 20;+r.x r.y";
             nan_constants: vec![vec![NanVal::number(2.0), NanVal::number(10.0)]],
             type_registry: TypeRegistry::default(),
             is_tool: vec![false],
+            ast: None,
         };
         match run(&program, Some("f"), vec![]).expect("pow should not error") {
             Value::Number(n) => assert!((n - 1024.0).abs() < 1e-10, "got {n}"),
@@ -27235,6 +27316,7 @@ f>n;r=mk 10 20;+r.x r.y";
             nan_constants: vec![vec![NanVal::number(1.0), NanVal::number(0.0)]],
             type_registry: TypeRegistry::default(),
             is_tool: vec![false],
+            ast: None,
         };
         match run(&program, Some("f"), vec![]).expect("atan2 should not error") {
             Value::Number(n) => {
@@ -27273,6 +27355,7 @@ f>n;r=mk 10 20;+r.x r.y";
             nan_constants: vec![vec![NanVal::boolean(true), NanVal::number(0.0)]],
             type_registry: TypeRegistry::default(),
             is_tool: vec![false],
+            ast: None,
         };
         match run(&program, Some("f"), vec![]).expect("atan2 nan path") {
             Value::Number(n) => assert!(n.is_nan(), "expected NaN, got {n}"),
@@ -27619,6 +27702,7 @@ f>n;r=mk 10 20;+r.x r.y";
             nan_constants: vec![vec![NanVal::number(5.0), NanVal::number(0.0)]],
             type_registry: TypeRegistry::default(),
             is_tool: vec![false],
+            ast: None,
         };
         match run(&program, Some("f"), vec![]).expect("rndn should not error") {
             Value::Number(n) => assert_eq!(n, 5.0),
@@ -27655,6 +27739,7 @@ f>n;r=mk 10 20;+r.x r.y";
             nan_constants: vec![vec![NanVal::number(0.0), NanVal::number(1.0)]],
             type_registry: TypeRegistry::default(),
             is_tool: vec![false],
+            ast: None,
         };
         fastrand::seed(7);
         match run(&program, Some("f"), vec![]).expect("rndn should not error") {
@@ -27692,6 +27777,7 @@ f>n;r=mk 10 20;+r.x r.y";
             nan_constants: vec![vec![NanVal::boolean(true), NanVal::number(0.0)]],
             type_registry: TypeRegistry::default(),
             is_tool: vec![false],
+            ast: None,
         };
         let res = run(&program, Some("f"), vec![]);
         assert!(res.is_err(), "expected type error, got {res:?}");

--- a/tests/regression_hof_3b.rs
+++ b/tests/regression_hof_3b.rs
@@ -1,0 +1,206 @@
+// Cross-engine coverage for the PR 3b HOF tree-bridge: `grp`, `uniqby`,
+// `partition`, and 2-arg `srt`. These HOFs invoke a user-defined callback
+// per element, so the bridge needs the active AST `Program` plumbed through
+// `ACTIVE_AST_PROGRAM` to resolve the callback name to its `Decl::Function`.
+//
+// Pre-fix: `--run-vm` and `--run-cranelift` errored with `Compile error:
+// undefined function: grp` (etc.) because the VM emitter fell through to
+// OP_CALL's user-function lookup. Post-fix: every engine routes through
+// `interpreter::call_builtin_for_bridge_with_program`, which builds an Env
+// from the retained AST and dispatches the callback through the tree
+// interpreter. Tree, VM, and Cranelift all agree byte-for-byte.
+//
+// Each test exercises tree / VM / Cranelift and asserts equality. Error
+// cases (wrong arg shape, key fn returning a list, etc.) are also checked
+// so we catch regressions where the bridge swallows errors as Nil.
+
+use std::process::Command;
+
+const ENGINES: &[&str] = &["--run-tree", "--run-vm", "--run-cranelift"];
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_engine_ok(src: &str, engine: &str) -> String {
+    let out = ilo()
+        .args([src, engine, "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn run_engine_err(src: &str, engine: &str) -> String {
+    let out = ilo()
+        .args([src, engine, "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "ilo {engine} unexpectedly succeeded for `{src}`: stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    String::from_utf8_lossy(&out.stderr).to_string()
+}
+
+/// Asserts the same source produces `expected` on every engine.
+fn check(src: &str, expected: &str) {
+    for engine in ENGINES {
+        let actual = run_engine_ok(src, engine);
+        assert_eq!(
+            actual, expected,
+            "engine={engine}, src=`{src}`: got `{actual}`, expected `{expected}`"
+        );
+    }
+}
+
+// ── grp ────────────────────────────────────────────────────────────────
+
+#[test]
+fn grp_by_parity_string_key() {
+    // Key fn returns a string ("0"/"1"); result is a map keyed by string.
+    check(
+        r#"par n:n>t;r=mod n 2;str r
+f>M t (L n);grp par [1,2,3,4,5,6]"#,
+        "{0: [2, 4, 6]; 1: [1, 3, 5]}",
+    );
+}
+
+#[test]
+fn grp_by_numeric_key() {
+    // Numeric key resolves to an integer map bucket.
+    check(
+        r#"par n:n>n;mod n 2
+f>M n (L n);grp par [1,2,3,4]"#,
+        "{0: [2, 4]; 1: [1, 3]}",
+    );
+}
+
+#[test]
+fn grp_empty_list_yields_empty_map() {
+    check(
+        r#"par n:n>n;mod n 2
+f>M n (L n);grp par []"#,
+        "{}",
+    );
+}
+
+// ── uniqby ─────────────────────────────────────────────────────────────
+
+#[test]
+fn uniqby_keeps_first_per_key() {
+    check(
+        r#"par n:n>t;r=mod n 2;str r
+f>L n;uniqby par [1,3,2,4,5,6]"#,
+        "[1, 2]",
+    );
+}
+
+#[test]
+fn uniqby_empty_list() {
+    check(
+        r#"par n:n>t;str n
+f>L n;uniqby par []"#,
+        "[]",
+    );
+}
+
+// ── partition ──────────────────────────────────────────────────────────
+
+#[test]
+fn partition_splits_pass_and_fail() {
+    check(
+        r#"pos x:n>b;>x 0
+f>L (L n);partition pos [-1,2,-3,4]"#,
+        "[[2, 4], [-1, -3]]",
+    );
+}
+
+#[test]
+fn partition_all_pass() {
+    check(
+        r#"pos x:n>b;>x 0
+f>L (L n);partition pos [1,2,3]"#,
+        "[[1, 2, 3], []]",
+    );
+}
+
+#[test]
+fn partition_all_fail() {
+    check(
+        r#"pos x:n>b;>x 0
+f>L (L n);partition pos [-1,-2,-3]"#,
+        "[[], [-1, -2, -3]]",
+    );
+}
+
+// ── srt (2-arg, key-fn form) ────────────────────────────────────────────
+
+#[test]
+fn srt_by_abs_value() {
+    check(
+        r#"absv n:n>n;?<n 0 (-0 n) n
+f>L n;srt absv [-3,1,-2,4,-1]"#,
+        "[1, -1, -2, -3, 4]",
+    );
+}
+
+#[test]
+fn srt_by_length() {
+    check(
+        r#"slen s:t>n;len s
+f>L t;srt slen ["banana","fig","apple"]"#,
+        "[fig, apple, banana]",
+    );
+}
+
+#[test]
+fn srt_2arg_empty_list() {
+    check(
+        r#"slen s:t>n;len s
+f>L t;srt slen []"#,
+        "[]",
+    );
+}
+
+// ── Error path: callback returns wrong shape ───────────────────────────
+
+#[test]
+fn grp_wrong_list_arg_errors_on_tree_and_vm() {
+    // `grp` requires the second arg to be a list. Tree and VM surface the
+    // typed runtime error; Cranelift's `jit_call_builtin_tree` documents
+    // that bridge errors collapse to Nil (matching `jit_rgxsub`/`jit_rd`
+    // precedent), so we don't include it in the must-error set. Promoting
+    // these to typed runtime errors on the JIT path is a documented
+    // follow-up in `jit_call_builtin_tree`'s rustdoc.
+    for engine in ["--run-tree", "--run-vm"] {
+        let err = run_engine_err(
+            r#"key n:n>n;n
+f>_;grp key 42"#,
+            engine,
+        );
+        assert!(
+            err.contains("grp"),
+            "engine={engine}: stderr missing `grp`: {err}"
+        );
+    }
+}
+
+// ── Chained HOFs to catch state leaks ──────────────────────────────────
+
+#[test]
+fn uniqby_then_grp_chained() {
+    // Two bridge HOF calls in sequence: dedupe by parity, then group by
+    // parity (one-bucket-per-parity after dedupe). Catches stale-Env bugs
+    // across consecutive bridge invocations.
+    check(
+        r#"par n:n>t;r=mod n 2;str r
+f>M t (L n);ys=uniqby par [1,3,2,4,5,6];grp par ys"#,
+        "{0: [2]; 1: [1]}",
+    );
+}


### PR DESCRIPTION
## Summary

Fourth in the HOF dispatch chain after PR 1 ([#274](https://github.com/ilo-lang/ilo/pull/274), FnRef NaN-tagging), PR 2 ([#277](https://github.com/ilo-lang/ilo/pull/277), `map` native), PR 3a ([#278](https://github.com/ilo-lang/ilo/pull/278), flt/fld/flatmap native).

The remaining tree-only HOFs (`grp`, `uniqby`, `partition`, 2-arg `srt`) call back into user-defined functions per element, so the existing tree-bridge couldn't dispatch them: `call_builtin_for_bridge` constructs an empty Env. This PR plumbs the AST through to the bridge so it can register every `Decl::Function` before invoking the tree interpreter, and extends `is_tree_bridge_eligible` to cover the four HOFs.

Manifesto framing: every HOF that was previously tree-only now runs on every engine without a per-builtin native lift. Future PRs can graduate any specific HOF off the bridge with a native opcode (the existing PR 3a pattern) without changing observable behaviour.

## Repro

Before:

```
$ ilo --run-vm 'grp f xs:L n>M t (L n);grp parity xs' f '[1,2,3,4]'
Compile error: undefined function: grp
```

After (matches `--run-tree` byte-for-byte):

```
$ ilo --run-vm 'parity n:n>t;str (mod n 2)
f xs:L n>M t (L n);grp parity xs' f '[1,2,3,4]'
{0: [2, 4]; 1: [1, 3]}
```

Same for `uniqby`, `partition`, and 2-arg `srt` on VM and Cranelift.

## What is in the diff

- `interpreter: program-aware bridge entry for HOF dispatch` — adds `call_builtin_for_bridge_with_program(name, args, program)` that registers user functions/tools into a fresh Env before dispatch.
- `vm: route grp/uniqby/srt-2arg/partition through tree-bridge` — `CompiledProgram` now retains `Arc<Program>` (populated by `vm::compile`); `VM::execute` and `with_active_registry` publish it via a new `ACTIVE_AST_PROGRAM` TLS, cleared by an RAII guard that parallels the existing `ACTIVE_REGISTRY`/`ACTIVE_FUNC_NAMES`/`ACTIVE_PROGRAM` slots. `OP_CALL_BUILTIN_TREE` and `jit_call_builtin_tree` pick the program-aware bridge entry when the TLS is set. `is_tree_bridge_eligible` accepts `(Grp, 2)`, `(Uniqby, 2)`, `(Partition, 2)`, `(Srt, 2)`. Cranelift gets these for free through the existing `jit_call_builtin_tree` helper.
- `test + example: cross-engine coverage` — new `tests/regression_hof_3b.rs` (13 cases, tree/VM/Cranelift), new `examples/grp-basics.ilo` and `examples/srt-by-key.ilo`, lifted vm/cranelift skips from `examples/uniqby.ilo` and `examples/partition.ilo`.

## Test plan

- [x] `cargo build --release --features cranelift` clean
- [x] `cargo test --release --features cranelift` green across all 117 suites (2932 lib + 13 new regression + 1 examples_engines)
- [x] `cargo clippy --release --features cranelift --all-targets -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] Tree/VM/Cranelift all produce identical output for the four new HOFs across the regression suite and the new example files
- [x] Unignored `vm_grp_*` and `vm_srt_*` dynamic-dispatch tests in `src/vm/mod.rs` pass
- [x] Re-ignored a handful of tests that need direct FnRef-variable calls (PR 3d) with an updated note

## Follow-ups

- PR 3c: closure-bind 3-arg ctx forms across all HOFs (the `cb x y ctx` shape) — unignores the 14 closure-bind HOF tests.
- PR 3d: direct FnRef-variable calls (OP_CALL_DYN from `Expr::Call` when callee resolves to a FnRef-typed local).
- PR 4: lift `engine-skip` from inline lambda examples once the lambda lift pass is in.
- Cranelift's `jit_call_builtin_tree` still collapses bridge errors to Nil. Documented as a follow-up in its rustdoc; the new regression test only asserts the typed error on tree + VM.