### PR TITLE
vm + cranelift: closure-bind HOF ctx forms via tree-bridge

### DIFF
--- a/examples/closure-bind.ilo
+++ b/examples/closure-bind.ilo
@@ -21,9 +21,9 @@ prices pm:M t n syms:L t>L n;map look pm syms
 
 prices-demo>L n;m=mset mmap "a" 10;m=mset m "b" 20;prices m ["a","b","a"]
 
--- engine-skip: vm
+-- jit lacks HOF dispatch entirely (see regression_builtins_as_hof.rs).
+-- vm + cranelift route closure-bind through the tree-bridge from PR 3c.
 -- engine-skip: jit
--- engine-skip: cranelift
 -- run: main
 -- out: [c, a, b]
 -- run: prices-demo

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -378,11 +378,14 @@ pub(crate) const OP_PANIC_UNWRAP: u8 = 164;
 /// round-tripping is lossless. Adding a new entry here makes the builtin
 /// callable from `--run-vm` and `--run-cranelift` for free.
 ///
-/// HOFs (`grp`, `uniqby`, `partition`, 2-arg `srt`, dynamic-fmt `wr`)
-/// are NOT eligible: they get native VM lifts in the HOF dispatch chain
-/// (PR 3b+). `map`, `flt`, `fld`, and `flatmap` are already lifted — see
-/// the `(Builtin::Map, 2)` / `(Builtin::Flt, 2)` / `(Builtin::Fld, 3)` /
-/// `(Builtin::Flatmap, 2)` arms in the compiler.
+/// HOFs that have native VM lifts (`map 2`, `flt 2`, `fld 3`, `flatmap 2`)
+/// short-circuit before this check — see the matching arms in the compiler.
+/// The closure-bind ctx forms of those HOFs (`map fn ctx xs`, `flt fn ctx xs`,
+/// `fld fn ctx xs init`) are NOT lifted natively; they ride the same
+/// tree-bridge path as `grp`/`uniqby`/`partition`/`srt` because the ctx
+/// adds an extra OP_CALL_DYN arg the native emitters don't currently shape.
+/// Going through the bridge keeps cross-engine parity with the tree-walker
+/// for the same per-call cost as `srt 2` (PR 3b).
 pub(crate) fn is_tree_bridge_eligible(b: crate::builtins::Builtin, argc: usize) -> bool {
     use crate::builtins::Builtin;
     match (b, argc) {
@@ -397,12 +400,18 @@ pub(crate) fn is_tree_bridge_eligible(b: crate::builtins::Builtin, argc: usize) 
         (Builtin::Sleep, 1) => true,
         // HOFs that take a FnRef + list. The bridge routes them through the
         // tree interpreter, which dispatches user-fn callbacks via the
-        // Env populated from the ACTIVE_AST_PROGRAM TLS. Closure-captured
-        // (3-arg) shapes still error here; those land in PR 3c.
+        // Env populated from the ACTIVE_AST_PROGRAM TLS.
         (Builtin::Grp, 2) => true,
         (Builtin::Uniqby, 2) => true,
         (Builtin::Partition, 2) => true,
         (Builtin::Srt, 2) => true,
+        // Closure-bind ctx variants. The fn receives an extra ctx arg the
+        // native emitters don't shape today — bridge keeps semantics aligned
+        // with the tree interpreter and adds VM/Cranelift coverage in PR 3c.
+        (Builtin::Map, 3) => true,
+        (Builtin::Flt, 3) => true,
+        (Builtin::Fld, 4) => true,
+        (Builtin::Srt, 3) => true,
         _ => false,
     }
 }
@@ -2987,12 +2996,14 @@ impl RegCompiler {
                             return acc_reg;
                         }
                         // Builtins that fall through:
-                        //   - tree-bridge eligible (rgx, rgxall, fmt-variadic, rd 2-arg, rdb)
-                        //     → routed to OP_CALL_BUILTIN_TREE below
-                        //   - HOFs (grp/uniqby/partition/srt 2-arg/wr 3-arg with
-                        //     dynamic fmt) → still error; their native lift lands
-                        //     in PR 3b+ of the HOF dispatch chain. `map`, `flt`,
-                        //     `fld`, and `flatmap` are lifted above.
+                        //   - tree-bridge eligible (rgx, rgxall, fmt-variadic,
+                        //     rd 2-arg, rdb, sleep, grp/uniqby/partition/srt 2-arg
+                        //     from PR 3b, map/flt/fld/srt closure-bind ctx forms
+                        //     from PR 3c) → routed to OP_CALL_BUILTIN_TREE below.
+                        //   - Anything else (e.g. `wr` 3-arg with dynamic fmt)
+                        //     still errors here; the native lift lands later in
+                        //     the HOF dispatch chain. `map`, `flt`, `fld`, and
+                        //     `flatmap` 2-arg forms have native lifts above.
                         _ => {}
                     }
                 }

--- a/tests/regression_closure_bind.rs
+++ b/tests/regression_closure_bind.rs
@@ -11,9 +11,11 @@
 //   flt fn xs       (2-arg) vs. flt fn ctx xs       (3-arg)
 //   fld fn xs init  (3-arg) vs. fld fn ctx xs init  (4-arg)
 //
-// VM and Cranelift JIT do not implement HOF dispatch at all (see
-// regression_builtins_as_hof.rs), so closure-bind is exercised on the
-// tree-walking interpreter only.
+// As of PR 3c, the closure-bind variants run on every engine. The VM and
+// Cranelift paths route through the tree-bridge (the same mechanism `grp`,
+// `uniqby`, `partition`, and 2-arg `srt` use from PR 3b). The bridge calls
+// back into the tree interpreter for the inner HOF loop, which is where the
+// user-function dispatch already works correctly.
 
 use std::process::Command;
 
@@ -31,10 +33,10 @@ fn write_src(name: &str, src: &str) -> std::path::PathBuf {
     path
 }
 
-fn run_ok(src: &str, entry: &str, args: &[&str]) -> String {
+fn run_ok_on(engine: &str, src: &str, entry: &str, args: &[&str]) -> String {
     let path = write_src(entry, src);
     let mut cmd = ilo();
-    cmd.arg(&path).arg("--run-tree").arg(entry);
+    cmd.arg(&path).arg(engine).arg(entry);
     for a in args {
         cmd.arg(a);
     }
@@ -42,10 +44,27 @@ fn run_ok(src: &str, entry: &str, args: &[&str]) -> String {
     let _ = std::fs::remove_file(&path);
     assert!(
         out.status.success(),
-        "ilo failed for `{src}`: stderr={}",
+        "ilo {engine} failed for `{src}`: stderr={}",
         String::from_utf8_lossy(&out.stderr)
     );
     String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn run_all(src: &str, entry: &str, args: &[&str], expected: &str) {
+    for engine in ["--run-tree", "--run-vm", "--run-cranelift"] {
+        let actual = run_ok_on(engine, src, entry, args);
+        assert_eq!(
+            actual, expected,
+            "engine {engine} produced {actual:?}, expected {expected:?} for src `{src}`"
+        );
+    }
+}
+
+// Tree-only variant kept for the verifier-error tests below — those produce
+// the same diagnostic on every engine, but the verifier runs before any
+// engine-specific dispatch, so we only need one path to confirm.
+fn run_ok(src: &str, entry: &str, args: &[&str]) -> String {
+    run_ok_on("--run-tree", src, entry, args)
 }
 
 fn run_err(src: &str, entry: &str) -> String {
@@ -84,7 +103,7 @@ fn srt_with_external_lookup() {
         "{SRT_BY_LOOKUP}\nmain>L t;m=mset mmap \"a\" 2;m=mset m \"b\" 3;m=mset m \"c\" 1;\
          top m [\"a\",\"b\",\"c\"]"
     );
-    assert_eq!(run_ok(&src, "main", &[]), "[c, a, b]");
+    run_all(&src, "main", &[], "[c, a, b]");
 }
 
 // ── map: enrich elements via external lookup ───────────────────────────────
@@ -99,7 +118,7 @@ fn map_with_lookup() {
         "{MAP_WITH_LOOKUP}\nmain>L n;m=mset mmap \"a\" 10;m=mset m \"b\" 20;\
          prices m [\"a\",\"b\",\"a\"]"
     );
-    assert_eq!(run_ok(&src, "main", &[]), "[10, 20, 10]");
+    run_all(&src, "main", &[], "[10, 20, 10]");
 }
 
 // ── flt: filter by external threshold ──────────────────────────────────────
@@ -110,13 +129,11 @@ above t:n xs:L n>L n;flt big t xs";
 
 #[test]
 fn flt_with_threshold() {
-    assert_eq!(
-        run_ok(
-            &format!("{FLT_WITH_THRESHOLD}\nmain>L n;above 4 [1,5,3,8,2]"),
-            "main",
-            &[]
-        ),
-        "[5, 8]"
+    run_all(
+        &format!("{FLT_WITH_THRESHOLD}\nmain>L n;above 4 [1,5,3,8,2]"),
+        "main",
+        &[],
+        "[5, 8]",
     );
 }
 
@@ -129,13 +146,11 @@ total k:n xs:L n>n;fld add-scaled k xs 0";
 #[test]
 fn fld_with_external_accumulator() {
     // sum of [1,2,3] each scaled by 10 → 60
-    assert_eq!(
-        run_ok(
-            &format!("{FLD_WITH_ACCUM}\nmain>n;total 10 [1,2,3]"),
-            "main",
-            &[]
-        ),
-        "60"
+    run_all(
+        &format!("{FLD_WITH_ACCUM}\nmain>n;total 10 [1,2,3]"),
+        "main",
+        &[],
+        "60",
     );
 }
 


### PR DESCRIPTION
## Summary

PR 3c in the HOF dispatch chain. The closure-bind variants of `map`, `flt`, `fld`, and `srt` (the 3-arg / 4-arg forms that thread an extra `ctx` value into every fn invocation) now run on VM and Cranelift, not just the tree interpreter.

Builds on #277 (native `map`), #278 (native `flt` / `fld` / `flatmap`), and #279 (tree-bridge for `grp` / `uniqby` / `partition` / 2-arg `srt`).

## Repro

Before, this program errored on VM/Cranelift with `UndefinedFunction` because the dispatcher had no path for ctx-bearing HOFs:

```
look sym:t m:M t n>n;r=mget m sym;?r{n v:v;_:0}
prices pm:M t n syms:L t>L n;map look pm syms

main>L n;m=mset mmap "a" 10;m=mset m "b" 20;prices m ["a","b","a"]
```

After, all three engines produce `[10, 20, 10]`.

## What's in the diff

- `vm: route closure-bind HOF ctx forms through tree-bridge` adds `(Map, 3)`, `(Flt, 3)`, `(Fld, 4)`, `(Srt, 3)` to `is_tree_bridge_eligible`. The existing 2-arg native arms short-circuit first, so the common shape still wins on the fast loop. Only the closure-bind forms pay the bridge round-trip, the same cost as 2-arg `srt` from PR 3b.
- `test: cross-engine coverage for closure-bind HOF variants` lifts the four happy-path tests in `regression_closure_bind.rs` (srt-by-lookup, map-with-lookup, flt-with-threshold, fld-with-external-accumulator) to run via `run_all` across tree, vm, and cranelift. Verifier-error tests stay tree-only because verify is engine-independent.
- `example: lift vm/cranelift skip from closure-bind.ilo` removes the two engine-skip directives. `jit` skip stays because jit lacks HOF dispatch entirely.

## Test plan

- [x] `cargo test --release --features cranelift --test regression_closure_bind` (8 passed)
- [x] `cargo test --release --features cranelift --test examples_engines` (1 passed; closure-bind.ilo now exercised on vm + cranelift)
- [x] `cargo test --release --features cranelift` full suite (2932 + every integration suite green)
- [x] `cargo fmt --check`
- [x] `cargo clippy --release --features cranelift --all-targets -- -D warnings`

## Follow-ups

- PR 3d: direct FnRef-variable calls (`f = dbl; f 10`) lifted to OP_CALL_DYN from `Expr::Call`.
- PR 4: lift `engine-skip: vm/cranelift` from inline-lambda examples, now that FnRef + HOF dispatch work everywhere.