### PR TITLE
fix(aot): strip top-level ~/^ wrappers in compiled binaries

### DIFF
--- a/examples/aot-wrapper-strip.ilo
+++ b/examples/aot-wrapper-strip.ilo
@@ -1,0 +1,23 @@
+-- AOT-compiled binaries match the in-process runners on Result-wrapper
+-- output. A program whose entry function returns `~v` prints `v` bare on
+-- stdout (exit 0); one that returns `^e` prints `^e` on stderr (exit 1).
+--
+-- Before PR #281 the in-process runners (tree, VM, Cranelift JIT) split
+-- top-level Result output as above, but `ilo compile main.ilo` still
+-- routed the result through the in-program `jit_prt` helper, so AOT
+-- binaries kept printing the wrapper and always exited 0 — even for `^e`.
+-- generate_main now uses a dedicated `jit_prt_main_result` helper that
+-- mirrors the in-process behaviour and returns the exit code.
+--
+-- This example pins the happy path. The failing path is exercised in the
+-- dedicated cross-engine regression test in
+-- tests/regression_aot_wrapper_strip.rs, which compiles each case to a
+-- real binary and compares byte-for-byte against all three in-process
+-- runners. (The example harness only drives the in-process runners, not
+-- AOT, so this `.ilo` file is the in-context learning artefact for the
+-- happy path; the regression test is the AOT contract.)
+
+m>R t t;~"hello"
+
+-- run:
+-- out: hello

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -137,6 +137,11 @@ struct HelperFuncs {
     mdel: FuncId,
     // Print, trim, uniq
     prt: FuncId,
+    /// AOT main-result printer: strips top-level `Value::Ok` wrapper on
+    /// stdout and routes `Value::Err` to stderr with exit 1. See
+    /// `jit_prt_main_result` in `src/vm/mod.rs`. Returns a u64 exit code
+    /// (0 or 1) that `generate_main` truncates to i32 for `main`.
+    prt_main: FuncId,
     trm: FuncId,
     upr: FuncId,
     lwr: FuncId,
@@ -318,6 +323,7 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         mdel: declare_helper(module, "jit_mdel", 2, 1),
         // Print, trim, uniq
         prt: declare_helper(module, "jit_prt", 1, 1),
+        prt_main: declare_helper(module, "jit_prt_main_result", 1, 1),
         trm: declare_helper(module, "jit_trm", 1, 1),
         upr: declare_helper(module, "jit_upr", 1, 1),
         lwr: declare_helper(module, "jit_lwr", 1, 1),
@@ -3729,15 +3735,20 @@ fn generate_main(
     let call_inst = builder.ins().call(user_fref, &call_args);
     let result = builder.inst_results(call_inst)[0];
 
-    // Print the result using jit_prt (handles all value types: numbers, strings, bools, etc.)
-    let prt_fref = module.declare_func_in_func(helpers.prt, builder.func);
-    builder.ins().call(prt_fref, &[result]);
+    // Print the top-level result. Use `jit_prt_main_result` (not `jit_prt`)
+    // so AOT binaries match the in-process runners' behaviour from PR #275:
+    // a top-level `~v` prints bare on stdout (exit 0); a top-level `^e`
+    // prints `^e` on stderr (exit 1). The helper returns the desired exit
+    // code packed in a u64; we truncate to i32 for `main`.
+    let prt_main_fref = module.declare_func_in_func(helpers.prt_main, builder.func);
+    let call_prt = builder.ins().call(prt_main_fref, &[result]);
+    let exit_u64 = builder.inst_results(call_prt)[0];
 
     // Call ilo_aot_fini() before returning
     let fini_fref = module.declare_func_in_func(helpers.aot_fini, builder.func);
     builder.ins().call(fini_fref, &[]);
-    let zero = builder.ins().iconst(I32, 0);
-    builder.ins().return_(&[zero]);
+    let exit_i32 = builder.ins().ireduce(I32, exit_u64);
+    builder.ins().return_(&[exit_i32]);
 
     builder.finalize();
 

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -338,6 +338,7 @@ fn register_helpers(builder: &mut JITBuilder) {
         ("jit_mdel", jit_mdel as *const u8),
         // Print, trim, uniq
         ("jit_prt", jit_prt as *const u8),
+        ("jit_prt_main_result", jit_prt_main_result as *const u8),
         ("jit_trm", jit_trm as *const u8),
         ("jit_upr", jit_upr as *const u8),
         ("jit_lwr", jit_lwr as *const u8),

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -13157,6 +13157,48 @@ pub(crate) extern "C" fn jit_prt(v: u64) -> u64 {
     v
 }
 
+/// AOT entry-point print: mirrors `print_value`'s top-level Result-wrapper
+/// treatment used by the in-process runners (tree/VM/Cranelift JIT). A
+/// top-level `Value::Ok(inner)` prints the inner value bare (no `~`) on
+/// stdout and exits 0. A top-level `Value::Err(_)` prints `^<inner>` on
+/// stderr and exits 1. Anything else prints via Display on stdout, exit 0.
+///
+/// The in-program `prnt` builtin keeps using `jit_prt` (which always shows
+/// the wrapper) — those callers are *inside* a program and genuinely want
+/// to see `~v`/`^e`.
+///
+/// Returns the desired process exit code (0 or 1) packed in a u64, which
+/// `generate_main` truncates to i32 and returns from `main`.
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_prt_main_result(v: u64) -> u64 {
+    let nv = NanVal(v);
+    // Decide based on tag before reifying to a Value (cheap and avoids a
+    // pointless heap clone for the common Number/Bool/Nil case).
+    let tag = v & TAG_MASK;
+    if tag == TAG_ERR {
+        // `Value::Err(inner)` Displays as `^<inner>`.
+        eprintln!("{}", nv.to_value());
+        nv.clone_rc();
+        return 1;
+    }
+    if tag == TAG_OK {
+        // Strip the wrapper: print the inner value bare on stdout. `to_value`
+        // on a TAG_OK NanVal always produces `Value::Ok(inner)`; the explicit
+        // fallback to Display on the wrapped value is dead code in practice
+        // but keeps the helper total in the face of a future tag refactor.
+        match nv.to_value() {
+            Value::Ok(inner) => println!("{}", inner),
+            other => println!("{}", other),
+        }
+        nv.clone_rc();
+        return 0;
+    }
+    println!("{}", nv.to_value());
+    nv.clone_rc();
+    0
+}
+
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn jit_trm(v: u64) -> u64 {

--- a/tests/regression_aot_wrapper_strip.rs
+++ b/tests/regression_aot_wrapper_strip.rs
@@ -1,0 +1,172 @@
+// Regression test: AOT-compiled binaries must strip the top-level `~`/`^`
+// Result wrapper on stdout/stderr the same way the in-process runners do.
+//
+// Background:
+//
+// PR #275 split top-level Result handling for the in-process runners
+// (tree, VM, Cranelift JIT) so that `~v` returned from main prints `v`
+// bare on stdout (exit 0) and `^e` prints `^e` on stderr (exit 1). The
+// AOT path (`ilo compile main.ilo -o ./main && ./main`) was left calling
+// the `jit_prt` helper directly from `generate_main`, so AOT binaries
+// kept printing the visible wrapper and always exited 0 — even for `^e`.
+//
+// The fix routes `generate_main`'s final result through a new helper,
+// `jit_prt_main_result`, that mirrors `print_value`'s top-level treatment
+// and returns the desired process exit code. The in-program `prnt`
+// builtin still uses `jit_prt` (which always shows the wrapper) — that
+// path is *inside* a program and genuinely wants `~v` / `^e` visible.
+//
+// Each case here compares the AOT binary's stdout, stderr, and exit code
+// against the three in-process runners byte-for-byte, so any future
+// divergence between AOT and the others shows up immediately in CI.
+//
+// Gated on the `cranelift` feature because both AOT compile and the
+// `--run-cranelift` baseline require it.
+
+#![cfg(feature = "cranelift")]
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+/// Per-process counter so concurrent test threads don't stomp each
+/// other's source / binary paths in /tmp.
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn tmp_paths(tag: &str) -> (PathBuf, PathBuf) {
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let src = std::env::temp_dir().join(format!("ilo-aot-{tag}-{pid}-{n}.ilo"));
+    let bin = std::env::temp_dir().join(format!("ilo-aot-{tag}-{pid}-{n}.bin"));
+    (src, bin)
+}
+
+/// Run the in-process Cranelift runner and capture (stdout, stderr, exit).
+fn run_in_process(src_path: &PathBuf, engine: &str) -> (Vec<u8>, Vec<u8>, i32) {
+    let out = ilo()
+        .arg(src_path)
+        .arg(engine)
+        .output()
+        .expect("failed to run ilo in-process");
+    (out.stdout, out.stderr, out.status.code().unwrap_or(-1))
+}
+
+/// Compile the source to an AOT binary, run it, capture (stdout, stderr, exit).
+fn run_aot(src_path: &PathBuf, bin_path: &PathBuf) -> (Vec<u8>, Vec<u8>, i32) {
+    let compile = ilo()
+        .args(["compile"])
+        .arg(src_path)
+        .arg("-o")
+        .arg(bin_path)
+        .output()
+        .expect("failed to invoke ilo compile");
+    assert!(
+        compile.status.success(),
+        "ilo compile failed: stdout={:?} stderr={:?}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr),
+    );
+    let out = Command::new(bin_path)
+        .output()
+        .expect("failed to run AOT binary");
+    (out.stdout, out.stderr, out.status.code().unwrap_or(-1))
+}
+
+/// Assert AOT output matches all three in-process runners (tree, VM,
+/// Cranelift) byte-for-byte, and matches the explicit expected values.
+fn assert_aot_matches_in_process(
+    tag: &str,
+    src: &str,
+    expected_stdout: &[u8],
+    expected_stderr: &[u8],
+    expected_exit: i32,
+) {
+    let (src_path, bin_path) = tmp_paths(tag);
+    std::fs::write(&src_path, src).expect("write ilo source");
+
+    let (aot_stdout, aot_stderr, aot_exit) = run_aot(&src_path, &bin_path);
+
+    assert_eq!(
+        aot_stdout,
+        expected_stdout,
+        "{tag}: AOT stdout mismatch. got={:?} expected={:?}",
+        String::from_utf8_lossy(&aot_stdout),
+        String::from_utf8_lossy(expected_stdout),
+    );
+    assert_eq!(
+        aot_stderr,
+        expected_stderr,
+        "{tag}: AOT stderr mismatch. got={:?} expected={:?}",
+        String::from_utf8_lossy(&aot_stderr),
+        String::from_utf8_lossy(expected_stderr),
+    );
+    assert_eq!(
+        aot_exit, expected_exit,
+        "{tag}: AOT exit mismatch. got={aot_exit} expected={expected_exit}",
+    );
+
+    // Cross-engine parity: AOT must match all three in-process runners
+    // byte-for-byte. This is the contract PR #275 set for in-process and
+    // this PR extends to AOT.
+    for engine in ["--run-tree", "--run-vm", "--run-cranelift"] {
+        let (s, e, c) = run_in_process(&src_path, engine);
+        assert_eq!(
+            s,
+            aot_stdout,
+            "{tag}/{engine}: stdout diverges from AOT. in-proc={:?} aot={:?}",
+            String::from_utf8_lossy(&s),
+            String::from_utf8_lossy(&aot_stdout),
+        );
+        assert_eq!(
+            e,
+            aot_stderr,
+            "{tag}/{engine}: stderr diverges from AOT. in-proc={:?} aot={:?}",
+            String::from_utf8_lossy(&e),
+            String::from_utf8_lossy(&aot_stderr),
+        );
+        assert_eq!(
+            c, aot_exit,
+            "{tag}/{engine}: exit diverges from AOT. in-proc={c} aot={aot_exit}",
+        );
+    }
+
+    // Best-effort cleanup; ignore failures.
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+}
+
+// ── ~"hello" → stdout `hello\n`, exit 0 ───────────────────────────────────
+
+#[test]
+fn aot_ok_text_strips_wrapper_to_stdout() {
+    assert_aot_matches_in_process("ok-text", "m>R t t;~\"hello\"", b"hello\n", b"", 0);
+}
+
+// ── ^"err" → stderr `^err\n`, exit 1 ──────────────────────────────────────
+
+#[test]
+fn aot_err_routes_to_stderr_exit_1() {
+    assert_aot_matches_in_process("err-text", "m>R t t;^\"err\"", b"", b"^err\n", 1);
+}
+
+// ── bare 42 → stdout `42\n`, exit 0 ───────────────────────────────────────
+
+#[test]
+fn aot_bare_value_unchanged() {
+    assert_aot_matches_in_process("bare-num", "m>n;42", b"42\n", b"", 0);
+}
+
+// ── ~7 (number-typed Result) → stdout `7\n`, exit 0 ───────────────────────
+//
+// Pins the wrapper-strip for a number-typed Result variant in addition to
+// the text variant above. A regression that strips only `~"text"` and not
+// `~num` would otherwise slip through.
+
+#[test]
+fn aot_ok_num_strips_wrapper_to_stdout() {
+    assert_aot_matches_in_process("ok-num", "m>R n t;~7", b"7\n", b"", 0);
+}


### PR DESCRIPTION
## Summary

PR #275 made the in-process runners (tree, VM, Cranelift JIT) treat top-level Result returns specially: `~v` from main prints `v` bare on stdout (exit 0), `^e` prints `^e` on stderr (exit 1). The AOT path (`ilo compile main.ilo -o ./main && ./main`) was left calling the in-program `jit_prt` helper from `generate_main`, so AOT binaries kept printing the visible wrapper and always exited 0, even for `^e`. That's a real cost for shell callers piping a compiled ilo program: they have to strip a leading `~` and have no way to detect failure without parsing stdout.

This PR adds a dedicated `jit_prt_main_result` helper that mirrors `print_value`'s top-level treatment and returns the desired exit code; `generate_main` calls it and truncates the result to i32 for `main()`. The in-program `prnt` builtin keeps using `jit_prt` (which always shows the wrapper), because those callers are inside a program and genuinely want to see `~v` / `^e`.

## Repro before/after

```
$ cat /tmp/aot-err.ilo
m>R t t;^"err"

$ ilo compile /tmp/aot-err.ilo -o /tmp/aot-err-bin

# before
$ /tmp/aot-err-bin; echo "exit=$?"
^err
exit=0

# after
$ /tmp/aot-err-bin; echo "exit=$?"
^err          # on stderr
exit=1
```

And `~"hello"` now prints bare `hello` on stdout from an AOT binary, same as the three in-process runners.

## What's in the diff

- `aot runtime: add jit_prt_main_result helper` (`src/vm/mod.rs`, `src/vm/jit_cranelift.rs`) — new extern "C" helper that dispatches on `TAG_OK` / `TAG_ERR` and returns the exit code packed in u64; registered in the JIT symbol table so the helper resolves at link time for AOT.
- `cranelift aot: route generate_main result through jit_prt_main_result` (`src/vm/compile_cranelift.rs`) — adds `prt_main: FuncId` to `HelperFuncs`, declares the import, and switches `generate_main` to call it and ireduce the u64 result into the i32 `main` return.
- `test + example: cross-engine AOT wrapper-strip coverage` (`tests/regression_aot_wrapper_strip.rs`, `examples/aot-wrapper-strip.ilo`) — compiles each case to a real AOT binary and asserts byte-for-byte parity against tree, VM, and Cranelift JIT in-process; covers `~"hello"`, `^"err"`, bare `42`, and `~7`.

## Test plan

- [x] `cargo build --release --features cranelift` regenerates `libilo.a` with the new helper
- [x] `cargo test --release --features cranelift --test regression_aot_wrapper_strip` — 4 passed
- [x] Full `cargo test --release --features cranelift` — all 118 test binaries pass, no failures
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --release --features cranelift --all-targets -- -D warnings` clean
- [x] Manual smoke: AOT stdout/stderr/exit match tree/VM/Cranelift in-process byte-for-byte for all three cases

## Follow-ups

- AOT arg parsing has a pre-existing oddity where a CLI int reaches `num` and the program prints `nil` instead of the parsed number (visible if you AOT-compile `examples/main-err-exit-code.ilo` and run `./bin 42`). Unrelated to this fix; the in-process runners get it right. Will log it separately in the assessment doc.