### PR TITLE
Cranelift JIT nil-sweep batch 3: arithmetic, comparison, numeric-unary

### DIFF
--- a/examples/jit-nil-sweep-batch3.ilo
+++ b/examples/jit-nil-sweep-batch3.ilo
@@ -1,0 +1,102 @@
+-- Positive paths for the batch-3 helpers (Group A: arithmetic, comparison,
+-- numeric unary/binary). The companion regression suite asserts that the
+-- error paths now route through JIT_RUNTIME_ERROR with packed span_bits;
+-- this example pins the happy paths cross-engine via the examples_engines
+-- harness so future codegen changes can't silently regress them.
+
+add-nums>n;+2 3
+add-text>t;+"foo" "bar"
+sub-nums>n;- 10 3
+mul-nums>n;* 4 5
+div-nums>n;/ 10 4
+mod-nums>n;mod 10 3
+neg-num>n;- 5
+gt-nums>b;> 5 3
+lt-nums>b;< 2 7
+ge-nums>b;>= 5 5
+le-nums>b;<= 3 3
+gt-text>b;> "b" "a"
+abs-num>n;abs -7
+min-num>n;min 3 5
+max-num>n;max 3 5
+flr-num>n;flr 3.7
+cel-num>n;cel 3.2
+rou-num>n;rou 3.5
+clamp-mid>n;clamp 5 0 10
+clamp-hi>n;clamp 15 0 10
+clamp-lo>n;clamp -5 0 10
+len-text>n;len "hello"
+len-list>n;len [1 2 3]
+str-num>t;str 42
+
+-- run: add-nums
+-- out: 5
+
+-- run: add-text
+-- out: foobar
+
+-- run: sub-nums
+-- out: 7
+
+-- run: mul-nums
+-- out: 20
+
+-- run: div-nums
+-- out: 2.5
+
+-- run: mod-nums
+-- out: 1
+
+-- run: neg-num
+-- out: -5
+
+-- run: gt-nums
+-- out: true
+
+-- run: lt-nums
+-- out: true
+
+-- run: ge-nums
+-- out: true
+
+-- run: le-nums
+-- out: true
+
+-- run: gt-text
+-- out: true
+
+-- run: abs-num
+-- out: 7
+
+-- run: min-num
+-- out: 3
+
+-- run: max-num
+-- out: 5
+
+-- run: flr-num
+-- out: 3
+
+-- run: cel-num
+-- out: 4
+
+-- run: rou-num
+-- out: 4
+
+-- run: clamp-mid
+-- out: 5
+
+-- run: clamp-hi
+-- out: 10
+
+-- run: clamp-lo
+-- out: 0
+
+-- run: len-text
+-- out: 5
+
+-- run: len-list
+-- out: 3
+
+-- run: str-num
+-- out: 42

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -204,21 +204,21 @@ fn declare_helper(
 
 fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
     HelperFuncs {
-        add: declare_helper(module, "jit_add", 2, 1),
-        add_inplace: declare_helper(module, "jit_add_inplace", 2, 1),
+        add: declare_helper(module, "jit_add", 3, 1),
+        add_inplace: declare_helper(module, "jit_add_inplace", 3, 1),
         concat: declare_helper(module, "jit_concat", 2, 1),
         concat_inplace: declare_helper(module, "jit_concat_inplace", 2, 1),
-        sub: declare_helper(module, "jit_sub", 2, 1),
-        mul: declare_helper(module, "jit_mul", 2, 1),
-        div: declare_helper(module, "jit_div", 2, 1),
+        sub: declare_helper(module, "jit_sub", 3, 1),
+        mul: declare_helper(module, "jit_mul", 3, 1),
+        div: declare_helper(module, "jit_div", 3, 1),
         eq: declare_helper(module, "jit_eq", 2, 1),
         ne: declare_helper(module, "jit_ne", 2, 1),
-        gt: declare_helper(module, "jit_gt", 2, 1),
-        lt: declare_helper(module, "jit_lt", 2, 1),
-        ge: declare_helper(module, "jit_ge", 2, 1),
-        le: declare_helper(module, "jit_le", 2, 1),
+        gt: declare_helper(module, "jit_gt", 3, 1),
+        lt: declare_helper(module, "jit_lt", 3, 1),
+        ge: declare_helper(module, "jit_ge", 3, 1),
+        le: declare_helper(module, "jit_le", 3, 1),
         not: declare_helper(module, "jit_not", 1, 1),
-        neg: declare_helper(module, "jit_neg", 1, 1),
+        neg: declare_helper(module, "jit_neg", 2, 1),
         truthy: declare_helper(module, "jit_truthy", 1, 1),
         wrapok: declare_helper(module, "jit_wrapok", 1, 1),
         wraperr: declare_helper(module, "jit_wraperr", 1, 1),
@@ -227,16 +227,16 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         unwrap: declare_helper(module, "jit_unwrap", 1, 1),
         jit_move: declare_helper(module, "jit_move", 1, 1),
         drop_rc: declare_helper(module, "jit_drop_rc", 1, 0),
-        len: declare_helper(module, "jit_len", 1, 1),
-        str_fn: declare_helper(module, "jit_str", 1, 1),
-        num: declare_helper(module, "jit_num", 1, 1),
-        abs: declare_helper(module, "jit_abs", 1, 1),
-        min: declare_helper(module, "jit_min", 2, 1),
-        clamp: declare_helper(module, "jit_clamp", 3, 1),
-        max: declare_helper(module, "jit_max", 2, 1),
-        flr: declare_helper(module, "jit_flr", 1, 1),
-        cel: declare_helper(module, "jit_cel", 1, 1),
-        rou: declare_helper(module, "jit_rou", 1, 1),
+        len: declare_helper(module, "jit_len", 2, 1),
+        str_fn: declare_helper(module, "jit_str", 2, 1),
+        num: declare_helper(module, "jit_num", 2, 1),
+        abs: declare_helper(module, "jit_abs", 2, 1),
+        min: declare_helper(module, "jit_min", 3, 1),
+        clamp: declare_helper(module, "jit_clamp", 4, 1),
+        max: declare_helper(module, "jit_max", 3, 1),
+        flr: declare_helper(module, "jit_flr", 2, 1),
+        cel: declare_helper(module, "jit_cel", 2, 1),
+        rou: declare_helper(module, "jit_rou", 2, 1),
         pow: declare_helper(module, "jit_pow", 2, 1),
         sqrt: declare_helper(module, "jit_sqrt", 1, 1),
         log: declare_helper(module, "jit_log", 1, 1),
@@ -1352,8 +1352,10 @@ fn compile_function_body(
                         OP_DIV => helpers.div,
                         _ => unreachable!(),
                     };
+                    let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                    let span_arg = builder.ins().iconst(I64, span_bits);
                     let fref = get_func_ref(&mut builder, module, helper);
-                    let call_inst = builder.ins().call(fref, &[bv, cv]);
+                    let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                     let slow_result = builder.inst_results(call_inst)[0];
                     builder.ins().jump(merge_block, &[slow_result]);
 
@@ -1501,19 +1503,23 @@ fn compile_function_body(
                     let fast_result = builder.ins().select(cmp, true_val, false_val);
                     builder.ins().jump(merge_block, &[fast_result]);
 
-                    // Slow path: call helper
+                    // Slow path: call helper. EQ/NE keep 2-arg signature; the
+                    // ordered comparisons now error on type mismatch and take
+                    // a packed span_bits immediate as their third arg.
                     builder.switch_to_block(slow_block);
-                    let helper = match op {
-                        OP_LT => helpers.lt,
-                        OP_GT => helpers.gt,
-                        OP_LE => helpers.le,
-                        OP_GE => helpers.ge,
-                        OP_EQ => helpers.eq,
-                        OP_NE => helpers.ne,
+                    let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                    let span_arg = builder.ins().iconst(I64, span_bits);
+                    let (helper, args): (FuncId, Vec<_>) = match op {
+                        OP_LT => (helpers.lt, vec![bv, cv, span_arg]),
+                        OP_GT => (helpers.gt, vec![bv, cv, span_arg]),
+                        OP_LE => (helpers.le, vec![bv, cv, span_arg]),
+                        OP_GE => (helpers.ge, vec![bv, cv, span_arg]),
+                        OP_EQ => (helpers.eq, vec![bv, cv]),
+                        OP_NE => (helpers.ne, vec![bv, cv]),
                         _ => unreachable!(),
                     };
                     let fref = get_func_ref(&mut builder, module, helper);
-                    let call_inst = builder.ins().call(fref, &[bv, cv]);
+                    let call_inst = builder.ins().call(fref, &args);
                     let slow_result = builder.inst_results(call_inst)[0];
                     builder.ins().jump(merge_block, &[slow_result]);
 
@@ -1581,8 +1587,10 @@ fn compile_function_body(
                     }
                 } else {
                     let bv = builder.use_var(vars[b_idx]);
+                    let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                    let span_arg = builder.ins().iconst(I64, span_bits);
                     let fref = get_func_ref(&mut builder, module, helpers.neg);
-                    let call_inst = builder.ins().call(fref, &[bv]);
+                    let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                     let result = builder.inst_results(call_inst)[0];
                     builder.def_var(vars[a_idx], result);
                 }
@@ -1610,8 +1618,10 @@ fn compile_function_body(
                 skip_next = true;
                 let d_idx = ((data_inst >> 16) & 0xFF) as usize;
                 let dv = builder.use_var(vars[d_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.clamp);
-                let call_inst = builder.ins().call(fref, &[bv, cv, dv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, dv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
                 if a_idx < reg_count && reg_always_num[a_idx] {
@@ -1911,8 +1921,10 @@ fn compile_function_body(
             // ── Builtins: 1-arg → 1-return ──
             OP_LEN => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.len);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
                 if a_idx < reg_count && reg_always_num[a_idx] {
@@ -1922,22 +1934,28 @@ fn compile_function_body(
             }
             OP_STR => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.str_fn);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_NUM => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.num);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_ABS => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.abs);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
                 if a_idx < reg_count && reg_always_num[a_idx] {
@@ -1948,8 +1966,10 @@ fn compile_function_body(
             OP_MIN => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.min);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
                 if a_idx < reg_count && reg_always_num[a_idx] {
@@ -1960,8 +1980,10 @@ fn compile_function_body(
             OP_MAX => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.max);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
                 if a_idx < reg_count && reg_always_num[a_idx] {
@@ -1971,8 +1993,10 @@ fn compile_function_body(
             }
             OP_FLR => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.flr);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
                 if a_idx < reg_count && reg_always_num[a_idx] {
@@ -1982,8 +2006,10 @@ fn compile_function_body(
             }
             OP_CEL => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.cel);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
                 if a_idx < reg_count && reg_always_num[a_idx] {
@@ -1993,8 +2019,10 @@ fn compile_function_body(
             }
             OP_ROU => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.rou);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
                 if a_idx < reg_count && reg_always_num[a_idx] {

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -191,7 +191,7 @@ struct HelperFuncs {
 /// larger than ~4 GiB) are clamped to `u32::MAX`; this only affects
 /// diagnostic rendering, never program correctness.
 #[inline]
-fn pack_span_bits(span: crate::ast::Span) -> i64 {
+pub(super) fn pack_span_bits(span: crate::ast::Span) -> i64 {
     let start = span.start.min(u32::MAX as usize) as u64;
     let end = span.end.min(u32::MAX as usize) as u64;
     ((start << 32) | end) as i64
@@ -376,21 +376,21 @@ fn register_helpers(builder: &mut JITBuilder) {
 
 fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
     HelperFuncs {
-        add: declare_helper(module, "jit_add", 2, 1),
-        add_inplace: declare_helper(module, "jit_add_inplace", 2, 1),
+        add: declare_helper(module, "jit_add", 3, 1),
+        add_inplace: declare_helper(module, "jit_add_inplace", 3, 1),
         concat: declare_helper(module, "jit_concat", 2, 1),
         concat_inplace: declare_helper(module, "jit_concat_inplace", 2, 1),
-        sub: declare_helper(module, "jit_sub", 2, 1),
-        mul: declare_helper(module, "jit_mul", 2, 1),
-        div: declare_helper(module, "jit_div", 2, 1),
+        sub: declare_helper(module, "jit_sub", 3, 1),
+        mul: declare_helper(module, "jit_mul", 3, 1),
+        div: declare_helper(module, "jit_div", 3, 1),
         eq: declare_helper(module, "jit_eq", 2, 1),
         ne: declare_helper(module, "jit_ne", 2, 1),
-        gt: declare_helper(module, "jit_gt", 2, 1),
-        lt: declare_helper(module, "jit_lt", 2, 1),
-        ge: declare_helper(module, "jit_ge", 2, 1),
-        le: declare_helper(module, "jit_le", 2, 1),
+        gt: declare_helper(module, "jit_gt", 3, 1),
+        lt: declare_helper(module, "jit_lt", 3, 1),
+        ge: declare_helper(module, "jit_ge", 3, 1),
+        le: declare_helper(module, "jit_le", 3, 1),
         not: declare_helper(module, "jit_not", 1, 1),
-        neg: declare_helper(module, "jit_neg", 1, 1),
+        neg: declare_helper(module, "jit_neg", 2, 1),
         truthy: declare_helper(module, "jit_truthy", 1, 1),
         wrapok: declare_helper(module, "jit_wrapok", 1, 1),
         wraperr: declare_helper(module, "jit_wraperr", 1, 1),
@@ -400,17 +400,17 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         panic_unwrap: declare_helper(module, "jit_panic_unwrap", 1, 1),
         jit_move: declare_helper(module, "jit_move", 1, 1),
         drop_rc: declare_helper(module, "jit_drop_rc", 1, 0),
-        len: declare_helper(module, "jit_len", 1, 1),
-        str_fn: declare_helper(module, "jit_str", 1, 1),
-        num: declare_helper(module, "jit_num", 1, 1),
-        abs: declare_helper(module, "jit_abs", 1, 1),
-        mod_fn: declare_helper(module, "jit_mod", 2, 1),
-        clamp: declare_helper(module, "jit_clamp", 3, 1),
-        min: declare_helper(module, "jit_min", 2, 1),
-        max: declare_helper(module, "jit_max", 2, 1),
-        flr: declare_helper(module, "jit_flr", 1, 1),
-        cel: declare_helper(module, "jit_cel", 1, 1),
-        rou: declare_helper(module, "jit_rou", 1, 1),
+        len: declare_helper(module, "jit_len", 2, 1),
+        str_fn: declare_helper(module, "jit_str", 2, 1),
+        num: declare_helper(module, "jit_num", 2, 1),
+        abs: declare_helper(module, "jit_abs", 2, 1),
+        mod_fn: declare_helper(module, "jit_mod", 3, 1),
+        clamp: declare_helper(module, "jit_clamp", 4, 1),
+        min: declare_helper(module, "jit_min", 3, 1),
+        max: declare_helper(module, "jit_max", 3, 1),
+        flr: declare_helper(module, "jit_flr", 2, 1),
+        cel: declare_helper(module, "jit_cel", 2, 1),
+        rou: declare_helper(module, "jit_rou", 2, 1),
         pow: declare_helper(module, "jit_pow", 2, 1),
         sqrt: declare_helper(module, "jit_sqrt", 1, 1),
         log: declare_helper(module, "jit_log", 1, 1),
@@ -1480,8 +1480,10 @@ fn compile_function_body(
                         OP_DIV => helpers.div,
                         _ => unreachable!(),
                     };
+                    let span_bits = pack_span_bits(chunk.spans[ip]);
+                    let span_arg = builder.ins().iconst(I64, span_bits);
                     let fref = get_func_ref(&mut builder, module, helper);
-                    let call_inst = builder.ins().call(fref, &[bv, cv]);
+                    let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                     let slow_result = builder.inst_results(call_inst)[0];
                     builder.ins().jump(merge_block, &[slow_result]);
 
@@ -1630,19 +1632,25 @@ fn compile_function_body(
                     let fast_result = builder.ins().select(cmp, true_val, false_val);
                     builder.ins().jump(merge_block, &[fast_result]);
 
-                    // Slow path: call helper
+                    // Slow path: call helper. EQ/NE never error (any-type
+                    // equality compares NanVal bits and returns a boolean), so
+                    // they keep the 2-arg signature. LT/GT/LE/GE now signal
+                    // type errors via JIT_RUNTIME_ERROR and take a span_bits
+                    // immediate as their third arg.
                     builder.switch_to_block(slow_block);
-                    let helper = match op {
-                        OP_LT => helpers.lt,
-                        OP_GT => helpers.gt,
-                        OP_LE => helpers.le,
-                        OP_GE => helpers.ge,
-                        OP_EQ => helpers.eq,
-                        OP_NE => helpers.ne,
+                    let span_bits = pack_span_bits(chunk.spans[ip]);
+                    let span_arg = builder.ins().iconst(I64, span_bits);
+                    let (helper, args): (FuncId, Vec<_>) = match op {
+                        OP_LT => (helpers.lt, vec![bv, cv, span_arg]),
+                        OP_GT => (helpers.gt, vec![bv, cv, span_arg]),
+                        OP_LE => (helpers.le, vec![bv, cv, span_arg]),
+                        OP_GE => (helpers.ge, vec![bv, cv, span_arg]),
+                        OP_EQ => (helpers.eq, vec![bv, cv]),
+                        OP_NE => (helpers.ne, vec![bv, cv]),
                         _ => unreachable!(),
                     };
                     let fref = get_func_ref(&mut builder, module, helper);
-                    let call_inst = builder.ins().call(fref, &[bv, cv]);
+                    let call_inst = builder.ins().call(fref, &args);
                     let slow_result = builder.inst_results(call_inst)[0];
                     builder.ins().jump(merge_block, &[slow_result]);
 
@@ -1711,8 +1719,10 @@ fn compile_function_body(
                     }
                 } else {
                     let bv = builder.use_var(vars[b_idx]);
+                    let span_bits = pack_span_bits(chunk.spans[ip]);
+                    let span_arg = builder.ins().iconst(I64, span_bits);
                     let fref = get_func_ref(&mut builder, module, helpers.neg);
-                    let call_inst = builder.ins().call(fref, &[bv]);
+                    let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                     let result = builder.inst_results(call_inst)[0];
                     builder.def_var(vars[a_idx], result);
                 }
@@ -1975,8 +1985,10 @@ fn compile_function_body(
             }
             OP_LEN => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.len);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
                 if a_idx < reg_count && reg_always_num[a_idx] {
@@ -1987,22 +1999,28 @@ fn compile_function_body(
             }
             OP_STR => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.str_fn);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_NUM => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.num);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_ABS => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.abs);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
                 if a_idx < reg_count && reg_always_num[a_idx] {
@@ -2014,8 +2032,10 @@ fn compile_function_body(
             OP_MIN => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.min);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
                 if a_idx < reg_count && reg_always_num[a_idx] {
@@ -2027,8 +2047,10 @@ fn compile_function_body(
             OP_MAX => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.max);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
                 if a_idx < reg_count && reg_always_num[a_idx] {
@@ -2040,8 +2062,10 @@ fn compile_function_body(
             OP_MOD => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.mod_fn);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
                 if a_idx < reg_count && reg_always_num[a_idx] {
@@ -2058,8 +2082,10 @@ fn compile_function_body(
                 skip_next = true;
                 let d_idx = ((data_inst >> 16) & 0xFF) as usize;
                 let dv = builder.use_var(vars[d_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.clamp);
-                let call_inst = builder.ins().call(fref, &[bv, cv, dv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, dv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
                 if a_idx < reg_count && reg_always_num[a_idx] {
@@ -2070,8 +2096,10 @@ fn compile_function_body(
             }
             OP_FLR => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.flr);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
                 if a_idx < reg_count && reg_always_num[a_idx] {
@@ -2082,8 +2110,10 @@ fn compile_function_body(
             }
             OP_CEL => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.cel);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
                 if a_idx < reg_count && reg_always_num[a_idx] {
@@ -2094,8 +2124,10 @@ fn compile_function_body(
             }
             OP_ROU => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.rou);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
                 if a_idx < reg_count && reg_always_num[a_idx] {

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -9503,7 +9503,7 @@ fn nanval_truthy(v: NanVal) -> bool {
 /// allocates fresh storage, never mutates the inputs. The Cranelift compiler
 /// picks this for non-rebind OP_ADD (the general `b = +a x` shape) so the
 /// caller's `a` is preserved.
-pub(crate) extern "C" fn jit_add(a: u64, b: u64) -> u64 {
+pub(crate) extern "C" fn jit_add(a: u64, b: u64, span_bits: u64) -> u64 {
     let av = NanVal(a);
     let bv = NanVal(b);
     if av.is_number() && bv.is_number() {
@@ -9544,7 +9544,8 @@ pub(crate) extern "C" fn jit_add(a: u64, b: u64) -> u64 {
             return NanVal::heap_list(new_items).0;
         }
     }
-    TAG_NIL // error fallback
+    jit_set_runtime_error_with_span(VmError::Type("cannot add non-matching types"), span_bits);
+    TAG_NIL
 }
 
 /// In-place add helper — for string inputs, mutates the left string when the
@@ -9565,7 +9566,7 @@ pub(crate) extern "C" fn jit_add(a: u64, b: u64) -> u64 {
 /// fixed for OP_ADD_SS via the jit_concat / jit_concat_inplace split.
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_add_inplace(a: u64, b: u64) -> u64 {
+pub(crate) extern "C" fn jit_add_inplace(a: u64, b: u64, span_bits: u64) -> u64 {
     let av = NanVal(a);
     let bv = NanVal(b);
     if av.is_number() && bv.is_number() {
@@ -9627,7 +9628,8 @@ pub(crate) extern "C" fn jit_add_inplace(a: u64, b: u64) -> u64 {
             return NanVal::heap_list(new_items).0;
         }
     }
-    TAG_NIL // error fallback
+    jit_set_runtime_error_with_span(VmError::Type("cannot add non-matching types"), span_bits);
+    TAG_NIL
 }
 
 /// Clone-always concat helper — the safe path for OP_ADD_SS / OP_ADD when
@@ -9724,38 +9726,42 @@ pub(crate) extern "C" fn jit_concat_inplace(a: u64, b: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_sub(a: u64, b: u64) -> u64 {
+pub(crate) extern "C" fn jit_sub(a: u64, b: u64, span_bits: u64) -> u64 {
     let av = NanVal(a);
     let bv = NanVal(b);
     if av.is_number() && bv.is_number() {
         return NanVal::number(av.as_number() - bv.as_number()).0;
     }
+    jit_set_runtime_error_with_span(VmError::Type("cannot subtract non-numbers"), span_bits);
     TAG_NIL
 }
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_mul(a: u64, b: u64) -> u64 {
+pub(crate) extern "C" fn jit_mul(a: u64, b: u64, span_bits: u64) -> u64 {
     let av = NanVal(a);
     let bv = NanVal(b);
     if av.is_number() && bv.is_number() {
         return NanVal::number(av.as_number() * bv.as_number()).0;
     }
+    jit_set_runtime_error_with_span(VmError::Type("cannot multiply non-numbers"), span_bits);
     TAG_NIL
 }
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_div(a: u64, b: u64) -> u64 {
+pub(crate) extern "C" fn jit_div(a: u64, b: u64, span_bits: u64) -> u64 {
     let av = NanVal(a);
     let bv = NanVal(b);
     if av.is_number() && bv.is_number() {
         let dv = bv.as_number();
         if dv == 0.0 {
+            jit_set_runtime_error_with_span(VmError::DivisionByZero, span_bits);
             return TAG_NIL;
         }
         return NanVal::number(av.as_number() / dv).0;
     }
+    jit_set_runtime_error_with_span(VmError::Type("cannot divide non-numbers"), span_bits);
     TAG_NIL
 }
 
@@ -9773,7 +9779,7 @@ pub(crate) extern "C" fn jit_ne(a: u64, b: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_gt(a: u64, b: u64) -> u64 {
+pub(crate) extern "C" fn jit_gt(a: u64, b: u64, span_bits: u64) -> u64 {
     let av = NanVal(a);
     let bv = NanVal(b);
     if av.is_number() && bv.is_number() {
@@ -9782,12 +9788,16 @@ pub(crate) extern "C" fn jit_gt(a: u64, b: u64) -> u64 {
     if av.is_string() && bv.is_string() {
         return NanVal::boolean(unsafe { nanval_str_cmp(av, bv) == std::cmp::Ordering::Greater }).0;
     }
+    jit_set_runtime_error_with_span(
+        VmError::Type("cannot compare > : operands must be same type (n or t)"),
+        span_bits,
+    );
     TAG_FALSE
 }
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_lt(a: u64, b: u64) -> u64 {
+pub(crate) extern "C" fn jit_lt(a: u64, b: u64, span_bits: u64) -> u64 {
     let av = NanVal(a);
     let bv = NanVal(b);
     if av.is_number() && bv.is_number() {
@@ -9796,12 +9806,16 @@ pub(crate) extern "C" fn jit_lt(a: u64, b: u64) -> u64 {
     if av.is_string() && bv.is_string() {
         return NanVal::boolean(unsafe { nanval_str_cmp(av, bv) == std::cmp::Ordering::Less }).0;
     }
+    jit_set_runtime_error_with_span(
+        VmError::Type("cannot compare < : operands must be same type (n or t)"),
+        span_bits,
+    );
     TAG_FALSE
 }
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_ge(a: u64, b: u64) -> u64 {
+pub(crate) extern "C" fn jit_ge(a: u64, b: u64, span_bits: u64) -> u64 {
     let av = NanVal(a);
     let bv = NanVal(b);
     if av.is_number() && bv.is_number() {
@@ -9810,12 +9824,16 @@ pub(crate) extern "C" fn jit_ge(a: u64, b: u64) -> u64 {
     if av.is_string() && bv.is_string() {
         return NanVal::boolean(unsafe { nanval_str_cmp(av, bv) != std::cmp::Ordering::Less }).0;
     }
+    jit_set_runtime_error_with_span(
+        VmError::Type("cannot compare >= : operands must be same type (n or t)"),
+        span_bits,
+    );
     TAG_FALSE
 }
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_le(a: u64, b: u64) -> u64 {
+pub(crate) extern "C" fn jit_le(a: u64, b: u64, span_bits: u64) -> u64 {
     let av = NanVal(a);
     let bv = NanVal(b);
     if av.is_number() && bv.is_number() {
@@ -9824,6 +9842,10 @@ pub(crate) extern "C" fn jit_le(a: u64, b: u64) -> u64 {
     if av.is_string() && bv.is_string() {
         return NanVal::boolean(unsafe { nanval_str_cmp(av, bv) != std::cmp::Ordering::Greater }).0;
     }
+    jit_set_runtime_error_with_span(
+        VmError::Type("cannot compare <= : operands must be same type (n or t)"),
+        span_bits,
+    );
     TAG_FALSE
 }
 
@@ -9835,11 +9857,12 @@ pub(crate) extern "C" fn jit_not(a: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_neg(a: u64) -> u64 {
+pub(crate) extern "C" fn jit_neg(a: u64, span_bits: u64) -> u64 {
     let v = NanVal(a);
     if v.is_number() {
         return NanVal::number(-v.as_number()).0;
     }
+    jit_set_runtime_error_with_span(VmError::Type("cannot negate non-number"), span_bits);
     TAG_NIL
 }
 
@@ -9972,7 +9995,7 @@ pub(crate) extern "C" fn jit_drop_rc(v: u64) {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_len(a: u64) -> u64 {
+pub(crate) extern "C" fn jit_len(a: u64, span_bits: u64) -> u64 {
     let v = NanVal(a);
     if v.is_string() {
         let s = unsafe {
@@ -9988,14 +10011,25 @@ pub(crate) extern "C" fn jit_len(a: u64) -> u64 {
     {
         return NanVal::number(items.len() as f64).0;
     }
+    // Map support: tree/VM both accept maps in `len`. Mirror it here.
+    if v.is_heap()
+        && let HeapObj::Map(m) = unsafe { v.as_heap_ref() }
+    {
+        return NanVal::number(m.len() as f64).0;
+    }
+    jit_set_runtime_error_with_span(
+        VmError::Type("len requires string, list, or map"),
+        span_bits,
+    );
     TAG_NIL
 }
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_str(a: u64) -> u64 {
+pub(crate) extern "C" fn jit_str(a: u64, span_bits: u64) -> u64 {
     let v = NanVal(a);
     if !v.is_number() {
+        jit_set_runtime_error_with_span(VmError::Type("str requires a number"), span_bits);
         return TAG_NIL;
     }
     let n = v.as_number();
@@ -10009,9 +10043,10 @@ pub(crate) extern "C" fn jit_str(a: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_num(a: u64) -> u64 {
+pub(crate) extern "C" fn jit_num(a: u64, span_bits: u64) -> u64 {
     let v = NanVal(a);
     if !v.is_string() {
+        jit_set_runtime_error_with_span(VmError::Type("num requires a string"), span_bits);
         return TAG_NIL;
     }
     let s = unsafe {
@@ -10031,34 +10066,37 @@ pub(crate) extern "C" fn jit_num(a: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_abs(a: u64) -> u64 {
+pub(crate) extern "C" fn jit_abs(a: u64, span_bits: u64) -> u64 {
     let v = NanVal(a);
     if v.is_number() {
         NanVal::number(v.as_number().abs()).0
     } else {
+        jit_set_runtime_error_with_span(VmError::Type("abs requires a number"), span_bits);
         TAG_NIL
     }
 }
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_mod(a: u64, b: u64) -> u64 {
+pub(crate) extern "C" fn jit_mod(a: u64, b: u64, span_bits: u64) -> u64 {
     let av = NanVal(a);
     let bv = NanVal(b);
     if av.is_number() && bv.is_number() {
         let dv = bv.as_number();
         if dv == 0.0 {
+            jit_set_runtime_error_with_span(VmError::Type("modulo by zero"), span_bits);
             return TAG_NIL;
         }
         NanVal::number(av.as_number() % dv).0
     } else {
+        jit_set_runtime_error_with_span(VmError::Type("mod requires numbers"), span_bits);
         TAG_NIL
     }
 }
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_clamp(x: u64, lo: u64, hi: u64) -> u64 {
+pub(crate) extern "C" fn jit_clamp(x: u64, lo: u64, hi: u64, span_bits: u64) -> u64 {
     let xv = NanVal(x);
     let lv = NanVal(lo);
     let hv = NanVal(hi);
@@ -10066,63 +10104,69 @@ pub(crate) extern "C" fn jit_clamp(x: u64, lo: u64, hi: u64) -> u64 {
         // result = max(lo, min(hi, x)); when lo > hi, result == lo.
         NanVal::number(xv.as_number().min(hv.as_number()).max(lv.as_number())).0
     } else {
+        jit_set_runtime_error_with_span(VmError::Type("clamp requires numbers"), span_bits);
         TAG_NIL
     }
 }
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_min(a: u64, b: u64) -> u64 {
+pub(crate) extern "C" fn jit_min(a: u64, b: u64, span_bits: u64) -> u64 {
     let av = NanVal(a);
     let bv = NanVal(b);
     if av.is_number() && bv.is_number() {
         NanVal::number(av.as_number().min(bv.as_number())).0
     } else {
+        jit_set_runtime_error_with_span(VmError::Type("min/max require numbers"), span_bits);
         TAG_NIL
     }
 }
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_max(a: u64, b: u64) -> u64 {
+pub(crate) extern "C" fn jit_max(a: u64, b: u64, span_bits: u64) -> u64 {
     let av = NanVal(a);
     let bv = NanVal(b);
     if av.is_number() && bv.is_number() {
         NanVal::number(av.as_number().max(bv.as_number())).0
     } else {
+        jit_set_runtime_error_with_span(VmError::Type("min/max require numbers"), span_bits);
         TAG_NIL
     }
 }
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_flr(a: u64) -> u64 {
+pub(crate) extern "C" fn jit_flr(a: u64, span_bits: u64) -> u64 {
     let v = NanVal(a);
     if v.is_number() {
         NanVal::number(v.as_number().floor()).0
     } else {
+        jit_set_runtime_error_with_span(VmError::Type("flr/cel/rou requires a number"), span_bits);
         TAG_NIL
     }
 }
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_cel(a: u64) -> u64 {
+pub(crate) extern "C" fn jit_cel(a: u64, span_bits: u64) -> u64 {
     let v = NanVal(a);
     if v.is_number() {
         NanVal::number(v.as_number().ceil()).0
     } else {
+        jit_set_runtime_error_with_span(VmError::Type("flr/cel/rou requires a number"), span_bits);
         TAG_NIL
     }
 }
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_rou(a: u64) -> u64 {
+pub(crate) extern "C" fn jit_rou(a: u64, span_bits: u64) -> u64 {
     let v = NanVal(a);
     if v.is_number() {
         NanVal::number(v.as_number().round()).0
     } else {
+        jit_set_runtime_error_with_span(VmError::Type("flr/cel/rou requires a number"), span_bits);
         TAG_NIL
     }
 }
@@ -19147,36 +19191,45 @@ mod tests {
 
         #[test]
         fn jit_sub_numbers() {
-            let r = jit_sub(num(10.0), num(3.0));
+            let r = jit_sub(num(10.0), num(3.0), 0);
             assert!(is_num(r));
             assert_eq!(as_num(r), 7.0);
         }
 
         #[test]
-        fn jit_sub_non_numbers_returns_nil() {
+        fn jit_sub_non_numbers_signals_runtime_error() {
+            // Type error on the slow path now signals via JIT_RUNTIME_ERROR
+            // and returns TAG_NIL, matching the tree/VM "cannot subtract
+            // non-numbers" raise (sweep batch 3).
+            let _ = jit_take_runtime_error();
             let s = NanVal::heap_string("hello".into());
-            let r = jit_sub(s.0, num(1.0));
+            let r = jit_sub(s.0, num(1.0), 0);
             assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("subtract")));
         }
 
         #[test]
         fn jit_mul_numbers() {
-            let r = jit_mul(num(4.0), num(5.0));
+            let r = jit_mul(num(4.0), num(5.0), 0);
             assert!(is_num(r));
             assert_eq!(as_num(r), 20.0);
         }
 
         #[test]
         fn jit_div_numbers() {
-            let r = jit_div(num(10.0), num(4.0));
+            let r = jit_div(num(10.0), num(4.0), 0);
             assert!(is_num(r));
             assert_eq!(as_num(r), 2.5);
         }
 
         #[test]
-        fn jit_div_by_zero_returns_nil() {
-            let r = jit_div(num(5.0), num(0.0));
+        fn jit_div_by_zero_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let r = jit_div(num(5.0), num(0.0), 0);
             assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::DivisionByZero));
         }
 
         #[test]
@@ -19201,28 +19254,28 @@ mod tests {
 
         #[test]
         fn jit_gt_numbers() {
-            assert!(as_bool(jit_gt(num(5.0), num(3.0))));
-            assert!(!as_bool(jit_gt(num(3.0), num(5.0))));
+            assert!(as_bool(jit_gt(num(5.0), num(3.0), 0)));
+            assert!(!as_bool(jit_gt(num(3.0), num(5.0), 0)));
         }
 
         #[test]
         fn jit_lt_numbers() {
-            assert!(as_bool(jit_lt(num(2.0), num(7.0))));
-            assert!(!as_bool(jit_lt(num(7.0), num(2.0))));
+            assert!(as_bool(jit_lt(num(2.0), num(7.0), 0)));
+            assert!(!as_bool(jit_lt(num(7.0), num(2.0), 0)));
         }
 
         #[test]
         fn jit_ge_numbers() {
-            assert!(as_bool(jit_ge(num(5.0), num(5.0))));
-            assert!(as_bool(jit_ge(num(6.0), num(5.0))));
-            assert!(!as_bool(jit_ge(num(4.0), num(5.0))));
+            assert!(as_bool(jit_ge(num(5.0), num(5.0), 0)));
+            assert!(as_bool(jit_ge(num(6.0), num(5.0), 0)));
+            assert!(!as_bool(jit_ge(num(4.0), num(5.0), 0)));
         }
 
         #[test]
         fn jit_le_numbers() {
-            assert!(as_bool(jit_le(num(3.0), num(3.0))));
-            assert!(as_bool(jit_le(num(2.0), num(3.0))));
-            assert!(!as_bool(jit_le(num(4.0), num(3.0))));
+            assert!(as_bool(jit_le(num(3.0), num(3.0), 0)));
+            assert!(as_bool(jit_le(num(2.0), num(3.0), 0)));
+            assert!(!as_bool(jit_le(num(4.0), num(3.0), 0)));
         }
 
         #[test]
@@ -19241,16 +19294,19 @@ mod tests {
 
         #[test]
         fn jit_neg_number() {
-            let r = jit_neg(num(5.0));
+            let r = jit_neg(num(5.0), 0);
             assert!(is_num(r));
             assert_eq!(as_num(r), -5.0);
         }
 
         #[test]
-        fn jit_neg_non_number_returns_nil() {
+        fn jit_neg_non_number_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
             let s = NanVal::heap_string("x".into());
-            let r = jit_neg(s.0);
+            let r = jit_neg(s.0, 0);
             assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("negate")));
         }
 
         #[test]
@@ -19336,28 +19392,44 @@ mod tests {
         }
 
         #[test]
-        fn jit_gt_non_numbers_returns_false() {
-            // Non-number, non-string → returns TAG_FALSE
-            let r = jit_gt(TAG_NIL, TAG_NIL);
+        fn jit_gt_non_numbers_signals_runtime_error() {
+            // Mixed-type ordered comparison was previously permissive and
+            // returned TAG_FALSE. After sweep batch 3 it signals through
+            // JIT_RUNTIME_ERROR (return value remains TAG_FALSE so the IR
+            // can carry on until the JIT entry point surfaces the error,
+            // matching jit_gt/lt/ge/le contract).
+            let _ = jit_take_runtime_error();
+            let r = jit_gt(TAG_NIL, TAG_NIL, 0);
             assert!(!as_bool(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("compare >")));
         }
 
         #[test]
-        fn jit_lt_non_numbers_returns_false() {
-            let r = jit_lt(TAG_NIL, num(1.0));
+        fn jit_lt_non_numbers_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let r = jit_lt(TAG_NIL, num(1.0), 0);
             assert!(!as_bool(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("compare <")));
         }
 
         #[test]
-        fn jit_ge_non_numbers_returns_false() {
-            let r = jit_ge(TAG_NIL, num(1.0));
+        fn jit_ge_non_numbers_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let r = jit_ge(TAG_NIL, num(1.0), 0);
             assert!(!as_bool(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("compare >=")));
         }
 
         #[test]
-        fn jit_le_non_numbers_returns_false() {
-            let r = jit_le(TAG_NIL, num(1.0));
+        fn jit_le_non_numbers_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let r = jit_le(TAG_NIL, num(1.0), 0);
             assert!(!as_bool(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("compare <=")));
         }
 
         // ── String comparison ops ──────────────────────────────────────────
@@ -19368,31 +19440,31 @@ mod tests {
 
         #[test]
         fn jit_gt_strings_true() {
-            let r = jit_gt(str_val("b"), str_val("a"));
+            let r = jit_gt(str_val("b"), str_val("a"), 0);
             assert!(as_bool(r));
         }
 
         #[test]
         fn jit_gt_strings_false() {
-            let r = jit_gt(str_val("a"), str_val("b"));
+            let r = jit_gt(str_val("a"), str_val("b"), 0);
             assert!(!as_bool(r));
         }
 
         #[test]
         fn jit_lt_strings_true() {
-            let r = jit_lt(str_val("a"), str_val("b"));
+            let r = jit_lt(str_val("a"), str_val("b"), 0);
             assert!(as_bool(r));
         }
 
         #[test]
         fn jit_ge_strings_equal() {
-            let r = jit_ge(str_val("a"), str_val("a"));
+            let r = jit_ge(str_val("a"), str_val("a"), 0);
             assert!(as_bool(r));
         }
 
         #[test]
         fn jit_le_strings_less() {
-            let r = jit_le(str_val("a"), str_val("b"));
+            let r = jit_le(str_val("a"), str_val("b"), 0);
             assert!(as_bool(r));
         }
 
@@ -19400,7 +19472,7 @@ mod tests {
 
         #[test]
         fn jit_add_strings_concat() {
-            let r = jit_add(str_val("hello "), str_val("world"));
+            let r = jit_add(str_val("hello "), str_val("world"), 0);
             let rv = NanVal(r);
             assert!(rv.is_string());
             let HeapObj::Str(s) = (unsafe { rv.as_heap_ref() }) else {
@@ -19411,9 +19483,12 @@ mod tests {
         }
 
         #[test]
-        fn jit_add_non_numeric_non_string_returns_nil() {
-            let r = jit_add(TAG_NIL, num(1.0));
+        fn jit_add_non_numeric_non_string_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let r = jit_add(TAG_NIL, num(1.0), 0);
             assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("add non-matching")));
         }
 
         // RC=1 fast path: sole-owner left string is mutated in place.
@@ -19422,7 +19497,7 @@ mod tests {
             // str_val creates a fresh Rc with strong_count == 1.
             let lhs = str_val("foo");
             let rhs = str_val("bar");
-            let r = jit_add(lhs, rhs);
+            let r = jit_add(lhs, rhs, 0);
             let rv = NanVal(r);
             assert!(rv.is_string());
             let HeapObj::Str(s) = (unsafe { rv.as_heap_ref() }) else {
@@ -19438,7 +19513,7 @@ mod tests {
             let lhs_nan = NanVal::heap_string("hello ".to_string());
             lhs_nan.clone_rc(); // strong_count is now 2
             let rhs = str_val("world");
-            let r = jit_add(lhs_nan.0, rhs);
+            let r = jit_add(lhs_nan.0, rhs, 0);
             let rv = NanVal(r);
             assert!(rv.is_string());
             let HeapObj::Str(s) = (unsafe { rv.as_heap_ref() }) else {
@@ -19453,7 +19528,7 @@ mod tests {
 
         #[test]
         fn jit_len_string() {
-            let r = jit_len(str_val("hello"));
+            let r = jit_len(str_val("hello"), 0);
             assert!(is_num(r));
             assert_eq!(as_num(r), 5.0);
         }
@@ -19466,22 +19541,25 @@ mod tests {
                 NanVal::number(3.0),
             ];
             let list = NanVal::heap_list(items);
-            let r = jit_len(list.0);
+            let r = jit_len(list.0, 0);
             assert!(is_num(r));
             assert_eq!(as_num(r), 3.0);
         }
 
         #[test]
-        fn jit_len_non_string_non_list_returns_nil() {
-            let r = jit_len(TAG_NIL);
+        fn jit_len_non_string_non_list_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let r = jit_len(TAG_NIL, 0);
             assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("len requires")));
         }
 
         // ── jit_str ────────────────────────────────────────────────────────
 
         #[test]
         fn jit_str_number_to_string() {
-            let r = jit_str(num(42.0));
+            let r = jit_str(num(42.0), 0);
             let rv = NanVal(r);
             assert!(rv.is_string());
             let HeapObj::Str(s) = (unsafe { rv.as_heap_ref() }) else {
@@ -19493,15 +19571,18 @@ mod tests {
 
         #[test]
         fn jit_str_float_to_string() {
-            let r = jit_str(num(3.14));
+            let r = jit_str(num(3.14), 0);
             let rv = NanVal(r);
             assert!(rv.is_string());
         }
 
         #[test]
-        fn jit_str_non_number_returns_nil() {
-            let r = jit_str(TAG_NIL);
+        fn jit_str_non_number_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let r = jit_str(TAG_NIL, 0);
             assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("str requires")));
         }
 
         // ── jit_hd ────────────────────────────────────────────────────────

--- a/tests/regression_jit_nil_sweep_batch3.rs
+++ b/tests/regression_jit_nil_sweep_batch3.rs
@@ -1,0 +1,261 @@
+// Regression tests for the Cranelift JIT-helper permissive-nil sweep, batch 3.
+//
+// Helpers in scope (Group A — arithmetic, comparison, numeric unary/binary):
+//   jit_add, jit_add_inplace, jit_sub, jit_mul, jit_div, jit_mod, jit_neg,
+//   jit_gt, jit_lt, jit_ge, jit_le, jit_abs, jit_min, jit_max, jit_flr,
+//   jit_cel, jit_rou, jit_clamp, jit_len, jit_str, jit_num.
+//
+// Before this PR these helpers silently returned TAG_NIL (or TAG_FALSE for
+// the ordered comparisons) on failure paths where tree/VM raise runtime
+// errors. The fix routes the failure paths through the `JIT_RUNTIME_ERROR`
+// TLS cell introduced in #254, threading a packed source-span immediate so
+// diagnostics render with a caret matching tree/VM.
+//
+// Most of these helpers are only reachable through the slow path of an op
+// (e.g. OP_SUB calls jit_sub only when neither operand is statically known
+// to be a number). The ilo source-level verifier rejects programs that
+// statically mix types (ILO-T009 / ILO-T010 / ILO-T012), so per-helper
+// error-path tests live as unit tests inside `src/vm/mod.rs` that drive
+// the helpers directly. These CLI tests focus on cross-engine happy-path
+// parity — pinning that wiring the span/error threads did not regress the
+// success cases (operations between numbers, strings, lists) across tree,
+// VM, and Cranelift JIT.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn check_stdout(engine: &str, src: &str, expected: &str) {
+    let out = ilo()
+        .args([src, engine, "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "engine={engine}: expected success for `{src}`, got stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&out.stdout).trim(),
+        expected,
+        "engine={engine}: stdout mismatch for `{src}`"
+    );
+}
+
+// Run a check across all three engines and assert identical output.
+fn check_all(src: &str, expected: &str) {
+    check_stdout("--run-tree", src, expected);
+    check_stdout("--run-vm", src, expected);
+    #[cfg(feature = "cranelift")]
+    check_stdout("--run-cranelift", src, expected);
+}
+
+// ── Arithmetic happy paths ────────────────────────────────────────────────
+
+#[test]
+fn add_numbers_cross_engine() {
+    check_all("f>n;+2 3", "5");
+}
+
+#[test]
+fn add_strings_cross_engine() {
+    check_all("f>t;+\"foo\" \"bar\"", "foobar");
+}
+
+#[test]
+fn add_lists_cross_engine() {
+    check_all("f>L n;+[1 2] [3 4]", "[1, 2, 3, 4]");
+}
+
+#[test]
+fn sub_numbers_cross_engine() {
+    check_all("f>n;- 10 3", "7");
+}
+
+#[test]
+fn mul_numbers_cross_engine() {
+    check_all("f>n;* 4 5", "20");
+}
+
+#[test]
+fn div_numbers_cross_engine() {
+    check_all("f>n;/ 10 4", "2.5");
+}
+
+#[test]
+fn mod_numbers_cross_engine() {
+    check_all("f>n;mod 10 3", "1");
+}
+
+#[test]
+fn neg_number_cross_engine() {
+    check_all("f>n;- 5", "-5");
+}
+
+// ── Division-by-zero parity ───────────────────────────────────────────────
+//
+// Tree, VM, and Cranelift JIT all raise on `n / 0`. Pin that the message is
+// recognisable and parity holds across engines. Cranelift only goes through
+// `jit_div` for the slow path; the always-num inline path also goes through
+// the new error route via `jit_set_runtime_error_with_span(VmError::DivisionByZero, ...)`
+// (see comment in jit_div) — but with `f>n;/ x 0` the verifier knows both
+// are n, so it inlines fdiv which produces inf, not an error. To exercise
+// the helper we need a non-always-num path; the divide-by-zero error path
+// is exercised by the helper unit test `jit_div_by_zero_signals_runtime_error`.
+// At the CLI level we pin the more useful invariant: VM and tree both error
+// on /n 0, and Cranelift's fdiv produces inf (the existing semantic gap
+// outside this batch's scope).
+
+fn divide_by_zero_errors(engine: &str) {
+    let out = ilo()
+        .args(["f>n;/ 5 0", engine, "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "engine={engine}: expected divide-by-zero error, got stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("divide")
+            || stderr.contains("zero")
+            || stderr.contains("division")
+            || stderr.contains("Division"),
+        "engine={engine}: expected divide/zero in stderr, got: {stderr}"
+    );
+}
+
+#[test]
+fn div_by_zero_tree() {
+    divide_by_zero_errors("--run-tree");
+}
+
+#[test]
+fn div_by_zero_vm() {
+    divide_by_zero_errors("--run-vm");
+}
+
+// Note: Cranelift CLI div-by-zero behaviour for always-num inline path
+// produces inf (not an error). The helper slow path now errors but isn't
+// reached from this surface-level program. Tracked separately.
+
+// ── Comparison happy paths ────────────────────────────────────────────────
+
+#[test]
+fn gt_numbers_cross_engine() {
+    check_all("f>b;> 5 3", "true");
+    check_all("f>b;> 3 5", "false");
+}
+
+#[test]
+fn lt_numbers_cross_engine() {
+    check_all("f>b;< 2 7", "true");
+}
+
+#[test]
+fn ge_numbers_cross_engine() {
+    check_all("f>b;>= 5 5", "true");
+}
+
+#[test]
+fn le_numbers_cross_engine() {
+    check_all("f>b;<= 3 3", "true");
+}
+
+#[test]
+fn gt_strings_cross_engine() {
+    check_all("f>b;> \"b\" \"a\"", "true");
+}
+
+#[test]
+fn lt_strings_cross_engine() {
+    check_all("f>b;< \"a\" \"b\"", "true");
+}
+
+// ── Numeric unary / binary helpers ────────────────────────────────────────
+
+#[test]
+fn abs_number_cross_engine() {
+    check_all("f>n;abs -7", "7");
+}
+
+#[test]
+fn min_numbers_cross_engine() {
+    check_all("f>n;min 3 5", "3");
+}
+
+#[test]
+fn max_numbers_cross_engine() {
+    check_all("f>n;max 3 5", "5");
+}
+
+#[test]
+fn flr_number_cross_engine() {
+    check_all("f>n;flr 3.7", "3");
+}
+
+#[test]
+fn cel_number_cross_engine() {
+    check_all("f>n;cel 3.2", "4");
+}
+
+#[test]
+fn rou_number_cross_engine() {
+    check_all("f>n;rou 3.5", "4");
+}
+
+#[test]
+fn clamp_in_range_cross_engine() {
+    check_all("f>n;clamp 5 0 10", "5");
+}
+
+#[test]
+fn clamp_above_max_cross_engine() {
+    check_all("f>n;clamp 15 0 10", "10");
+}
+
+#[test]
+fn clamp_below_min_cross_engine() {
+    check_all("f>n;clamp -5 0 10", "0");
+}
+
+// ── len / str / num happy paths ───────────────────────────────────────────
+
+#[test]
+fn len_string_cross_engine() {
+    check_all("f>n;len \"hello\"", "5");
+}
+
+#[test]
+fn len_list_cross_engine() {
+    check_all("f>n;len [1 2 3]", "3");
+}
+
+#[test]
+fn str_number_cross_engine() {
+    check_all("f>t;str 42", "42");
+}
+
+// ── No stale-error leak across successive Cranelift calls ─────────────────
+//
+// PR #254's JitRuntimeErrorGuard clears the TLS error cell on entry/exit.
+// Confirm that a helper-set error on an /errored/ Cranelift call does not
+// leak into the next fresh invocation. We can't easily provoke a Cranelift
+// helper-driven error from surface ilo (verifier rejects mixed-type ops),
+// so we use the empty-list `hd` path from batch 1 as the carrier and run a
+// happy-path arithmetic program afterwards.
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn no_stale_jit_error_leak_after_hd_error_then_arithmetic() {
+    let first = ilo()
+        .args(["f>n;hd []", "--run-cranelift", "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(!first.status.success(), "first call should error on hd []");
+    // Second fresh process: arithmetic must succeed cleanly.
+    check_stdout("--run-cranelift", "f>n;+ 1 2", "3");
+}


### PR DESCRIPTION
## Summary

Batch 3 of the Cranelift JIT-helper permissive-nil sweep. Routes the
arithmetic, comparison, and numeric unary/binary helpers through the
`JIT_RUNTIME_ERROR` TLS channel introduced in [#254](https://github.com/ilo-lang/ilo/pull/254), with span_bits packed
at the cranelift call site so diagnostics render with a caret matching
tree and VM.

Batches 1 and 2 ([#264](https://github.com/ilo-lang/ilo/pull/264) and [#259](https://github.com/ilo-lang/ilo/pull/259)) covered list/record/map helpers; this
batch is the next chunk down the residual-helpers audit list. Helpers
in scope (Group A, 21 functions):

- arithmetic: `jit_add`, `jit_add_inplace`, `jit_sub`, `jit_mul`, `jit_div`, `jit_mod`, `jit_neg`
- comparison: `jit_gt`, `jit_lt`, `jit_ge`, `jit_le` (EQ/NE keep 2-arg sig — NanVal-bit equality is total)
- numeric unary/binary: `jit_abs`, `jit_min`, `jit_max`, `jit_flr`, `jit_cel`, `jit_rou`, `jit_clamp`
- coercion / length: `jit_len`, `jit_str`, `jit_num`

Manifesto framing: arithmetic-slow-path divergence is the highest
token-cost-saved item in the residual sweep. Every silent nil from
`n - "x"` on a register the verifier can't prove numeric was a
bewildered agent retry. Now agents see the same `cannot subtract
non-numbers` message they get on tree and VM, with the caret pointing
at the offending site.

## Repro before / after

Before this change, exercising the type-error path of any Group A
helper (e.g. via the in-tree unit-test API that bypasses the verifier
to drive the helpers directly):

```rust
let r = jit_sub(str_val("hello"), num(1.0));  // old 2-arg sig
assert!(is_nil(r));                            // permissive-nil
// no error surfaced
```

After:

```rust
let _ = jit_take_runtime_error();
let r = jit_sub(str_val("hello"), num(1.0), 0);
assert!(is_nil(r));
let err = jit_take_runtime_error().expect("expected pending error");
assert!(matches!(err.0, VmError::Type(msg) if msg.contains("subtract")));
```

At the CLI level the verifier still rejects most surface programs
that statically mix types (ILO-T009 / ILO-T010 / ILO-T012), so the
slow-path helpers are usually unreachable from naive ilo. The error
plumbing matters for the dynamic-dispatch cases (FnRef returns, union
types via match results) and for any future codegen that emits the
slow path.

## What's in the diff (per commit)

1. **route arithmetic + comparison + numeric-unary JIT helpers through JIT_RUNTIME_ERROR**
   - 21 helper signatures gain `span_bits: u64` (or `+1` for clamp's already-3-arg shape)
   - Each error path replaces bare `TAG_NIL` (or `TAG_FALSE` for ordered comparison) with `jit_set_runtime_error_with_span(VmError::Type(...), span_bits) + TAG_NIL/TAG_FALSE`
   - Error wording matches the VM dispatcher's `vm_err!` messages so cross-engine diagnostics are byte-identical
   - `jit_len` gains a Map arm to match tree/VM's "len requires string, list, or map" — was missing entirely
   - declare_helper arities updated in both `src/vm/jit_cranelift.rs` (in-process JIT) and `src/vm/compile_cranelift.rs` (AOT)
   - AOT dispatch sites pull `pack_span_bits` via the now-pub(super) helper
   - vm::tests::jit_helpers unit tests updated to assert the runtime-error cell is set and carries the right `VmError` variant

2. **add cross-engine regression suite for batch-3 helpers**
   - 29 tests asserting tree / VM / cranelift JIT happy-path parity for every helper touched in this batch
   - No-stale-error-leak guard pinning `JitRuntimeErrorGuard`'s clear-on-entry contract

3. **add example pinning batch-3 helper happy paths through examples_engines**
   - `examples/jit-nil-sweep-batch3.ilo` with 24 entry points
   - Runs through tree / VM / cranelift via the examples_engines harness; doubles as in-context teaching example for agents

## Test plan

- [x] `cargo build --release --features cranelift` — green
- [x] `cargo clippy --release --features cranelift --all-targets` — clean
- [x] `cargo fmt` — clean
- [x] `cargo test --release --features cranelift --lib` — 2932 passed, 0 failed (52 ignored)
- [x] `cargo test --release --features cranelift --test regression_jit_nil_sweep_batch3` — 29/29 passed
- [x] `cargo test --release --features cranelift --test examples_engines` — passed
- [x] Full `cargo test --release --features cranelift` — every suite green

## Follow-ups

This is batch 3 of 7 in the Cranelift JIT-helper permissive-nil sweep.
Remaining batches queued (one PR each, separate worktrees):

- **Batch 4** — Group B text + len/coerce: `jit_fmt2`, `jit_trm`, `jit_upr`, `jit_lwr`, `jit_cap`, `jit_padl`, `jit_padr`, `jit_ord`, `jit_chr`, `jit_chars`, `jit_unq`, `jit_frq`
- **Batch 5** — Group C collections: `jit_spl`, `jit_cat`, `jit_has`, `jit_range`, `jit_window`, `jit_zip`, `jit_chunks`, `jit_enumerate`, `jit_setunion`, `jit_setinter`, `jit_setdiff`, `jit_rev`, `jit_srt`, `jit_rsrt`, `jit_cumsum`
- **Batch 6** — Group D stats + linear algebra: `jit_median`, `jit_quantile`, `jit_stdev`, `jit_variance`, `jit_fft`, `jit_ifft`, `jit_transpose`, `jit_matmul`, `jit_dot`, `jit_det`, `jit_inv`, `jit_solve`
- **Batch 7** — Group E I/O type-error paths: `jit_rd`, `jit_rdl`, `jit_wr`, `jit_wrl`, `jit_jpar`, `jit_rdjl`, `jit_dtfmt`, `jit_dtparse`

Per the audit, these helpers are correctly permissive-by-design and stay out of scope: `jit_pow`/`jit_sqrt`/`jit_log`/`jit_exp`/`jit_sin`/`jit_cos`/`jit_tan`/`jit_log10`/`jit_log2`/`jit_atan2` (both VM and JIT return `f64::NAN` on non-numeric — already parity); `jit_concat`/`jit_concat_inplace` (only emitted for typed-string OP_ADD_SS by the type checker, defensive `unreachable!()` is correct); `jit_listget` OOB / `jit_mget` missing-key (legitimate-miss returns nil by `O _` semantics).