### PR TITLE
vm + cranelift: dispatch FnRef-variable calls dynamically (HOF dispatch PR 3d)

### DIFF
--- a/examples/fnref-var-call.ilo
+++ b/examples/fnref-var-call.ilo
@@ -1,0 +1,33 @@
+-- Calling a variable that holds a FnRef. Before PR 3d the VM compiler
+-- routed every `Expr::Call` through a static func-name lookup, so
+-- `f = dbl; f 10` errored with `UndefinedFunction: f` on the VM and
+-- Cranelift engines even though the tree interpreter resolved it via
+-- `callee_from_scope`. Now `Expr::Call` checks the locals first and
+-- emits `OP_CALL_DYN` against the local's register, dispatching at
+-- runtime based on the value (FnRef NanVal or Text-named function).
+--
+-- This example pins three shapes the fix unblocks, each exercised
+-- through the `examples_engines.rs` harness on every engine.
+
+-- User function used as a value, then invoked through a local.
+dbl x:n>n;*x 2
+
+-- 1. User-fn assigned to a local, then called.
+viaref>n;f=dbl;f 10
+
+-- 2. Builtin assigned to a local, then called.
+viabuiltin>n;f=abs;f -3
+
+-- 3. FnRef threaded through a function parameter (the canonical
+--    user-defined HOF shape: `apl` takes a callback and applies
+--    it to an argument).
+apl f:F n n x:n>n;f x
+
+viaparam>n;apl dbl 7
+
+-- run: viaref
+-- out: 20
+-- run: viabuiltin
+-- out: 3
+-- run: viaparam
+-- out: 14

--- a/src/main.rs
+++ b/src/main.rs
@@ -2634,7 +2634,7 @@ fn run_cranelift_engine(
         let nan_consts = &compiled.nan_constants[func_idx];
         let nan_args: Vec<u64> = run_args
             .iter()
-            .map(|v| vm::NanVal::from_value(v).0)
+            .map(|v| vm::NanVal::from_value_with_program(v, &compiled.func_names).0)
             .collect();
         match vm::jit_cranelift::compile_and_call(chunk, nan_consts, &nan_args, &compiled) {
             Ok(result_bits) => {
@@ -2990,7 +2990,10 @@ fn run_default(
             if let Some(func_idx) = compiled.func_names.iter().position(|n| n == target) {
                 let chunk = &compiled.chunks[func_idx];
                 let nan_consts = &compiled.nan_constants[func_idx];
-                let nan_args: Vec<u64> = args.iter().map(|v| vm::NanVal::from_value(v).0).collect();
+                let nan_args: Vec<u64> = args
+                    .iter()
+                    .map(|v| vm::NanVal::from_value_with_program(v, &compiled.func_names).0)
+                    .collect();
                 match vm::jit_cranelift::compile_and_call(chunk, nan_consts, &nan_args, &compiled) {
                     Ok(result_bits) => {
                         // Use the program-aware bridge so a user-fn FnRef

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -3022,14 +3022,69 @@ impl RegCompiler {
                     return self.emit_call_builtin_tree(builtin, args, *unwrap);
                 }
 
-                // NOTE: Dynamic call by FnRef-in-register (the `cb 3`
-                // pattern where `cb` is a parameter typed `F ...`) is
-                // recognised here in PR 2 onward — see OP_CALL_DYN. PR 1
-                // only ships the value-side plumbing (FnRef tag, LOADFN,
-                // dispatcher arms), so calling a FnRef-typed local still
-                // surfaces as UndefinedFunction below. The HOF call-site
-                // tests that depend on this are gated with `#[ignore]`
-                // and are unblocked together in PR 2's first HOF lift.
+                // Dynamic call by FnRef-in-register (PR 3d). When `function`
+                // resolves to a local variable, the callee is whatever value
+                // sits in that register at runtime — a FnRef NanVal, a Text
+                // naming a function, or (eventually) a Closure. We emit
+                // OP_CALL_DYN against the local's register and let the
+                // dispatcher resolve dynamically, matching the tree
+                // interpreter's `callee_from_scope` behaviour.
+                //
+                // Local shadowing wins over top-level fn names: `f=dbl; f 10`
+                // calls the value bound to `f`, not a top-level `f` if one
+                // happened to exist. This mirrors the tree interpreter.
+                if let Some(fn_reg) = self.resolve_local(function) {
+                    let arg_regs: Vec<u8> = args.iter().map(|a| self.compile_expr(a)).collect();
+
+                    // OP_CALL_DYN reads args from R[A+1..=A+argc] — contiguous
+                    // slot immediately after the result register.
+                    let a = self.alloc_reg();
+                    let args_base = self.next_reg;
+                    assert!(
+                        (self.next_reg as usize) + args.len() <= 255,
+                        "register overflow: dynamic call requires too many register slots"
+                    );
+                    self.next_reg += args.len() as u8;
+                    if self.next_reg > self.max_reg {
+                        self.max_reg = self.next_reg;
+                    }
+                    for (i, &arg_reg) in arg_regs.iter().enumerate() {
+                        let target = args_base + i as u8;
+                        if arg_reg != target {
+                            self.emit_abc(OP_MOVE, target, arg_reg, 0);
+                        }
+                    }
+
+                    assert!(
+                        args.len() <= 255,
+                        "dynamic call has {} args; OP_CALL_DYN argc field is 8 bits",
+                        args.len()
+                    );
+                    self.emit_abc(OP_CALL_DYN, a, fn_reg, args.len() as u8);
+
+                    // Result register tracking — unknown record type, not
+                    // statically numeric (the callee's return type isn't
+                    // known until dispatch).
+                    self.current_all_regs_numeric = false;
+                    self.reg_is_num[a as usize] = false;
+                    self.reg_record_type[a as usize] = u16::MAX;
+                    self.next_reg = a + 1;
+
+                    // Auto-unwrap (`!`, `!!`): callee return type is unknown
+                    // statically, so route through the Result-shaped unwrap
+                    // helper which handles Ok/Err and lets non-Result values
+                    // pass through. Optional-unwrap requires the static type
+                    // info we don't have here; tree semantics for `!` on a
+                    // dynamic callee return treat nil as a propagation, but
+                    // adding that requires a separate opcode pair and is out
+                    // of scope for PR 3d.
+                    if unwrap.is_any() {
+                        self.emit_result_unwrap(a, *unwrap);
+                        self.next_reg = a + 1;
+                    }
+
+                    return a;
+                }
 
                 let arg_regs: Vec<u8> = args.iter().map(|a| self.compile_expr(a)).collect();
                 let func_idx = self
@@ -4398,7 +4453,7 @@ impl NanVal {
     /// Like `from_value` but resolves user-function FnRefs against the
     /// supplied `func_names` slice. Used by the VM's bridge layer when
     /// crossing back into the tree interpreter and vice versa.
-    pub(crate) fn from_value_with_program(val: &Value, func_names: &[String]) -> Self {
+    pub fn from_value_with_program(val: &Value, func_names: &[String]) -> Self {
         match val {
             Value::List(items) => NanVal::heap_list(
                 items
@@ -4740,7 +4795,10 @@ impl<'a> VmState<'a> {
                 .ok_or_else(|| VmError::UndefinedFunction {
                     name: func_name.to_string(),
                 })?;
-        let nan_args: Vec<NanVal> = args.iter().map(NanVal::from_value).collect();
+        let nan_args: Vec<NanVal> = args
+            .iter()
+            .map(|v| NanVal::from_value_with_program(v, &self.vm.program.func_names))
+            .collect();
         self.vm.setup_call(func_idx, nan_args, 0);
         self.vm.execute() // returns VmError for bench compatibility
     }
@@ -4829,7 +4887,14 @@ impl<'a> VM<'a> {
     }
 
     fn call(&mut self, func_idx: u16, args: Vec<Value>) -> Result<Value, VmRuntimeError> {
-        let nan_args: Vec<NanVal> = args.iter().map(NanVal::from_value).collect();
+        // Program-aware NanVal encoding so a `Value::FnRef(user_fn)` arg
+        // becomes a real FnRef NanVal (not the `<fn:name>` sentinel that
+        // bare `from_value` falls back to). Required so OP_CALL_DYN sees a
+        // proper FnRef when callers pass a user-fn directly as an entry arg.
+        let nan_args: Vec<NanVal> = args
+            .iter()
+            .map(|v| NanVal::from_value_with_program(v, &self.program.func_names))
+            .collect();
         self.setup_call(func_idx, nan_args, 0);
         self.execute().map_err(|e| self.make_runtime_error(e))
     }
@@ -6410,7 +6475,29 @@ impl<'a> VM<'a> {
                     let a = ((inst >> 16) & 0xFF) as u8;
                     let b = ((inst >> 8) & 0xFF) as u8;
                     let n_args = (inst & 0xFF) as usize;
-                    let callee = reg!(base + b as usize);
+                    let mut callee = reg!(base + b as usize);
+                    // Text callee — resolve the name to a user fn or builtin
+                    // and re-shape into a FnRef NanVal. This mirrors the
+                    // tree interpreter's `Value::Text(name)` callee path
+                    // (`callee_from_scope`) so a function name held as a
+                    // string (e.g. read from argv) dispatches the same way
+                    // as a FnRef.
+                    if callee.is_string() && !callee.is_fnref() {
+                        let name_val = callee.to_value_with_program(&self.program.func_names);
+                        if let Value::Text(name) = name_val {
+                            if let Some(idx) =
+                                self.program.func_names.iter().position(|n| n == &*name)
+                            {
+                                callee = NanVal::fnref(FnRefKind::User, idx as u32);
+                            } else if let Some(b) = crate::builtins::Builtin::from_name(&name) {
+                                callee = NanVal::fnref(FnRefKind::Builtin, b.tag() as u32);
+                            } else {
+                                vm_err!(VmError::Type(
+                                    "dynamic call: text callee names no known function"
+                                ));
+                            }
+                        }
+                    }
                     if !callee.is_fnref() {
                         vm_err!(VmError::Type(
                             "dynamic call: callee is not a function reference"
@@ -11770,7 +11857,31 @@ pub(crate) extern "C" fn jit_call_builtin_tree(tag: u64, argc: u64, regs_ptr: u6
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn jit_call_dyn(callee_bits: u64, argc: u64, regs_ptr: u64) -> u64 {
-    let callee = NanVal(callee_bits);
+    let mut callee = NanVal(callee_bits);
+    // Text callee — resolve through the active program's func_names. Mirrors
+    // the OP_CALL_DYN dispatcher path so a function name held as a string
+    // works the same on every engine.
+    if callee.is_string() && !callee.is_fnref() {
+        let prog_ptr = ACTIVE_PROGRAM.with(|cell| cell.get());
+        if prog_ptr.is_null() {
+            return TAG_NIL;
+        }
+        // SAFETY: ACTIVE_PROGRAM is published by with_active_registry for
+        // the duration of the JIT entry, and cleared by its drop guard.
+        let program: &CompiledProgram = unsafe { &*prog_ptr };
+        let name_val = callee.to_value_with_program(&program.func_names);
+        if let Value::Text(name) = name_val {
+            if let Some(idx) = program.func_names.iter().position(|n| n == &*name) {
+                callee = NanVal::fnref(FnRefKind::User, idx as u32);
+            } else if let Some(b) = crate::builtins::Builtin::from_name(&name) {
+                callee = NanVal::fnref(FnRefKind::Builtin, b.tag() as u32);
+            } else {
+                return TAG_NIL;
+            }
+        } else {
+            return TAG_NIL;
+        }
+    }
     if !callee.is_fnref() {
         return TAG_NIL;
     }
@@ -23139,7 +23250,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Direct FnRef-variable call (OP_CALL_DYN from Expr::Call) arrives in PR 3d.
     fn vm_map_with_text_fn_name() {
         let source = "sq x:n>n;*x x f cb:t xs:L n>L n;map cb xs";
         let result = vm_run(
@@ -24119,7 +24229,6 @@ mod tests {
     // ── FnRef callee from scope ─────────────────────────────────────────
 
     #[test]
-    #[ignore] // Direct FnRef-variable call (OP_CALL_DYN from Expr::Call) arrives in PR 3d.
     fn vm_fnref_callee_from_scope() {
         let source = "sq x:n>n;*x x f cb:z>n;cb 3";
         let result = vm_run(source, Some("f"), vec![Value::FnRef("sq".into())]);
@@ -24127,14 +24236,12 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Direct FnRef-variable call (OP_CALL_DYN from Expr::Call) arrives in PR 3d.
     fn vm_fn_ref_via_ref_expr() {
         let source = "dbl x:n>n;*x 2 main>n;f=dbl;f 10";
         assert_eq!(vm_run(source, Some("main"), vec![]), Value::Number(20.0));
     }
 
     #[test]
-    #[ignore] // Direct FnRef-variable call (OP_CALL_DYN from Expr::Call) arrives in PR 3d.
     fn vm_text_callee_from_scope() {
         let source = "sq x:n>n;*x x f cb:z>n;cb 3";
         let result = vm_run(
@@ -24146,7 +24253,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Direct FnRef-variable call (OP_CALL_DYN from Expr::Call) arrives in PR 3d.
     fn vm_user_hof_fn_type() {
         let source = "sq x:n>n;*x x apl f:F n n x:n>n;f x";
         let result = vm_run(

--- a/tests/regression_fnref_var_call.rs
+++ b/tests/regression_fnref_var_call.rs
@@ -1,0 +1,86 @@
+// Regression: calling a variable that holds a FnRef should dispatch
+// dynamically on every engine. Before PR 3d the VM compiler treated
+// `Expr::Call.function` as a static function-name lookup and surfaced
+// `UndefinedFunction` for `f=dbl; f 10` shapes where `f` was a local.
+// The tree interpreter has always resolved these via `callee_from_scope`,
+// so the cross-engine contract was silently broken on VM and Cranelift.
+//
+// Three call-site shapes are covered, each across tree, vm and cranelift:
+//
+// 1. User-fn assigned to a local — `f = dbl; f 10`
+// 2. Builtin assigned to a local — `f = abs; f -3`
+// 3. FnRef threaded through a function argument — `apl f x = f x;
+//    apl dbl 7`. The HOF receives a FnRef param and the call site
+//    `f x` must dispatch via OP_CALL_DYN.
+//
+// Each test calls every engine to make sure they agree on the output.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "engine={engine}: run failed, stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+#[cfg(feature = "cranelift")]
+const ENGINES: &[&str] = &["--run-tree", "--run-vm", "--run-cranelift"];
+#[cfg(not(feature = "cranelift"))]
+const ENGINES: &[&str] = &["--run-tree", "--run-vm"];
+
+// User-fn assigned to a local, then invoked: `f = dbl; f 10` → 20.
+#[test]
+fn fnref_var_call_user_fn() {
+    let src = "dbl x:n>n;*x 2 main>n;f=dbl;f 10";
+    for engine in ENGINES {
+        let out = run(engine, src, "main");
+        assert_eq!(out, "20", "engine={engine}");
+    }
+}
+
+// Builtin assigned to a local, then invoked. `abs` is a one-arg builtin
+// available as a value (its FnRef tag round-trips through registers).
+#[test]
+fn fnref_var_call_builtin() {
+    let src = "main>n;f=abs;f -3";
+    for engine in ENGINES {
+        let out = run(engine, src, "main");
+        assert_eq!(out, "3", "engine={engine}");
+    }
+}
+
+// FnRef threaded through a function parameter typed `F n n`. The HOF
+// `apl` receives the callback as `f` and invokes it inside its body.
+// This is the canonical user-defined HOF shape PR 3d unblocks.
+#[test]
+fn fnref_var_call_through_hof_param() {
+    let src = "dbl x:n>n;*x 2 apl f:F n n x:n>n;f x main>n;apl dbl 7";
+    for engine in ENGINES {
+        let out = run(engine, src, "main");
+        assert_eq!(out, "14", "engine={engine}");
+    }
+}
+
+// FnRef param chained through two user HOFs. Tests that the FnRef
+// value survives a register hop between functions and still dispatches
+// dynamically at the inner call site. Pre-fix this errored with
+// `UndefinedFunction: cb` on VM/Cranelift.
+#[test]
+fn fnref_var_call_chained_hofs() {
+    let src = "inc x:n>n;+x 1 apl f:F n n x:n>n;f x twice f:F n n x:n>n;apl f (apl f x) main>n;twice inc 5";
+    for engine in ENGINES {
+        let out = run(engine, src, "main");
+        assert_eq!(out, "7", "engine={engine}");
+    }
+}


### PR DESCRIPTION
## Summary

Continues the HOF-dispatch chain after #279 (PR 3b) and #280 (PR 3c). When `Expr::Call.function` resolves to a local variable, the VM compiler now emits `OP_CALL_DYN` against that register instead of trying to look the name up in `func_names`. The dispatcher reads the callee at runtime, so a FnRef NanVal, a Text holding a function name, or (eventually) a Closure all dispatch the same way as the tree interpreter's `callee_from_scope` path.

Closes the long-standing cross-engine divergence where `f = dbl; f 10` and user-defined HOFs like `apl f x = f x; apl dbl 7` errored with `UndefinedFunction` on VM and Cranelift but worked on the tree interpreter.

## Repro before / after

Before:
```
$ ilo 'dbl x:n>n;*x 2 main>n;f=dbl;f 10' --run-vm main
error: undefined function: f
```

After:
```
$ ilo 'dbl x:n>n;*x 2 main>n;f=dbl;f 10' --run-vm main
20
```

Same fix works on `--run-cranelift` via the existing `jit_call_dyn` lowering from #277. Tree was already correct.

## What's in the diff

**Commit 1 - vm + cranelift: dispatch FnRef-variable calls dynamically**
- `Expr::Call` in `src/vm/mod.rs`: when `function` matches a local, emit `OP_CALL_DYN` against the local's register. Local shadowing wins over top-level fn names, mirroring the tree interpreter. Auto-unwrap (`!`, `!!`) routes through the Result-shaped path since the callee's return type isn't known statically.
- `OP_CALL_DYN` dispatcher + `jit_call_dyn` extended: a Text-typed callee resolves through `program.func_names` (or `Builtin::from_name`) into a synthetic FnRef NanVal and re-enters the existing FnRef-User / FnRef-Builtin dispatch arms. This is what unblocks `vm_text_callee_from_scope` and `vm_map_with_text_fn_name`.
- `VM::call` and `Engine::call` entry paths use `NanVal::from_value_with_program` so a `Value::FnRef(user_fn)` arg becomes a real FnRef NanVal instead of falling back to the `<fn:name>` heap-string sentinel. `from_value_with_program` is promoted to `pub` so `main.rs` can use the same encoding for CLI args.
- 5 previously-ignored unit tests unignored: `vm_fnref_callee_from_scope`, `vm_fn_ref_via_ref_expr`, `vm_text_callee_from_scope`, `vm_user_hof_fn_type`, `vm_map_with_text_fn_name`.

**Commit 2 - add cross-engine regression + example for fnref var-calls**
- `tests/regression_fnref_var_call.rs`: four shapes across tree, vm, and cranelift (user-fn-as-local, builtin-as-local, F-typed HOF param, two-level user HOF chain).
- `examples/fnref-var-call.ilo`: same three primary shapes wired into `examples_engines.rs` so future engines opt in automatically.

## Test plan

- [x] `cargo build --release --features cranelift`
- [x] `cargo test --release --features cranelift` (full suite green)
- [x] 5 previously-ignored `vm_*` tests pass
- [x] New `regression_fnref_var_call` passes on tree + vm + cranelift
- [x] `examples_engines` runs `fnref-var-call.ilo` on every engine
- [x] `cargo fmt --check`
- [x] `cargo clippy --release --features cranelift --all-targets -- -D warnings`

## Follow-ups

- Closure-callee dispatch from `Expr::Call` (when a local holds a `Value::Closure`) still routes through the tree-bridge in PR 3c. Lifting that to a native VM op is a separate effort once the FnRef + captures encoding stabilises.
- Optional-unwrap on a dynamic callee return is currently routed through the Result-shaped unwrap helper; full Optional support requires either a static type hint at the call site or a hybrid opcode pair.