### PR TITLE
Route collection JIT helpers through JIT_RUNTIME_ERROR (batch 5)

### DIFF
--- a/examples/jit-nil-sweep-batch5.ilo
+++ b/examples/jit-nil-sweep-batch5.ilo
@@ -1,0 +1,61 @@
+-- Pins the happy paths for the Group C collection helpers wired through
+-- JIT_RUNTIME_ERROR in PR-batch-5: spl, cat, has, range, window, zip,
+-- chunks, enumerate, setunion, setinter, setdiff, rev, srt, rsrt, cumsum.
+--
+-- The error paths now match tree/VM (raise VmError::Type with a specific
+-- message instead of silent nil). These happy paths are pinned across all
+-- engines via tests/examples_engines.rs so any future regression in the
+-- success cases is caught.
+
+spl-basic>L t;spl "a,b,c" ","
+cat-basic>t;cat ["a" "b" "c"] ","
+has-text>b;has "hello world" "world"
+has-list>b;has [1 2 3] 2
+range-basic>L n;range 0 4
+window-basic>L (L n);window 2 [1 2 3 4]
+zip-basic>L (L n);zip [1 2 3] [10 20 30]
+chunks-basic>L (L n);chunks 2 [1 2 3 4 5]
+enumerate-basic>L (L n);enumerate [10 20 30]
+setunion-basic>L n;setunion [1 2 3] [3 4 5]
+setinter-basic>L n;setinter [1 2 3 4] [3 4 5 6]
+setdiff-basic>L n;setdiff [1 2 3 4] [3 4 5]
+rev-string>t;rev "hello"
+rev-list>L n;rev [1 2 3]
+srt-numbers>L n;srt [3 1 2]
+rsrt-numbers>L n;rsrt [1 3 2]
+cumsum-basic>L n;cumsum [1 2 3 4]
+
+-- run: spl-basic
+-- out: [a, b, c]
+-- run: cat-basic
+-- out: a,b,c
+-- run: has-text
+-- out: true
+-- run: has-list
+-- out: true
+-- run: range-basic
+-- out: [0, 1, 2, 3]
+-- run: window-basic
+-- out: [[1, 2], [2, 3], [3, 4]]
+-- run: zip-basic
+-- out: [[1, 10], [2, 20], [3, 30]]
+-- run: chunks-basic
+-- out: [[1, 2], [3, 4], [5]]
+-- run: enumerate-basic
+-- out: [[0, 10], [1, 20], [2, 30]]
+-- run: setunion-basic
+-- out: [1, 2, 3, 4, 5]
+-- run: setinter-basic
+-- out: [3, 4]
+-- run: setdiff-basic
+-- out: [1, 2]
+-- run: rev-string
+-- out: olleh
+-- run: rev-list
+-- out: [3, 2, 1]
+-- run: srt-numbers
+-- out: [1, 2, 3]
+-- run: rsrt-numbers
+-- out: [3, 2, 1]
+-- run: cumsum-basic
+-- out: [1, 3, 6, 10]

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -261,27 +261,27 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         now: declare_helper(module, "jit_now", 0, 1),
         env: declare_helper(module, "jit_env", 1, 1),
         get: declare_helper(module, "jit_get", 1, 1),
-        spl: declare_helper(module, "jit_spl", 2, 1),
-        cat: declare_helper(module, "jit_cat", 2, 1),
-        has: declare_helper(module, "jit_has", 2, 1),
+        spl: declare_helper(module, "jit_spl", 3, 1),
+        cat: declare_helper(module, "jit_cat", 3, 1),
+        has: declare_helper(module, "jit_has", 3, 1),
         hd: declare_helper(module, "jit_hd", 1, 1),
         at: declare_helper(module, "jit_at", 2, 1),
         fmt2: declare_helper(module, "jit_fmt2", 2, 1),
-        zip: declare_helper(module, "jit_zip", 2, 1),
-        enumerate: declare_helper(module, "jit_enumerate", 1, 1),
-        range: declare_helper(module, "jit_range", 2, 1),
-        window: declare_helper(module, "jit_window", 2, 1),
-        chunks: declare_helper(module, "jit_chunks", 2, 1),
-        setunion: declare_helper(module, "jit_setunion", 2, 1),
-        setinter: declare_helper(module, "jit_setinter", 2, 1),
-        setdiff: declare_helper(module, "jit_setdiff", 2, 1),
+        zip: declare_helper(module, "jit_zip", 3, 1),
+        enumerate: declare_helper(module, "jit_enumerate", 2, 1),
+        range: declare_helper(module, "jit_range", 3, 1),
+        window: declare_helper(module, "jit_window", 3, 1),
+        chunks: declare_helper(module, "jit_chunks", 3, 1),
+        setunion: declare_helper(module, "jit_setunion", 3, 1),
+        setinter: declare_helper(module, "jit_setinter", 3, 1),
+        setdiff: declare_helper(module, "jit_setdiff", 3, 1),
         tl: declare_helper(module, "jit_tl", 1, 1),
-        rev: declare_helper(module, "jit_rev", 1, 1),
-        srt: declare_helper(module, "jit_srt", 1, 1),
-        rsrt: declare_helper(module, "jit_rsrt", 1, 1),
+        rev: declare_helper(module, "jit_rev", 2, 1),
+        srt: declare_helper(module, "jit_srt", 2, 1),
+        rsrt: declare_helper(module, "jit_rsrt", 2, 1),
         fft: declare_helper(module, "jit_fft", 2, 1),
         ifft: declare_helper(module, "jit_ifft", 2, 1),
-        cumsum: declare_helper(module, "jit_cumsum", 1, 1),
+        cumsum: declare_helper(module, "jit_cumsum", 2, 1),
         median: declare_helper(module, "jit_median", 2, 1),
         quantile: declare_helper(module, "jit_quantile", 3, 1),
         stdev: declare_helper(module, "jit_stdev", 2, 1),
@@ -2207,24 +2207,30 @@ fn compile_function_body(
             OP_SPL => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.spl);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_CAT => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.cat);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_HAS => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.has);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
@@ -2254,63 +2260,79 @@ fn compile_function_body(
             OP_ZIP => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.zip);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_ENUMERATE => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.enumerate);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_RANGE => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.range);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_WINDOW => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.window);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_CHUNKS => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.chunks);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_SETUNION => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.setunion);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_SETINTER => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.setinter);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_SETDIFF => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.setdiff);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
@@ -2323,22 +2345,28 @@ fn compile_function_body(
             }
             OP_REV => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.rev);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_SRT => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.srt);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_SRTDESC => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.rsrt);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
@@ -2362,8 +2390,10 @@ fn compile_function_body(
             }
             OP_CUMSUM => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.cumsum);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -431,9 +431,9 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         now: declare_helper(module, "jit_now", 0, 1),
         env: declare_helper(module, "jit_env", 1, 1),
         get: declare_helper(module, "jit_get", 1, 1),
-        spl: declare_helper(module, "jit_spl", 2, 1),
-        cat: declare_helper(module, "jit_cat", 2, 1),
-        has: declare_helper(module, "jit_has", 2, 1),
+        spl: declare_helper(module, "jit_spl", 3, 1),
+        cat: declare_helper(module, "jit_cat", 3, 1),
+        has: declare_helper(module, "jit_has", 3, 1),
         // jit_hd / jit_at / jit_tl take a packed (start<<32)|end span_bits
         // immediate as their trailing arg so cranelift runtime errors carry
         // a source span like tree / VM. See `vm/mod.rs` JIT runtime-error
@@ -441,21 +441,21 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         hd: declare_helper(module, "jit_hd", 2, 1),
         at: declare_helper(module, "jit_at", 3, 1),
         fmt2: declare_helper(module, "jit_fmt2", 2, 1),
-        zip: declare_helper(module, "jit_zip", 2, 1),
-        enumerate: declare_helper(module, "jit_enumerate", 1, 1),
-        range: declare_helper(module, "jit_range", 2, 1),
-        window: declare_helper(module, "jit_window", 2, 1),
-        chunks: declare_helper(module, "jit_chunks", 2, 1),
-        setunion: declare_helper(module, "jit_setunion", 2, 1),
-        setinter: declare_helper(module, "jit_setinter", 2, 1),
-        setdiff: declare_helper(module, "jit_setdiff", 2, 1),
+        zip: declare_helper(module, "jit_zip", 3, 1),
+        enumerate: declare_helper(module, "jit_enumerate", 2, 1),
+        range: declare_helper(module, "jit_range", 3, 1),
+        window: declare_helper(module, "jit_window", 3, 1),
+        chunks: declare_helper(module, "jit_chunks", 3, 1),
+        setunion: declare_helper(module, "jit_setunion", 3, 1),
+        setinter: declare_helper(module, "jit_setinter", 3, 1),
+        setdiff: declare_helper(module, "jit_setdiff", 3, 1),
         tl: declare_helper(module, "jit_tl", 2, 1),
-        rev: declare_helper(module, "jit_rev", 1, 1),
-        srt: declare_helper(module, "jit_srt", 1, 1),
-        rsrt: declare_helper(module, "jit_rsrt", 1, 1),
+        rev: declare_helper(module, "jit_rev", 2, 1),
+        srt: declare_helper(module, "jit_srt", 2, 1),
+        rsrt: declare_helper(module, "jit_rsrt", 2, 1),
         fft: declare_helper(module, "jit_fft", 2, 1),
         ifft: declare_helper(module, "jit_ifft", 2, 1),
-        cumsum: declare_helper(module, "jit_cumsum", 1, 1),
+        cumsum: declare_helper(module, "jit_cumsum", 2, 1),
         median: declare_helper(module, "jit_median", 2, 1),
         quantile: declare_helper(module, "jit_quantile", 3, 1),
         stdev: declare_helper(module, "jit_stdev", 2, 1),
@@ -2317,24 +2317,30 @@ fn compile_function_body(
             OP_SPL => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.spl);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_CAT => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.cat);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_HAS => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.has);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
@@ -2368,63 +2374,79 @@ fn compile_function_body(
             OP_ZIP => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.zip);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_ENUMERATE => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.enumerate);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_RANGE => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.range);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_WINDOW => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.window);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_CHUNKS => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.chunks);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_SETUNION => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.setunion);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_SETINTER => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.setinter);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_SETDIFF => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.setdiff);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
@@ -2439,22 +2461,28 @@ fn compile_function_body(
             }
             OP_REV => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.rev);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_SRT => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.srt);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_SRTDESC => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.rsrt);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
@@ -2478,8 +2506,10 @@ fn compile_function_body(
             }
             OP_CUMSUM => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.cumsum);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -10871,10 +10871,11 @@ pub(crate) extern "C" fn jit_getmany(a: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_spl(a: u64, b: u64) -> u64 {
+pub(crate) extern "C" fn jit_spl(a: u64, b: u64, span_bits: u64) -> u64 {
     let av = NanVal(a);
     let bv = NanVal(b);
     if !av.is_string() || !bv.is_string() {
+        jit_set_runtime_error_with_span(VmError::Type("spl requires two strings"), span_bits);
         return TAG_NIL;
     }
     let text = unsafe {
@@ -10898,10 +10899,15 @@ pub(crate) extern "C" fn jit_spl(a: u64, b: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_cat(a: u64, b: u64) -> u64 {
+pub(crate) extern "C" fn jit_cat(a: u64, b: u64, span_bits: u64) -> u64 {
     let av = NanVal(a);
     let bv = NanVal(b);
-    if !bv.is_string() || !av.is_heap() {
+    if !bv.is_string() {
+        jit_set_runtime_error_with_span(VmError::Type("cat requires a text separator"), span_bits);
+        return TAG_NIL;
+    }
+    if !av.is_heap() {
+        jit_set_runtime_error_with_span(VmError::Type("cat requires a list"), span_bits);
         return TAG_NIL;
     }
     let sep = unsafe {
@@ -10912,11 +10918,18 @@ pub(crate) extern "C" fn jit_cat(a: u64, b: u64) -> u64 {
     };
     let items = match unsafe { av.as_heap_ref() } {
         HeapObj::List(l) => l,
-        _ => return TAG_NIL,
+        _ => {
+            jit_set_runtime_error_with_span(VmError::Type("cat requires a list"), span_bits);
+            return TAG_NIL;
+        }
     };
     let mut parts = Vec::with_capacity(items.len());
     for item in items {
         if !item.is_string() {
+            jit_set_runtime_error_with_span(
+                VmError::Type("cat: list items must be text"),
+                span_bits,
+            );
             return TAG_NIL;
         }
         let s = unsafe {
@@ -10932,12 +10945,16 @@ pub(crate) extern "C" fn jit_cat(a: u64, b: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_has(a: u64, b: u64) -> u64 {
+pub(crate) extern "C" fn jit_has(a: u64, b: u64, span_bits: u64) -> u64 {
     let collection = NanVal(a);
     let needle = NanVal(b);
     if collection.is_string() {
         if !needle.is_string() {
-            return TAG_FALSE;
+            jit_set_runtime_error_with_span(
+                VmError::Type("has: text search requires text needle"),
+                span_bits,
+            );
+            return TAG_NIL;
         }
         let found = unsafe {
             let haystack = match collection.as_heap_ref() {
@@ -10958,7 +10975,8 @@ pub(crate) extern "C" fn jit_has(a: u64, b: u64) -> u64 {
         let found = items.iter().any(|item| nanval_equal(*item, needle));
         return NanVal::boolean(found).0;
     }
-    TAG_FALSE
+    jit_set_runtime_error_with_span(VmError::Type("has requires a list or text"), span_bits);
+    TAG_NIL
 }
 
 #[cfg(feature = "cranelift")]
@@ -11104,14 +11122,16 @@ pub(crate) extern "C" fn jit_lst(list: u64, idx: u64, val: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_range(a: u64, b: u64) -> u64 {
+pub(crate) extern "C" fn jit_range(a: u64, b: u64, span_bits: u64) -> u64 {
     let va = NanVal(a);
     let vb = NanVal(b);
     if !va.is_number() || !vb.is_number() {
+        jit_set_runtime_error_with_span(VmError::Type("range requires numbers"), span_bits);
         return TAG_NIL;
     }
     // Reject non-integer bounds rather than silently truncating.
     if va.as_number().fract() != 0.0 || vb.as_number().fract() != 0.0 {
+        jit_set_runtime_error_with_span(VmError::Type("range: bounds must be integers"), span_bits);
         return TAG_NIL;
     }
     let start = va.as_number() as i64;
@@ -11121,6 +11141,7 @@ pub(crate) extern "C" fn jit_range(a: u64, b: u64) -> u64 {
     }
     let len = (end - start) as u64;
     if len > 1_000_000 {
+        jit_set_runtime_error_with_span(VmError::Type("range too large (max 1000000)"), span_bits);
         return TAG_NIL;
     }
     let mut out: Vec<NanVal> = Vec::with_capacity(len as usize);
@@ -11132,23 +11153,35 @@ pub(crate) extern "C" fn jit_range(a: u64, b: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_window(n_val: u64, xs_val: u64) -> u64 {
+pub(crate) extern "C" fn jit_window(n_val: u64, xs_val: u64, span_bits: u64) -> u64 {
     let vn = NanVal(n_val);
     let vxs = NanVal(xs_val);
     if !vn.is_number() {
+        jit_set_runtime_error_with_span(VmError::Type("window: size must be a number"), span_bits);
         return TAG_NIL;
     }
     let nf = vn.as_number();
     if !nf.is_finite() || nf <= 0.0 || nf.fract() != 0.0 {
+        jit_set_runtime_error_with_span(
+            VmError::Type("window: size must be a positive integer"),
+            span_bits,
+        );
         return TAG_NIL;
     }
     let n = nf as usize;
     if !vxs.is_heap() {
+        jit_set_runtime_error_with_span(VmError::Type("window arg 2 requires a list"), span_bits);
         return TAG_NIL;
     }
     let xs = match unsafe { vxs.as_heap_ref() } {
         HeapObj::List(items) => items,
-        _ => return TAG_NIL,
+        _ => {
+            jit_set_runtime_error_with_span(
+                VmError::Type("window arg 2 requires a list"),
+                span_bits,
+            );
+            return TAG_NIL;
+        }
     };
     if n > xs.len() {
         return NanVal::heap_list(Vec::new()).0;
@@ -11167,19 +11200,30 @@ pub(crate) extern "C" fn jit_window(n_val: u64, xs_val: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_zip(a: u64, b: u64) -> u64 {
+pub(crate) extern "C" fn jit_zip(a: u64, b: u64, span_bits: u64) -> u64 {
     let va = NanVal(a);
     let vb = NanVal(b);
-    if !va.is_heap() || !vb.is_heap() {
+    if !va.is_heap() {
+        jit_set_runtime_error_with_span(VmError::Type("zip arg 1 requires a list"), span_bits);
+        return TAG_NIL;
+    }
+    if !vb.is_heap() {
+        jit_set_runtime_error_with_span(VmError::Type("zip arg 2 requires a list"), span_bits);
         return TAG_NIL;
     }
     let xs = match unsafe { va.as_heap_ref() } {
         HeapObj::List(items) => items,
-        _ => return TAG_NIL,
+        _ => {
+            jit_set_runtime_error_with_span(VmError::Type("zip arg 1 requires a list"), span_bits);
+            return TAG_NIL;
+        }
     };
     let ys = match unsafe { vb.as_heap_ref() } {
         HeapObj::List(items) => items,
-        _ => return TAG_NIL,
+        _ => {
+            jit_set_runtime_error_with_span(VmError::Type("zip arg 2 requires a list"), span_bits);
+            return TAG_NIL;
+        }
     };
     let n = xs.len().min(ys.len());
     let mut out: Vec<NanVal> = Vec::with_capacity(n);
@@ -11194,19 +11238,36 @@ pub(crate) extern "C" fn jit_zip(a: u64, b: u64) -> u64 {
 }
 
 #[cfg(feature = "cranelift")]
-fn jit_setop_impl(a: u64, b: u64, op: u8) -> u64 {
+fn jit_setop_impl(a: u64, b: u64, op: u8, span_bits: u64) -> u64 {
     let va = NanVal(a);
     let vb = NanVal(b);
-    if !va.is_heap() || !vb.is_heap() {
+    if !va.is_heap() {
+        jit_set_runtime_error_with_span(VmError::Type("setop arg 1 requires a list"), span_bits);
+        return TAG_NIL;
+    }
+    if !vb.is_heap() {
+        jit_set_runtime_error_with_span(VmError::Type("setop arg 2 requires a list"), span_bits);
         return TAG_NIL;
     }
     let xs = match unsafe { va.as_heap_ref() } {
         HeapObj::List(items) => items,
-        _ => return TAG_NIL,
+        _ => {
+            jit_set_runtime_error_with_span(
+                VmError::Type("setop arg 1 requires a list"),
+                span_bits,
+            );
+            return TAG_NIL;
+        }
     };
     let ys = match unsafe { vb.as_heap_ref() } {
         HeapObj::List(items) => items,
-        _ => return TAG_NIL,
+        _ => {
+            jit_set_runtime_error_with_span(
+                VmError::Type("setop arg 2 requires a list"),
+                span_bits,
+            );
+            return TAG_NIL;
+        }
     };
     let op_name = match op {
         OP_SETUNION => "setunion",
@@ -11219,7 +11280,13 @@ fn jit_setop_impl(a: u64, b: u64, op: u8) -> u64 {
     for x in xs {
         let k = match setops_key(*x, op_name) {
             Ok(k) => k,
-            Err(_) => return TAG_NIL,
+            Err(_) => {
+                jit_set_runtime_error_with_span(
+                    VmError::Type("setop: elements must be text, number, or bool"),
+                    span_bits,
+                );
+                return TAG_NIL;
+            }
         };
         if set_a.insert(k.clone()) {
             first_a.insert(k, *x);
@@ -11230,7 +11297,13 @@ fn jit_setop_impl(a: u64, b: u64, op: u8) -> u64 {
     for y in ys {
         let k = match setops_key(*y, op_name) {
             Ok(k) => k,
-            Err(_) => return TAG_NIL,
+            Err(_) => {
+                jit_set_runtime_error_with_span(
+                    VmError::Type("setop: elements must be text, number, or bool"),
+                    span_bits,
+                );
+                return TAG_NIL;
+            }
         };
         if set_b.insert(k.clone()) {
             first_b.insert(k, *y);
@@ -11255,32 +11328,36 @@ fn jit_setop_impl(a: u64, b: u64, op: u8) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_setunion(a: u64, b: u64) -> u64 {
-    jit_setop_impl(a, b, OP_SETUNION)
+pub(crate) extern "C" fn jit_setunion(a: u64, b: u64, span_bits: u64) -> u64 {
+    jit_setop_impl(a, b, OP_SETUNION, span_bits)
 }
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_setinter(a: u64, b: u64) -> u64 {
-    jit_setop_impl(a, b, OP_SETINTER)
+pub(crate) extern "C" fn jit_setinter(a: u64, b: u64, span_bits: u64) -> u64 {
+    jit_setop_impl(a, b, OP_SETINTER, span_bits)
 }
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_setdiff(a: u64, b: u64) -> u64 {
-    jit_setop_impl(a, b, OP_SETDIFF)
+pub(crate) extern "C" fn jit_setdiff(a: u64, b: u64, span_bits: u64) -> u64 {
+    jit_setop_impl(a, b, OP_SETDIFF, span_bits)
 }
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_enumerate(a: u64) -> u64 {
+pub(crate) extern "C" fn jit_enumerate(a: u64, span_bits: u64) -> u64 {
     let va = NanVal(a);
     if !va.is_heap() {
+        jit_set_runtime_error_with_span(VmError::Type("enumerate requires a list"), span_bits);
         return TAG_NIL;
     }
     let xs = match unsafe { va.as_heap_ref() } {
         HeapObj::List(items) => items,
-        _ => return TAG_NIL,
+        _ => {
+            jit_set_runtime_error_with_span(VmError::Type("enumerate requires a list"), span_bits);
+            return TAG_NIL;
+        }
     };
     let mut out: Vec<NanVal> = Vec::with_capacity(xs.len());
     for (i, &v) in xs.iter().enumerate() {
@@ -11292,23 +11369,32 @@ pub(crate) extern "C" fn jit_enumerate(a: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_chunks(a: u64, b: u64) -> u64 {
+pub(crate) extern "C" fn jit_chunks(a: u64, b: u64, span_bits: u64) -> u64 {
     let va = NanVal(a);
     let vb = NanVal(b);
     if !va.is_number() {
+        jit_set_runtime_error_with_span(VmError::Type("chunks: size must be a number"), span_bits);
         return TAG_NIL;
     }
     let n_raw = va.as_number();
     if n_raw.fract() != 0.0 || n_raw <= 0.0 {
+        jit_set_runtime_error_with_span(
+            VmError::Type("chunks: size must be a positive integer"),
+            span_bits,
+        );
         return TAG_NIL;
     }
     let n = n_raw as usize;
     if !vb.is_heap() {
+        jit_set_runtime_error_with_span(VmError::Type("chunks: requires a list"), span_bits);
         return TAG_NIL;
     }
     let xs = match unsafe { vb.as_heap_ref() } {
         HeapObj::List(items) => items,
-        _ => return TAG_NIL,
+        _ => {
+            jit_set_runtime_error_with_span(VmError::Type("chunks: requires a list"), span_bits);
+            return TAG_NIL;
+        }
     };
     let mut out: Vec<NanVal> = Vec::with_capacity(xs.len().div_ceil(n));
     for chunk in xs.chunks(n) {
@@ -11363,7 +11449,7 @@ pub(crate) extern "C" fn jit_tl(a: u64, span_bits: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_rev(a: u64) -> u64 {
+pub(crate) extern "C" fn jit_rev(a: u64, span_bits: u64) -> u64 {
     let v = NanVal(a);
     if v.is_string() {
         let s = unsafe {
@@ -11387,12 +11473,13 @@ pub(crate) extern "C" fn jit_rev(a: u64) -> u64 {
         reversed.reverse();
         return NanVal::heap_list(reversed).0;
     }
+    jit_set_runtime_error_with_span(VmError::Type("rev requires a list or text"), span_bits);
     TAG_NIL
 }
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_srt(a: u64) -> u64 {
+pub(crate) extern "C" fn jit_srt(a: u64, span_bits: u64) -> u64 {
     let v = NanVal(a);
     if v.is_string() {
         let s = unsafe {
@@ -11439,7 +11526,13 @@ pub(crate) extern "C" fn jit_srt(a: u64) -> u64 {
             sorted.sort_by(|a, b| unsafe { nanval_str_cmp(*a, *b) });
             return NanVal::heap_list(sorted).0;
         }
+        jit_set_runtime_error_with_span(
+            VmError::Type("srt: list must contain all numbers or all text"),
+            span_bits,
+        );
+        return TAG_NIL;
     }
+    jit_set_runtime_error_with_span(VmError::Type("srt requires a list or text"), span_bits);
     TAG_NIL
 }
 
@@ -11770,7 +11863,7 @@ pub(crate) extern "C" fn jit_ifft(a: u64, span_bits: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_cumsum(a: u64) -> u64 {
+pub(crate) extern "C" fn jit_cumsum(a: u64, span_bits: u64) -> u64 {
     let v = NanVal(a);
     if v.is_heap()
         && let HeapObj::List(items) = unsafe { v.as_heap_ref() }
@@ -11779,6 +11872,10 @@ pub(crate) extern "C" fn jit_cumsum(a: u64) -> u64 {
         let mut out: Vec<NanVal> = Vec::with_capacity(items.len());
         for item in items {
             if !item.is_number() {
+                jit_set_runtime_error_with_span(
+                    VmError::Type("cumsum: list elements must be numbers"),
+                    span_bits,
+                );
                 return TAG_NIL;
             }
             total += item.as_number();
@@ -11786,12 +11883,16 @@ pub(crate) extern "C" fn jit_cumsum(a: u64) -> u64 {
         }
         return NanVal::heap_list(out).0;
     }
+    jit_set_runtime_error_with_span(
+        VmError::Type("cumsum requires a list of numbers"),
+        span_bits,
+    );
     TAG_NIL
 }
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_rsrt(a: u64) -> u64 {
+pub(crate) extern "C" fn jit_rsrt(a: u64, span_bits: u64) -> u64 {
     let v = NanVal(a);
     if v.is_string() {
         let s = unsafe {
@@ -11839,7 +11940,13 @@ pub(crate) extern "C" fn jit_rsrt(a: u64) -> u64 {
             sorted.sort_by(|a, b| unsafe { nanval_str_cmp(*b, *a) });
             return NanVal::heap_list(sorted).0;
         }
+        jit_set_runtime_error_with_span(
+            VmError::Type("rsrt: list must contain all numbers or all text"),
+            span_bits,
+        );
+        return TAG_NIL;
     }
+    jit_set_runtime_error_with_span(VmError::Type("rsrt requires a list or text"), span_bits);
     TAG_NIL
 }
 
@@ -19957,7 +20064,7 @@ mod tests {
 
         #[test]
         fn jit_rev_string() {
-            let r = jit_rev(str_val("hello"));
+            let r = jit_rev(str_val("hello"), 0);
             let rv = NanVal(r);
             assert!(rv.is_string());
             let HeapObj::Str(s) = (unsafe { rv.as_heap_ref() }) else {
@@ -19975,22 +20082,28 @@ mod tests {
                 NanVal::number(3.0),
             ];
             let list = NanVal::heap_list(items);
-            let r = jit_rev(list.0);
+            let r = jit_rev(list.0, 0);
             let rv = NanVal(r);
             assert!(rv.is_heap());
         }
 
         #[test]
-        fn jit_rev_non_string_non_list_returns_nil() {
-            let r = jit_rev(TAG_NIL);
+        fn jit_rev_non_string_non_list_signals_runtime_error() {
+            // Type error on the slow path now signals via JIT_RUNTIME_ERROR
+            // and returns TAG_NIL, matching the tree/VM "rev requires a list
+            // or text" raise (sweep batch 5).
+            let _ = jit_take_runtime_error();
+            let r = jit_rev(TAG_NIL, 0);
             assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("rev")));
         }
 
         // ── jit_srt ────────────────────────────────────────────────────────
 
         #[test]
         fn jit_srt_string_sorts_chars() {
-            let r = jit_srt(str_val("cab"));
+            let r = jit_srt(str_val("cab"), 0);
             let rv = NanVal(r);
             assert!(rv.is_string());
             let HeapObj::Str(s) = (unsafe { rv.as_heap_ref() }) else {
@@ -20008,7 +20121,7 @@ mod tests {
                 NanVal::number(2.0),
             ];
             let list = NanVal::heap_list(items);
-            let r = jit_srt(list.0);
+            let r = jit_srt(list.0, 0);
             let rv = NanVal(r);
             assert!(rv.is_heap());
         }
@@ -20021,7 +20134,7 @@ mod tests {
                 NanVal::heap_string("b".into()),
             ];
             let list = NanVal::heap_list(items);
-            let r = jit_srt(list.0);
+            let r = jit_srt(list.0, 0);
             let rv = NanVal(r);
             assert!(rv.is_heap());
         }
@@ -20029,15 +20142,30 @@ mod tests {
         #[test]
         fn jit_srt_empty_list_returns_list() {
             let list = NanVal::heap_list(vec![]);
-            let r = jit_srt(list.0);
+            let r = jit_srt(list.0, 0);
             let rv = NanVal(r);
             assert!(rv.is_heap());
         }
 
         #[test]
-        fn jit_srt_non_string_non_list_returns_nil() {
-            let r = jit_srt(TAG_NIL);
+        fn jit_srt_non_string_non_list_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let r = jit_srt(TAG_NIL, 0);
             assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("srt")));
+        }
+
+        #[test]
+        fn jit_srt_mixed_list_signals_runtime_error() {
+            // Mixed numbers + strings is the historical silent-nil case.
+            let _ = jit_take_runtime_error();
+            let items = vec![NanVal::number(1.0), NanVal::heap_string("a".into())];
+            let list = NanVal::heap_list(items);
+            let r = jit_srt(list.0, 0);
+            assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("numbers or all text")));
         }
 
         // ── jit_slc ────────────────────────────────────────────────────────
@@ -20084,13 +20212,13 @@ mod tests {
 
         #[test]
         fn jit_has_text_found() {
-            let r = jit_has(str_val("hello world"), str_val("world"));
+            let r = jit_has(str_val("hello world"), str_val("world"), 0);
             assert!(as_bool(r));
         }
 
         #[test]
         fn jit_has_text_not_found() {
-            let r = jit_has(str_val("hello"), str_val("xyz"));
+            let r = jit_has(str_val("hello"), str_val("xyz"), 0);
             assert!(!as_bool(r));
         }
 
@@ -20102,7 +20230,7 @@ mod tests {
                 NanVal::number(3.0),
             ];
             let list = NanVal::heap_list(items);
-            let r = jit_has(list.0, num(2.0));
+            let r = jit_has(list.0, num(2.0), 0);
             assert!(as_bool(r));
         }
 
@@ -20110,28 +20238,34 @@ mod tests {
         fn jit_has_list_not_found() {
             let items = vec![NanVal::number(1.0), NanVal::number(2.0)];
             let list = NanVal::heap_list(items);
-            let r = jit_has(list.0, num(5.0));
+            let r = jit_has(list.0, num(5.0), 0);
             assert!(!as_bool(r));
         }
 
         #[test]
-        fn jit_has_text_non_string_needle_returns_false() {
-            // collection is string but needle is not string
-            let r = jit_has(str_val("hello"), TAG_NIL);
-            assert!(!as_bool(r));
+        fn jit_has_text_non_string_needle_signals_runtime_error() {
+            // Was TAG_FALSE; tree/VM raise "has: text search requires text needle".
+            let _ = jit_take_runtime_error();
+            let r = jit_has(str_val("hello"), TAG_NIL, 0);
+            assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("text needle")));
         }
 
         #[test]
-        fn jit_has_non_string_non_list_returns_false() {
-            let r = jit_has(TAG_NIL, num(1.0));
-            assert!(!as_bool(r));
+        fn jit_has_non_string_non_list_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let r = jit_has(TAG_NIL, num(1.0), 0);
+            assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("has requires")));
         }
 
         // ── jit_spl ────────────────────────────────────────────────────────
 
         #[test]
         fn jit_spl_string_splits() {
-            let r = jit_spl(str_val("a,b,c"), str_val(","));
+            let r = jit_spl(str_val("a,b,c"), str_val(","), 0);
             let rv = NanVal(r);
             assert!(rv.is_heap());
             let HeapObj::List(items) = (unsafe { rv.as_heap_ref() }) else {
@@ -20141,9 +20275,12 @@ mod tests {
         }
 
         #[test]
-        fn jit_spl_non_string_returns_nil() {
-            let r = jit_spl(TAG_NIL, str_val(","));
+        fn jit_spl_non_string_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let r = jit_spl(TAG_NIL, str_val(","), 0);
             assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("spl requires")));
         }
 
         // ── jit_cat ────────────────────────────────────────────────────────
@@ -20156,7 +20293,7 @@ mod tests {
                 NanVal::heap_string("c".into()),
             ];
             let list = NanVal::heap_list(items);
-            let r = jit_cat(list.0, str_val(","));
+            let r = jit_cat(list.0, str_val(","), 0);
             let rv = NanVal(r);
             assert!(rv.is_string());
             let HeapObj::Str(s) = (unsafe { rv.as_heap_ref() }) else {
@@ -20167,9 +20304,32 @@ mod tests {
         }
 
         #[test]
-        fn jit_cat_non_list_returns_nil() {
-            let r = jit_cat(TAG_NIL, str_val(","));
+        fn jit_cat_non_list_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let r = jit_cat(TAG_NIL, str_val(","), 0);
             assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("cat requires")));
+        }
+
+        #[test]
+        fn jit_cat_non_text_separator_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let list = NanVal::heap_list(vec![NanVal::heap_string("a".into())]);
+            let r = jit_cat(list.0, TAG_NIL, 0);
+            assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("text separator")));
+        }
+
+        #[test]
+        fn jit_cat_non_text_item_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let list = NanVal::heap_list(vec![NanVal::number(1.0)]);
+            let r = jit_cat(list.0, str_val(","), 0);
+            assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("items must be text")));
         }
 
         // ── jit_listappend ─────────────────────────────────────────────────

--- a/tests/regression_jit_nil_sweep_batch5.rs
+++ b/tests/regression_jit_nil_sweep_batch5.rs
@@ -1,0 +1,202 @@
+// Regression tests for the Cranelift JIT-helper permissive-nil sweep, batch 5.
+//
+// Helpers in scope (Group C — collections):
+//   jit_spl, jit_cat, jit_has, jit_range,
+//   jit_window, jit_zip, jit_chunks, jit_enumerate,
+//   jit_setunion, jit_setinter, jit_setdiff,
+//   jit_rev, jit_srt, jit_rsrt, jit_cumsum.
+//
+// Before this PR these helpers silently returned TAG_NIL on failure paths
+// where tree/VM raise runtime errors. The fix routes the failure paths
+// through the `JIT_RUNTIME_ERROR` TLS cell introduced in #254, threading a
+// packed source-span immediate so diagnostics render with a caret matching
+// tree/VM.
+//
+// As with batches 3/4: the ilo source-level verifier rejects programs that
+// statically mix types (ILO-T009 / ILO-T010 / ILO-T012), so per-helper
+// error-path tests live as unit tests inside `src/vm/mod.rs` that drive the
+// helpers directly. These CLI tests focus on cross-engine happy-path parity,
+// pinning that wiring the span/error threads did not regress the success
+// cases (split, join, has, range, window, zip, chunks, enumerate, set ops,
+// rev, srt/rsrt, cumsum) across tree, VM, and Cranelift JIT.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn check_stdout(engine: &str, src: &str, expected: &str) {
+    let out = ilo()
+        .args([src, engine, "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "engine={engine}: expected success for `{src}`, got stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&out.stdout).trim(),
+        expected,
+        "engine={engine}: stdout mismatch for `{src}`"
+    );
+}
+
+// Run a check across all three engines and assert identical output.
+fn check_all(src: &str, expected: &str) {
+    check_stdout("--run-tree", src, expected);
+    check_stdout("--run-vm", src, expected);
+    #[cfg(feature = "cranelift")]
+    check_stdout("--run-cranelift", src, expected);
+}
+
+// ── spl / cat happy paths ─────────────────────────────────────────────────
+
+#[test]
+fn spl_basic_cross_engine() {
+    check_all("f>L t;spl \"a,b,c\" \",\"", "[a, b, c]");
+}
+
+#[test]
+fn cat_basic_cross_engine() {
+    check_all("f>t;cat [\"a\" \"b\" \"c\"] \",\"", "a,b,c");
+}
+
+// ── has happy paths ───────────────────────────────────────────────────────
+
+#[test]
+fn has_text_found_cross_engine() {
+    check_all("f>b;has \"hello world\" \"world\"", "true");
+}
+
+#[test]
+fn has_text_not_found_cross_engine() {
+    check_all("f>b;has \"hello\" \"xyz\"", "false");
+}
+
+#[test]
+fn has_list_found_cross_engine() {
+    check_all("f>b;has [1 2 3] 2", "true");
+}
+
+#[test]
+fn has_list_not_found_cross_engine() {
+    check_all("f>b;has [1 2 3] 5", "false");
+}
+
+// ── range happy paths ─────────────────────────────────────────────────────
+
+#[test]
+fn range_basic_cross_engine() {
+    check_all("f>L n;range 0 4", "[0, 1, 2, 3]");
+}
+
+#[test]
+fn range_empty_when_start_ge_end_cross_engine() {
+    check_all("f>L n;range 5 5", "[]");
+}
+
+// ── window / zip / chunks / enumerate happy paths ─────────────────────────
+
+#[test]
+fn window_basic_cross_engine() {
+    check_all("f>L (L n);window 2 [1 2 3 4]", "[[1, 2], [2, 3], [3, 4]]");
+}
+
+#[test]
+fn window_larger_than_input_cross_engine() {
+    check_all("f>L (L n);window 5 [1 2 3]", "[]");
+}
+
+#[test]
+fn zip_basic_cross_engine() {
+    check_all(
+        "f>L (L n);zip [1 2 3] [10 20 30]",
+        "[[1, 10], [2, 20], [3, 30]]",
+    );
+}
+
+#[test]
+fn zip_truncates_to_shorter_cross_engine() {
+    check_all("f>L (L n);zip [1 2 3 4] [10 20]", "[[1, 10], [2, 20]]");
+}
+
+#[test]
+fn chunks_basic_cross_engine() {
+    check_all("f>L (L n);chunks 2 [1 2 3 4 5]", "[[1, 2], [3, 4], [5]]");
+}
+
+#[test]
+fn enumerate_basic_cross_engine() {
+    check_all(
+        "f>L (L n);enumerate [10 20 30]",
+        "[[0, 10], [1, 20], [2, 30]]",
+    );
+}
+
+// ── set ops happy paths ───────────────────────────────────────────────────
+
+#[test]
+fn setunion_basic_cross_engine() {
+    check_all("f>L n;setunion [1 2 3] [3 4 5]", "[1, 2, 3, 4, 5]");
+}
+
+#[test]
+fn setinter_basic_cross_engine() {
+    check_all("f>L n;setinter [1 2 3 4] [3 4 5 6]", "[3, 4]");
+}
+
+#[test]
+fn setdiff_basic_cross_engine() {
+    check_all("f>L n;setdiff [1 2 3 4] [3 4 5]", "[1, 2]");
+}
+
+// ── rev / srt / rsrt happy paths ──────────────────────────────────────────
+
+#[test]
+fn rev_string_cross_engine() {
+    check_all("f>t;rev \"hello\"", "olleh");
+}
+
+#[test]
+fn rev_list_cross_engine() {
+    check_all("f>L n;rev [1 2 3]", "[3, 2, 1]");
+}
+
+#[test]
+fn srt_numbers_cross_engine() {
+    check_all("f>L n;srt [3 1 2]", "[1, 2, 3]");
+}
+
+#[test]
+fn srt_strings_cross_engine() {
+    check_all("f>L t;srt [\"c\" \"a\" \"b\"]", "[a, b, c]");
+}
+
+#[test]
+fn srt_empty_list_cross_engine() {
+    check_all("f>L n;srt []", "[]");
+}
+
+#[test]
+fn rsrt_numbers_cross_engine() {
+    check_all("f>L n;rsrt [1 3 2]", "[3, 2, 1]");
+}
+
+#[test]
+fn rsrt_strings_cross_engine() {
+    check_all("f>L t;rsrt [\"a\" \"c\" \"b\"]", "[c, b, a]");
+}
+
+// ── cumsum happy paths ────────────────────────────────────────────────────
+
+#[test]
+fn cumsum_basic_cross_engine() {
+    check_all("f>L n;cumsum [1 2 3 4]", "[1, 3, 6, 10]");
+}
+
+#[test]
+fn cumsum_empty_cross_engine() {
+    check_all("f>L n;cumsum []", "[]");
+}


### PR DESCRIPTION
## Summary

Group C of the JIT-helper permissive-nil sweep. Routes the 15 collection-oriented Cranelift helpers through `JIT_RUNTIME_ERROR` so their error paths match tree-walker and bytecode VM behaviour. Same mechanic as batches 1/2/3/4 (#264, #259, #282, #281): each helper gains a `span_bits: u64` immediate, the JIT and AOT call sites pack and pass `pack_span_bits(chunk.spans[ip])`, and the helper calls `jit_set_runtime_error_with_span` instead of silently returning `TAG_NIL` / `TAG_FALSE` on type errors.

Helpers in this batch: `jit_spl`, `jit_cat`, `jit_has`, `jit_range`, `jit_window`, `jit_zip`, `jit_chunks`, `jit_enumerate`, `jit_setunion`, `jit_setinter`, `jit_setdiff`, `jit_rev`, `jit_srt`, `jit_rsrt`, `jit_cumsum`.

## Repro before/after

Before, an agent driving a slow-path mixed-type collection op got nil with no diagnostic. After this PR, the helper raises a `VmRuntimeError` with the same wording the VM dispatcher uses, with a caret pointing at the offending op. The ilo source-level verifier rejects most programs that would trigger these helpers' error paths statically (ILO-T009 / ILO-T010 / ILO-T012), but the helpers are still reachable through slow-path register dispatch where the verifier can't prove the operand type, so the parity matters for runtime-typed code paths and for bytecode loaded by other front-ends.

## What's in the diff

Per-commit:

1. **route collection JIT helpers through JIT_RUNTIME_ERROR** - `src/vm/mod.rs`. Every helper signature gains `span_bits: u64`. Every nil-on-error path becomes `jit_set_runtime_error_with_span(VmError::Type(...), span_bits); return TAG_NIL;` with the message borrowed from the VM dispatcher. `jit_srt` and `jit_rsrt` now distinguish mixed-list from non-list/non-text (matching VM). `jit_setop_impl` threads spans and surfaces the per-arg + per-element setop messages. Unit tests inside `vm::tests::jit_helpers` updated to assert `jit_take_runtime_error` is populated with the expected `VmError::Type` variant; added a new mixed-list test for `jit_srt` to pin the previously-silent diverging path.
2. **thread span_bits to batch-5 helpers from JIT and AOT call sites** - `src/vm/jit_cranelift.rs` + `src/vm/compile_cranelift.rs`. `declare_helper` arities bumped (2→3 or 1→2). Every call site now `pack_span_bits(chunk.spans[ip])` + `iconst` + appends the new arg to `builder.ins().call(...)`. Both the in-process JIT and the AOT lowering get the same treatment.
3. **add cross-engine regression suite for batch-5 helpers** - `tests/regression_jit_nil_sweep_batch5.rs`. 26 happy-path tests across `--run-tree`, `--run-vm`, and `--run-cranelift`.
4. **add example pinning batch-5 helper happy paths through examples_engines** - `examples/jit-nil-sweep-batch5.ilo`. Single example with 17 `-- run:` / `-- out:` assertions covering all 15 helpers, picked up by `tests/examples_engines.rs` for cross-engine pinning.

## Test plan

- [x] `cargo build --release --features cranelift` builds clean
- [x] `cargo fmt` clean
- [x] `cargo clippy --release --features cranelift --tests` clean
- [x] `cargo test --release --features cranelift` - full suite passes (2900+ tests, 0 failures across all binaries)
- [x] `tests/regression_jit_nil_sweep_batch5.rs` (26 tests) passes across tree, VM, and Cranelift
- [x] `tests/examples_engines.rs` exercises `examples/jit-nil-sweep-batch5.ilo` across every engine

## Follow-ups

- `jit_has` previously had two arms that returned `TAG_FALSE` (text-with-non-text-needle, non-list/non-text collection) instead of an error. Now both go through `JIT_RUNTIME_ERROR`. If any downstream code was relying on the silent-false behaviour, it will surface as a runtime error now. None in this repo.
- Remaining permissive-nil JIT helpers are tracked for a future batch (the doc comment above `jit_set_runtime_error_with_span` in `src/vm/mod.rs` flags `jit_lst`, `jit_listget`, `jit_index`, `jit_jpth`, `jit_slc` as not yet harmonised).