### PR TITLE
route I/O JIT helpers through JIT_RUNTIME_ERROR (batch 7)

### DIFF
--- a/examples/jit-io-roundtrip.ilo
+++ b/examples/jit-io-roundtrip.ilo
@@ -1,0 +1,33 @@
+-- Cross-engine I/O round-trip: write/read text and lines, parse JSONL,
+-- and format/parse a timestamp. Pins that the Cranelift JIT helpers
+-- jit_rd/jit_rdl/jit_wr/jit_wrl/jit_jpar/jit_rdjl/jit_dtfmt/jit_dtparse
+-- agree with tree/VM on success, and that their type-error paths now
+-- surface VmError::Type through JIT_RUNTIME_ERROR instead of silently
+-- returning nil. (The type-error paths are unit-tested directly; this
+-- file pins the happy paths so the examples harness exercises them on
+-- every engine.)
+
+text-roundtrip>t;w=wr!! "/tmp/ilo-jit-io-roundtrip-text.txt" "hello";rd!! "/tmp/ilo-jit-io-roundtrip-text.txt"
+
+lines-roundtrip>n;w=wrl!! "/tmp/ilo-jit-io-roundtrip-lines.txt" ["a" "b" "c"];es=rdl!! "/tmp/ilo-jit-io-roundtrip-lines.txt";len es
+
+jsonl-count>n;p="/tmp/ilo-jit-io-roundtrip.jsonl";w=wrl!! p ["{\"k\":1}" "{\"k\":2}"];es=rdjl p;len es
+
+dt-format>t;dtfmt!! 0 "%Y-%m-%d"
+
+dt-parse>n;dtparse!! "1970-01-01" "%Y-%m-%d"
+
+-- run: text-roundtrip
+-- out: hello
+
+-- run: lines-roundtrip
+-- out: 3
+
+-- run: jsonl-count
+-- out: 2
+
+-- run: dt-format
+-- out: 1970-01-01
+
+-- run: dt-parse
+-- out: 0

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -304,8 +304,8 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         listget: declare_helper(module, "jit_listget", 2, 1),
         jpth: declare_helper(module, "jit_jpth", 2, 1),
         jdmp: declare_helper(module, "jit_jdmp", 1, 1),
-        jpar: declare_helper(module, "jit_jpar", 1, 1),
-        rdjl: declare_helper(module, "jit_rdjl", 1, 1),
+        jpar: declare_helper(module, "jit_jpar", 2, 1),
+        rdjl: declare_helper(module, "jit_rdjl", 2, 1),
         call: declare_helper(module, "jit_call", 4, 1),
         // Type predicates
         isnum: declare_helper(module, "jit_isnum", 1, 1),
@@ -338,17 +338,17 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         partition: declare_helper(module, "jit_partition", 2, 1),
         frq: declare_helper(module, "jit_frq", 1, 1),
         // File I/O
-        rd: declare_helper(module, "jit_rd", 1, 1),
-        rdl: declare_helper(module, "jit_rdl", 1, 1),
-        wr: declare_helper(module, "jit_wr", 2, 1),
-        wrl: declare_helper(module, "jit_wrl", 2, 1),
+        rd: declare_helper(module, "jit_rd", 2, 1),
+        rdl: declare_helper(module, "jit_rdl", 2, 1),
+        wr: declare_helper(module, "jit_wr", 3, 1),
+        wrl: declare_helper(module, "jit_wrl", 3, 1),
         // HTTP
         post: declare_helper(module, "jit_post", 2, 1),
         geth: declare_helper(module, "jit_geth", 2, 1),
         posth: declare_helper(module, "jit_posth", 3, 1),
         getmany: declare_helper(module, "jit_getmany", 1, 1),
-        dtfmt: declare_helper(module, "jit_dtfmt", 2, 1),
-        dtparse: declare_helper(module, "jit_dtparse", 2, 1),
+        dtfmt: declare_helper(module, "jit_dtfmt", 3, 1),
+        dtparse: declare_helper(module, "jit_dtparse", 3, 1),
         call_builtin_tree: declare_helper(module, "jit_call_builtin_tree", 3, 1),
         call_dyn: declare_helper(module, "jit_call_dyn", 3, 1),
         panic_unwrap: declare_helper(module, "jit_panic_unwrap", 1, 1),
@@ -3378,31 +3378,39 @@ fn compile_function_body(
             }
             OP_JPAR => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.jpar);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_RDJL => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.rdjl);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_DTFMT => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.dtfmt);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_DTPARSE => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.dtparse);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
@@ -3612,31 +3620,39 @@ fn compile_function_body(
             // ── File I/O ──
             OP_RD => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.rd);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_RDL => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.rdl);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_WR => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.wr);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_WRL => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.wrl);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -482,8 +482,8 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         listget: declare_helper(module, "jit_listget", 2, 1),
         jpth: declare_helper(module, "jit_jpth", 2, 1),
         jdmp: declare_helper(module, "jit_jdmp", 1, 1),
-        jpar: declare_helper(module, "jit_jpar", 1, 1),
-        rdjl: declare_helper(module, "jit_rdjl", 1, 1),
+        jpar: declare_helper(module, "jit_jpar", 2, 1),
+        rdjl: declare_helper(module, "jit_rdjl", 2, 1),
         call: declare_helper(module, "jit_call", 4, 1),
         // Type predicates
         isnum: declare_helper(module, "jit_isnum", 1, 1),
@@ -515,10 +515,10 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         partition: declare_helper(module, "jit_partition", 2, 1),
         frq: declare_helper(module, "jit_frq", 1, 1),
         // File I/O
-        rd: declare_helper(module, "jit_rd", 1, 1),
-        rdl: declare_helper(module, "jit_rdl", 1, 1),
-        wr: declare_helper(module, "jit_wr", 2, 1),
-        wrl: declare_helper(module, "jit_wrl", 2, 1),
+        rd: declare_helper(module, "jit_rd", 2, 1),
+        rdl: declare_helper(module, "jit_rdl", 2, 1),
+        wr: declare_helper(module, "jit_wr", 3, 1),
+        wrl: declare_helper(module, "jit_wrl", 3, 1),
         // HTTP
         post: declare_helper(module, "jit_post", 2, 1),
         geth: declare_helper(module, "jit_geth", 2, 1),
@@ -528,8 +528,8 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         solve: declare_helper(module, "jit_solve", 3, 1),
         inv: declare_helper(module, "jit_inv", 2, 1),
         det: declare_helper(module, "jit_det", 2, 1),
-        dtfmt: declare_helper(module, "jit_dtfmt", 2, 1),
-        dtparse: declare_helper(module, "jit_dtparse", 2, 1),
+        dtfmt: declare_helper(module, "jit_dtfmt", 3, 1),
+        dtparse: declare_helper(module, "jit_dtparse", 3, 1),
         call_builtin_tree: declare_helper(module, "jit_call_builtin_tree", 3, 1),
         call_dyn: declare_helper(module, "jit_call_dyn", 3, 1),
     }
@@ -3957,31 +3957,39 @@ fn compile_function_body(
             }
             OP_JPAR => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.jpar);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_RDJL => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.rdjl);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_DTFMT => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.dtfmt);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_DTPARSE => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.dtparse);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
@@ -4188,31 +4196,39 @@ fn compile_function_body(
             // ── File I/O ──
             OP_RD => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.rd);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_RDL => {
                 let bv = builder.use_var(vars[b_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.rdl);
-                let call_inst = builder.ins().call(fref, &[bv]);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_WR => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.wr);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
             OP_WRL => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.wrl);
-                let call_inst = builder.ins().call(fref, &[bv, cv]);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -13001,9 +13001,10 @@ pub(crate) extern "C" fn jit_jdmp(a: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_jpar(a: u64) -> u64 {
+pub(crate) extern "C" fn jit_jpar(a: u64, span_bits: u64) -> u64 {
     let v = NanVal(a);
     if !v.is_string() {
+        jit_set_runtime_error_with_span(VmError::Type("jpar requires a string"), span_bits);
         return TAG_NIL;
     }
     let text = unsafe {
@@ -13020,9 +13021,10 @@ pub(crate) extern "C" fn jit_jpar(a: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_rdjl(a: u64) -> u64 {
+pub(crate) extern "C" fn jit_rdjl(a: u64, span_bits: u64) -> u64 {
     let v = NanVal(a);
     if !v.is_string() {
+        jit_set_runtime_error_with_span(VmError::Type("rdjl requires a string path"), span_bits);
         return TAG_NIL;
     }
     let path = unsafe {
@@ -13046,20 +13048,31 @@ pub(crate) extern "C" fn jit_rdjl(a: u64) -> u64 {
             }
             NanVal::heap_list(items).0
         }
-        // On file-read failure JIT returns nil; the VM dispatch path raises a
-        // typed runtime error. JIT helper-callers don't have a runtime-error
-        // channel, so nil is the conventional signal here (matches jit_rd /
-        // jit_jpar conventions for non-string inputs).
-        Err(_) => TAG_NIL,
+        // Mirror the VM's OP_RDJL handler: a read failure raises VmError::Type
+        // rather than wrapping the io::Error in a result. The error path
+        // surfaces through the JIT_RUNTIME_ERROR channel so cranelift renders
+        // the same diagnostic as tree/VM.
+        Err(_) => {
+            jit_set_runtime_error_with_span(VmError::Type("rdjl failed to read file"), span_bits);
+            TAG_NIL
+        }
     }
 }
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_dtfmt(epoch: u64, fmt: u64) -> u64 {
+pub(crate) extern "C" fn jit_dtfmt(epoch: u64, fmt: u64, span_bits: u64) -> u64 {
     let ev = NanVal(epoch);
     let fv = NanVal(fmt);
-    if !ev.is_number() || !fv.is_string() {
+    if !ev.is_number() {
+        jit_set_runtime_error_with_span(
+            VmError::Type("dtfmt requires a number (epoch)"),
+            span_bits,
+        );
+        return TAG_NIL;
+    }
+    if !fv.is_string() {
+        jit_set_runtime_error_with_span(VmError::Type("dtfmt requires a string format"), span_bits);
         return TAG_NIL;
     }
     let e_f = ev.as_number();
@@ -13095,10 +13108,11 @@ pub(crate) extern "C" fn jit_dtfmt(epoch: u64, fmt: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_dtparse(text: u64, fmt: u64) -> u64 {
+pub(crate) extern "C" fn jit_dtparse(text: u64, fmt: u64, span_bits: u64) -> u64 {
     let tv = NanVal(text);
     let fv = NanVal(fmt);
     if !tv.is_string() || !fv.is_string() {
+        jit_set_runtime_error_with_span(VmError::Type("dtparse requires two strings"), span_bits);
         return TAG_NIL;
     }
     let t_str = unsafe {
@@ -13745,9 +13759,10 @@ pub(crate) extern "C" fn jit_frq(v: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_rd(v: u64) -> u64 {
+pub(crate) extern "C" fn jit_rd(v: u64, span_bits: u64) -> u64 {
     let nv = NanVal(v);
     if !nv.is_string() {
+        jit_set_runtime_error_with_span(VmError::Type("rd requires a string path"), span_bits);
         return TAG_NIL;
     }
     let path = unsafe {
@@ -13772,9 +13787,10 @@ pub(crate) extern "C" fn jit_rd(v: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_rdl(v: u64) -> u64 {
+pub(crate) extern "C" fn jit_rdl(v: u64, span_bits: u64) -> u64 {
     let nv = NanVal(v);
     if !nv.is_string() {
+        jit_set_runtime_error_with_span(VmError::Type("rdl requires a string path"), span_bits);
         return TAG_NIL;
     }
     let path = unsafe {
@@ -13797,10 +13813,15 @@ pub(crate) extern "C" fn jit_rdl(v: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_wr(path_v: u64, content_v: u64) -> u64 {
+pub(crate) extern "C" fn jit_wr(path_v: u64, content_v: u64, span_bits: u64) -> u64 {
     let pv = NanVal(path_v);
     let cv = NanVal(content_v);
-    if !pv.is_string() || !cv.is_string() {
+    if !pv.is_string() {
+        jit_set_runtime_error_with_span(VmError::Type("wr arg 1 must be a string path"), span_bits);
+        return TAG_NIL;
+    }
+    if !cv.is_string() {
+        jit_set_runtime_error_with_span(VmError::Type("wr arg 2 must be a string"), span_bits);
         return TAG_NIL;
     }
     let path = unsafe {
@@ -13823,10 +13844,14 @@ pub(crate) extern "C" fn jit_wr(path_v: u64, content_v: u64) -> u64 {
 
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn jit_wrl(path_v: u64, list_v: u64) -> u64 {
+pub(crate) extern "C" fn jit_wrl(path_v: u64, list_v: u64, span_bits: u64) -> u64 {
     let pv = NanVal(path_v);
     let lv = NanVal(list_v);
     if !pv.is_string() {
+        jit_set_runtime_error_with_span(
+            VmError::Type("wrl arg 1 must be a string path"),
+            span_bits,
+        );
         return TAG_NIL;
     }
     let path = unsafe {
@@ -13836,6 +13861,7 @@ pub(crate) extern "C" fn jit_wrl(path_v: u64, list_v: u64) -> u64 {
         }
     };
     if (lv.0 & TAG_MASK) != TAG_LIST {
+        jit_set_runtime_error_with_span(VmError::Type("wrl arg 2 must be a list"), span_bits);
         return TAG_NIL;
     }
     let lines = unsafe {
@@ -13847,6 +13873,10 @@ pub(crate) extern "C" fn jit_wrl(path_v: u64, list_v: u64) -> u64 {
     let mut buf = String::new();
     for line in &lines {
         if !line.is_string() {
+            jit_set_runtime_error_with_span(
+                VmError::Type("wrl list elements must be strings"),
+                span_bits,
+            );
             return TAG_NIL;
         }
         let s = unsafe {
@@ -20234,14 +20264,14 @@ mod tests {
 
         #[test]
         fn jit_jpar_valid_json() {
-            let r = jit_jpar(str_val(r#"{"x":1}"#));
+            let r = jit_jpar(str_val(r#"{"x":1}"#), 0);
             let rv = NanVal(r);
             assert!(rv.is_heap());
         }
 
         #[test]
         fn jit_jpar_invalid_json() {
-            let r = jit_jpar(str_val("not json"));
+            let r = jit_jpar(str_val("not json"), 0);
             let rv = NanVal(r);
             assert!(rv.is_heap());
             let HeapObj::ErrVal(_) = (unsafe { rv.as_heap_ref() }) else {
@@ -20250,9 +20280,142 @@ mod tests {
         }
 
         #[test]
-        fn jit_jpar_non_string_returns_nil() {
-            let r = jit_jpar(TAG_NIL);
+        fn jit_jpar_non_string_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let r = jit_jpar(TAG_NIL, 0);
             assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("jpar")));
+        }
+
+        // ── jit_rdjl (batch 7) ─────────────────────────────────────────────
+
+        #[test]
+        fn jit_rdjl_non_string_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let r = jit_rdjl(TAG_NIL, 0);
+            assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("rdjl")));
+        }
+
+        #[test]
+        fn jit_rdjl_missing_file_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let r = jit_rdjl(str_val("/tmp/ilo-jit-batch7-does-not-exist.jsonl"), 0);
+            assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("rdjl")));
+        }
+
+        // ── jit_dtfmt (batch 7) ────────────────────────────────────────────
+
+        #[test]
+        fn jit_dtfmt_non_number_epoch_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let r = jit_dtfmt(str_val("not a number"), str_val("%Y"), 0);
+            assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(
+                matches!(err.0, VmError::Type(msg) if msg.contains("dtfmt") && msg.contains("epoch"))
+            );
+        }
+
+        #[test]
+        fn jit_dtfmt_non_string_fmt_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let r = jit_dtfmt(num(0.0), TAG_NIL, 0);
+            assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(
+                matches!(err.0, VmError::Type(msg) if msg.contains("dtfmt") && msg.contains("format"))
+            );
+        }
+
+        // ── jit_dtparse (batch 7) ──────────────────────────────────────────
+
+        #[test]
+        fn jit_dtparse_non_string_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let r = jit_dtparse(num(123.0), str_val("%Y"), 0);
+            assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("dtparse")));
+        }
+
+        // ── jit_rd / jit_rdl / jit_wr / jit_wrl (batch 7) ──────────────────
+
+        #[test]
+        fn jit_rd_non_string_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let r = jit_rd(num(42.0), 0);
+            assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("rd")));
+        }
+
+        #[test]
+        fn jit_rdl_non_string_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let r = jit_rdl(num(42.0), 0);
+            assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("rdl")));
+        }
+
+        #[test]
+        fn jit_wr_non_string_path_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let r = jit_wr(num(1.0), str_val("data"), 0);
+            assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(
+                matches!(err.0, VmError::Type(msg) if msg.contains("wr") && msg.contains("path"))
+            );
+        }
+
+        #[test]
+        fn jit_wr_non_string_content_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let r = jit_wr(str_val("/tmp/ilo-batch7"), num(1.0), 0);
+            assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(matches!(err.0, VmError::Type(msg) if msg.contains("wr arg 2")));
+        }
+
+        #[test]
+        fn jit_wrl_non_string_path_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let lst = NanVal::heap_list(vec![NanVal::heap_string("a".into())]);
+            let r = jit_wrl(num(1.0), lst.0, 0);
+            assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(
+                matches!(err.0, VmError::Type(msg) if msg.contains("wrl") && msg.contains("path"))
+            );
+        }
+
+        #[test]
+        fn jit_wrl_non_list_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let r = jit_wrl(str_val("/tmp/ilo-batch7-wrl"), num(1.0), 0);
+            assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(
+                matches!(err.0, VmError::Type(msg) if msg.contains("wrl") && msg.contains("list"))
+            );
+        }
+
+        #[test]
+        fn jit_wrl_non_string_element_signals_runtime_error() {
+            let _ = jit_take_runtime_error();
+            let lst = NanVal::heap_list(vec![NanVal::number(99.0)]);
+            let r = jit_wrl(str_val("/tmp/ilo-batch7-wrl"), lst.0, 0);
+            assert!(is_nil(r));
+            let err = jit_take_runtime_error().expect("expected pending error");
+            assert!(
+                matches!(err.0, VmError::Type(msg) if msg.contains("wrl") && msg.contains("strings"))
+            );
         }
 
         // ── jit_jpth ───────────────────────────────────────────────────────

--- a/tests/regression_jit_nil_sweep_batch7.rs
+++ b/tests/regression_jit_nil_sweep_batch7.rs
@@ -1,0 +1,198 @@
+// Regression tests for the Cranelift JIT-helper permissive-nil sweep, batch 7.
+//
+// Helpers in scope (Group E, I/O type-error paths):
+//   jit_rd, jit_rdl, jit_wr, jit_wrl, jit_jpar, jit_rdjl, jit_dtfmt, jit_dtparse.
+//
+// Before this PR these helpers silently returned TAG_NIL on the type-error
+// path (non-string path, non-number epoch, etc.) where tree/VM raise
+// VmError::Type with a specific message. jit_rdjl additionally hid a real
+// I/O failure behind TAG_NIL where the VM's OP_RDJL handler raises a
+// "rdjl failed to read file" type error.
+//
+// After: each type-error path threads VmError::Type through
+// jit_set_runtime_error_with_span using the same wording the VM dispatcher
+// uses ("rd requires a string path", "dtfmt requires a number (epoch)", etc.).
+//
+// The ilo source-level verifier rejects programs that statically pass a
+// non-string to `rd`/`wr`/`dtfmt`/... (ILO-T013), so the per-helper
+// type-error paths are unit-tested directly in src/vm/mod.rs. These CLI
+// tests pin cross-engine happy-path parity: that wiring the span/error
+// threads did not regress the success cases for actual I/O across tree,
+// VM, and Cranelift JIT.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn check_stdout(engine: &str, src: &str, expected: &str) {
+    let out = ilo()
+        .args([src, engine, "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "engine={engine}: expected success for `{src}`, got stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&out.stdout).trim(),
+        expected,
+        "engine={engine}: stdout mismatch for `{src}`"
+    );
+}
+
+fn check_all(src: &str, expected: &str) {
+    check_stdout("--run-tree", src, expected);
+    check_stdout("--run-vm", src, expected);
+    #[cfg(feature = "cranelift")]
+    check_stdout("--run-cranelift", src, expected);
+}
+
+// ── jit_wr + jit_rd round-trip (text file) ────────────────────────────────
+
+#[test]
+fn wr_then_rd_text_cross_engine() {
+    // Write a unique file per engine variant by including a sentinel in the
+    // path; otherwise the three engines race when tests run in parallel.
+    let path_tree = "/tmp/ilo-jit-batch7-wr-rd-tree.txt";
+    let path_vm = "/tmp/ilo-jit-batch7-wr-rd-vm.txt";
+    let path_cl = "/tmp/ilo-jit-batch7-wr-rd-cl.txt";
+    let _ = std::fs::remove_file(path_tree);
+    let _ = std::fs::remove_file(path_vm);
+    let _ = std::fs::remove_file(path_cl);
+
+    // wr returns R t t (Ok path on success); we strip with postfix !!.
+    check_stdout(
+        "--run-tree",
+        &format!("f>t;w=wr!! \"{path_tree}\" \"hello\";rd!! \"{path_tree}\""),
+        "hello",
+    );
+    check_stdout(
+        "--run-vm",
+        &format!("f>t;w=wr!! \"{path_vm}\" \"hello\";rd!! \"{path_vm}\""),
+        "hello",
+    );
+    #[cfg(feature = "cranelift")]
+    check_stdout(
+        "--run-cranelift",
+        &format!("f>t;w=wr!! \"{path_cl}\" \"hello\";rd!! \"{path_cl}\""),
+        "hello",
+    );
+}
+
+// ── jit_wrl + jit_rdl round-trip (lines file) ─────────────────────────────
+
+#[test]
+fn wrl_then_rdl_cross_engine() {
+    let path_tree = "/tmp/ilo-jit-batch7-wrl-rdl-tree.txt";
+    let path_vm = "/tmp/ilo-jit-batch7-wrl-rdl-vm.txt";
+    let path_cl = "/tmp/ilo-jit-batch7-wrl-rdl-cl.txt";
+    let _ = std::fs::remove_file(path_tree);
+    let _ = std::fs::remove_file(path_vm);
+    let _ = std::fs::remove_file(path_cl);
+
+    check_stdout(
+        "--run-tree",
+        &format!("f>n;w=wrl!! \"{path_tree}\" [\"a\" \"b\" \"c\"];es=rdl!! \"{path_tree}\";len es"),
+        "3",
+    );
+    check_stdout(
+        "--run-vm",
+        &format!("f>n;w=wrl!! \"{path_vm}\" [\"a\" \"b\" \"c\"];es=rdl!! \"{path_vm}\";len es"),
+        "3",
+    );
+    #[cfg(feature = "cranelift")]
+    check_stdout(
+        "--run-cranelift",
+        &format!("f>n;w=wrl!! \"{path_cl}\" [\"a\" \"b\" \"c\"];es=rdl!! \"{path_cl}\";len es"),
+        "3",
+    );
+}
+
+// ── jit_jpar happy path ───────────────────────────────────────────────────
+
+#[test]
+fn jpar_valid_json_cross_engine() {
+    // jpar returns R _ t. Unwrap with !! and pull out a known string field
+    // via jpth on the original text so the test doesn't depend on dynamic-map
+    // shape rendering across engines.
+    check_all("f>t;jpth!! \"{\\\"k\\\":\\\"v\\\"}\" \"k\"", "v");
+}
+
+// ── jit_rdjl happy path ───────────────────────────────────────────────────
+
+#[test]
+fn rdjl_reads_jsonl_cross_engine() {
+    let path_tree = "/tmp/ilo-jit-batch7-rdjl-tree.jsonl";
+    let path_vm = "/tmp/ilo-jit-batch7-rdjl-vm.jsonl";
+    let path_cl = "/tmp/ilo-jit-batch7-rdjl-cl.jsonl";
+    let _ = std::fs::remove_file(path_tree);
+    let _ = std::fs::remove_file(path_vm);
+    let _ = std::fs::remove_file(path_cl);
+
+    let prog_tree = format!(
+        "prep p:t>R t t;wrl p [\"{{\\\"k\\\":1}}\" \"{{\\\"k\\\":2}}\" \"{{\\\"k\\\":3}}\"]\nf>n;w=prep \"{path_tree}\";es=rdjl \"{path_tree}\";len es"
+    );
+    let prog_vm = format!(
+        "prep p:t>R t t;wrl p [\"{{\\\"k\\\":1}}\" \"{{\\\"k\\\":2}}\" \"{{\\\"k\\\":3}}\"]\nf>n;w=prep \"{path_vm}\";es=rdjl \"{path_vm}\";len es"
+    );
+    let prog_cl = format!(
+        "prep p:t>R t t;wrl p [\"{{\\\"k\\\":1}}\" \"{{\\\"k\\\":2}}\" \"{{\\\"k\\\":3}}\"]\nf>n;w=prep \"{path_cl}\";es=rdjl \"{path_cl}\";len es"
+    );
+
+    check_stdout("--run-tree", &prog_tree, "3");
+    check_stdout("--run-vm", &prog_vm, "3");
+    #[cfg(feature = "cranelift")]
+    check_stdout("--run-cranelift", &prog_cl, "3");
+}
+
+// ── jit_dtfmt happy path ──────────────────────────────────────────────────
+
+#[test]
+fn dtfmt_epoch_zero_cross_engine() {
+    check_all("f>t;dtfmt!! 0 \"%Y-%m-%d\"", "1970-01-01");
+}
+
+// ── jit_dtparse happy path ────────────────────────────────────────────────
+
+#[test]
+fn dtparse_round_trip_cross_engine() {
+    check_all("f>n;dtparse!! \"1970-01-01\" \"%Y-%m-%d\"", "0");
+}
+
+// ── No stale-error leak across successive Cranelift calls ─────────────────
+//
+// The JitRuntimeErrorGuard clears the TLS error cell on entry/exit. Confirm
+// that a helper-set error on an /errored/ Cranelift call does not leak into
+// the next fresh invocation. We use the empty-list `hd` carrier (a batch-1
+// helper) and run a happy-path file round-trip afterwards.
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn no_stale_jit_error_leak_after_hd_error_then_io() {
+    let first = ilo()
+        .args(["f>n;hd []", "--run-cranelift", "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(!first.status.success(), "first call should error on hd []");
+
+    let path = "/tmp/ilo-jit-batch7-no-leak.txt";
+    let _ = std::fs::remove_file(path);
+    let src = format!("f>t;w=wr!! \"{path}\" \"ok\";rd!! \"{path}\"");
+    let second = ilo()
+        .args([src.as_str(), "--run-cranelift", "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        second.status.success(),
+        "second call should succeed, got stderr={}",
+        String::from_utf8_lossy(&second.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&second.stdout).trim(),
+        "ok",
+        "second call stdout mismatch"
+    );
+}


### PR DESCRIPTION
## Summary

Group E of the JIT-helper permissive-nil sweep (batches 1-6 in #264, #259, #282, #285). Routes the type-error paths in `jit_rd`, `jit_rdl`, `jit_wr`, `jit_wrl`, `jit_jpar`, `jit_rdjl`, `jit_dtfmt`, `jit_dtparse` through `JIT_RUNTIME_ERROR` so cranelift surfaces a `VmError::Type` diagnostic on the same inputs where tree and VM raise. `jit_rdjl` additionally routes its `fs::read_to_string` failure through the same channel to match `OP_RDJL` in the VM. The Result-typed `heap_err` returns in `jit_rd`/`jit_rdl`/`jit_wr`/`jit_wrl` for actual filesystem failures are preserved unchanged because the VM produces the same `heap_err` there too.

Manifesto-aligned: agents calling `rd path` with a value they expected to be a string (but wasn't, through dynamic dispatch) previously got `nil` on Cranelift and a typed error on tree/VM. They now get the same diagnostic everywhere, with no token cost in the source program.

## Repro

Before, on Cranelift:

```
jit_rd(non-string) -> TAG_NIL
jit_dtfmt(text, fmt) -> TAG_NIL
jit_wrl(path, non-list) -> TAG_NIL
jit_rdjl("missing-file") -> TAG_NIL
```

After:

```
jit_rd(non-string) -> sets VmError::Type("rd requires a string path"), TAG_NIL
jit_dtfmt(text, fmt) -> sets VmError::Type("dtfmt requires a number (epoch)"), TAG_NIL
jit_wrl(path, non-list) -> sets VmError::Type("wrl arg 2 must be a list"), TAG_NIL
jit_rdjl("missing-file") -> sets VmError::Type("rdjl failed to read file"), TAG_NIL
```

`JIT_RUNTIME_ERROR` is then picked up by the entry-point post-call check (PR #254) and surfaced as `VmRuntimeError` with a caret matching tree/VM.

## What's in the diff (per commit)

- `12a92e7` route I/O JIT helpers through JIT_RUNTIME_ERROR. All eight helpers grow a `span_bits: u64` immediate; call sites in `src/vm/jit_cranelift.rs` (in-process JIT) and `src/vm/compile_cranelift.rs` (AOT) pack `chunk.spans[ip]` and pass it through. `declare_helper` arities updated in both modules. The existing `jit_jpar` unit tests are updated for the new signature, and 11 new unit tests cover every type-error path for the eight helpers.
- `ea6295c` add cross-engine regression suite for batch-7 helpers. 7 CLI tests pin happy-path parity for wr/rd, wrl/rdl, jpar, rdjl, dtfmt, dtparse across tree, VM, Cranelift, plus a stale-error-leak guard.
- `181eff5` add example pinning batch-7 helper happy paths through examples_engines. Five functions in `examples/jit-io-roundtrip.ilo` run on every engine via the `tests/examples_engines.rs` harness.

## Test plan

- [x] `cargo build --release --features cranelift` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --release --features cranelift --all-targets` clean
- [x] `cargo test --release --features cranelift` 4992 passing across 123 binaries (zero failures)
- [x] New `regression_jit_nil_sweep_batch7` suite passes on all engines (7/7)
- [x] New `examples/jit-io-roundtrip.ilo` runs clean on tree, VM, Cranelift
- [x] No em dashes in new code; commit messages follow the project's human-voice style

## Follow-ups

Groups F+ (network helpers `jit_get`/`jit_post`/`jit_geth`/`jit_posth`/`jit_getmany`, `jit_env`, the remaining map/record nil-returners) are not in this batch. The Cranelift CLI div-by-zero behaviour for the always-num inline path noted in batch 3 is still tracked separately.