### PR TITLE
vm + cranelift: register aliasing on shadow-rebind from Ref

### DIFF
--- a/examples/shadow-rebind-alias.ilo
+++ b/examples/shadow-rebind-alias.ilo
@@ -1,0 +1,35 @@
+-- `b = a` then `b = <new>` must NOT clobber `a`.
+--
+-- The VM compiler resolves `Expr::Ref(a)` to `a`'s register directly with
+-- no MOVE (free read). Pre-fix, the `Stmt::Let` new-binding path then
+-- aliased `b` to that same register, so a later `b = 99` reassignment
+-- overwrote the shared slot and corrupted `a`. Cranelift inherited the
+-- bug because it lowers VM bytecode. Tree-walker was always correct.
+--
+-- The fix: when the compiled RHS register is already owned by an existing
+-- local, allocate a fresh register and emit OP_MOVE so each user-visible
+-- binding has its own slot. One extra MOVE per shadow-from-ref, no impact
+-- on the common `b = +a 1` / `b = mset a k v` shapes (those already
+-- allocate fresh registers from the arithmetic/builtin ops).
+
+-- Number: the original repro from the Zipf-slope corruption report.
+number-shadow>L n;z=3.14;t=z;t = *t 2;[t z]
+
+-- Map: same shape, different value type. mset returns a fresh map but
+-- `b = a` first must give b its own slot.
+map-shadow>t;a=mset (mmap) "k" 1;b=a;b = mset b "k" 99;fmt "{}|{}" (mget a "k") (mget b "k")
+
+-- List: classic shadow followed by accumulator rebind.
+list-shadow>L L n;a=[1 2];b=a;b = +=b 99;[a b]
+
+-- Text: shadow followed by self-concat.
+text-shadow>t;a="x";b=a;b = +b "y";fmt "{}|{}" a b
+
+-- run: number-shadow
+-- out: [6.28, 3.14]
+-- run: map-shadow
+-- out: 1|99
+-- run: list-shadow
+-- out: [[1, 2], [1, 2, 99]]
+-- run: text-shadow
+-- out: x|xy

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -1171,7 +1171,24 @@ impl RegCompiler {
                     }
                 } else {
                     let reg = self.compile_expr(value);
-                    self.add_local(name, reg);
+                    // Avoid register aliasing on shadow-rebind from a bare Ref.
+                    // `Expr::Ref(src)` returns `src`'s register directly with no
+                    // MOVE (free read). For `b = a` where `b` is a new binding,
+                    // that would make `b` and `a` share a register, so a later
+                    // `b = 99` would clobber `a` too. Detect when the compiled
+                    // RHS register is owned by an existing local and copy into
+                    // a fresh register so each user-visible binding has its own
+                    // slot. Type hints transfer to the new register.
+                    if self.locals.iter().any(|(_, r)| *r == reg) {
+                        let fresh = self.alloc_reg();
+                        self.emit_abc(OP_MOVE, fresh, reg, 0);
+                        self.reg_record_type[fresh as usize] = self.reg_record_type[reg as usize];
+                        self.reg_is_num[fresh as usize] = self.reg_is_num[reg as usize];
+                        self.reg_is_str[fresh as usize] = self.reg_is_str[reg as usize];
+                        self.add_local(name, fresh);
+                    } else {
+                        self.add_local(name, reg);
+                    }
                 }
                 None
             }

--- a/tests/regression_shadow_rebind_alias.rs
+++ b/tests/regression_shadow_rebind_alias.rs
@@ -1,0 +1,243 @@
+// Regression tests for the VM/Cranelift shadow-rebind register aliasing bug.
+//
+// Background:
+//
+// The VM compiler resolves `Expr::Ref(name)` to the source local's register
+// directly with no MOVE (free read). Pre-fix, the `Stmt::Let` new-binding
+// path then called `add_local(new_name, src_reg)`, aliasing the new local
+// to the source register. A later `new_name = <expr>` would resolve back
+// to that shared register and clobber the source. The classic shape:
+//
+//     a = 5
+//     b = a            -- b aliases a's register
+//     b = 99           -- writes to the shared slot, corrupts a
+//     [a b]            -- pre-fix: [99, 99], post-fix: [5, 99]
+//
+// Tree-walker is unaffected (Env::set walks named bindings, no register
+// aliasing). Cranelift inherited the bug because it lowers VM bytecode.
+//
+// This bug pre-dates Phase 2b (#261/#273/#276): bisecting against v0.11.1
+// shows the same shape mis-behaving on VM+Cranelift on both releases. The
+// nlp-engineer Zipf-slope corruption report attributed it to Phase 2b but
+// the root cause is this long-standing alias hole.
+//
+// The fix: when the compiled RHS register is already owned by an existing
+// local, allocate a fresh register and emit OP_MOVE before add_local. One
+// extra MOVE per shadow-from-ref. No effect on `b = +a 1` / `b = mset a k v`
+// because those already allocate fresh registers from arithmetic/builtin ops.
+//
+// All tests cross-engine (tree, VM, Cranelift) so a divergence between
+// backends fails CI.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+// ── Number shadow-rebind: the original Zipf-slope repro shape ──────────────
+//
+// `t=z; t = *t 2` writes a fresh number into the t-slot. Pre-fix, t shared
+// z's register on VM/Cranelift and z came back as 6.28 too.
+
+const NUMBER_SHADOW_REBIND: &str = "go>L n;z=3.14;t=z;t = *t 2;[t z]";
+
+#[test]
+fn number_shadow_rebind_tree() {
+    assert_eq!(
+        run("--run-tree", NUMBER_SHADOW_REBIND, "go"),
+        "[6.28, 3.14]"
+    );
+}
+
+#[test]
+fn number_shadow_rebind_vm() {
+    assert_eq!(run("--run-vm", NUMBER_SHADOW_REBIND, "go"), "[6.28, 3.14]");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn number_shadow_rebind_cranelift() {
+    assert_eq!(
+        run("--run-cranelift", NUMBER_SHADOW_REBIND, "go"),
+        "[6.28, 3.14]"
+    );
+}
+
+// ── Number shadow-then-literal-overwrite: the minimal repro ────────────────
+//
+// `a=5; b=a; b=99` is the smallest pattern that surfaces the bug. No
+// arithmetic, no Phase 2b types, no peepholes. Just bare-Ref shadow and a
+// literal rebind.
+
+const NUMBER_SHADOW_LITERAL_OVERWRITE: &str = "go>L n;a=5;b=a;b=99;[a b]";
+
+#[test]
+fn number_shadow_literal_overwrite_tree() {
+    assert_eq!(
+        run("--run-tree", NUMBER_SHADOW_LITERAL_OVERWRITE, "go"),
+        "[5, 99]"
+    );
+}
+
+#[test]
+fn number_shadow_literal_overwrite_vm() {
+    assert_eq!(
+        run("--run-vm", NUMBER_SHADOW_LITERAL_OVERWRITE, "go"),
+        "[5, 99]"
+    );
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn number_shadow_literal_overwrite_cranelift() {
+    assert_eq!(
+        run("--run-cranelift", NUMBER_SHADOW_LITERAL_OVERWRITE, "go"),
+        "[5, 99]"
+    );
+}
+
+// ── Map shadow-rebind ──────────────────────────────────────────────────────
+//
+// Shadow then re-key. The mset peephole only fires for `name = mset name k v`,
+// so this is the alias-hazard path (`b = mset b k v` after `b = a`).
+
+const MAP_SHADOW_REBIND: &str = concat!(
+    "go>t;",
+    "a=mset (mmap) \"k\" 1;",
+    "b=a;",
+    "b = mset b \"k\" 99;",
+    "fmt \"{}|{}\" (mget a \"k\") (mget b \"k\")"
+);
+
+#[test]
+fn map_shadow_rebind_tree() {
+    assert_eq!(run("--run-tree", MAP_SHADOW_REBIND, "go"), "1|99");
+}
+
+#[test]
+fn map_shadow_rebind_vm() {
+    assert_eq!(run("--run-vm", MAP_SHADOW_REBIND, "go"), "1|99");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn map_shadow_rebind_cranelift() {
+    assert_eq!(run("--run-cranelift", MAP_SHADOW_REBIND, "go"), "1|99");
+}
+
+// ── List shadow-rebind ─────────────────────────────────────────────────────
+
+const LIST_SHADOW_REBIND: &str = "go>L L n;a=[1 2];b=a;b = +=b 99;[a b]";
+
+#[test]
+fn list_shadow_rebind_tree() {
+    assert_eq!(
+        run("--run-tree", LIST_SHADOW_REBIND, "go"),
+        "[[1, 2], [1, 2, 99]]"
+    );
+}
+
+#[test]
+fn list_shadow_rebind_vm() {
+    assert_eq!(
+        run("--run-vm", LIST_SHADOW_REBIND, "go"),
+        "[[1, 2], [1, 2, 99]]"
+    );
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn list_shadow_rebind_cranelift() {
+    assert_eq!(
+        run("--run-cranelift", LIST_SHADOW_REBIND, "go"),
+        "[[1, 2], [1, 2, 99]]"
+    );
+}
+
+// ── Text shadow-rebind ─────────────────────────────────────────────────────
+
+const TEXT_SHADOW_REBIND: &str = "go>t;a=\"x\";b=a;b = +b \"y\";fmt \"{}|{}\" a b";
+
+#[test]
+fn text_shadow_rebind_tree() {
+    assert_eq!(run("--run-tree", TEXT_SHADOW_REBIND, "go"), "x|xy");
+}
+
+#[test]
+fn text_shadow_rebind_vm() {
+    assert_eq!(run("--run-vm", TEXT_SHADOW_REBIND, "go"), "x|xy");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn text_shadow_rebind_cranelift() {
+    assert_eq!(run("--run-cranelift", TEXT_SHADOW_REBIND, "go"), "x|xy");
+}
+
+// ── Transitive shadow: a → b → c, then write c ─────────────────────────────
+//
+// Pre-fix, all three would alias the same register and the c write would
+// corrupt both a and b. Confirms the fix handles chained shadows, not just
+// the two-level case.
+
+const TRANSITIVE_SHADOW: &str = "go>L n;a=7;b=a;c=b;c=99;[a b c]";
+
+#[test]
+fn transitive_shadow_tree() {
+    assert_eq!(run("--run-tree", TRANSITIVE_SHADOW, "go"), "[7, 7, 99]");
+}
+
+#[test]
+fn transitive_shadow_vm() {
+    assert_eq!(run("--run-vm", TRANSITIVE_SHADOW, "go"), "[7, 7, 99]");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn transitive_shadow_cranelift() {
+    assert_eq!(
+        run("--run-cranelift", TRANSITIVE_SHADOW, "go"),
+        "[7, 7, 99]"
+    );
+}
+
+// ── Non-aliasing happy path stays cheap ────────────────────────────────────
+//
+// `b = +a 1` allocates a fresh register from the BinOp::Add path and never
+// aliases. The fix's `locals.iter().any(...)` check must not trip here.
+// Pin the result to lock in that we still get correct values.
+
+const NON_ALIASING_HAPPY_PATH: &str = "go>L n;a=5;b=+a 1;b=99;[a b]";
+
+#[test]
+fn non_aliasing_happy_path_tree() {
+    assert_eq!(run("--run-tree", NON_ALIASING_HAPPY_PATH, "go"), "[5, 99]");
+}
+
+#[test]
+fn non_aliasing_happy_path_vm() {
+    assert_eq!(run("--run-vm", NON_ALIASING_HAPPY_PATH, "go"), "[5, 99]");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn non_aliasing_happy_path_cranelift() {
+    assert_eq!(
+        run("--run-cranelift", NON_ALIASING_HAPPY_PATH, "go"),
+        "[5, 99]"
+    );
+}


### PR DESCRIPTION
## Summary

The VM bytecode compiler's `Stmt::Let` new-binding path was aliasing the new local to the source local's register whenever the RHS was a bare `Ref`. The classic shape:

```
a = 5
b = a            -- pre-fix: b aliased a's register
b = 99           -- writes to the shared slot, corrupts a
[a b]            -- pre-fix: [99, 99], post-fix: [5, 99]
```

`Expr::Ref(name)` resolves to the source's register directly with no MOVE (free read). `add_local(new_name, src_reg)` then made the new local share that register, so a later rebind clobbered the source. The tree-walker was always correct (named bindings, no register aliasing). Cranelift inherited the bug because it lowers VM bytecode, so fixing the VM compiler fixes both backends.

Originally surfaced as a 'Phase 2b silent miscompile' report citing #261 / #273 / #276 and a numeric Zipf-slope corruption on a Moby Dick sample. A v0.11.1 bisect (one tag before Phase 2b landed) shows VM and Cranelift have the same alias hole on both releases. So this is a long-standing bug in the compiler, not a Phase 2b regression. The reframed PR title and branch (`fix/vm-shadow-rebind-alias`) reflect what's actually being fixed.

This is the kind of bug that should never ship: silent miscompile on a trivial numeric rebind pattern, no error, no warning, wrong answer. One extra MOVE per shadow-from-ref is cheap insurance against the token-cost of debug retries and lost trust in agents.

## Repro

Before:

\`\`\`
$ ilo --run-vm 'go>L n;a=5;b=a;b=99;[a b]' go
[99, 99]
$ ilo --run-vm 'go>L n;z=3.14;t=z;t = *t 2;[t z]' go
[6.28, 6.28]
\`\`\`

After:

\`\`\`
$ ilo --run-vm 'go>L n;a=5;b=a;b=99;[a b]' go
[5, 99]
$ ilo --run-vm 'go>L n;z=3.14;t=z;t = *t 2;[t z]' go
[6.28, 3.14]
\`\`\`

Same outputs on `--run-tree` (unchanged) and `--run-cranelift` (now matches).

## What's in the diff

- `vm: avoid register aliasing on shadow-rebind from Ref` (src/vm/mod.rs): when the compiled RHS register is already owned by an existing local, allocate a fresh register and emit `OP_MOVE` before `add_local`. Type hints (`reg_record_type`, `reg_is_num`, `reg_is_str`) transfer to the new register so downstream peepholes still fire. No effect on `b = +a 1` / `b = mset a k v` because those already allocate fresh registers from the arithmetic / builtin ops.
- `test: cross-engine regression coverage for shadow-rebind alias` (tests/regression_shadow_rebind_alias.rs): 21 tests across tree, VM, Cranelift covering Number / Map / List / Text shadow-then-rebind, transitive chains (a to b to c), and the non-aliasing happy path so the new guard doesn't trip when the RHS already allocated a fresh register.
- `example: shadow-rebind-alias pins the four typed shapes` (examples/shadow-rebind-alias.ilo): four shapes with `-- run` / `-- out` assertions so the examples_engines harness exercises them on every engine. Doubles as an in-context learning example for agents who hit the `b = a; b = <new>` pattern.

## Test plan

- [x] Tree, VM, Cranelift all agree on the minimal repros (`a=5;b=a;b=99` and `z=3.14;t=z;t = *t 2`).
- [x] Tree, VM, Cranelift all agree on a Zipf-slope-shape regression (the original report's pattern).
- [x] `cargo test --release --features cranelift`: 125 test binaries pass, 0 failures.
- [x] `cargo fmt --check`: clean.
- [x] `cargo clippy --release --features cranelift --all-targets -- -D warnings`: clean.
- [x] examples_engines harness runs the new `shadow-rebind-alias.ilo` across tree, VM, Cranelift.

## Follow-ups

- SPEC.md / SKILL.md note on mutation vs rebind. Several persona reports filed alongside this one claimed bare `+=xs v` and bare `mset m k v` should mutate the named binding. They don't, and shouldn't: that's the assignment form's job (`xs = +=xs v` / `m = mset m k v`). Worth a one-line clarification in the spec so future personas don't re-litigate the same misread.