### PR TITLE
skill: annotate dtparse and dtfmt as Result-wrapped in Time section

### DIFF
--- a/skills/ilo/SKILL.md
+++ b/skills/ilo/SKILL.md
@@ -172,7 +172,7 @@ mkeys m                -- sorted key list
 **JSON**: `jpth` `jdmp` `jpar`
 **Map**: `mmap` `mget` `mset` `mhas` `mkeys` `mvals` `mdel`
 **HOF**: `map` `flt` `fld`
-**Time**: `now` `sleep` `dtfmt` `dtparse`
+**Time**: `now` `sleep` `dtfmt` `dtparse` (note: `dtparse s fmt > R n t`, `dtfmt ts fmt > R t t`, both Result-wrapped)
 
 ## Naming Convention
 


### PR DESCRIPTION
## Summary

A devops-sre persona rerun reported \`dtparse\` returning \`R n t\` as a regression against v0.11.1 docs. I investigated and the claim is wrong: \`dtparse\` has returned \`R n t\` since the first commit (\`f7ebaa7\`, #198), and v0.11.1's only \`dtparse\` documentation (\`examples/datetime.ilo\`) already stated \`R n t\`. SPEC.md and README.md have been consistent throughout.

The persona's inference gap came from \`skills/ilo/SKILL.md\`, which listed Time builtins by bare name only. With no signature shown, an agent that loaded the skill but not SPEC.md (or that misremembered) had nothing to anchor against. This patch closes that gap with a one-line annotation.

This is a manifesto win: agents that load only the skill now know the signature in-context, so one fewer SPEC round-trip per dtparse use, and no more false-positive regression reports.

## What's in the diff

- \`skills/ilo/SKILL.md\`: append \`(note: dtparse s fmt > R n t, dtfmt ts fmt > R t t, both Result-wrapped)\` to the Time builtins line.

## Repro

Before (in v0.11.1, v0.11.2, current main, all identical):
\`\`\`
dtparse "2024-01-15" "%Y-%m-%d"   -- Ok(1705276800)
\`\`\`
After this PR: same behaviour. Doc-only clarification.

## Test plan

- [x] \`cargo test --release --features cranelift --test skill_md\` passes (9 tests).
- [x] Full suite green locally except for 7 AOT tests that fail due to \`CARGO_TARGET_DIR\` override (libilo.a path resolution); unrelated to this change.
- [ ] CI green.

## Follow-ups

None. The annotation pattern can be extended to other terse builtin lines if future personas mis-infer their signatures, but I'd rather wait for evidence than pre-emptively bloat the skill.