### PR TITLE
fix: sum and avg now work on VM and Cranelift, not just tree

### DIFF
--- a/examples/sum-avg.ilo
+++ b/examples/sum-avg.ilo
@@ -1,0 +1,27 @@
+-- `sum` and `avg` over a list of numbers. Both are 1-arg reducers and
+-- work identically on the tree-walking interpreter, the bytecode VM, and
+-- the Cranelift JIT.
+--
+-- sum xs:L n > n  -- total of xs; empty list returns 0
+-- avg xs:L n > n  -- arithmetic mean; empty list errors
+
+-- Total of a small list of integers.
+total>n;sum [1, 2, 3, 4]
+
+-- Empty list sums to zero (matches the tree-walker; no special-case needed).
+empty-total>n;sum []
+
+-- Arithmetic mean of a list of integers; result is a float when not exact.
+mean>n;avg [1, 2, 3, 4]
+
+-- Mean of a singleton list is the element itself.
+mean-one>n;avg [42]
+
+-- run: total
+-- out: 10
+-- run: empty-total
+-- out: 0
+-- run: mean
+-- out: 2.5
+-- run: mean-one
+-- out: 42

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -100,6 +100,8 @@ struct HelperFuncs {
     quantile: FuncId,
     stdev: FuncId,
     variance: FuncId,
+    sum: FuncId,
+    avg: FuncId,
     slc: FuncId,
     rgxsub: FuncId,
     take: FuncId,
@@ -286,6 +288,8 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         quantile: declare_helper(module, "jit_quantile", 3, 1),
         stdev: declare_helper(module, "jit_stdev", 2, 1),
         variance: declare_helper(module, "jit_variance", 2, 1),
+        sum: declare_helper(module, "jit_sum", 2, 1),
+        avg: declare_helper(module, "jit_avg", 2, 1),
         slc: declare_helper(module, "jit_slc", 3, 1),
         rgxsub: declare_helper(module, "jit_rgxsub", 3, 1),
         take: declare_helper(module, "jit_take", 2, 1),
@@ -1011,8 +1015,8 @@ fn compile_function_body(
                 | OP_MULK_N | OP_DIVK_N | OP_LEN | OP_ABS | OP_MIN | OP_MAX | OP_FLR | OP_CEL
                 | OP_ROU | OP_RND0 | OP_RND2 | OP_RNDN | OP_NOW | OP_MOD | OP_CLAMP | OP_POW
                 | OP_SQRT | OP_LOG | OP_EXP | OP_SIN | OP_COS | OP_TAN | OP_LOG10 | OP_LOG2
-                | OP_ATAN2 | OP_MEDIAN | OP_QUANTILE | OP_STDEV | OP_VARIANCE | OP_DOT | OP_DET
-                | OP_ORD => {
+                | OP_ATAN2 | OP_MEDIAN | OP_QUANTILE | OP_STDEV | OP_VARIANCE | OP_SUM | OP_AVG
+                | OP_DOT | OP_DET | OP_ORD => {
                     num_write[a] = true;
                 }
                 // LOADK: numeric only when the constant itself is a number.
@@ -2432,6 +2436,24 @@ fn compile_function_body(
                 let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
                 let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.variance);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_SUM => {
+                let bv = builder.use_var(vars[b_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
+                let fref = get_func_ref(&mut builder, module, helpers.sum);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_AVG => {
+                let bv = builder.use_var(vars[b_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
+                let fref = get_func_ref(&mut builder, module, helpers.avg);
                 let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -5825,30 +5825,20 @@ f a:t b:t>t;join a b"#,
         // Exercise the OP_SUM AOT codegen block (helper-call, F64-shadow
         // refresh). Doesn't need libilo.a; just verifies IR generation.
         let bytes = compile_to_object_bytes("f>n;sum [1, 2, 3, 4]");
-        assert!(
-            bytes.is_ok(),
-            "OP_SUM codegen failed: {:?}",
-            bytes.err()
-        );
+        assert!(bytes.is_ok(), "OP_SUM codegen failed: {:?}", bytes.err());
     }
 
     #[test]
     fn codegen_cov_op_avg() {
         let bytes = compile_to_object_bytes("f>n;avg [1, 2, 3, 4]");
-        assert!(
-            bytes.is_ok(),
-            "OP_AVG codegen failed: {:?}",
-            bytes.err()
-        );
+        assert!(bytes.is_ok(), "OP_AVG codegen failed: {:?}", bytes.err());
     }
 
     #[test]
     fn codegen_cov_op_sum_avg_arithmetic() {
         // Sum/avg results feeding into an OP_SUB_NN — exercises the F64
         // shadow refresh path in the AOT compiler.
-        let bytes = compile_to_object_bytes(
-            "f>n;a=avg [10, 20, 30];s=sum [1, 2, 3];-a s",
-        );
+        let bytes = compile_to_object_bytes("f>n;a=avg [10, 20, 30];s=sum [1, 2, 3];-a s");
         assert!(
             bytes.is_ok(),
             "OP_SUM/OP_AVG + OP_SUB_NN codegen failed: {:?}",

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -5818,6 +5818,44 @@ f a:t b:t>t;join a b"#,
         );
     }
 
+    // ── OP_SUM / OP_AVG codegen ──────────────────────────────────────────────
+
+    #[test]
+    fn codegen_cov_op_sum() {
+        // Exercise the OP_SUM AOT codegen block (helper-call, F64-shadow
+        // refresh). Doesn't need libilo.a; just verifies IR generation.
+        let bytes = compile_to_object_bytes("f>n;sum [1, 2, 3, 4]");
+        assert!(
+            bytes.is_ok(),
+            "OP_SUM codegen failed: {:?}",
+            bytes.err()
+        );
+    }
+
+    #[test]
+    fn codegen_cov_op_avg() {
+        let bytes = compile_to_object_bytes("f>n;avg [1, 2, 3, 4]");
+        assert!(
+            bytes.is_ok(),
+            "OP_AVG codegen failed: {:?}",
+            bytes.err()
+        );
+    }
+
+    #[test]
+    fn codegen_cov_op_sum_avg_arithmetic() {
+        // Sum/avg results feeding into an OP_SUB_NN — exercises the F64
+        // shadow refresh path in the AOT compiler.
+        let bytes = compile_to_object_bytes(
+            "f>n;a=avg [10, 20, 30];s=sum [1, 2, 3];-a s",
+        );
+        assert!(
+            bytes.is_ok(),
+            "OP_SUM/OP_AVG + OP_SUB_NN codegen failed: {:?}",
+            bytes.err()
+        );
+    }
+
     // ── OP_LOADK with heap value (list constant) ─────────────────────────────
 
     #[test]

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -107,6 +107,8 @@ struct HelperFuncs {
     quantile: FuncId,
     stdev: FuncId,
     variance: FuncId,
+    sum: FuncId,
+    avg: FuncId,
     slc: FuncId,
     lst: FuncId,
     rgxsub: FuncId,
@@ -291,6 +293,8 @@ fn register_helpers(builder: &mut JITBuilder) {
         ("jit_quantile", jit_quantile as *const u8),
         ("jit_stdev", jit_stdev as *const u8),
         ("jit_variance", jit_variance as *const u8),
+        ("jit_sum", jit_sum as *const u8),
+        ("jit_avg", jit_avg as *const u8),
         ("jit_slc", jit_slc as *const u8),
         ("jit_lst", jit_lst as *const u8),
         ("jit_rgxsub", jit_rgxsub as *const u8),
@@ -460,6 +464,8 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         quantile: declare_helper(module, "jit_quantile", 3, 1),
         stdev: declare_helper(module, "jit_stdev", 2, 1),
         variance: declare_helper(module, "jit_variance", 2, 1),
+        sum: declare_helper(module, "jit_sum", 2, 1),
+        avg: declare_helper(module, "jit_avg", 2, 1),
         slc: declare_helper(module, "jit_slc", 3, 1),
         lst: declare_helper(module, "jit_lst", 3, 1),
         rgxsub: declare_helper(module, "jit_rgxsub", 3, 1),
@@ -1062,8 +1068,8 @@ fn compile_function_body(
                 | OP_FLR | OP_CEL | OP_ROU | OP_RND0 | OP_RND2 | OP_RNDN | OP_NOW
                 | OP_MOD | OP_CLAMP | OP_POW | OP_SQRT | OP_LOG | OP_EXP | OP_SIN | OP_COS
                 | OP_TAN | OP_LOG10 | OP_LOG2 | OP_ATAN2
-                | OP_MEDIAN | OP_QUANTILE | OP_STDEV | OP_VARIANCE | OP_DOT | OP_DET
-                | OP_ORD => {
+                | OP_MEDIAN | OP_QUANTILE | OP_STDEV | OP_VARIANCE | OP_SUM | OP_AVG | OP_DOT
+                | OP_DET | OP_ORD => {
                     num_write[a] = true;
                 }
                 // LOADK: numeric only when the constant itself is a number.
@@ -2523,6 +2529,15 @@ fn compile_function_body(
                 let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
+                // Stats helpers return a NaN-boxed number; the F64 shadow must be
+                // refreshed so a subsequent OP_*_NN fast-path reads the real
+                // result, not whatever stale value the shadow holds. Without
+                // this, e.g. `-(median xs) (median ys)` reads zero.
+                if a_idx < reg_count && reg_always_num[a_idx] {
+                    let mf = cranelift_codegen::ir::MemFlags::new();
+                    let rf = builder.ins().bitcast(F64, mf, result);
+                    builder.def_var(f64_vars[a_idx], rf);
+                }
             }
             OP_QUANTILE => {
                 let bv = builder.use_var(vars[b_idx]);
@@ -2533,6 +2548,11 @@ fn compile_function_body(
                 let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
+                if a_idx < reg_count && reg_always_num[a_idx] {
+                    let mf = cranelift_codegen::ir::MemFlags::new();
+                    let rf = builder.ins().bitcast(F64, mf, result);
+                    builder.def_var(f64_vars[a_idx], rf);
+                }
             }
             OP_STDEV => {
                 let bv = builder.use_var(vars[b_idx]);
@@ -2542,6 +2562,11 @@ fn compile_function_body(
                 let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
+                if a_idx < reg_count && reg_always_num[a_idx] {
+                    let mf = cranelift_codegen::ir::MemFlags::new();
+                    let rf = builder.ins().bitcast(F64, mf, result);
+                    builder.def_var(f64_vars[a_idx], rf);
+                }
             }
             OP_VARIANCE => {
                 let bv = builder.use_var(vars[b_idx]);
@@ -2551,6 +2576,39 @@ fn compile_function_body(
                 let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
+                if a_idx < reg_count && reg_always_num[a_idx] {
+                    let mf = cranelift_codegen::ir::MemFlags::new();
+                    let rf = builder.ins().bitcast(F64, mf, result);
+                    builder.def_var(f64_vars[a_idx], rf);
+                }
+            }
+            OP_SUM => {
+                let bv = builder.use_var(vars[b_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
+                let fref = get_func_ref(&mut builder, module, helpers.sum);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+                if a_idx < reg_count && reg_always_num[a_idx] {
+                    let mf = cranelift_codegen::ir::MemFlags::new();
+                    let rf = builder.ins().bitcast(F64, mf, result);
+                    builder.def_var(f64_vars[a_idx], rf);
+                }
+            }
+            OP_AVG => {
+                let bv = builder.use_var(vars[b_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
+                let fref = get_func_ref(&mut builder, module, helpers.avg);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+                if a_idx < reg_count && reg_always_num[a_idx] {
+                    let mf = cranelift_codegen::ir::MemFlags::new();
+                    let rf = builder.ins().bitcast(F64, mf, result);
+                    builder.def_var(f64_vars[a_idx], rf);
+                }
             }
             OP_SLC => {
                 // slc(R[B], R[C], R[D]) — D in data word A field

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -254,6 +254,8 @@ pub(crate) const OP_MEDIAN: u8 = 141; // R[A] = median(R[B])
 pub(crate) const OP_QUANTILE: u8 = 142; // R[A] = quantile(R[B], R[C])
 pub(crate) const OP_STDEV: u8 = 143; // R[A] = stdev(R[B])
 pub(crate) const OP_VARIANCE: u8 = 144; // R[A] = variance(R[B])
+pub(crate) const OP_SUM: u8 = 165; // R[A] = sum(R[B])  — empty list = 0
+pub(crate) const OP_AVG: u8 = 166; // R[A] = avg(R[B])  — empty list errors
 // Higher-order: uniqby fn xs — pre-allocated, HOF dispatch not yet wired in VM.
 pub(crate) const OP_UNIQBY: u8 = 116; // R[A] = uniqby(R[B] (fn-ref), R[C] (list))
 // Higher-order: partition fn xs — pre-allocated, HOF dispatch not yet wired in VM.
@@ -2277,6 +2279,20 @@ impl RegCompiler {
                             let rb = self.compile_expr(&args[0]);
                             let ra = self.alloc_reg();
                             self.emit_abc(OP_VARIANCE, ra, rb, 0);
+                            self.reg_is_num[ra as usize] = true;
+                            return ra;
+                        }
+                        (Builtin::Sum, 1) => {
+                            let rb = self.compile_expr(&args[0]);
+                            let ra = self.alloc_reg();
+                            self.emit_abc(OP_SUM, ra, rb, 0);
+                            self.reg_is_num[ra as usize] = true;
+                            return ra;
+                        }
+                        (Builtin::Avg, 1) => {
+                            let rb = self.compile_expr(&args[0]);
+                            let ra = self.alloc_reg();
+                            self.emit_abc(OP_AVG, ra, rb, 0);
                             self.reg_is_num[ra as usize] = true;
                             return ra;
                         }
@@ -8748,6 +8764,24 @@ impl<'a> VM<'a> {
                         Err(msg) => vm_err!(VmError::Type(msg)),
                     }
                 }
+                OP_SUM => {
+                    let a = ((inst >> 16) & 0xFF) as usize + base;
+                    let b = ((inst >> 8) & 0xFF) as usize + base;
+                    let v = reg!(b);
+                    match vm_sum(v) {
+                        Ok(out) => reg_set!(a, out),
+                        Err(msg) => vm_err!(VmError::Type(msg)),
+                    }
+                }
+                OP_AVG => {
+                    let a = ((inst >> 16) & 0xFF) as usize + base;
+                    let b = ((inst >> 8) & 0xFF) as usize + base;
+                    let v = reg!(b);
+                    match vm_avg(v) {
+                        Ok(out) => reg_set!(a, out),
+                        Err(msg) => vm_err!(VmError::Type(msg)),
+                    }
+                }
                 OP_SLC => {
                     // Two-instruction sequence: OP_SLC A=result B=list C=start; data word A=end_reg
                     // Bounds accept negative integers Python-style (`-1` = last element).
@@ -11803,6 +11837,50 @@ fn vm_variance(v: NanVal) -> Result<NanVal, &'static str> {
     Ok(NanVal::number(sse / (n - 1) as f64))
 }
 
+/// `sum xs` — total of a list of numbers. Empty list returns 0 (matches
+/// tree-walker semantics in `src/interpreter/mod.rs`). NaN-propagation:
+/// any NaN element yields NaN.
+fn vm_sum(v: NanVal) -> Result<NanVal, &'static str> {
+    if !v.is_heap() {
+        return Err("sum requires a list of numbers");
+    }
+    let items = match unsafe { v.as_heap_ref() } {
+        HeapObj::List(items) => items,
+        _ => return Err("sum requires a list of numbers"),
+    };
+    let mut total = 0.0_f64;
+    for item in items {
+        if !item.is_number() {
+            return Err("sum: list elements must be numbers");
+        }
+        total += item.as_number();
+    }
+    Ok(NanVal::number(total))
+}
+
+/// `avg xs` — arithmetic mean of a list of numbers. Empty list is an error
+/// (matches tree-walker semantics in `src/interpreter/mod.rs`).
+fn vm_avg(v: NanVal) -> Result<NanVal, &'static str> {
+    if !v.is_heap() {
+        return Err("avg requires a list of numbers");
+    }
+    let items = match unsafe { v.as_heap_ref() } {
+        HeapObj::List(items) => items,
+        _ => return Err("avg requires a list of numbers"),
+    };
+    if items.is_empty() {
+        return Err("avg: cannot average an empty list");
+    }
+    let mut total = 0.0_f64;
+    for item in items {
+        if !item.is_number() {
+            return Err("avg: list elements must be numbers");
+        }
+        total += item.as_number();
+    }
+    Ok(NanVal::number(total / items.len() as f64))
+}
+
 fn vm_stdev(v: NanVal) -> Result<NanVal, &'static str> {
     let nums = vm_collect_numbers(v, "stdev")?;
     let n = nums.len();
@@ -11821,6 +11899,30 @@ fn vm_stdev(v: NanVal) -> Result<NanVal, &'static str> {
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn jit_median(a: u64, span_bits: u64) -> u64 {
     match vm_median(NanVal(a)) {
+        Ok(v) => v.0,
+        Err(e) => {
+            jit_set_runtime_error_with_span(VmError::Type(e), span_bits);
+            TAG_NIL
+        }
+    }
+}
+
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_sum(a: u64, span_bits: u64) -> u64 {
+    match vm_sum(NanVal(a)) {
+        Ok(v) => v.0,
+        Err(e) => {
+            jit_set_runtime_error_with_span(VmError::Type(e), span_bits);
+            TAG_NIL
+        }
+    }
+}
+
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_avg(a: u64, span_bits: u64) -> u64 {
+    match vm_avg(NanVal(a)) {
         Ok(v) => v.0,
         Err(e) => {
             jit_set_runtime_error_with_span(VmError::Type(e), span_bits);
@@ -24542,7 +24644,6 @@ mod tests {
     // ── sum, avg ────────────────────────────────────────────────────────
 
     #[test]
-    #[ignore] // VM missing builtin implementation
     fn vm_sum_basic() {
         let source = "f xs:L n>n;sum xs";
         let result = vm_run(
@@ -24559,7 +24660,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // VM missing builtin implementation
     fn vm_sum_empty() {
         let source = "f xs:L n>n;sum xs";
         assert_eq!(
@@ -24581,7 +24681,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // VM missing builtin implementation
     fn vm_avg_basic() {
         let source = "f xs:L n>n;avg xs";
         let result = vm_run(

--- a/tests/regression_sum_avg_cross_engine.rs
+++ b/tests/regression_sum_avg_cross_engine.rs
@@ -1,0 +1,226 @@
+// Cross-engine regression tests for `sum` and `avg`.
+//
+// Before this fix, the VM compiler had no dispatch arm for `Builtin::Sum`
+// or `Builtin::Avg`, so any call fell through to the named-function lookup
+// and failed with "Compile error: undefined function: sum" (and likewise
+// for `avg`) on both `--run-vm` and `--run-cranelift`. The tree-walking
+// interpreter handled both builtins directly and worked correctly.
+//
+// These tests pin the behaviour across all three engines: happy paths,
+// the `avg []` error case, the `sum []` zero case, and type/argument
+// errors (non-list, non-numeric elements).
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_ok(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} {src:?} unexpectedly failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn run_err(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "ilo {engine} {src:?} unexpectedly succeeded: stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    // ilo emits structured JSON diagnostics on stderr; we just check for
+    // substrings so the test is robust to formatting changes.
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+#[cfg(feature = "cranelift")]
+const ENGINES_ALL: &[&str] = &["--run-tree", "--run-vm", "--run-cranelift"];
+#[cfg(not(feature = "cranelift"))]
+const ENGINES_ALL: &[&str] = &["--run-tree", "--run-vm"];
+
+// ── sum ──────────────────────────────────────────────────────────────
+
+#[test]
+fn sum_happy_path_cross_engine() {
+    let src = "f>n;sum [1, 2, 3, 4]";
+    for engine in ENGINES_ALL {
+        assert_eq!(run_ok(engine, src, "f"), "10", "{engine}: sum [1..4] = 10");
+    }
+}
+
+#[test]
+fn sum_floats_cross_engine() {
+    let src = "f>n;sum [1.5, 2.5, 3.0]";
+    for engine in ENGINES_ALL {
+        assert_eq!(run_ok(engine, src, "f"), "7", "{engine}: sum floats");
+    }
+}
+
+#[test]
+fn sum_singleton_cross_engine() {
+    let src = "f>n;sum [42]";
+    for engine in ENGINES_ALL {
+        assert_eq!(run_ok(engine, src, "f"), "42", "{engine}: sum [42]");
+    }
+}
+
+#[test]
+fn sum_empty_returns_zero_cross_engine() {
+    // Tree-walker semantics: `sum []` is 0, not an error. VM and Cranelift
+    // must match.
+    let src = "f>n;sum []";
+    for engine in ENGINES_ALL {
+        assert_eq!(run_ok(engine, src, "f"), "0", "{engine}: sum [] = 0");
+    }
+}
+
+#[test]
+fn sum_negative_numbers_cross_engine() {
+    let src = "f>n;sum [-1, -2, -3]";
+    for engine in ENGINES_ALL {
+        assert_eq!(run_ok(engine, src, "f"), "-6", "{engine}: sum negatives");
+    }
+}
+
+#[test]
+fn sum_non_list_errors_cross_engine() {
+    let src = "f>n;sum 42";
+    for engine in ENGINES_ALL {
+        let err = run_err(engine, src, "f");
+        assert!(
+            err.contains("sum") || err.contains("list"),
+            "{engine}: expected sum/list in error, got: {err}"
+        );
+    }
+}
+
+#[test]
+fn sum_non_numeric_element_errors_cross_engine() {
+    let src = r#"f>n;sum ["a", "b"]"#;
+    for engine in ENGINES_ALL {
+        let err = run_err(engine, src, "f");
+        assert!(
+            err.contains("sum") || err.contains("number"),
+            "{engine}: expected sum/number in error, got: {err}"
+        );
+    }
+}
+
+// ── avg ──────────────────────────────────────────────────────────────
+
+#[test]
+fn avg_happy_path_cross_engine() {
+    let src = "f>n;avg [1, 2, 3, 4]";
+    for engine in ENGINES_ALL {
+        assert_eq!(run_ok(engine, src, "f"), "2.5", "{engine}: avg [1..4]");
+    }
+}
+
+#[test]
+fn avg_integer_result_cross_engine() {
+    let src = "f>n;avg [2, 4, 6]";
+    for engine in ENGINES_ALL {
+        assert_eq!(run_ok(engine, src, "f"), "4", "{engine}: avg [2,4,6] = 4");
+    }
+}
+
+#[test]
+fn avg_singleton_cross_engine() {
+    let src = "f>n;avg [42]";
+    for engine in ENGINES_ALL {
+        assert_eq!(run_ok(engine, src, "f"), "42", "{engine}: avg [42]");
+    }
+}
+
+#[test]
+fn avg_negative_numbers_cross_engine() {
+    let src = "f>n;avg [-2, -4, -6]";
+    for engine in ENGINES_ALL {
+        assert_eq!(run_ok(engine, src, "f"), "-4", "{engine}: avg negatives");
+    }
+}
+
+#[test]
+fn avg_empty_errors_cross_engine() {
+    // Tree-walker semantics: `avg []` is an error (cannot average an empty
+    // list). VM and Cranelift must error too.
+    let src = "f>n;avg []";
+    for engine in ENGINES_ALL {
+        let err = run_err(engine, src, "f");
+        assert!(
+            err.contains("avg") && (err.contains("empty") || err.contains("average")),
+            "{engine}: expected avg/empty in error, got: {err}"
+        );
+    }
+}
+
+#[test]
+fn avg_non_list_errors_cross_engine() {
+    let src = "f>n;avg 42";
+    for engine in ENGINES_ALL {
+        let err = run_err(engine, src, "f");
+        assert!(
+            err.contains("avg") || err.contains("list"),
+            "{engine}: expected avg/list in error, got: {err}"
+        );
+    }
+}
+
+#[test]
+fn avg_non_numeric_element_errors_cross_engine() {
+    let src = r#"f>n;avg ["a", "b"]"#;
+    for engine in ENGINES_ALL {
+        let err = run_err(engine, src, "f");
+        assert!(
+            err.contains("avg") || err.contains("number"),
+            "{engine}: expected avg/number in error, got: {err}"
+        );
+    }
+}
+
+// ── interactions ──────────────────────────────────────────────────────
+
+#[test]
+fn sum_avg_composed_cross_engine() {
+    // Exercises both opcodes in a single function body to make sure they
+    // can coexist in the same compiled chunk on every engine.
+    let src = "f>n;-(avg [10, 20, 30]) (sum [1, 2, 3])";
+    for engine in ENGINES_ALL {
+        assert_eq!(run_ok(engine, src, "f"), "14", "{engine}: avg - sum");
+    }
+}
+
+#[test]
+fn sum_avg_arithmetic_on_results_cross_engine() {
+    // Regression: the Cranelift JIT keeps an F64 shadow per register for
+    // OP_*_NN fast paths. Helper-call opcodes (OP_SUM, OP_AVG, and the
+    // adjacent OP_MEDIAN/OP_STDEV/OP_VARIANCE/OP_QUANTILE) used to write
+    // only the I64 NanVal slot, leaving the F64 shadow stale at zero.
+    // A subsequent OP_SUB_NN/OP_ADD_NN over the result then read the
+    // stale shadow and silently produced 0.
+    let src = "f>n;a=avg [10, 20, 30];s=sum [1, 2, 3];-a s";
+    for engine in ENGINES_ALL {
+        assert_eq!(run_ok(engine, src, "f"), "14", "{engine}: -avg sum");
+    }
+    let src = "f>n;a=avg [10, 20, 30];s=sum [1, 2, 3];+a s";
+    for engine in ENGINES_ALL {
+        assert_eq!(run_ok(engine, src, "f"), "26", "{engine}: +avg sum");
+    }
+    // Same hazard for the adjacent stats family; covering median here keeps
+    // the F64-shadow contract consistent across every helper-call numeric op.
+    let src = "f>n;a=median [10, 20, 30];b=median [1, 2, 3];-a b";
+    for engine in ENGINES_ALL {
+        assert_eq!(run_ok(engine, src, "f"), "18", "{engine}: median diff");
+    }
+}


### PR DESCRIPTION
## Summary

`ilo file.ilo --run-vm` and `--run-cranelift` reported `Compile error: undefined function: sum` / `avg`. The tree-walker had both builtins wired up directly; the VM compiler had dedicated arms for `median`, `stdev`, `variance`, `quantile`, and `cumsum` but none for `sum` or `avg`, so they fell through to the named-function lookup and errored.

Manifesto framing: every agent reaching for `sum xs` on the VM hits a confusing "undefined function" diagnostic that names a real builtin, then has to rewrite the call as `fld + xs 0`. Tokens wasted and trust burned. The fix restores symmetry with the rest of the stats family across all three engines.

While fixing this I noticed the existing stats family (`median`, `stdev`, `variance`, `quantile`) had a Cranelift correctness bug: the per-register F64 shadow used by the OP_*_NN fast paths was never refreshed after a helper call, so any arithmetic over a stats result silently produced `0` on `--run-cranelift`. Fixed in the same PR with cross-cutting coverage.

## Repro

Before:
```
$ echo 'r>n;avg [1, 2, 3, 4]' > t.ilo
$ ilo t.ilo --run r
2.5
$ ilo t.ilo --run-vm r
Compile error: undefined function: avg
$ ilo t.ilo --run-cranelift r
Compile error: undefined function: avg
```

After: `2.5` on every engine. Empty list: `sum []` returns `0`, `avg []` errors with `avg: cannot average an empty list`, matching tree-walker semantics on every backend.

## What's in the diff

- `ae3768c` vm: new `OP_SUM` (165) and `OP_AVG` (166) opcodes with compile arms in `build_call`, dispatch handlers, `vm_sum` / `vm_avg` helpers, and `jit_sum` / `jit_avg` for the Cranelift handoff. Un-ignores `vm_sum_basic`, `vm_sum_empty`, `vm_avg_basic` now that the VM backs them.
- `393d7a8` cranelift: wire the new opcodes through the JIT and AOT compilers (helper FuncIds, declarations, symbol registrations, codegen blocks). In the same commit, refresh the F64 shadow after every stats helper call (median, quantile, stdev, variance, sum, avg) so subsequent OP_*_NN fast paths read the real numeric result instead of a stale zero. Both numeric-output classification passes (jit + AOT) include the new ops so `reg_always_num` flows through.
- `4f191c0` test: 16-test cross-engine regression file pinning the happy paths, the empty-list contracts (sum=0, avg=error), the wrong-type / non-numeric-element errors, and the F64-shadow hazard (including the pre-existing median variant). New `examples/sum-avg.ilo` picked up by `examples_engines` so every backend round-trips it.

## Test plan

- [x] `cargo test --release --features cranelift --test regression_sum_avg_cross_engine` — 16/16 pass
- [x] `cargo test --release --features cranelift --test examples_engines` — pass
- [x] `cargo test --release --features cranelift --lib` — pass (the only failures with `CARGO_TARGET_DIR` set are pre-existing AOT tests that look for `libilo.a` in the default target dir; clean target passes 7/7)
- [x] Manual repro across all three engines (tree, VM, cranelift) for: sum/avg happy path, empty list, non-list arg, non-numeric element, arithmetic-on-results (the F64-shadow hazard)
- [x] `cargo fmt --check` clean

## Follow-ups

None for this fix. The OP_SUM/OP_AVG dispatch in the VM has the same inline shape as OP_MEDIAN; a future refactor could collapse the six stats codegen blocks behind a small helper, but that's pure cleanup with no behavioural change.