### PR TITLE
parser: anchor incomplete-fn-header errors at the offending function (ILO-P020)

### DIFF
--- a/skills/ilo/SKILL.md
+++ b/skills/ilo/SKILL.md
@@ -335,5 +335,6 @@ count p:t>R n t;ls=rdl! p;~(len ls)
 9. **`main:>n;body` signature** — no `:` between fn name and `>`. Write `main>n;body`. Parser emits ILO-P003 with a hint.
 10. **`cond{^"err"}` braced-conditional discards the body** — for early return use the braceless form `cond ^"err"`, or wrap with `{ret ^"err"}`. Post-parse hint surfaces this.
 11. **Multi-line function/loop bodies** — bodies are single-line, `;`-separated. Newlines inside a body collapse to `;`, so `@k xs\n body` becomes `@k xs;body` which fails with `expected LBrace, got Semi`. Write `@k xs{body}` on one line. Parser emits ILO-P003 with a hint.
+12. **`ILO-P020 incomplete function header`** — a function header (`name params>type;body`) must finish on its own line. `f a:n` with no `>type;body` after it, or `f a:n>R` with no err-type, surfaces ILO-P020 anchored at the offending function — fix the header you wrote, not the function the error span happens to be near.
 
 $ARGUMENTS

--- a/src/diagnostic/registry.rs
+++ b/src/diagnostic/registry.rs
@@ -302,6 +302,46 @@ The parens make the `fmt` call self-contained, so the outer's arg counter
 treats it as a single operand.
 "#,
     },
+    ErrorEntry {
+        code: "ILO-P020",
+        short: "incomplete function header",
+        long: r#"## ILO-P020: incomplete function header
+
+A function header (`name params>type;body`) ran off the end of its line
+without supplying everything the parser needed. The most common shapes:
+
+**Missing return type after `>`:**
+
+    f1 a:n>n;+a 1
+    f2 a:n>R
+    main>n;0
+
+`f2`'s `R` (Result) needs an ok-type AND an err-type; here the line ends
+with just `R`.
+
+**Missing `>` entirely:**
+
+    f1 a:n>n;+a 1
+    f2 a:n
+    main>n;0
+
+Without `>` the parser cannot tell where the parameter list ends and the
+return type starts.
+
+**Fix:** finish the header on the same line as the function name. If you
+want to wrap a long header across multiple lines, indent the
+continuation:
+
+    f2 a:n
+      >R n t;...
+
+Indented lines are joined with `;` automatically; only an unindented
+line break ends a declaration.
+
+This diagnostic exists so the error span lands on the function whose
+header is incomplete, not on the next function in the file.
+"#,
+    },
     // ── Type / Verifier ──────────────────────────────────────────────────────
     ErrorEntry {
         code: "ILO-T001",

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -102,31 +102,42 @@ impl Parser {
         self.decl_boundary.get(self.pos).copied().flatten()
     }
 
-    /// Emit ILO-P020 if we've crossed a top-level declaration boundary while
-    /// still parsing the header of `fn_name`. The error span is anchored at
-    /// the offending function (preferring `header_start` if it points at a
-    /// real token; falling back to `prev_span()` otherwise) so the
-    /// diagnostic lands on the right line in multi-function files.
+    /// Emit ILO-P020 if we've crossed a top-level declaration boundary OR hit
+    /// EOF while still parsing the header of `fn_name`. The error span is
+    /// anchored at the offending function (preferring `header_start` if it
+    /// points at a real token; falling back to `prev_span()` otherwise) so
+    /// the diagnostic lands on the right line in multi-function files.
     ///
     /// `header_start` is the span of the function name token captured at the
     /// start of `parse_fn_decl`. Passing it through keeps the error pinned to
     /// the function name itself rather than whatever was last consumed
     /// (which can be a `>` on the same line — fine — but is cleaner this way).
+    ///
+    /// EOF is treated as a "soft boundary" here: a file that simply ends
+    /// inside a function header is the same class of bug as one that
+    /// continues into another decl, and the persona needs the same hint.
+    /// Without this branch, EOF mid-header falls through to the default
+    /// `peek_span()` error path which returns `Span::UNKNOWN` and renders
+    /// as line 1 col 1 — pre-existing infra-wide limitation we route around
+    /// here for the fn-header case specifically.
     fn check_fn_header_boundary(&self, fn_name: &str, header_start: Span) -> Result<()> {
-        if self.boundary_at_cursor().is_none() {
+        if self.boundary_at_cursor().is_none() && !self.at_end() {
             return Ok(());
         }
         let mut anchor = header_start;
         if anchor.start == anchor.end {
             anchor = self.prev_span();
         }
+        let trailing = if self.at_end() {
+            "header runs off the end of the file"
+        } else {
+            "header runs off the end of the line"
+        };
         Err(ParseError {
             code: "ILO-P020",
             position: self.pos,
             span: anchor,
-            message: format!(
-                "incomplete function header for `{fn_name}`: header runs off the end of the line"
-            ),
+            message: format!("incomplete function header for `{fn_name}`: {trailing}"),
             hint: Some(
                 "a function header is `name params>type;body` — finish it on the same line, or indent the continuation so the parser keeps it inside this function".to_string(),
             ),
@@ -779,20 +790,28 @@ impl Parser {
 
     fn parse_type(&mut self) -> Result<Type> {
         // Safety net: if we're about to read a type from across a top-level
-        // declaration boundary, the source is malformed (a nested type slot
-        // ran off the end of its line — e.g. `f2 a:n>R\nmain>...` where `R`
-        // expects an err-type that never arrives). Anchor the diagnostic at
-        // the previous token so it lands on the offending function's line
-        // rather than wherever the next declaration starts. Header-level
-        // callers (`parse_fn_decl`) catch this first and emit the friendlier
-        // ILO-P020; this guard only fires for nested type slots inside
-        // `R`/`M`/`F`/`L`/`O`/`S` where the header-level check can't see in.
-        if self.boundary_at_cursor().is_some() {
+        // declaration boundary or from past EOF, the source is malformed (a
+        // nested type slot ran off the end of its line — e.g.
+        // `f2 a:n>R\nmain>...` where `R` expects an err-type that never
+        // arrives, or `main a:n>R` where the file ends). Anchor the
+        // diagnostic at the previous token so it lands on the offending
+        // function's line rather than wherever the next declaration starts
+        // (or line 1 col 1 when EOF falls back to `Span::UNKNOWN`).
+        // Header-level callers (`parse_fn_decl`) catch this first and emit
+        // the friendlier ILO-P020; this guard only fires for nested type
+        // slots inside `R`/`M`/`F`/`L`/`O`/`S` where the header-level check
+        // can't see in.
+        if self.boundary_at_cursor().is_some() || self.at_end() {
+            let (code, msg): (&'static str, &str) = if self.at_end() {
+                ("ILO-P008", "expected type, got end of file")
+            } else {
+                ("ILO-P007", "expected type, got end of line")
+            };
             return Err(ParseError {
-                code: "ILO-P007",
+                code,
                 position: self.pos,
                 span: self.prev_span(),
-                message: "expected type, got end of line".to_string(),
+                message: msg.to_string(),
                 hint: None,
             });
         }
@@ -4607,13 +4626,18 @@ mod tests {
 
     #[test]
     fn eof_while_expecting_identifier() {
-        // `f x:n>n;y=` — incomplete let binding, hits EOF when expecting identifier or expression
+        // `f` alone hits EOF inside the function header (no params, no `>`,
+        // no return type). After the ILO-P020 boundary-anchor work, this
+        // surfaces as "incomplete function header" anchored at `f` rather
+        // than a generic EOF message with `Span::UNKNOWN`. Either shape is
+        // fine for the persona — the assertion just needs to confirm a
+        // real parse error fired, not pin the exact wording.
         let (_, errors) = parse_str_errors("f");
         assert!(!errors.is_empty(), "expected parse error");
         assert!(
-            errors
-                .iter()
-                .any(|e| e.message.contains("EOF") || e.message.contains("expected")),
+            errors.iter().any(|e| e.message.contains("EOF")
+                || e.message.contains("expected")
+                || e.message.contains("incomplete function header")),
             "unexpected error messages: {:?}",
             errors
         );

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6,6 +6,17 @@ use std::collections::HashMap;
 pub struct Parser {
     tokens: Vec<(Token, Span)>,
     pos: usize,
+    /// Parallel to `tokens` with length `tokens.len() + 1`. Entry `i` is
+    /// `Some(span)` iff at least one unindented `Token::Newline` (a top-level
+    /// declaration boundary, as produced by `lexer::normalize_newlines`) sat
+    /// immediately before token `i` in the pre-filter stream. The trailing
+    /// entry covers any newlines after the last surviving token. Populated in
+    /// `Parser::new` before newlines are filtered out, then consulted by
+    /// `parse_fn_decl`/`parse_params`/`parse_type` to keep header parsing from
+    /// walking off the end of one function and into the next. Without this,
+    /// a malformed header on line N reports its error span on line N+1 or
+    /// later, sending personas to bisect the wrong function.
+    decl_boundary: Vec<Option<Span>>,
     /// Known function arities, populated with builtins at construction
     /// and extended with user-function headers as they're parsed.
     fn_arity: HashMap<String, usize>,
@@ -40,21 +51,86 @@ type Result<T> = std::result::Result<T, ParseError>;
 
 impl Parser {
     pub fn new(tokens: Vec<(Token, Span)>) -> Self {
-        // Filter out newlines — idea9 uses ; as separator
-        let tokens: Vec<(Token, Span)> = tokens
-            .into_iter()
-            .filter(|(t, _)| *t != Token::Newline)
-            .collect();
+        // Filter out newlines — idea9 uses ; as separator. Each surviving
+        // `Token::Newline` came out of `lexer::normalize_newlines`, which
+        // converts indented continuations into `;` and only keeps a literal
+        // newline at column 0 (an unambiguous top-level decl boundary). We
+        // throw the tokens away to keep the rest of the parser simple, but
+        // remember WHERE they sat in `decl_boundary` so header parsing in
+        // `parse_fn_decl` can detect when it would walk past one and into
+        // the next function. Without that signal, error spans land on the
+        // wrong function in multi-function files.
+        let mut filtered: Vec<(Token, Span)> = Vec::with_capacity(tokens.len());
+        let mut decl_boundary: Vec<Option<Span>> = Vec::with_capacity(tokens.len() + 1);
+        let mut pending: Option<Span> = None;
+        for (tok, span) in tokens.into_iter() {
+            if tok == Token::Newline {
+                // Coalesce a run of consecutive newlines into the first one's
+                // span; either way the meaning ("a decl boundary sat here") is
+                // identical and one span is enough for diagnostics.
+                if pending.is_none() {
+                    pending = Some(span);
+                }
+                continue;
+            }
+            decl_boundary.push(pending.take());
+            filtered.push((tok, span));
+        }
+        // Trailing entry covers any newlines after the final surviving token.
+        decl_boundary.push(pending.take());
+        debug_assert_eq!(decl_boundary.len(), filtered.len() + 1);
         let (fn_arity, fn_param_is_fn) = builtin_arity_tables();
         Parser {
-            tokens,
+            tokens: filtered,
             pos: 0,
+            decl_boundary,
             fn_arity,
             fn_param_is_fn,
             no_whitespace_call: false,
             lifted_decls: Vec::new(),
             lambda_counter: 0,
         }
+    }
+
+    /// Returns `Some(span)` if an unindented newline (top-level declaration
+    /// boundary) sits immediately before the current token. The span points
+    /// at the newline byte itself, but for diagnostic anchoring callers
+    /// typically prefer `prev_span()` (the last token of the offending
+    /// function's line). Returns `None` if no boundary precedes `self.pos`
+    /// or the parser is at EOF beyond the recorded range.
+    fn boundary_at_cursor(&self) -> Option<Span> {
+        self.decl_boundary.get(self.pos).copied().flatten()
+    }
+
+    /// Emit ILO-P020 if we've crossed a top-level declaration boundary while
+    /// still parsing the header of `fn_name`. The error span is anchored at
+    /// the offending function (preferring `header_start` if it points at a
+    /// real token; falling back to `prev_span()` otherwise) so the
+    /// diagnostic lands on the right line in multi-function files.
+    ///
+    /// `header_start` is the span of the function name token captured at the
+    /// start of `parse_fn_decl`. Passing it through keeps the error pinned to
+    /// the function name itself rather than whatever was last consumed
+    /// (which can be a `>` on the same line — fine — but is cleaner this way).
+    fn check_fn_header_boundary(&self, fn_name: &str, header_start: Span) -> Result<()> {
+        if self.boundary_at_cursor().is_none() {
+            return Ok(());
+        }
+        let mut anchor = header_start;
+        if anchor.start == anchor.end {
+            anchor = self.prev_span();
+        }
+        Err(ParseError {
+            code: "ILO-P020",
+            position: self.pos,
+            span: anchor,
+            message: format!(
+                "incomplete function header for `{fn_name}`: header runs off the end of the line"
+            ),
+            hint: Some(
+                "a function header is `name params>type;body` — finish it on the same line, or indent the continuation so the parser keeps it inside this function".to_string(),
+            ),
+        })
     }
 
     fn peek(&self) -> Option<&Token> {
@@ -612,6 +688,12 @@ impl Parser {
             ));
         }
         let params = self.parse_params()?;
+        // After params, before we touch `>` and the return type, make sure we
+        // haven't crossed a top-level decl boundary. If we have, the header
+        // is incomplete — surface ILO-P020 anchored at this function's name
+        // rather than letting `expect(Greater)`/`parse_type` walk into the
+        // next function and report the error on the wrong line.
+        self.check_fn_header_boundary(&name, start)?;
         // Register arity + per-param fn-ref flags BEFORE parsing the body so
         // recursive self-references inside the body benefit from eager
         // call-arg expansion (e.g. `fac n:n>n;?=n 0{1}{*n fac -n 1}` —
@@ -637,6 +719,9 @@ impl Parser {
             ));
         }
         self.expect(&Token::Greater)?;
+        // Same check between `>` and the return type: `f2 a:n>\n` must report
+        // against `f2`, not against whatever ident starts the next line.
+        self.check_fn_header_boundary(&name, start)?;
         let return_type = self.parse_type()?;
         // The header/body boundary is normally a `;`, but a newline (filtered
         // out before parsing) leaves no separator. Accept either: consume a
@@ -693,6 +778,24 @@ impl Parser {
     // ---- Types ----
 
     fn parse_type(&mut self) -> Result<Type> {
+        // Safety net: if we're about to read a type from across a top-level
+        // declaration boundary, the source is malformed (a nested type slot
+        // ran off the end of its line — e.g. `f2 a:n>R\nmain>...` where `R`
+        // expects an err-type that never arrives). Anchor the diagnostic at
+        // the previous token so it lands on the offending function's line
+        // rather than wherever the next declaration starts. Header-level
+        // callers (`parse_fn_decl`) catch this first and emit the friendlier
+        // ILO-P020; this guard only fires for nested type slots inside
+        // `R`/`M`/`F`/`L`/`O`/`S` where the header-level check can't see in.
+        if self.boundary_at_cursor().is_some() {
+            return Err(ParseError {
+                code: "ILO-P007",
+                position: self.pos,
+                span: self.prev_span(),
+                message: "expected type, got end of line".to_string(),
+                hint: None,
+            });
+        }
         match self.peek().cloned() {
             Some(Token::LParen) => {
                 self.advance();
@@ -814,9 +917,22 @@ impl Parser {
     }
 
     /// Parse parameter list: `name:type name:type ...`
+    ///
+    /// Stops at the first non-`Ident:type` shape, and also stops at a top-level
+    /// declaration boundary (an unindented newline in the source) so a
+    /// malformed header like `f2 a:n` missing its `>type` does not slurp the
+    /// next function's name (`main`) as another parameter.
     fn parse_params(&mut self) -> Result<Vec<Param>> {
         let mut params = Vec::new();
         while let Some(Token::Ident(_)) = self.peek() {
+            // A top-level newline before the next ident means the previous
+            // function's header ended without a `>type;body` — stop here and
+            // let `parse_fn_decl` surface a precise ILO-P020 against the
+            // offending function's line, instead of letting this loop drag
+            // tokens across the boundary.
+            if self.boundary_at_cursor().is_some() {
+                break;
+            }
             // Look ahead for colon to distinguish params from other constructs
             if self.pos + 1 < self.tokens.len()
                 && self.token_at(self.pos + 1) == Some(&Token::Colon)

--- a/tests/regression_multi_fn_error_span.rs
+++ b/tests/regression_multi_fn_error_span.rs
@@ -1,0 +1,213 @@
+//! Regression: parse-error spans for a malformed function header used to
+//! land on the WRONG function in multi-function files. The parser filters
+//! all `Token::Newline`s globally, so when the header of function N is
+//! malformed (e.g. `f2 a:n>R` missing the err-type, or `f2 a:n` missing
+//! `>type;body`), `parse_type` / `parse_params` happily walked across the
+//! newline and consumed tokens from function N+1. The resulting error span
+//! pointed at function N+1, sending personas to bisect the wrong line.
+//!
+//! Fix: `Parser::new` now records top-level decl boundaries (unindented
+//! newlines, which `lexer::normalize_newlines` already preserves as
+//! `Token::Newline`) before filtering them out. `parse_fn_decl` checks the
+//! boundary between params/`>`/return-type and emits the friendly ILO-P020
+//! anchored at the offending function's name. `parse_params` stops at a
+//! boundary so it can't slurp the next function's name as another param.
+//! `parse_type` has a safety-net check for nested type slots
+//! (`R`/`M`/`F`/`L`/`O`/`S`) that anchors its ILO-P007 at the previous
+//! token's line instead of the next decl.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+/// Run `ilo --json <src>` and return stderr. JSON diagnostic mode makes
+/// the `line` field unambiguous, which is what these tests pin on.
+fn run_err_json(src: &str) -> String {
+    let out = ilo()
+        .arg("--json")
+        .arg(src)
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "expected failure for {src:?}, stdout: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+fn run_ok(src: &str) {
+    let out = ilo().arg(src).output().expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "expected success for {src:?}, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Find the first `line` value in JSON diagnostic stderr. Crude but enough
+/// for these tests since the first error is always the one we care about.
+fn first_error_line(stderr: &str) -> usize {
+    let key = "\"line\":";
+    let idx = stderr
+        .find(key)
+        .unwrap_or_else(|| panic!("no line field in stderr:\n{stderr}"));
+    let tail = &stderr[idx + key.len()..];
+    let end = tail
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(tail.len());
+    tail[..end]
+        .parse()
+        .unwrap_or_else(|_| panic!("could not parse line number from stderr:\n{stderr}"))
+}
+
+fn first_error_code(stderr: &str) -> String {
+    let key = "\"code\":\"";
+    let idx = stderr
+        .find(key)
+        .unwrap_or_else(|| panic!("no code field in stderr:\n{stderr}"));
+    let tail = &stderr[idx + key.len()..];
+    let end = tail.find('"').expect("unterminated code field");
+    tail[..end].to_string()
+}
+
+#[test]
+fn missing_err_type_attributes_to_offending_function() {
+    // `f2`'s header has `>R` with no err-type before the line ends. The
+    // error must land on line 2 (where `f2` lives), not on line 3 (`main`)
+    // where the parser used to land it after walking across the newline.
+    let src = "f1 a:n>n;+a 1\nf2 a:n>R\nmain>n;0";
+    let err = run_err_json(src);
+    assert_eq!(
+        first_error_line(&err),
+        2,
+        "expected error on line 2 (f2), got stderr:\n{err}"
+    );
+    // The safety net inside `parse_type` fires here with the new "got end
+    // of line" wording.
+    assert!(
+        err.contains("end of line"),
+        "expected 'end of line' wording in stderr:\n{err}"
+    );
+}
+
+#[test]
+fn missing_arrow_attributes_to_offending_function() {
+    // `f2 a:n` has no `>type;body`. The parser used to keep `parse_params`
+    // running, slurp `main` as the next param, then surface a P003 on
+    // line 3. Now ILO-P020 fires anchored at `f2` on line 2.
+    let src = "f1 a:n>n;+a 1\nf2 a:n\nmain>n;0";
+    let err = run_err_json(src);
+    assert_eq!(
+        first_error_line(&err),
+        2,
+        "expected error on line 2 (f2), got stderr:\n{err}"
+    );
+    assert_eq!(
+        first_error_code(&err),
+        "ILO-P020",
+        "expected ILO-P020 for incomplete header, got stderr:\n{err}"
+    );
+    assert!(
+        err.contains("`f2`"),
+        "expected error to name `f2`, got stderr:\n{err}"
+    );
+}
+
+#[test]
+fn missing_return_type_after_arrow_attributes_to_offending_function() {
+    // `f2 a:n>` ends with `>` and no return type. The space between `>`
+    // and the newline is where the header gives up.
+    let src = "f1 a:n>n;+a 1\nf2 a:n>\nmain>n;0";
+    let err = run_err_json(src);
+    assert_eq!(
+        first_error_line(&err),
+        2,
+        "expected error on line 2 (f2), got stderr:\n{err}"
+    );
+    // Either ILO-P020 (boundary check between `>` and return type) or
+    // ILO-P007 (parse_type safety net), both anchored at line 2.
+    let code = first_error_code(&err);
+    assert!(
+        code == "ILO-P020" || code == "ILO-P007",
+        "expected ILO-P020 or ILO-P007, got {code}, stderr:\n{err}"
+    );
+}
+
+#[test]
+fn error_on_middle_of_three_functions_does_not_bleed_either_way() {
+    // Three-function file with the fault in the middle. The error must
+    // land on line 2 (the offending function) — not line 1 (the prior
+    // function) and not line 3 (the next function). This is the strongest
+    // shape of the regression: bleed in either direction is a bug.
+    let src = "f1 a:n>n;+a 1\nf2 a:n>R\nf3 a:n>n;-a 1";
+    let err = run_err_json(src);
+    assert_eq!(
+        first_error_line(&err),
+        2,
+        "error must land on line 2 (f2), got stderr:\n{err}"
+    );
+}
+
+#[test]
+fn error_on_first_function_stays_on_first_function() {
+    // Symmetric: fault on line 1. Even without a previous function to
+    // bleed onto, the span must stay on line 1.
+    let src = "f1 a:n>R\nf2 a:n>n;+a 1\nmain>n;0";
+    let err = run_err_json(src);
+    assert_eq!(
+        first_error_line(&err),
+        1,
+        "error must stay on line 1 (f1), got stderr:\n{err}"
+    );
+}
+
+#[test]
+fn error_on_last_function_with_body_attribution() {
+    // Fault on the final function, but with content after it on the same
+    // line so the parser hits an in-line boundary, not EOF. (The pure-EOF
+    // case `... main a:n>R` falls back to ILO-P008 with a `Span::UNKNOWN`
+    // anchor — a pre-existing limitation unrelated to this fix.) Here
+    // `main a:n` with no `>type;body` is a same-shape fault as `f2 a:n`
+    // earlier in the file: ILO-P020 must anchor at line 3.
+    let src = "f1 a:n>n;+a 1\nf2 a:n>n;-a 1\nmain a:n\n";
+    let err = run_err_json(src);
+    assert_eq!(
+        first_error_line(&err),
+        3,
+        "error must land on line 3 (main), got stderr:\n{err}"
+    );
+}
+
+#[test]
+fn valid_multi_function_file_still_parses() {
+    // Sanity: the boundary checks must not reject well-formed multi-fn
+    // input. Two helpers and a main, all on their own lines, with normal
+    // headers and bodies.
+    run_ok("inc a:n>n;+a 1\ndec a:n>n;-a 1\nmain>n;inc 1");
+}
+
+#[test]
+fn valid_indented_continuation_still_parses() {
+    // `normalize_newlines` turns an indented continuation into a `;`, so a
+    // function whose body wraps onto the next line is NOT a decl boundary
+    // from the parser's perspective. The boundary check must let this
+    // through unchanged. Mirrors the shape from `examples/multiline-bodies.ilo`.
+    let src = "f a:n>n\n  b=+a 1\n  *b 2\nmain>n;f 3";
+    run_ok(src);
+}
+
+#[test]
+fn no_param_function_missing_return_type_attributes_correctly() {
+    // Zero-param function variant: `f2>` with nothing after the `>`. Same
+    // class of fault, different code path (no params to short-circuit).
+    let src = "f1>n;1\nf2>\nmain>n;0";
+    let err = run_err_json(src);
+    assert_eq!(
+        first_error_line(&err),
+        2,
+        "expected error on line 2 (f2), got stderr:\n{err}"
+    );
+}

--- a/tests/regression_multi_fn_error_span.rs
+++ b/tests/regression_multi_fn_error_span.rs
@@ -165,19 +165,40 @@ fn error_on_first_function_stays_on_first_function() {
 }
 
 #[test]
-fn error_on_last_function_with_body_attribution() {
-    // Fault on the final function, but with content after it on the same
-    // line so the parser hits an in-line boundary, not EOF. (The pure-EOF
-    // case `... main a:n>R` falls back to ILO-P008 with a `Span::UNKNOWN`
-    // anchor — a pre-existing limitation unrelated to this fix.) Here
-    // `main a:n` with no `>type;body` is a same-shape fault as `f2 a:n`
-    // earlier in the file: ILO-P020 must anchor at line 3.
-    let src = "f1 a:n>n;+a 1\nf2 a:n>n;-a 1\nmain a:n\n";
+fn error_on_last_function_stays_on_last_function() {
+    // Fault on the final function: nothing after it for the parser to bleed
+    // into. The parse hits EOF mid-header rather than a decl boundary, but
+    // the attribution must still land on the right line. The header-level
+    // check in `parse_fn_decl` treats EOF as a soft boundary and the
+    // `parse_type` safety net anchors EOF errors at `prev_span()` rather
+    // than the default `Span::UNKNOWN` (which renders as line 1 col 1).
+    let src = "f1 a:n>n;+a 1\nf2 a:n>n;-a 1\nmain a:n>R";
     let err = run_err_json(src);
     assert_eq!(
         first_error_line(&err),
         3,
         "error must land on line 3 (main), got stderr:\n{err}"
+    );
+}
+
+#[test]
+fn last_function_missing_arrow_at_eof_attributes_to_offending_function() {
+    // Sibling of `missing_arrow_attributes_to_offending_function` but with
+    // the fault on the final function and the file ending immediately
+    // after. Without the EOF branch in `check_fn_header_boundary` this
+    // would fall through to ILO-P004 (`expected Greater, got EOF`) with
+    // `Span::UNKNOWN` and land at line 1 col 1.
+    let src = "f1 a:n>n;+a 1\nf2 a:n>n;-a 1\nmain a:n";
+    let err = run_err_json(src);
+    assert_eq!(
+        first_error_line(&err),
+        3,
+        "error must land on line 3 (main), got stderr:\n{err}"
+    );
+    assert_eq!(
+        first_error_code(&err),
+        "ILO-P020",
+        "expected ILO-P020 for incomplete header at EOF, got stderr:\n{err}"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes a token-spend trap reported by qa-tester + devops-sre rerun3: a malformed function header in a multi-function file used to report its error span on the **wrong** function. Personas wasted session time bisecting which function actually had the bug.

The root cause is in `Parser::new`: every `Token::Newline` is filtered out before parsing. When `parse_fn_decl` reads a malformed header, `parse_type` / `parse_params` happily walked across the newline into the next function and emitted the error there.

Manifesto framing: a correctly attributed span lands the persona on the right line first try instead of forcing a token-expensive bisect.

## Repro (before → after)

```ilo
f1 a:n>n;+a 1
f2 a:n>R       -- f2's err-type is missing
main>n;0
```

- **Before**: `ILO-P003: expected Greater, got Ident("main")` at line 3 col 1 (the start of `main`).
- **After**: `ILO-P007: expected type, got end of line` at line 2 col 8 (anchored on `f2`'s line).

```ilo
f1 a:n>n;+a 1
f2 a:n         -- f2 missing `>type;body` entirely
main>n;0
```

- **Before**: `ILO-P003` at line 3 col 1.
- **After**: `ILO-P020: incomplete function header for \`f2\`: header runs off the end of the line` at line 2 col 1, with a hint pointing at the `name params>type;body` shape and the indent-the-continuation workaround.

EOF cases (file ends mid-header) used to fall through to `Span::UNKNOWN` and render as line 1 col 1. Now they anchor at the previous token (last token of the offending function's line) and surface ILO-P020 with the same friendly message.

## What's in the diff (per commit)

1. **`parser: anchor incomplete-header errors at the offending function`** — Parser records decl-boundary metadata in `Parser::new` (parallel `Vec<Option<Span>>` populated before newlines are filtered out). New helper `check_fn_header_boundary` runs at the two header pinch points in `parse_fn_decl` (after params, after `>`). `parse_params` stops at a boundary so the loop can't drag the next function's name in as another param. `parse_type` gets a safety net for nested type slots that anchors its existing ILO-P007 at `prev_span()`.
2. **`diag: document ILO-P020 incomplete function header`** — registry entry with the three failure shapes (missing return type, missing `>`, missing err-type after `R`) and the indent-the-continuation workaround. SKILL.md common-mistakes gets a matching entry as #12.
3. **`test: cross-line attribution for parse errors in multi-fn files`** — initial 9 regression cases.
4. **`parser: extend ILO-P020 to cover EOF mid-fn-header`** — `check_fn_header_boundary` treats EOF as a soft boundary alongside decl boundaries. `parse_type` EOF case anchors at `prev_span()` instead of `Span::UNKNOWN`. Existing `eof_while_expecting_identifier` parser unit test had its assertion updated to accept the strictly-better ILO-P020 wording.
5. **`test: cover EOF mid-fn-header attribution`** — 1 additional case + restoration of `error_on_last_function_stays_on_last_function` to assert proper attribution (not the EOF-fallback shape it was relaxed to mid-development).

ILO-P020 not P019 because P017/P018/P019 are already documented in SPEC.md/ai.txt for the import system. Pre-existing namespace mess; this PR doesn't touch it, just steps around.

## Test plan

- [x] New regression test `tests/regression_multi_fn_error_span.rs` — 10 cases covering missing-err-type, missing-`>`, missing-return-type-after-arrow, middle-of-three attribution, first-fn attribution, last-fn EOF attribution, last-fn missing-`>` EOF attribution, zero-param-fn variant, valid multi-fn parity, valid indented continuation parity. All passing.
- [x] Parser unit tests (`cargo test --lib parser::`) — 295/295 passing, including the updated `eof_while_expecting_identifier`.
- [x] Existing P001-cascade regression — 5/5 passing.
- [x] Full suite: 3064 passing locally. 7 AOT Cranelift tests fail with `cannot find libilo.a — Searched: target/release/libilo.a` because they hardcode `target/` and ignore my `CARGO_TARGET_DIR=target-isolated` override. CI uses the default target dir and won't hit this — pre-existing infra constraint, not caused by this PR.
- [x] Manual repros verified on the rebased release binary across all four shapes (mid-file/EOF × missing-arrow/missing-err-type).

## Follow-ups

- EOF rendering as `Span::UNKNOWN` (line 1 col 1) is infra-wide — every error site uses `peek_span()` which returns `UNKNOWN` at EOF. This PR routes around it for the fn-header case specifically. A follow-up could replace `peek_span()` with a `prev_span()`-on-EOF fallback site by site.
- P017/P018/P019 are double-booked between the parser (lambda capture, variadic, my originally-planned slot) and the import system (SPEC.md / ai.txt / main.rs). Worth untangling in a separate cleanup PR; not in scope here.