### PR TITLE
fix: cranelift JIT srt-after-map TLS desync silent miscompile

### DIFF
--- a/examples/srt-after-map-inline-lambda.ilo
+++ b/examples/srt-after-map-inline-lambda.ilo
@@ -1,0 +1,27 @@
+-- Two inline lambdas in the same function body, where the first feeds a
+-- native-dispatch HOF (`map` / `flt` / `fld` / `flatmap`) and the second
+-- feeds a tree-bridge HOF (`srt` / `grp` / `uniqby` / `partition`). The
+-- pdf-analyst frq+srt shape is the canonical case: build [count word]
+-- pairs from `frq` + `mget`, then sort by count.
+--
+-- Regression note: before the TLS save-restore fix in #?? the second HOF
+-- on Cranelift JIT returned `nil` because the first HOF's per-element
+-- VM re-entry blanked the ACTIVE_FUNC_NAMES / ACTIVE_AST_PROGRAM
+-- thread-locals on exit. Tree/VM were unaffected. The cross-engine
+-- harness exercises this on every engine so the desync can't drift back.
+
+-- The frq+srt pdf-analyst shape: rank words by frequency.
+top-words ws:L t>L (L _);fr=frq ws;ks=mkeys fr;pairs=[];@k ks{c=mget fr k;pairs=+=pairs [c k]};srt (p:L _>n;p.0) pairs
+
+-- Native (map) → bridge (srt) in the same function body, no shared data.
+map-then-srt>L (L _);a=map (x:n>n;+x 1) [1 2 3];srt (p:L _>n;p.0) [[2 "a"] [1 "b"]]
+
+-- Native (flt) → bridge (srt) — also covers the desync.
+flt-then-srt>L (L _);a=flt (x:n>b;>x 1) [1 2 3];srt (p:L _>n;p.0) [[2 "a"] [1 "b"]]
+
+-- run: top-words ["apple","apple","banana","apple","cherry","banana"]
+-- out: [[1, cherry], [2, banana], [3, apple]]
+-- run: map-then-srt
+-- out: [[1, b], [2, a]]
+-- run: flt-then-srt
+-- out: [[1, b], [2, a]]

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -4004,15 +4004,33 @@ fn active_func_name(id: u32) -> Option<String> {
 /// still get correct FnRef name resolution in jdmp / Display /
 /// to_value paths.
 pub fn with_active_registry<R>(program: &CompiledProgram, f: impl FnOnce() -> R) -> R {
-    struct ClearGuard;
-    impl Drop for ClearGuard {
+    // Save-restore the four TLS slots so a nested `with_active_registry`
+    // (e.g. `jit_call_dyn` re-entering the VM on a user-fn callback during
+    // a HOF call) doesn't clobber the outer JIT's TLS state when the inner
+    // call returns. Without this, a second tree-bridge HOF in the same
+    // outer Cranelift entry would see null pointers and the FnRef arg
+    // would deserialise to a synthetic `<user_fn:N>` placeholder, producing
+    // a silent miscompile (cf. the pdf-analyst rerun4 srt-after-map repro
+    // and `fix/srt-cranelift-nil`).
+    struct RestoreGuard {
+        registry: *const TypeRegistry,
+        func_names: *const Vec<String>,
+        program: *const CompiledProgram,
+        ast_program: *const Program,
+    }
+    impl Drop for RestoreGuard {
         fn drop(&mut self) {
-            ACTIVE_REGISTRY.with(|r| r.set(std::ptr::null()));
-            ACTIVE_FUNC_NAMES.with(|r| r.set(std::ptr::null()));
-            ACTIVE_PROGRAM.with(|r| r.set(std::ptr::null()));
-            ACTIVE_AST_PROGRAM.with(|r| r.set(std::ptr::null()));
+            ACTIVE_REGISTRY.with(|r| r.set(self.registry));
+            ACTIVE_FUNC_NAMES.with(|r| r.set(self.func_names));
+            ACTIVE_PROGRAM.with(|r| r.set(self.program));
+            ACTIVE_AST_PROGRAM.with(|r| r.set(self.ast_program));
         }
     }
+
+    let prev_registry = ACTIVE_REGISTRY.with(|r| r.get());
+    let prev_func_names = ACTIVE_FUNC_NAMES.with(|r| r.get());
+    let prev_program = ACTIVE_PROGRAM.with(|r| r.get());
+    let prev_ast_program = ACTIVE_AST_PROGRAM.with(|r| r.get());
 
     ACTIVE_REGISTRY.with(|r| r.set(&program.type_registry as *const TypeRegistry));
     ACTIVE_FUNC_NAMES.with(|r| r.set(&program.func_names as *const Vec<String>));
@@ -4020,51 +4038,85 @@ pub fn with_active_registry<R>(program: &CompiledProgram, f: impl FnOnce() -> R)
     if let Some(ast) = &program.ast {
         ACTIVE_AST_PROGRAM.with(|r| r.set(ast.as_ref() as *const Program));
     }
-    let _guard = ClearGuard;
+    let _guard = RestoreGuard {
+        registry: prev_registry,
+        func_names: prev_func_names,
+        program: prev_program,
+        ast_program: prev_ast_program,
+    };
     f()
 }
 
 /// Clear the active `TypeRegistry` pointer.
 ///
-/// Called at the end of `VM::execute()` where wrapping in a closure is
-/// impractical. The `execute` method also uses `ActiveRegistryGuard` to ensure
-/// the pointer is cleared on early return or panic.
+/// Called from the AOT runtime tear-down where the program is going away
+/// and there is no prior pointer to restore. `VM::execute()` uses the
+/// save-restore `ActiveRegistryGuard` instead so nested executions don't
+/// clobber the outer JIT's TLS state.
 fn clear_active_registry() {
     ACTIVE_REGISTRY.with(|r| r.set(std::ptr::null()));
 }
 
-/// RAII guard that clears `ACTIVE_REGISTRY` on drop.
+/// RAII guard that restores `ACTIVE_REGISTRY` to its previous value on drop.
 ///
-/// Used inside `VM::execute()` to guarantee cleanup even on `?` early returns
-/// or panics.
-pub(crate) struct ActiveRegistryGuard;
+/// Used inside `VM::execute()` to guarantee the slot is restored even on
+/// `?` early returns or panics. Save-restore (not clear-to-null) so a
+/// nested VM run inside an outer Cranelift JIT entry doesn't blank the
+/// outer's pointer when the inner returns — see `fix/srt-cranelift-nil`
+/// for the silent-miscompile this prevents.
+pub(crate) struct ActiveRegistryGuard {
+    prev: *const TypeRegistry,
+}
+
+impl ActiveRegistryGuard {
+    pub(crate) fn new(prev: *const TypeRegistry) -> Self {
+        Self { prev }
+    }
+}
 
 impl Drop for ActiveRegistryGuard {
     fn drop(&mut self) {
-        clear_active_registry();
+        ACTIVE_REGISTRY.with(|r| r.set(self.prev));
     }
 }
 
-/// RAII guard that clears `ACTIVE_FUNC_NAMES` on drop, paralleling
-/// `ActiveRegistryGuard`. Set by `VM::execute()` so jdmp / error paths
-/// can resolve user-fn FnRef ids to names without a Program reference.
-pub(crate) struct ActiveFuncNamesGuard;
+/// RAII guard that restores `ACTIVE_FUNC_NAMES` to its previous value on
+/// drop, paralleling `ActiveRegistryGuard`. Set by `VM::execute()` so
+/// jdmp / error paths can resolve user-fn FnRef ids to names without
+/// threading the program reference through every helper.
+pub(crate) struct ActiveFuncNamesGuard {
+    prev: *const Vec<String>,
+}
+
+impl ActiveFuncNamesGuard {
+    pub(crate) fn new(prev: *const Vec<String>) -> Self {
+        Self { prev }
+    }
+}
 
 impl Drop for ActiveFuncNamesGuard {
     fn drop(&mut self) {
-        ACTIVE_FUNC_NAMES.with(|r| r.set(std::ptr::null()));
+        ACTIVE_FUNC_NAMES.with(|r| r.set(self.prev));
     }
 }
 
-/// RAII guard that clears `ACTIVE_AST_PROGRAM` on drop, paralleling the
-/// other VM-side TLS guards. Set by `VM::execute()` when the
-/// `CompiledProgram` retains its AST; cleared on return or panic so the
-/// pointer can never outlive the borrow.
-pub(crate) struct ActiveAstProgramGuard;
+/// RAII guard that restores `ACTIVE_AST_PROGRAM` to its previous value on
+/// drop, paralleling the other VM-side TLS guards. Set by `VM::execute()`
+/// when the `CompiledProgram` retains its AST; restored on return or
+/// panic so a nested VM run can't blank an outer JIT's pointer.
+pub(crate) struct ActiveAstProgramGuard {
+    prev: *const Program,
+}
+
+impl ActiveAstProgramGuard {
+    pub(crate) fn new(prev: *const Program) -> Self {
+        Self { prev }
+    }
+}
 
 impl Drop for ActiveAstProgramGuard {
     fn drop(&mut self) {
-        ACTIVE_AST_PROGRAM.with(|r| r.set(std::ptr::null()));
+        ACTIVE_AST_PROGRAM.with(|r| r.set(self.prev));
     }
 }
 
@@ -5003,22 +5055,27 @@ impl<'a> VM<'a> {
     fn execute(&mut self) -> VmResult<Value> {
         // Set active registry for arena record promotion in nanval_to_json and JIT callbacks.
         // `self.program` is owned by the VM and outlives `execute()`.
-        // The guard ensures the pointer is cleared on return or panic.
+        // The guard restores the previous pointer on return or panic — not
+        // null — so a nested execute() (e.g. `jit_call_dyn` re-entering on a
+        // user-fn HOF callback) leaves the outer JIT's TLS state intact.
+        let prev_registry = ACTIVE_REGISTRY.with(|r| r.get());
         ACTIVE_REGISTRY.with(|r| r.set(&self.program.type_registry as *const TypeRegistry));
-        let _registry_guard = ActiveRegistryGuard;
+        let _registry_guard = ActiveRegistryGuard::new(prev_registry);
 
         // Same shape for func_names: VM-side serialisation paths
         // (jdmp, errors) need to resolve user-fn FnRef ids back to names
         // without threading the program reference through every helper.
+        let prev_func_names = ACTIVE_FUNC_NAMES.with(|r| r.get());
         ACTIVE_FUNC_NAMES.with(|r| r.set(&self.program.func_names as *const Vec<String>));
-        let _func_names_guard = ActiveFuncNamesGuard;
+        let _func_names_guard = ActiveFuncNamesGuard::new(prev_func_names);
 
         // Publish the retained AST (if any) for the tree-bridge's HOF
-        // dispatch path. Cleared on return/panic by the guard.
+        // dispatch path. Restored on return/panic by the guard.
+        let prev_ast_program = ACTIVE_AST_PROGRAM.with(|r| r.get());
         if let Some(ast) = &self.program.ast {
             ACTIVE_AST_PROGRAM.with(|r| r.set(ast.as_ref() as *const Program));
         }
-        let _ast_guard = ActiveAstProgramGuard;
+        let _ast_guard = ActiveAstProgramGuard::new(prev_ast_program);
         // SAFETY: execute() is only called from call() after setup_call() has pushed
         // a frame, so frames is non-empty.
         let frame = unsafe { self.frames.last().unwrap_unchecked() };

--- a/tests/regression_lambdas_cross_engine.rs
+++ b/tests/regression_lambdas_cross_engine.rs
@@ -176,3 +176,89 @@ fn lambda_fld_empty_list_returns_seed() {
     let src = "main xs:L n>n;fld (a:n x:n>n;+a x) xs 7";
     run_all(src, "main", &["[]"], "7");
 }
+
+// ── Sequential HOFs in the same function ────────────────────────────────
+//
+// Regression: prior to the TLS save-restore fix in `fix/srt-cranelift-nil`,
+// a tree-bridge HOF (srt-2arg / grp / uniqby / partition) running after a
+// native-dispatch HOF (map / flt / fld / flatmap) in the same Cranelift
+// entry returned `nil`. The native HOF's per-element callback re-entered
+// the VM via `jit_call_dyn → VM::new(program).call(...)`; the inner
+// execute()'s drop guards nulled `ACTIVE_FUNC_NAMES` / `ACTIVE_AST_PROGRAM`
+// on return, so the second HOF's FnRef arg deserialised to a
+// `<user_fn:N>` placeholder the tree-bridge couldn't dispatch, and the
+// bridge swallowed the failure as TAG_NIL. Tree/VM were fine; only the
+// Cranelift JIT path had the TLS desync. Pin every combination so this
+// can't drift back.
+
+#[test]
+fn lambda_map_then_srt_no_tls_desync() {
+    // Two inline lambdas in the same function body: one in `map`
+    // (native dispatch), then one in `srt` (tree-bridge). On Cranelift
+    // the second used to return nil; now must match tree/VM.
+    let src =
+        "main>L (L _);a=map (x:n>n;+x 1) [1 2 3];sk=srt (p:L _>n;p.0) [[2 \"a\"] [1 \"b\"]];sk";
+    run_all(src, "main", &[], "[[1, b], [2, a]]");
+}
+
+#[test]
+fn lambda_flt_then_srt_no_tls_desync() {
+    let src =
+        "main>L (L _);a=flt (x:n>b;>x 1) [1 2 3];sk=srt (p:L _>n;p.0) [[2 \"a\"] [1 \"b\"]];sk";
+    run_all(src, "main", &[], "[[1, b], [2, a]]");
+}
+
+#[test]
+fn lambda_fld_then_srt_no_tls_desync() {
+    let src = "main>L (L _);s=fld (a:n x:n>n;+a x) [1 2 3] 0;sk=srt (p:L _>n;p.0) [[2 \"a\"] [1 \"b\"]];sk";
+    run_all(src, "main", &[], "[[1, b], [2, a]]");
+}
+
+#[test]
+fn lambda_flatmap_then_srt_no_tls_desync() {
+    let src = "main>L (L _);a=flatmap (x:n>L n;[x x]) [1 2];sk=srt (p:L _>n;p.0) [[2 \"a\"] [1 \"b\"]];sk";
+    run_all(src, "main", &[], "[[1, b], [2, a]]");
+}
+
+#[test]
+fn lambda_map_then_srt_frq_mget_pairs() {
+    // The original pdf-analyst rerun4 shape: frq + mget loop builds
+    // `[count word]` pairs, then srt-by-count. Exercises the
+    // tree-bridge for frq AND srt with an intervening native HOF
+    // (map) earlier in the function body.
+    let src = "main>L (L _);ws=[\"apple\" \"apple\" \"banana\" \"apple\" \"cherry\" \"banana\"];dummy=map (w:t>n;len w) ws;fr=frq ws;ks=mkeys fr;pairs=[];@k ks{c=mget fr k;pairs=+=pairs [c k]};sk=srt (p:L _>n;p.0) pairs;sk";
+    run_all(src, "main", &[], "[[1, cherry], [2, banana], [3, apple]]");
+}
+
+#[test]
+fn lambda_map_then_grp_no_tls_desync() {
+    // grp is also tree-bridge for the 2-arg form (PR 3b). Confirm
+    // the TLS desync didn't only affect srt. Key returns the parity
+    // bucket as a string ("even" / "odd") so the grouped map keys
+    // are predictable across engines.
+    let src = "main>L n;a=map (x:n>n;*x 2) [1 2 3];g=grp (x:n>t;?>x 5 \"big\" \"small\") [1 6 2 7 3 8];mget g \"big\"";
+    run_all(src, "main", &[], "[6, 7, 8]");
+}
+
+#[test]
+fn lambda_map_then_uniqby_no_tls_desync() {
+    // uniqby key: parity via `?` ternary (`%` isn't an ilo operator;
+    // arithmetic mod isn't needed for this regression).
+    let src = "main>L n;a=map (x:n>n;+x 1) [1 2 3];uniqby (x:n>b;>x 3) [1 2 3 4 5]";
+    run_all(src, "main", &[], "[1, 4]");
+}
+
+#[test]
+fn lambda_map_then_partition_no_tls_desync() {
+    let src = "main>L (L n);a=map (x:n>n;+x 1) [1 2 3];partition (x:n>b;>x 2) [1 2 3 4 5]";
+    run_all(src, "main", &[], "[[3, 4, 5], [1, 2]]");
+}
+
+#[test]
+fn lambda_map_then_srt_then_map_no_tls_desync() {
+    // Three HOFs back-to-back across the native/bridge boundary in
+    // both directions: native → bridge → native. The post-bridge
+    // native call still needs the program-aware FnRef resolution.
+    let src = "main>L n;a=map (x:n>n;+x 1) [1 2 3];sk=srt (p:L _>n;p.0) [[2 \"a\"] [1 \"b\"]];map (x:n>n;*x 10) [4 5 6]";
+    run_all(src, "main", &[], "[40, 50, 60]");
+}


### PR DESCRIPTION
## Summary

Cranelift JIT silently returned `nil` from `srt fn xs` (and `grp` / `uniqby` / `partition`) when another HOF with an inline-lambda callback had run earlier in the same function. Tree and VM produced the correct sorted list. Caught by pdf-analyst rerun4 via the `frq` + `mget` + `srt` pattern, then minimised down to two inline lambdas in the same function body.

## Repro

```
main>_;a=map (x:n>n;+x 1) [1 2 3];sk=srt (p:L _>n;p.0) [[2 "a"] [1 "b"]];sk
```

Before:
- `--run-tree` → `[[1, b], [2, a]]`
- `--run-vm` → `[[1, b], [2, a]]`
- `--run-cranelift` → `nil`

After: all three engines agree on `[[1, b], [2, a]]`.

## Root cause

The four TLS slots `ACTIVE_REGISTRY`, `ACTIVE_FUNC_NAMES`, `ACTIVE_PROGRAM`, `ACTIVE_AST_PROGRAM` had drop guards that NULL'd the slot unconditionally on scope exit. That is safe at the top-level Cranelift entry, but a per-element HOF callback re-enters the VM via `jit_call_dyn -> VM::new(program).call(...)`; the inner `execute()`'s guards then NULL the slots when the inner returns, leaving the outer JIT with no TLS state.

The next tree-bridge HOF in the same Cranelift entry saw null `ACTIVE_FUNC_NAMES`, deserialised its FnRef arg to a synthetic `<user_fn:N>` placeholder Text, failed to dispatch it through the tree interpreter, and the bridge swallowed the failure as `TAG_NIL` (legacy nil-sweep gap, filed separately).

Regressed when the HOF dispatch chain (#277 / #278 / #279 / #280 / #283) introduced the sub-VM re-entry path. Pre-#277, `map` was tree-bridge-only and the inner-VM re-entry didn't exist, so the TLS desync never happened.

## What is in the diff

**Commit 1 — `vm: save-restore TLS guards`.** The four guards now snapshot the previous pointer at construction and restore it on drop. Linear stack discipline across arbitrary nesting; the outermost restore still ends at null. `clear_active_registry()` retained for the AOT runtime tear-down path where there is no prior pointer to restore.

**Commit 2 — `test: cross-engine regression`.** Nine new tests in `regression_lambdas_cross_engine.rs` cover every native HOF (map/flt/fld/flatmap) followed by every tree-bridge HOF (srt/grp/uniqby/partition). Plus the original pdf-analyst frq + mget shape, and a native->bridge->native sandwich. New `examples/srt-after-map-inline-lambda.ilo` exercises the same pattern through `tests/examples_engines.rs` so the higher-level harness catches future drift too.

## Test plan

- [x] Repro from pdf-analyst rerun4 (`min2.ilo`) now matches tree/VM on Cranelift
- [x] Nine new cross-engine regression tests pass on tree / VM / Cranelift
- [x] New `examples/srt-after-map-inline-lambda.ilo` runs identically on every engine via `tests/examples_engines.rs`
- [x] Full `cargo test --release --features cranelift` green (3071 + 24 + 30 + ... passes, 0 failures)
- [x] `cargo fmt --check` and `cargo clippy --release --features cranelift -- -D warnings` clean

## Follow-ups (filed, out of scope here)

- Promote tree-bridge errors from silent `TAG_NIL` to runtime errors for HOFs (`srt`, `grp`, `uniqby`, `partition`) so a callback failure surfaces as ILO-R instead of `nil`. Independent of this PR; logged in `ilo_assessment_feedback.md` parked section.