### PR TITLE
cli: restore documented auto-run for main and inline programs

### DIFF
--- a/examples/autorun-main.ilo
+++ b/examples/autorun-main.ilo
@@ -1,0 +1,14 @@
+-- `ilo file.ilo` auto-runs `main` when a multi-function file
+-- defines one. SKILL.md: "Multi-function files require either a
+-- function name argument or a function called `main`."
+--
+-- This example also pins that explicit func args still work and
+-- that helpers can be called from main like any other fn.
+
+helper a:n>n;+a 1
+main>n;helper 41
+
+-- run: main
+-- out: 42
+-- run: helper 9
+-- out: 10

--- a/src/main.rs
+++ b/src/main.rs
@@ -6704,23 +6704,21 @@ mod tests {
     fn dispatch_bare_args_minus_e_code_shorthand() {
         // -e as the inline code flag (not the --expanded flag here since engine_flag is None
         // and args[m] = -e triggers the expanded path, but -e as argv[1] triggers
-        // the "treat args[2] as code" path)
+        // the "treat args[2] as code" path).
+        //
+        // Inline auto-run: a zero-arg single fn runs with no extra args
+        // and exits 0. (Comment-only / no-fn snippets still AST-dump;
+        // covered in regression_cli_default.rs.)
         let global = cli::Global {
             ansi: false,
             text: false,
             json: false,
             no_hints: false,
         };
-        // dispatch_bare_args: args[1] == "-e" → args[2] is the code string
         let code = dispatch_bare_args(
-            vec![
-                "ilo".to_string(),
-                "-e".to_string(),
-                "f x:n>n;*x 2".to_string(),
-            ],
+            vec!["ilo".to_string(), "-e".to_string(), "f>n;42".to_string()],
             &global,
         );
-        // No args past the code: should dump AST JSON (exit 0)
         assert_eq!(code, 0);
     }
 
@@ -6807,9 +6805,11 @@ mod tests {
     }
 
     #[test]
-    fn dispatch_bare_args_emit_no_target_dumps_ast() {
+    fn dispatch_bare_args_emit_no_target_runs_default() {
         // --emit with no target arg: target = None → dispatch_run gets emit=None,
-        // falls through to default engine execution with no rest args → AST JSON dump (exit 0)
+        // falls through to default engine execution. With a zero-arg
+        // single-fn inline snippet, the default engine auto-runs it and
+        // exits 0. (See SKILL.md for the inline auto-run contract.)
         let global = cli::Global {
             ansi: false,
             text: false,
@@ -6819,12 +6819,11 @@ mod tests {
         let code = dispatch_bare_args(
             vec![
                 "ilo".to_string(),
-                "f x:n>n;*x 2".to_string(),
+                "f>n;42".to_string(),
                 "--emit".to_string(),
             ],
             &global,
         );
-        // None emit → falls to default engine with no rest → AST JSON dump → exit 0
         assert_eq!(code, 0);
     }
 
@@ -7504,13 +7503,16 @@ mod tests {
         assert_eq!(code, 1);
     }
 
-    // ── dispatch_run: no args → AST JSON dump ────────────────────────────────
+    // ── dispatch_run: no rest args → auto-runs the inline entry ──────────────
 
     #[test]
-    fn dispatch_run_no_rest_args_dumps_ast_json() {
-        // When rest is empty and func_name not found → dumps AST JSON
+    fn dispatch_run_no_rest_args_auto_runs_inline() {
+        // Inline auto-run: with rest empty and a runnable inline entry
+        // (single zero-arg fn) the default engine runs it and exits 0.
+        // The legacy "always AST-dump" inline contract is preserved
+        // only for non-runnable shapes; see regression_cli_default.rs.
         let run_args = cli::RunArgs {
-            source: "f x:n>n;*x 2".to_string(),
+            source: "f>n;42".to_string(),
             engine: cli::Engine::Default,
             run_tree: false,
             run: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2693,12 +2693,22 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
                 )
             }
             cli::Engine::Default => {
-                // Default: func-name heuristic + Cranelift JIT with interpreter fallback
+                // Default: func-name heuristic + Cranelift JIT with interpreter fallback.
+                //
+                // Inline-lambda lifting emits synthetic `__lit_N` top-level
+                // decls (see parser/mod.rs ~line 2863). These are an
+                // implementation detail of HOF dispatch — they must not show
+                // up in the "available functions" listing, must not satisfy
+                // the auto-run heuristic, and must not be selectable as a
+                // CLI positional arg. The `__` prefix is reserved for the
+                // compiler; filtering on it is safe.
                 let func_names: Vec<&str> = program
                     .declarations
                     .iter()
                     .filter_map(|d| match d {
-                        ast::Decl::Function { name, .. } => Some(name.as_str()),
+                        ast::Decl::Function { name, .. } if !name.starts_with("__") => {
+                            Some(name.as_str())
+                        }
                         _ => None,
                     })
                     .collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -2756,10 +2756,30 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
                         }
                     }
                 } else {
-                    // Inline code with no func arg and no other mode flag:
-                    // legacy AST-dump path. Preserved for tooling and for
-                    // `ilo '<snippet>'` inspection. Documented since 0.x.
-                    return dump_ast_json(&program);
+                    // Inline code with no func arg and no other mode flag.
+                    //
+                    // SKILL.md documents: "Inline programs (`ilo 'code'`)
+                    // and single-function files run their entry function
+                    // with the remaining CLI args; no explicit function
+                    // name needed." Auto-run when there's a runnable
+                    // target: a function called `main`, or a single
+                    // user-defined function.
+                    //
+                    // Silently AST-dumping a runnable inline program was a
+                    // soundness hazard for piped consumers — they got
+                    // valid-looking JSON on stdout with exit code 0 that
+                    // was NOT the program result.
+                    //
+                    // Zero-fn or multi-fn-without-main inline snippets
+                    // still AST-dump, preserving the tooling escape hatch
+                    // from PR #178. `--ast` remains the explicit form for
+                    // pinning AST-dump output regardless of fn shape.
+                    match func_names.len() {
+                        0 => return dump_ast_json(&program),
+                        1 => (None, vec![]),
+                        _ if func_names.contains(&"main") => (Some("main"), vec![]),
+                        _ => return dump_ast_json(&program),
+                    }
                 };
 
                 run_default(&program, func_name, run_args, &source, mode, explicit_json)

--- a/src/main.rs
+++ b/src/main.rs
@@ -2727,12 +2727,16 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
                     }
                 } else if is_file {
                     // File with no func arg: auto-run if there's exactly one
-                    // function, list available functions if there are
-                    // several, AST-dump if there are none (declarations-only
-                    // file — useful for inspecting type/alias-only modules).
+                    // function, auto-run `main` if a multi-fn file defines
+                    // one, list available functions if there are several
+                    // without a `main`, AST-dump if there are none
+                    // (declarations-only file — useful for inspecting
+                    // type/alias-only modules). SKILL.md documents the
+                    // main-as-default convention; see `[CLI invocation]`.
                     match func_names.len() {
                         0 => return dump_ast_json(&program),
                         1 => (None, vec![]),
+                        _ if func_names.contains(&"main") => (Some("main"), vec![]),
                         _ => {
                             eprintln!(
                                 "error: {} defines multiple functions, please specify one.",

--- a/tests/eval_inline.rs
+++ b/tests/eval_inline.rs
@@ -21,9 +21,12 @@ fn inline_single_func_bare_args() {
 }
 
 #[test]
-fn inline_no_args_outputs_ast() {
+fn inline_ast_flag_outputs_ast() {
+    // Inline snippets now auto-run when there's a runnable entry;
+    // `--ast` is the explicit form for AST inspection. This test pins
+    // parser+verifier acceptance of a many-arg function declaration.
     let out = ilo()
-        .args(["tot p:n q:n r:n>n;s=*p q;t=*s r;+s t"])
+        .args(["--ast", "tot p:n q:n r:n>n;s=*p q;t=*s r;+s t"])
         .output()
         .expect("failed to run ilo");
     assert!(out.status.success());
@@ -35,14 +38,13 @@ fn inline_no_args_outputs_ast() {
     );
 }
 
-// Inline-no-func AST-dump mode is an inspection path, not an execution path.
-// Verify errors on partial snippets (e.g. a function body that references
-// an undeclared name) should not gate the AST dump; the user is exploring
-// structure, not running code.
+// `--ast` inspection mode is structural, not executional. Verify errors
+// on partial snippets (e.g. a function body that references an undeclared
+// name) should not gate the AST dump; the user is exploring structure.
 #[test]
-fn inline_no_args_skips_verify_errors_on_partial_snippet() {
+fn inline_ast_flag_skips_verify_errors_on_partial_snippet() {
     let out = ilo()
-        .args(["f>n;slc xs 0 1"])
+        .args(["--ast", "f>n;slc xs 0 1"])
         .output()
         .expect("failed to run ilo");
     assert!(
@@ -1712,9 +1714,10 @@ fn get_verifier_wrong_type() {
 
 #[test]
 fn dollar_parses_inline() {
-    // $"url" should parse and verify without error (returns AST when no args)
+    // $"url" should parse and verify without error. Uses --ast to
+    // inspect the parsed shape without invoking the runtime.
     let out = ilo()
-        .args([r#"f url:t>R t t;$url"#])
+        .args(["--ast", r#"f url:t>R t t;$url"#])
         .output()
         .expect("failed to run ilo");
     assert!(
@@ -1723,7 +1726,6 @@ fn dollar_parses_inline() {
         String::from_utf8_lossy(&out.stderr)
     );
     let stdout = String::from_utf8_lossy(&out.stdout);
-    // No args → AST output
     assert!(
         stdout.contains("get"),
         "expected 'get' in AST output, got: {}",
@@ -1733,9 +1735,9 @@ fn dollar_parses_inline() {
 
 #[test]
 fn dollar_bang_parses_inline() {
-    // $!url should parse as get! url — enclosing function must return R t t for ! to verify
+    // $!url should parse as get! url — enclosing function must return R t t for ! to verify.
     let out = ilo()
-        .args([r#"f url:t>R t t;~($!url)"#])
+        .args(["--ast", r#"f url:t>R t t;~($!url)"#])
         .output()
         .expect("failed to run ilo");
     assert!(
@@ -1783,12 +1785,12 @@ fn post_verifier_wrong_type_body() {
 
 #[test]
 fn post_returns_result_type() {
-    // post url body should type-check as R t t
+    // post url body should type-check as R t t. Use --ast to inspect
+    // the parsed shape without invoking the network at runtime.
     let out = ilo()
-        .args([r#"f url:t body:t>R t t;post url body"#])
+        .args(["--ast", r#"f url:t body:t>R t t;post url body"#])
         .output()
         .expect("failed to run ilo");
-    // No args → AST output; should succeed verification
     assert!(
         out.status.success(),
         "stderr: {}",
@@ -1798,9 +1800,9 @@ fn post_returns_result_type() {
 
 #[test]
 fn post_appears_in_ast() {
-    // post url body — no runtime args → AST output; verify succeeds
+    // post url body — inspect AST via --ast; verify succeeds.
     let out = ilo()
-        .args([r#"f url:t body:t>R t t;post url body"#])
+        .args(["--ast", r#"f url:t body:t>R t t;post url body"#])
         .output()
         .expect("failed to run ilo");
     assert!(

--- a/tests/regression_cli_default.rs
+++ b/tests/regression_cli_default.rs
@@ -4,13 +4,19 @@
 //
 // New behaviour:
 //   * `ilo file.ilo`           with exactly one fn → runs that fn
-//   * `ilo file.ilo`           with multiple fns   → prints a friendly
-//                                                    listing and exits 1
+//   * `ilo file.ilo`           with `main` defined → runs main
+//   * `ilo file.ilo`           multi-fn without main → friendly listing,
+//                                                      exits 1
 //   * `ilo file.ilo func args` keeps working unchanged
 //   * `ilo --ast file.ilo`     dumps the AST as JSON (explicit flag,
 //                              works before or after the source)
-//   * `ilo '<code>'`           inline with no func arg still AST-dumps
-//                              (legacy contract from PR #178 preserved)
+//   * `ilo '<code>'`           inline auto-runs main or single fn;
+//                              falls back to AST-dump only when there's
+//                              no runnable target (zero fns, or multi-fn
+//                              snippets without main). Soundness fix:
+//                              `ilo 'f>n;42'` used to silently AST-dump
+//                              to stdout with exit 0, breaking piped
+//                              consumers expecting the program result.
 
 use std::process::Command;
 
@@ -156,15 +162,79 @@ fn ast_flag_on_inline_code() {
     assert!(stdout.contains("\"declarations\""));
 }
 
-// ── legacy inline-no-func AST dump preserved ──────────────────────────────────
+// ── multi-fn file with `main` auto-runs main ──────────────────────────────────
 
 #[test]
-fn inline_no_func_still_dumps_ast() {
-    let (ok, stdout, _stderr) = run(&["f>n;5"]);
+fn multi_fn_file_with_main_auto_runs_main() {
+    // SKILL.md documents: "Multi-function files require either a
+    // function name argument or a function called `main`." Before this
+    // fix the CLI errored with 'defines multiple functions' even when
+    // main was the obvious entry.
+    let (_dir, path) = write_temp("helper a:n>n;+a 1\nmain>n;helper 41\n");
+    let (ok, stdout, stderr) = run(&[path.to_str().unwrap()]);
+    assert!(ok, "expected success; stderr: {stderr}");
+    assert_eq!(stdout.trim(), "42");
+    assert!(
+        !stderr.contains("defines multiple functions"),
+        "no listing should fire when main is defined; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn multi_fn_file_explicit_func_arg_overrides_main() {
+    // Explicit func arg still wins, even when main is defined.
+    let (_dir, path) = write_temp("helper>n;7\nmain>n;42\n");
+    let (ok, stdout, stderr) = run(&[path.to_str().unwrap(), "helper"]);
+    assert!(ok, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "7");
+}
+
+// ── inline code auto-runs runnable entries ────────────────────────────────────
+
+#[test]
+fn inline_single_fn_auto_runs() {
+    // Soundness fix: `ilo 'f>n;42'` used to AST-dump to stdout with
+    // exit 0. Piped consumers got valid-looking JSON that was not the
+    // program result. Now auto-runs the entry function per SKILL.md.
+    let (ok, stdout, stderr) = run(&["f>n;42"]);
+    assert!(ok, "expected success; stderr: {stderr}");
+    assert_eq!(stdout.trim(), "42");
+    assert!(
+        !stdout.contains("\"declarations\""),
+        "no AST dump expected for runnable inline snippet; got: {stdout}"
+    );
+}
+
+#[test]
+fn inline_multi_fn_with_main_auto_runs_main() {
+    let (ok, stdout, stderr) = run(&["helper a:n>n;+a 1\nmain>n;helper 41"]);
+    assert!(ok, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "42");
+}
+
+#[test]
+fn inline_multi_fn_without_main_still_dumps_ast() {
+    // Legacy contract from PR #178 preserved for non-runnable snippets:
+    // when there is no `main` and no single entry, the CLI can't pick
+    // one without guessing, so AST-dump remains the fallback. `--ast`
+    // is the explicit form for pinning this behaviour.
+    let (ok, stdout, _stderr) = run(&["foo>n;1\nbar>n;2"]);
     assert!(ok);
     assert!(
         stdout.contains("\"declarations\""),
-        "inline-no-func default AST dump should be preserved; got: {stdout}"
+        "non-runnable inline snippet should AST-dump; got: {stdout}"
+    );
+}
+
+#[test]
+fn inline_zero_fn_still_dumps_ast() {
+    // Comment-only inline snippets have zero declarations and nothing
+    // to run, so AST-dump is still the right fallback.
+    let (ok, stdout, _stderr) = run(&["-- comment only"]);
+    assert!(ok);
+    assert!(
+        stdout.contains("\"declarations\""),
+        "zero-fn inline snippet should AST-dump; got: {stdout}"
     );
 }
 
@@ -179,4 +249,26 @@ fn empty_file_dumps_ast() {
     let (ok, stdout, stderr) = run(&[path.to_str().unwrap()]);
     assert!(ok, "stderr: {stderr}");
     assert!(stdout.contains("\"declarations\""));
+}
+
+// ── synthetic inline-lambda decls hidden from listing ─────────────────────────
+
+#[test]
+fn synthetic_lambda_decls_hidden_from_multi_fn_listing() {
+    // Inline lambdas lift to synthetic `__lit_N` top-level decls. These
+    // are an implementation detail and must not surface in the
+    // "available functions" listing the CLI prints for a multi-fn file
+    // with no func arg and no main.
+    let (_dir, path) =
+        write_temp("sq xs:L n>L n;map (x:n>n;*x x) xs\nother xs:L n>L n;flt (x:n>b;>x 0) xs\n");
+    let (ok, _stdout, stderr) = run(&[path.to_str().unwrap()]);
+    assert!(!ok, "expected non-zero exit");
+    assert!(
+        !stderr.contains("__lit"),
+        "synthetic __lit_N names must not leak to user listing; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("sq") && stderr.contains("other"),
+        "real fn names should still be listed; stderr: {stderr}"
+    );
 }

--- a/tests/regression_friendly_errors.rs
+++ b/tests/regression_friendly_errors.rs
@@ -11,7 +11,14 @@ fn run_err(src: &str) -> String {
 }
 
 fn run_ok(src: &str) {
-    let out = ilo().arg(src).output().expect("failed to run ilo");
+    // These regressions pin parser/verifier acceptance. Since inline
+    // single-fn snippets now auto-run (and would fail arity without
+    // positional args), inspect via `--ast` instead to keep the
+    // parse-acceptance signal cleanly decoupled from runtime semantics.
+    let out = ilo()
+        .args(["--ast", src])
+        .output()
+        .expect("failed to run ilo");
     assert!(
         out.status.success(),
         "expected success for {src:?}, stderr: {}",

--- a/tests/regression_p001_cascade.rs
+++ b/tests/regression_p001_cascade.rs
@@ -26,7 +26,13 @@ fn run_err(src: &str) -> String {
 }
 
 fn run_ok(src: &str) {
-    let out = ilo().arg(src).output().expect("failed to run ilo");
+    // Use --ast so inline single-fn snippets with required params don't
+    // trip the new auto-run contract on a sanity-check (we only want
+    // parser/verifier acceptance, not runtime).
+    let out = ilo()
+        .args(["--ast", src])
+        .output()
+        .expect("failed to run ilo");
     assert!(
         out.status.success(),
         "expected success for {src:?}, stderr: {}",


### PR DESCRIPTION
## Summary

Two soundness-class regressions in the CLI default-engine dispatch:

1. **`ilo file.ilo` with `main`-as-default broken.** A multi-fn file containing `main` was erroring with `defines multiple functions, please specify one` instead of auto-running `main`. SKILL.md (`[CLI invocation]`) has documented this contract since 0.x.

2. **`ilo 'f>n;42'` silently AST-dumping.** Inline programs with a runnable entry were dumping AST JSON to stdout with exit 0 instead of running. For piped consumers this is the worst kind of bug: valid-looking JSON output that is not the program result. SKILL.md: *"Inline programs (`ilo 'code'`) and single-function files run their entry function with the remaining CLI args; no explicit function name needed."*

Plus a related papercut several persona reports flagged: synthetic `__lit_N` inline-lambda decls were leaking into the "available functions" listing.

The CLI default branch handled the single-fn-inline / multi-fn / main cases inconsistently with the documented contract, treating inline as "always AST-dump" and treating multi-fn files as "always error". This PR aligns the runtime with the docs and tightens the dispatcher to hide compiler-internal names.

## Repro

Before:
```
$ cat > /tmp/automain.ilo <<EOF
> helper a:n>n;+a 1
> main>n;helper 41
> EOF
$ ilo /tmp/automain.ilo
error: /tmp/automain.ilo defines multiple functions, please specify one.
available functions:
  helper
  main
$ ilo 'f>n;42'
{
  "declarations": [
    { "Function": { "name": "f", ... } }
  ]
}
$ echo $?
0
```

After:
```
$ ilo /tmp/automain.ilo
42
$ ilo 'f>n;42'
42
```

## What's in the diff

Five discrete commits:

1. **`cli: hide synthetic __lit_N decls from func-name discovery`** — filter `Decl::Function` whose name starts with `__` at the source. Synthetic names from inline-lambda lifting (parser/mod.rs ~line 2863) no longer leak into the auto-run heuristic, the multi-fn listing, or CLI positional-arg matching. `__` is reserved for the compiler so the filter is safe and forward-compatible if more synthetic prefixes land.
2. **`cli: prefer main when a multi-fn file omits the func arg`** — restore the documented `main`-as-default convention for multi-fn files. Multi-fn files without `main` keep the friendly listing.
3. **`cli: auto-run inline programs with a runnable entry`** — `ilo '<single fn>'` and `ilo '<multi-fn with main>'` now auto-run. Zero-fn (declaration-only / comment-only) and multi-fn-without-main inline snippets still AST-dump, preserving the inspection escape hatch from PR #178. `--ast` remains the explicit form for any case where AST output is wanted regardless of shape.
4. **`test: pin auto-run contract across file and inline paths`** — extends `tests/regression_cli_default.rs` with 7 new cross-cutting tests, adds `examples/autorun-main.ilo` so the engine harness exercises the main-as-default path across tree / VM / Cranelift, and so future agents have an in-context demonstration.
5. **`test: migrate pre-existing inline-snippet tests to --ast`** — several tests in `eval_inline.rs`, `regression_friendly_errors.rs`, `regression_p001_cascade.rs`, and `main.rs`'s embedded test module used inline single-fn snippets with required params as parse-acceptance smoke tests, relying on the implicit AST-dump path. Switched to explicit `--ast` so the parse-acceptance signal stays decoupled from runtime semantics.

## Test plan

- [x] `cargo test --release --features cranelift` — 5296 passed, 0 failed across 134 suites
- [x] `cargo fmt --check`
- [x] `cargo clippy --release --features cranelift --all-targets -- -D warnings`
- [x] New regressions: `multi_fn_file_with_main_auto_runs_main`, `multi_fn_file_explicit_func_arg_overrides_main`, `inline_single_fn_auto_runs`, `inline_multi_fn_with_main_auto_runs_main`, `inline_multi_fn_without_main_still_dumps_ast`, `inline_zero_fn_still_dumps_ast`, `synthetic_lambda_decls_hidden_from_multi_fn_listing`
- [x] `examples/autorun-main.ilo` runs across every engine via `tests/examples_engines.rs`
- [x] Manual repro verified fixed for both reported shapes
- [x] Existing legacy contracts still pinned: single-fn auto-run, multi-fn-without-main listing, `--ast` always wins, comment-only inline AST-dumps

## Follow-ups

None. SKILL.md was already correct; the bug was runtime drift from the documented contract.