### PR TITLE
Cranelift JIT OP_LISTAPPEND: route rebind shape through the in-place helper

### DIFF
--- a/examples/listappend-large-inplace.ilo
+++ b/examples/listappend-large-inplace.ilo
@@ -1,0 +1,38 @@
+-- Demonstrates the in-place OP_LISTAPPEND fast path on the in-process
+-- Cranelift JIT (the default engine).
+--
+-- The rebind shape `xs = += xs item` is the canonical foreach-build
+-- accumulator. Every engine has a peephole that emits OP_LISTAPPEND with
+-- destination register == source register, which the runtime then handles
+-- via an RC=1 in-place mutation (amortised O(1) per push) instead of
+-- cloning the whole list (O(n) per push, O(n²) total).
+--
+-- The cloning helper still exists for the non-rebind shape `ys = += xs item`,
+-- where the source must be preserved across the call. See
+-- examples/listappend-non-rebind-alias.ilo for that contract.
+--
+-- A v0.11.3 regression had the in-process Cranelift JIT calling the cloning
+-- helper unconditionally — the a_idx == b_idx peephole was added to the AOT
+-- path in 74668bb but missed in jit_cranelift.rs. A 210k-line workload then
+-- OOM-killed at ~51 GB RSS. The fix ports the peephole into the in-process
+-- JIT verbatim. This example pins the now-correct shape with a list big
+-- enough that an accidental return to the cloning path would balloon memory
+-- on every engine.
+
+-- Build [0, 1, ..., n-1] by repeated `+=` rebind. The result is just the
+-- length so the test harness compares cheaply on every engine.
+build n:n>n;xs=[];@i 0..n{xs=+=xs i};len xs
+
+-- A 5k-element accumulator. Pre-fix on the in-process JIT this allocated
+-- roughly sum(k for k in 0..5000) = ~12.5M NanVals of transient memory.
+-- Post-fix the Vec grows in place, peak memory stays at ~5k slots.
+demo-5k>n;build 5000
+
+-- A 10k-element accumulator for an even firmer regression catch. Tree and
+-- VM have always handled this in O(n); the in-process JIT now matches.
+demo-10k>n;build 10000
+
+-- run: demo-5k
+-- out: 5000
+-- run: demo-10k
+-- out: 10000

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -2749,7 +2749,23 @@ fn compile_function_body(
             OP_LISTAPPEND => {
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
-                let fref = get_func_ref(&mut builder, module, helpers.listappend);
+                // Pick the in-place helper only when the destination and source
+                // registers are the same SSA variable. The compiler peephole
+                // `name = += name item` emits a == b, which guarantees that
+                // returning the same Rc pointer at RC=1 is balanced. When a != b
+                // the in-place path would alias the result through both slots
+                // and silently mutate the caller's source list (see
+                // jit_listappend_inplace docs and the OP_MSET split in #249).
+                // Mirrors the same dispatch in compile_cranelift.rs (AOT). The
+                // peephole was added there in 74668bb but missed here, causing
+                // a foreach-build O(n²) memory blow-up on the default in-process
+                // JIT engine (210k-line log forensics OOM-killed at ~51 GB).
+                let helper_fn = if a_idx == b_idx {
+                    helpers.listappend_inplace
+                } else {
+                    helpers.listappend
+                };
+                let fref = get_func_ref(&mut builder, module, helper_fn);
                 let call_inst = builder.ins().call(fref, &[bv, cv]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);

--- a/tests/regression_listappend_inplace_jit.rs
+++ b/tests/regression_listappend_inplace_jit.rs
@@ -1,0 +1,221 @@
+// Regression tests for the in-process Cranelift JIT in-place OP_LISTAPPEND
+// peephole, ported from the AOT path in `src/vm/compile_cranelift.rs`.
+//
+// Background:
+//
+// Commit `74668bb` ("prevent OP_LISTAPPEND non-rebind aliasing on VM and
+// Cranelift") split the JIT helper into two:
+//
+//   * `jit_listappend`         — always clones the source list (safe for the
+//                                non-rebind shape `ys = +=xs item`).
+//   * `jit_listappend_inplace` — RC=1 in-place fast path with fall-back clone
+//                                (safe only when destination and source are
+//                                the same SSA variable).
+//
+// It then updated the AOT lowering (`src/vm/compile_cranelift.rs`) to pick
+// `listappend_inplace` only when `a_idx == b_idx` (the rebind shape the
+// compiler peephole `name = += name item` guarantees). But it forgot to make
+// the same change in the in-process JIT (`src/vm/jit_cranelift.rs`), which
+// continued to call the clone-only `listappend` unconditionally.
+//
+// Effect: every iteration of a foreach-build accumulator (`xs = += xs item`)
+// on the default engine cloned the entire list, giving O(n²) memory and time.
+// A 210k-line log forensics workload that ran end-to-end on v0.11.2 was
+// OOM-killed at ~51 GB RSS on v0.11.3. Smaller measurements with the v0.11.3
+// release binary showed Cranelift in-process JIT using 32× more memory than
+// tree/VM for the same 10k accumulator workload, while v0.11.2's JIT used
+// roughly the same as tree/VM (linear).
+//
+// Fix: port the `a_idx == b_idx` peephole into `jit_cranelift.rs` verbatim.
+// This file pins:
+//
+//   1. The rebind-shape foreach accumulator scales linearly in wall-clock on
+//      every engine, including the default in-process Cranelift JIT.
+//   2. The non-rebind shape (`ys = +=xs item`) still leaves `xs` untouched
+//      across all engines (the alias-fix from `74668bb` must hold).
+//   3. The accumulator produces correct output (length + final-element check)
+//      on all engines, so the perf optimisation didn't trade off correctness.
+//
+// The size (50k) is calibrated so the pre-fix O(n²) JIT path takes long
+// enough to be unambiguously distinguishable from the linear path without
+// burning excessive CI time. Pre-fix at 50k: roughly tens of seconds and
+// gigabytes of RSS. Post-fix: under a second.
+
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+// ── Correctness: 50k-element rebind accumulator returns the right list ──────
+//
+// Numeric and text variants exercise both the immediate-NaN-tagged item path
+// and the heap-RC item path through the JIT helper.
+
+const REBIND_50K_NUMERIC_LEN: &str =
+    "build n:n>n;xs=[];@i 0..n{xs=+=xs i};len xs\ndemo>n;build 50000";
+
+const REBIND_50K_NUMERIC_LAST: &str =
+    "build n:n>n;xs=[];@i 0..n{xs=+=xs i};at xs (-n 1) ?? -1\ndemo>n;build 50000";
+
+#[test]
+fn rebind_50k_numeric_len_tree() {
+    assert_eq!(run("--run-tree", REBIND_50K_NUMERIC_LEN, "demo"), "50000");
+}
+
+#[test]
+fn rebind_50k_numeric_len_vm() {
+    assert_eq!(run("--run-vm", REBIND_50K_NUMERIC_LEN, "demo"), "50000");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn rebind_50k_numeric_len_cranelift() {
+    assert_eq!(
+        run("--run-cranelift", REBIND_50K_NUMERIC_LEN, "demo"),
+        "50000"
+    );
+}
+
+#[test]
+fn rebind_50k_numeric_last_tree() {
+    assert_eq!(run("--run-tree", REBIND_50K_NUMERIC_LAST, "demo"), "49999");
+}
+
+#[test]
+fn rebind_50k_numeric_last_vm() {
+    assert_eq!(run("--run-vm", REBIND_50K_NUMERIC_LAST, "demo"), "49999");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn rebind_50k_numeric_last_cranelift() {
+    assert_eq!(
+        run("--run-cranelift", REBIND_50K_NUMERIC_LAST, "demo"),
+        "49999"
+    );
+}
+
+// ── Scale: 50k-element rebind accumulator must finish well under O(n²) ──────
+//
+// Pre-fix on the in-process Cranelift JIT this took tens of seconds with
+// multi-GB peak RSS. Post-fix it's well under a second. 15s ceiling is
+// generous enough for slow CI runners while catching any regression back to
+// the cloning path (which on 50k would always exceed it on the JIT).
+
+#[test]
+fn rebind_50k_accumulator_under_15s_tree() {
+    let start = Instant::now();
+    let out = run("--run-tree", REBIND_50K_NUMERIC_LEN, "demo");
+    let elapsed = start.elapsed();
+    assert_eq!(out, "50000");
+    assert!(
+        elapsed < Duration::from_secs(15),
+        "tree 50k rebind accumulator took {elapsed:?} — expected <15s"
+    );
+}
+
+#[test]
+fn rebind_50k_accumulator_under_15s_vm() {
+    let start = Instant::now();
+    let out = run("--run-vm", REBIND_50K_NUMERIC_LEN, "demo");
+    let elapsed = start.elapsed();
+    assert_eq!(out, "50000");
+    assert!(
+        elapsed < Duration::from_secs(15),
+        "vm 50k rebind accumulator took {elapsed:?} — expected <15s"
+    );
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn rebind_50k_accumulator_under_15s_cranelift() {
+    // This is the test that the original v0.11.3 regression failed: the
+    // in-process JIT cloned the list on every iteration, so 50k iterations
+    // ran in O(n²) and took roughly a minute with multi-GB RSS. With the
+    // a_idx==b_idx peephole ported into jit_cranelift.rs, runtime drops to
+    // sub-second.
+    let start = Instant::now();
+    let out = run("--run-cranelift", REBIND_50K_NUMERIC_LEN, "demo");
+    let elapsed = start.elapsed();
+    assert_eq!(out, "50000");
+    assert!(
+        elapsed < Duration::from_secs(15),
+        "cranelift 50k rebind accumulator took {elapsed:?} — expected <15s. \
+         The OP_LISTAPPEND a_idx==b_idx peephole in jit_cranelift.rs may have \
+         regressed back to the cloning helper."
+    );
+}
+
+// ── Alias fix from 74668bb still holds: distinct dest preserves source ──────
+//
+// `ys = +=xs item` must NOT mutate `xs` on any engine. The cloning helper is
+// the only correct path here; the fix this file pins is purely the perf
+// fast path on the rebind shape, not a semantics change.
+
+const NON_REBIND_DISTINCT_PRESERVES_XS: &str = "f>L n;xs=[1,2,3];ys=+=xs 99;xs";
+
+#[test]
+fn non_rebind_distinct_preserves_xs_tree() {
+    assert_eq!(
+        run("--run-tree", NON_REBIND_DISTINCT_PRESERVES_XS, "f"),
+        "[1, 2, 3]"
+    );
+}
+
+#[test]
+fn non_rebind_distinct_preserves_xs_vm() {
+    assert_eq!(
+        run("--run-vm", NON_REBIND_DISTINCT_PRESERVES_XS, "f"),
+        "[1, 2, 3]"
+    );
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn non_rebind_distinct_preserves_xs_cranelift() {
+    assert_eq!(
+        run("--run-cranelift", NON_REBIND_DISTINCT_PRESERVES_XS, "f"),
+        "[1, 2, 3]"
+    );
+}
+
+// ── Text-item rebind: heap-RC item path through the in-place helper ─────────
+//
+// Numbers are immediate NaN-tagged so they never exercise the item-side RC
+// path. Text items live on the heap, so a clone_rc/drop_rc imbalance in the
+// in-place helper would surface as a wrong value or a leak. 1k iterations is
+// enough to amplify any per-iter RC mismatch.
+
+const REBIND_TEXT_1K_LAST: &str =
+    "build n:n>t;xs=[];@i 0..n{xs=+=xs \"x\"};at xs (-n 1) ?? \"miss\"\ndemo>t;build 1000";
+
+#[test]
+fn rebind_text_1k_last_tree() {
+    assert_eq!(run("--run-tree", REBIND_TEXT_1K_LAST, "demo"), "x");
+}
+
+#[test]
+fn rebind_text_1k_last_vm() {
+    assert_eq!(run("--run-vm", REBIND_TEXT_1K_LAST, "demo"), "x");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn rebind_text_1k_last_cranelift() {
+    assert_eq!(run("--run-cranelift", REBIND_TEXT_1K_LAST, "demo"), "x");
+}


### PR DESCRIPTION
## Summary

Foreach-build accumulators (`xs = += xs item`) on the default in-process Cranelift JIT engine were running in O(n²) memory and time on v0.11.3, OOM-killing a 210k-line log forensics workload at ~51 GB RSS. v0.11.2 ran the same workload end-to-end. Tree, VM, and AOT-Cranelift were all unaffected.

Root cause sits in pre-v0.11.3 commit `74668bb` ("prevent OP_LISTAPPEND non-rebind aliasing on VM and Cranelift") — not in any of today's 16 PRs. That commit split `jit_listappend` into a clone-only helper and a new `jit_listappend_inplace` fast-path helper, added the `a_idx == b_idx` peephole at the AOT call site in `compile_cranelift.rs`, but missed the matching change at the in-process JIT call site in `jit_cranelift.rs`. The in-process JIT kept calling the clone-only helper unconditionally, so every `+=` rebind allocated a fresh Vec and copied the old contents.

## Repro before / after

10k-line input on the default engine, NASA-style log forensics workload (`/tmp/ilo-persona-logs-forensics-rerun4/main.ilo`):

| Engine | Pre-fix peak RSS | Post-fix peak RSS |
| --- | ---: | ---: |
| `--run-tree` | 88 MB | 88 MB |
| `--run-vm` | 86 MB | 86 MB |
| `--run-cranelift` (default) | **2.9 GB** | **153 MB** |

50k-line input on Cranelift, post-fix: 437 MB peak. Projects to ~1.8 GB at 210k, well clear of the 51 GB OOM the persona hit.

The pattern this PR fixes is the most common foreach idiom in real ilo programs (`xs=[];@k ks{xs=+=xs item}`), so the impact on any large-list build was the same — log analysis happened to hit it first because 200k+ rows.

## What's in the diff (per commit)

1. **`cranelift jit: route OP_LISTAPPEND through the in-place helper on rebind`** — three-line peephole in `src/vm/jit_cranelift.rs`. Verbatim port of the `a_idx == b_idx` dispatch already in `src/vm/compile_cranelift.rs:2510-2528`. Both helpers were already declared and registered in `jit_cranelift.rs` by 74668bb; only the OP_LISTAPPEND arm needed updating.
2. **`test: cross-engine regression for the in-process JIT listappend fast path`** — `tests/regression_listappend_inplace_jit.rs`. 15 tests across tree / VM / Cranelift: 50k accumulator correctness (length + last element), 15-second perf ceiling for the foreach-build accumulator on every engine, alias-preservation for the distinct-register shape `ys = +=xs item`, and 1k Text-item rebind exercising the heap-RC item path so a clone_rc/drop_rc imbalance in `jit_listappend_inplace` surfaces here.
3. **`example: large foreach-build accumulator pins the in-place path`** — `examples/listappend-large-inplace.ilo`. Picked up by the existing `tests/examples_engines.rs` harness with `-- run` / `-- out` annotations.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --release --features cranelift --tests -- -D warnings` clean
- [x] `cargo test --release --features cranelift` green: 5305 passed / 0 failed across the lib + every integration suite
- [x] New `regression_listappend_inplace_jit` suite green on tree / VM / Cranelift (15 tests, 0.17s)
- [x] `examples_engines` green on every engine including the new `listappend-large-inplace.ilo`
- [x] Existing `regression_listappend_aliasing` and `regression_shadow_rebind_alias` suites still green (the alias contract from 74668bb that this PR rides on)
- [x] Original repro verified post-fix: 10k Cranelift 2.9 GB → 153 MB; 50k 437 MB

## Follow-ups

- The repro is not fully linear post-fix (10k=56s, 50k=158s — closer to O(n^1.5)). That residual is the conditional-branch `mset` path in `extract-hour-status` and is a separate hotspot from the OOM fixed here. Not in scope for this PR; the OOM is cleared and memory is linear.