### PR TITLE
fix: prefix `??` accepts call expression as value side

### DIFF
--- a/examples/qq-call-default.ilo
+++ b/examples/qq-call-default.ilo
@@ -1,0 +1,22 @@
+-- Prefix `??` accepts a CALL expression as its value side.
+-- Common case: nil-coalesce on a map lookup with a default.
+-- `??mget m "k" 0` parses as `??(mget m "k") 0`, the arity-aware
+-- parser stops after `mget`'s 2 args and leaves `0` for the default.
+-- Previously you had to write `??(mget m "k") 0` or bind first; now
+-- the bare form Just Works, which is the most common nil-coalesce
+-- shape in agent-written ilo (mget lookups with a fallback).
+
+hit>n;m=mset mmap "k" 42;??mget m "k" 0
+miss>n;m=mset mmap "k" 42;??mget m "missing" 99
+
+-- Chained: first non-nil wins, mirroring infix chaining.
+chain>n;m=mset mmap "a" 1;??mget m "x" ??mget m "a" 0
+
+-- run: hit
+-- out: 42
+
+-- run: miss
+-- out: 99
+
+-- run: chain
+-- out: 1

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1898,10 +1898,15 @@ impl Parser {
             | Some(Token::Amp)
             | Some(Token::Pipe)
             | Some(Token::PlusEq) => self.parse_prefix_binop(),
-            // Prefix nil-coalesce: ??a b — mirror of infix `a ?? b`
+            // Prefix nil-coalesce: ??a b, mirror of infix `a ?? b`.
+            // The value side uses `parse_call_arg` (not `parse_operand`) so
+            // a known-arity function with args expands into a call expression,
+            // consuming exactly its declared arity. This lets `??mget m "k" 0`
+            // parse as `??(mget m "k") 0` without forcing parens or a bind-first
+            // line. The most common nil-coalesce site is `??mget ... default`.
             Some(Token::NilCoalesce) => {
                 self.advance();
-                let value = self.parse_operand()?;
+                let value = self.parse_call_arg(false, None)?;
                 let default = self.parse_expr_inner()?;
                 Ok(Expr::NilCoalesce {
                     value: Box::new(value),
@@ -2571,8 +2576,11 @@ or write `({fmt_name} \"...\" ...)` so its args are grouped."
             | Some(Token::Pipe)
             | Some(Token::PlusEq) => self.parse_prefix_binop(),
             Some(Token::NilCoalesce) => {
+                // See `parse_expr_inner` for the rationale: `parse_call_arg`
+                // expands a known-arity function into a call so `??mget m "k" 0`
+                // parses as `??(mget m "k") 0`.
                 self.advance();
-                let value = self.parse_operand()?;
+                let value = self.parse_call_arg(false, None)?;
                 let default = self.parse_expr_inner()?;
                 Ok(Expr::NilCoalesce {
                     value: Box::new(value),

--- a/tests/regression_prefix_nil_coalesce.rs
+++ b/tests/regression_prefix_nil_coalesce.rs
@@ -58,6 +58,22 @@ const PREFIX_INFIX_DEFAULT_VAL: &str = "f>n;a=3;b=4;c=5;?? c a+b";
 // Nested prefix nil-coalesce — confirm right-associativity matches infix.
 const PREFIX_NESTED_NIL: &str = "f>n;c=nil;d=nil;??c ??d 0";
 const PREFIX_NESTED_INNER: &str = "f>n;c=nil;d=9;??c ??d 0";
+// Prefix `??` where the value side is a CALL expression. Previously the
+// value side used `parse_operand` (atom-only), so `??mget m "k" 0` mis-parsed:
+// `mget` was taken as the value atom and `m "k" 0` as the default expression
+// (which then failed because `m` is a Map, not a function). With the arity-cap
+// fix, the value side is parsed via `parse_call_arg`, so a known-arity
+// function consumes exactly its declared arity and the remaining tokens
+// become the default. Workarounds (`??(mget m "k") 0`, bind-first) keep
+// working; the new shape is purely additive.
+const PREFIX_CALL_HIT: &str = "f>n;m=mset mmap \"k\" 42;??mget m \"k\" 0";
+const PREFIX_CALL_MISS: &str = "f>n;m=mset mmap \"k\" 42;??mget m \"missing\" 99";
+// Chained prefix `??` with two call value-sides:
+// `??mget m "x" ??mget m "a" 0` reads as `??(mget m "x") (??(mget m "a") 0)`,
+// first miss, second hit, expect `1`.
+const PREFIX_CALL_CHAIN: &str = "f>n;m=mset mmap \"a\" 1;??mget m \"x\" ??mget m \"a\" 0";
+// Paren workaround still parses correctly post-fix.
+const PREFIX_CALL_PAREN: &str = "f>n;m=mset mmap \"k\" 42;??(mget m \"k\") 0";
 
 fn check_all(engine: &str) {
     assert_eq!(
@@ -109,6 +125,26 @@ fn check_all(engine: &str) {
         run(engine, PREFIX_NESTED_INNER, "f"),
         "9",
         "prefix nested inner engine={engine}"
+    );
+    assert_eq!(
+        run(engine, PREFIX_CALL_HIT, "f"),
+        "42",
+        "prefix call hit engine={engine}"
+    );
+    assert_eq!(
+        run(engine, PREFIX_CALL_MISS, "f"),
+        "99",
+        "prefix call miss engine={engine}"
+    );
+    assert_eq!(
+        run(engine, PREFIX_CALL_CHAIN, "f"),
+        "1",
+        "prefix call chain engine={engine}"
+    );
+    assert_eq!(
+        run(engine, PREFIX_CALL_PAREN, "f"),
+        "42",
+        "prefix call paren workaround engine={engine}"
     );
 }
 


### PR DESCRIPTION
## Summary

Prefix `??` (nil-coalesce) was parsing its value side with `parse_operand`, which only consumes an atom. So the most common nil-coalesce shape in agent-written ilo, `??mget m "k" 0`, mis-parsed: `mget` was taken as the value atom and `m "k" 0` as the default expression, which then failed because `m` is a Map, not a function.

Workarounds existed (`??(mget m "k") 0`, bind-first), but every site cost extra tokens and agent attention. Manifesto framing: this is a parser-precedence tax paid on every map lookup with a fallback, and it can be removed for free with the arity-cap pattern the parser already uses in four other places.

## Repro before/after

`main>n;m=mset mmap "k" 42;v=??mget m "k" 0;v`

Before (main):

```
{"code":"ILO-T004","message":"undefined variable 'mget'", ...}
{"code":"ILO-T005","message":"'m' is a M _ n, not a function (called with 2 args)", ...}
```

After (this branch): `42`

## What's in the diff

Three commits, one logical change each:

1. **parser: prefix `??` accepts call expression as value side** — swaps the value-side parser in both prefix-`??` arms (`parse_expr_inner` and `parse_operand`) from `parse_operand()` to `parse_call_arg(false, None)`. `parse_call_arg` is a strict superset: it handles every operand case and additionally expands a known-arity ident into a call consuming exactly its declared arity. This mirrors the existing arity-cap behaviour in `no_whitespace_call` (list literals) and `parse_call_arg`'s own nested-call block. Identifier-only `??x default`, paren `??(expr) default`, infix `c??d`, and chained `f a ?? g b ?? d` all keep working because `parse_call_arg` falls through to `parse_operand` for non-known-arity idents.

2. **test: prefix `??` with call-expression value across all engines** — extends `tests/regression_prefix_nil_coalesce.rs` with four new cases (hit, miss, two-call chain, paren workaround still works) running on tree / VM / Cranelift.

3. **example: prefix `??` with map lookup and default** — `examples/qq-call-default.ilo`, pinned by the engine harness. Three `-- run:` entries (hit, miss, chain) act as both regression coverage and an in-context demo for agents.

## Test plan

- [x] Repro fixed on tree, VM, Cranelift (verified manually before commit)
- [x] `cargo test --release --features cranelift` full suite green (3071 + 340 + others = 0 failures)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --release --features cranelift --all-targets -- -D warnings` clean
- [x] Targeted regression file passes 3/3 engine variants
- [x] Examples harness picks up the new example file and passes
- [x] Existing workarounds (parens, bind-first) confirmed still working

## Follow-ups

None. Adjacent observation: `??-x default` (prefix-minus value side) is broken on main too, but that's a separate operand-handling issue and out of scope for this fix.