### PR TITLE
fix: flat now works on VM and Cranelift, not just tree

### DIFF
--- a/examples/flat.ilo
+++ b/examples/flat.ilo
@@ -1,5 +1,7 @@
--- flat xs:L (L a) > L a — flatten a list one level.
--- Non-list elements pass through unchanged.
+-- flat xs:L (L a) > L a, flatten a list one level. Inner lists are
+-- spliced into the result; non-list elements pass through unchanged.
+-- Works identically on the tree-walking interpreter, the bytecode VM,
+-- and the Cranelift JIT.
 
 -- Basic nested flatten
 basic>L n;flat [[1, 2], [3, 4]]
@@ -13,9 +15,9 @@ gaps>L n;flat [[1], [], [2]]
 -- Mixed: non-list items pass through
 mixed>L n;flat [[1, 2], 3, [4, 5]]
 
--- flat is tree-only (vm/cranelift don't implement it)
--- engine-skip: vm
--- engine-skip: cranelift
+-- Composes with sum so the result feeds a numeric reducer
+total>n;sum (flat [[1, 2], [3, 4]])
+
 -- run: basic
 -- out: [1, 2, 3, 4]
 -- run: empty
@@ -24,3 +26,5 @@ mixed>L n;flat [[1, 2], 3, [4, 5]]
 -- out: [1, 2]
 -- run: mixed
 -- out: [1, 2, 3, 4, 5]
+-- run: total
+-- out: 10

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -104,6 +104,7 @@ struct HelperFuncs {
     variance: FuncId,
     sum: FuncId,
     avg: FuncId,
+    flat: FuncId,
     slc: FuncId,
     rgxsub: FuncId,
     take: FuncId,
@@ -296,6 +297,7 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         variance: declare_helper(module, "jit_variance", 2, 1),
         sum: declare_helper(module, "jit_sum", 2, 1),
         avg: declare_helper(module, "jit_avg", 2, 1),
+        flat: declare_helper(module, "jit_flat", 2, 1),
         slc: declare_helper(module, "jit_slc", 3, 1),
         rgxsub: declare_helper(module, "jit_rgxsub", 3, 1),
         take: declare_helper(module, "jit_take", 2, 1),
@@ -1058,7 +1060,7 @@ fn compile_function_body(
                 | OP_RGXSUB | OP_ZIP | OP_ENUMERATE | OP_RANGE | OP_WINDOW | OP_CHUNKS
                 | OP_CUMSUM | OP_SETUNION | OP_SETINTER | OP_SETDIFF | OP_FFT | OP_IFFT
                 | OP_TRANSPOSE | OP_MATMUL | OP_INV | OP_SOLVE | OP_DTFMT | OP_DTPARSE
-                | OP_CALL_BUILTIN_TREE | OP_LOADFN | OP_CALL_DYN => {
+                | OP_FLAT | OP_CALL_BUILTIN_TREE | OP_LOADFN | OP_CALL_DYN => {
                     non_num_write[a] = true;
                     non_bool_write[a] = true;
                 }
@@ -2480,6 +2482,16 @@ fn compile_function_body(
                 let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
                 let span_arg = builder.ins().iconst(I64, span_bits);
                 let fref = get_func_ref(&mut builder, module, helpers.avg);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_FLAT => {
+                // flat returns a list, no F64-shadow refresh needed.
+                let bv = builder.use_var(vars[b_idx]);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
+                let fref = get_func_ref(&mut builder, module, helpers.flat);
                 let call_inst = builder.ins().call(fref, &[bv, span_arg]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
@@ -5878,6 +5890,13 @@ f a:t b:t>t;join a b"#,
     fn codegen_cov_op_avg() {
         let bytes = compile_to_object_bytes("f>n;avg [1, 2, 3, 4]");
         assert!(bytes.is_ok(), "OP_AVG codegen failed: {:?}", bytes.err());
+    }
+
+    #[test]
+    fn codegen_cov_op_flat() {
+        // Exercise the OP_FLAT AOT codegen block (helper-call, list return).
+        let bytes = compile_to_object_bytes("f>L n;flat [[1, 2], [3, 4]]");
+        assert!(bytes.is_ok(), "OP_FLAT codegen failed: {:?}", bytes.err());
     }
 
     #[test]

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -111,6 +111,7 @@ struct HelperFuncs {
     variance: FuncId,
     sum: FuncId,
     avg: FuncId,
+    flat: FuncId,
     slc: FuncId,
     lst: FuncId,
     rgxsub: FuncId,
@@ -301,6 +302,7 @@ fn register_helpers(builder: &mut JITBuilder) {
         ("jit_variance", jit_variance as *const u8),
         ("jit_sum", jit_sum as *const u8),
         ("jit_avg", jit_avg as *const u8),
+        ("jit_flat", jit_flat as *const u8),
         ("jit_slc", jit_slc as *const u8),
         ("jit_lst", jit_lst as *const u8),
         ("jit_rgxsub", jit_rgxsub as *const u8),
@@ -476,6 +478,7 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         variance: declare_helper(module, "jit_variance", 2, 1),
         sum: declare_helper(module, "jit_sum", 2, 1),
         avg: declare_helper(module, "jit_avg", 2, 1),
+        flat: declare_helper(module, "jit_flat", 2, 1),
         slc: declare_helper(module, "jit_slc", 3, 1),
         lst: declare_helper(module, "jit_lst", 3, 1),
         rgxsub: declare_helper(module, "jit_rgxsub", 3, 1),
@@ -1124,7 +1127,7 @@ fn compile_function_body(
                 | OP_PRT | OP_RD | OP_RDL | OP_WR | OP_WRL | OP_TRM | OP_UPR | OP_LWR | OP_CAP
                 | OP_PADL | OP_PADR | OP_PADLC | OP_PADRC | OP_CHR | OP_CHARS | OP_UNQ | OP_UNIQBY | OP_PARTITION | OP_FRQ | OP_NUM
                 | OP_RGXSUB | OP_TRANSPOSE | OP_MATMUL | OP_DTFMT | OP_DTPARSE
-                | OP_CALL_BUILTIN_TREE | OP_LOADFN | OP_CALL_DYN => {
+                | OP_FLAT | OP_CALL_BUILTIN_TREE | OP_LOADFN | OP_CALL_DYN => {
                     non_num_write[a] = true;
                     non_bool_write[a] = true;
                 }
@@ -2656,6 +2659,16 @@ fn compile_function_body(
                     let rf = builder.ins().bitcast(F64, mf, result);
                     builder.def_var(f64_vars[a_idx], rf);
                 }
+            }
+            OP_FLAT => {
+                // flat returns a list, no F64-shadow refresh.
+                let bv = builder.use_var(vars[b_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
+                let fref = get_func_ref(&mut builder, module, helpers.flat);
+                let call_inst = builder.ins().call(fref, &[bv, span_arg]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
             }
             OP_SLC => {
                 // slc(R[B], R[C], R[D]) — D in data word A field

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -258,6 +258,7 @@ pub(crate) const OP_STDEV: u8 = 143; // R[A] = stdev(R[B])
 pub(crate) const OP_VARIANCE: u8 = 144; // R[A] = variance(R[B])
 pub(crate) const OP_SUM: u8 = 165; // R[A] = sum(R[B])  — empty list = 0
 pub(crate) const OP_AVG: u8 = 166; // R[A] = avg(R[B])  — empty list errors
+pub(crate) const OP_FLAT: u8 = 171; // R[A] = flat(R[B]) — flatten one level, non-list elements pass through
 // Higher-order: uniqby fn xs — pre-allocated, HOF dispatch not yet wired in VM.
 pub(crate) const OP_UNIQBY: u8 = 116; // R[A] = uniqby(R[B] (fn-ref), R[C] (list))
 // Higher-order: partition fn xs — pre-allocated, HOF dispatch not yet wired in VM.
@@ -2322,6 +2323,15 @@ impl RegCompiler {
                             self.reg_is_num[ra as usize] = true;
                             return ra;
                         }
+                        (Builtin::Flat, 1) => {
+                            // flat xs — flatten a list one level. Non-list
+                            // elements pass through unchanged. Returns a list,
+                            // so reg_is_num stays false.
+                            let rb = self.compile_expr(&args[0]);
+                            let ra = self.alloc_reg();
+                            self.emit_abc(OP_FLAT, ra, rb, 0);
+                            return ra;
+                        }
                         (Builtin::Slc, 3) => {
                             // slc list start end — two-instruction sequence:
                             //   OP_SLC   A=result  B=list  C=start
@@ -3735,7 +3745,7 @@ fn chunk_is_all_numeric(chunk: &Chunk) -> bool {
             | OP_TL | OP_FMT2 | OP_RGXSUB | OP_ZIP | OP_ENUMERATE | OP_WINDOW | OP_FFT
             | OP_IFFT | OP_RANGE | OP_CHUNKS | OP_CUMSUM | OP_SETUNION | OP_SETINTER
             | OP_SETDIFF | OP_TRANSPOSE | OP_MATMUL | OP_INV | OP_SOLVE | OP_DTFMT | OP_DTPARSE
-            | OP_CALL_BUILTIN_TREE | OP_LOADFN | OP_CALL_DYN => {
+            | OP_FLAT | OP_CALL_BUILTIN_TREE | OP_LOADFN | OP_CALL_DYN => {
                 return false;
             }
             _ => {}
@@ -8957,6 +8967,15 @@ impl<'a> VM<'a> {
                         Err(msg) => vm_err!(VmError::Type(msg)),
                     }
                 }
+                OP_FLAT => {
+                    let a = ((inst >> 16) & 0xFF) as usize + base;
+                    let b = ((inst >> 8) & 0xFF) as usize + base;
+                    let v = reg!(b);
+                    match vm_flat(v) {
+                        Ok(out) => reg_set!(a, out),
+                        Err(msg) => vm_err!(VmError::Type(msg)),
+                    }
+                }
                 OP_SLC => {
                     // Two-instruction sequence: OP_SLC A=result B=list C=start; data word A=end_reg
                     // Bounds accept negative integers Python-style (`-1` = last element).
@@ -12031,6 +12050,39 @@ fn vm_sum(v: NanVal) -> Result<NanVal, &'static str> {
     Ok(NanVal::number(total))
 }
 
+/// `flat xs` — flatten a list one level. Inner lists are spliced into the
+/// result; non-list elements pass through unchanged. Matches the tree-walker
+/// semantics in `src/interpreter/mod.rs`.
+fn vm_flat(v: NanVal) -> Result<NanVal, &'static str> {
+    if !v.is_heap() {
+        return Err("flat: arg must be a list");
+    }
+    let items = match unsafe { v.as_heap_ref() } {
+        HeapObj::List(items) => items,
+        _ => return Err("flat: arg must be a list"),
+    };
+    let mut result: Vec<NanVal> = Vec::with_capacity(items.len());
+    for item in items {
+        if item.is_heap() {
+            match unsafe { item.as_heap_ref() } {
+                HeapObj::List(inner) => {
+                    for v in inner {
+                        v.clone_rc();
+                        result.push(*v);
+                    }
+                }
+                _ => {
+                    item.clone_rc();
+                    result.push(*item);
+                }
+            }
+        } else {
+            result.push(*item);
+        }
+    }
+    Ok(NanVal::heap_list(result))
+}
+
 /// `avg xs` — arithmetic mean of a list of numbers. Empty list is an error
 /// (matches tree-walker semantics in `src/interpreter/mod.rs`).
 fn vm_avg(v: NanVal) -> Result<NanVal, &'static str> {
@@ -12140,6 +12192,18 @@ pub(crate) extern "C" fn jit_median(a: u64, span_bits: u64) -> u64 {
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn jit_sum(a: u64, span_bits: u64) -> u64 {
     match vm_sum(NanVal(a)) {
+        Ok(v) => v.0,
+        Err(e) => {
+            jit_set_runtime_error_with_span(VmError::Type(e), span_bits);
+            TAG_NIL
+        }
+    }
+}
+
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_flat(a: u64, span_bits: u64) -> u64 {
+    match vm_flat(NanVal(a)) {
         Ok(v) => v.0,
         Err(e) => {
             jit_set_runtime_error_with_span(VmError::Type(e), span_bits);
@@ -25213,7 +25277,6 @@ mod tests {
     // ── flat ────────────────────────────────────────────────────────────
 
     #[test]
-    #[ignore] // VM missing builtin implementation
     fn vm_flat_nested() {
         let source = "f>L n;flat [[1, 2], [3], [4, 5]]";
         let result = vm_run(source, Some("f"), vec![]);
@@ -25229,7 +25292,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // VM missing builtin implementation
     fn vm_flat_mixed() {
         let source = "f>L n;flat [[1, 2], 3]";
         let result = vm_run(source, Some("f"), vec![]);
@@ -25242,7 +25304,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // VM missing builtin implementation
     fn vm_flat_empty() {
         assert_eq!(
             vm_run("f>L n;flat []", Some("f"), vec![]),

--- a/tests/regression_flat.rs
+++ b/tests/regression_flat.rs
@@ -1,7 +1,11 @@
-// Regression tests for the `flat` builtin: flatten a list one level.
-// Signature: `flat xs:L (L a) > L a`. Non-list elements pass through
-// unchanged. `flat` is currently tree-engine only; vm/cranelift report
-// an "undefined function" compile error.
+// Tree-engine regression tests for the `flat` builtin: flatten a list one
+// level. Signature: `flat xs:L (L a) > L a`. Non-list elements pass through
+// unchanged.
+//
+// Cross-engine coverage (tree + VM + Cranelift) lives in
+// `tests/regression_flat_cross_engine.rs`. The two `*_undefined` tests
+// that used to live here were removed when `flat` was wired through VM
+// and Cranelift in `fix/flat-cross-engine`.
 
 use std::process::Command;
 
@@ -20,19 +24,6 @@ fn run_ok(engine: &str, src: &str) -> String {
         String::from_utf8_lossy(&out.stderr)
     );
     String::from_utf8_lossy(&out.stdout).trim().to_string()
-}
-
-fn run_err(engine: &str, src: &str) -> String {
-    let out = ilo()
-        .args([src, engine, "f"])
-        .output()
-        .expect("failed to run ilo");
-    assert!(
-        !out.status.success(),
-        "ilo {engine} unexpectedly succeeded for `{src}`: stdout={}",
-        String::from_utf8_lossy(&out.stdout)
-    );
-    String::from_utf8_lossy(&out.stderr).to_string() + &String::from_utf8_lossy(&out.stdout)
 }
 
 #[test]
@@ -67,28 +58,5 @@ fn flat_mixed_passes_non_list_through_tree() {
     assert_eq!(
         run_ok("--run-tree", "f>L n;flat [[1, 2], 3, [4, 5]]"),
         "[1, 2, 3, 4, 5]"
-    );
-}
-
-// vm/cranelift do not implement `flat` yet — they should reject the
-// program at compile time with an "undefined function" error rather
-// than producing a wrong answer silently.
-
-#[test]
-fn flat_vm_undefined() {
-    let err = run_err("--run-vm", "f>L n;flat [[1, 2], [3, 4]]");
-    assert!(
-        err.contains("flat") || err.contains("undefined"),
-        "expected vm to report missing flat, got: {err}"
-    );
-}
-
-#[cfg(feature = "cranelift")]
-#[test]
-fn flat_cranelift_undefined() {
-    let err = run_err("--run-cranelift", "f>L n;flat [[1, 2], [3, 4]]");
-    assert!(
-        err.contains("flat") || err.contains("undefined"),
-        "expected cranelift to report missing flat, got: {err}"
     );
 }

--- a/tests/regression_flat_cross_engine.rs
+++ b/tests/regression_flat_cross_engine.rs
@@ -1,0 +1,199 @@
+// Cross-engine regression tests for `flat`.
+//
+// Before this fix, the VM compiler had no dispatch arm for `Builtin::Flat`
+// and Cranelift had no helper wired through, so any call fell through to
+// the named-function lookup and failed with
+// "Compile error: undefined function: flat" on both `--run-vm` and
+// `--run-cranelift`. The tree-walking interpreter handled it directly and
+// worked correctly.
+//
+// These tests pin the behaviour across all three engines: happy paths,
+// the empty-list contract, the non-list-elements pass-through contract,
+// and the wrong-type error case.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_ok(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} {src:?} unexpectedly failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn run_err(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "ilo {engine} {src:?} unexpectedly succeeded: stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+#[cfg(feature = "cranelift")]
+const ENGINES_ALL: &[&str] = &["--run-tree", "--run-vm", "--run-cranelift"];
+#[cfg(not(feature = "cranelift"))]
+const ENGINES_ALL: &[&str] = &["--run-tree", "--run-vm"];
+
+// ── happy paths ─────────────────────────────────────────────────────────
+
+#[test]
+fn flat_basic_nested_cross_engine() {
+    let src = "f>L n;flat [[1, 2], [3, 4]]";
+    for engine in ENGINES_ALL {
+        assert_eq!(
+            run_ok(engine, src, "f"),
+            "[1, 2, 3, 4]",
+            "{engine}: flat [[1, 2], [3, 4]]"
+        );
+    }
+}
+
+#[test]
+fn flat_three_inner_lists_cross_engine() {
+    let src = "f>L n;flat [[1], [2, 3], [4, 5, 6]]";
+    for engine in ENGINES_ALL {
+        assert_eq!(
+            run_ok(engine, src, "f"),
+            "[1, 2, 3, 4, 5, 6]",
+            "{engine}: flat three inner lists"
+        );
+    }
+}
+
+#[test]
+fn flat_inner_empties_dropped_cross_engine() {
+    // [[1], [], [2]] → [1, 2]: empty inner lists splice to nothing.
+    let src = "f>L n;flat [[1], [], [2]]";
+    for engine in ENGINES_ALL {
+        assert_eq!(
+            run_ok(engine, src, "f"),
+            "[1, 2]",
+            "{engine}: empty inner list dropped"
+        );
+    }
+}
+
+#[test]
+fn flat_singleton_outer_cross_engine() {
+    let src = "f>L n;flat [[1, 2, 3]]";
+    for engine in ENGINES_ALL {
+        assert_eq!(
+            run_ok(engine, src, "f"),
+            "[1, 2, 3]",
+            "{engine}: singleton outer"
+        );
+    }
+}
+
+// ── empty outer list ────────────────────────────────────────────────────
+
+#[test]
+fn flat_empty_outer_cross_engine() {
+    let src = "f>L n;flat []";
+    for engine in ENGINES_ALL {
+        assert_eq!(run_ok(engine, src, "f"), "[]", "{engine}: flat []");
+    }
+}
+
+// ── non-list elements pass through ──────────────────────────────────────
+
+#[test]
+fn flat_scalars_only_pass_through_cross_engine() {
+    // Per tree semantics: `flat` is "flatten one level", a list of scalars
+    // is returned with scalars in place.
+    let src = "f>L n;flat [1, 2, 3]";
+    for engine in ENGINES_ALL {
+        assert_eq!(
+            run_ok(engine, src, "f"),
+            "[1, 2, 3]",
+            "{engine}: scalar pass-through"
+        );
+    }
+}
+
+#[test]
+fn flat_mixed_pass_non_list_through_cross_engine() {
+    // Nested lists are spliced, scalars are kept in place.
+    let src = "f>L n;flat [[1, 2], 3, [4, 5]]";
+    for engine in ENGINES_ALL {
+        assert_eq!(
+            run_ok(engine, src, "f"),
+            "[1, 2, 3, 4, 5]",
+            "{engine}: mixed list/scalar"
+        );
+    }
+}
+
+// ── strings inside the outer list ───────────────────────────────────────
+
+#[test]
+fn flat_nested_text_lists_cross_engine() {
+    let src = "f>L t;flat [[\"a\", \"b\"], [\"c\"]]";
+    for engine in ENGINES_ALL {
+        assert_eq!(
+            run_ok(engine, src, "f"),
+            "[a, b, c]",
+            "{engine}: nested text lists"
+        );
+    }
+}
+
+// ── error: arg is not a list ───────────────────────────────────────────
+
+#[test]
+fn flat_wrong_arg_type_cross_engine() {
+    // Verifier should catch this at compile-time on all engines with a
+    // type error mentioning `flat`. We just check that the program
+    // doesn't succeed and that the diagnostic mentions `flat`.
+    let src = "f>L n;flat 42";
+    for engine in ENGINES_ALL {
+        let err = run_err(engine, src, "f");
+        assert!(
+            err.contains("flat") || err.contains("list"),
+            "{engine}: expected flat/list mention, got: {err}"
+        );
+    }
+}
+
+// ── arithmetic on result list ──────────────────────────────────────────
+
+#[test]
+fn flat_result_consumed_by_len_cross_engine() {
+    // Pipe the flat result into `len` to make sure the returned NanVal is
+    // a real list across all backends (not stashed in the F64 shadow).
+    let src = "f>n;len (flat [[1, 2], [3, 4, 5]])";
+    for engine in ENGINES_ALL {
+        assert_eq!(
+            run_ok(engine, src, "f"),
+            "5",
+            "{engine}: len of flatten result"
+        );
+    }
+}
+
+#[test]
+fn flat_result_consumed_by_sum_cross_engine() {
+    // Composes with another cross-engine reducer added in PR #295.
+    let src = "f>n;sum (flat [[1, 2], [3, 4]])";
+    for engine in ENGINES_ALL {
+        assert_eq!(
+            run_ok(engine, src, "f"),
+            "10",
+            "{engine}: sum of flatten result"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`ilo file.ilo --run-vm` and `--run-cranelift` reported `Compile error: undefined function: flat`. The tree-walker had the builtin wired up directly; the VM compiler had no dispatch arm for `Builtin::Flat`, so it fell through to the named-function lookup and errored. Cranelift inherited the same hole. Mirroring the sum/avg cross-engine pattern from #295.

Manifesto framing: every agent reaching for `flat xs` on the VM or Cranelift hits a confusing "undefined function" diagnostic that names a real builtin, then has to write a manual `fld + xs []` accumulator instead. Routing-tsp rerun4 surfaced this for the fourth time. Cross-engine parity restored.

## Repro

Before:
```
$ echo 'f>L n;flat [[1, 2], [3, 4]]' > t.ilo
$ ilo t.ilo --run-tree f
[1, 2, 3, 4]
$ ilo t.ilo --run-vm f
Compile error: undefined function: flat
$ ilo t.ilo --run-cranelift f
Compile error: undefined function: flat
```

After: `[1, 2, 3, 4]` on every engine. Empty outer list returns `[]`, non-list inner elements pass through unchanged, wrong-type arg errors with `flat: arg must be a list` on all backends.

## What's in the diff

- `2cb4bbc` vm: new `OP_FLAT` (171) opcode with compile arm in `build_call`, dispatch handler, `vm_flat` helper that mirrors the tree-walker semantics (inner lists spliced, non-list elements pass through, with proper `clone_rc` for RC accounting just like `OP_SETUNION`), and `jit_flat` for the Cranelift handoff. Un-ignores `vm_flat_nested`, `vm_flat_mixed`, `vm_flat_empty` now that the VM backs them. `OP_FLAT` joins the heap-producing-ops list in `chunk_is_all_numeric` so it correctly disqualifies const-folding.
- `24ae400` cranelift: wire the new opcode through the JIT and AOT compilers (helper FuncIds, declarations, symbol registrations, codegen blocks). `OP_FLAT` joins the non-numeric output classification in both JIT and AOT so the F64 register shadow stays unset for list results. Smoke test in the AOT module exercises the new codegen path.
- `24ee0e2` test: 11-test cross-engine regression file pinning happy paths, empty-list contract, scalar pass-through, wrong-type error, and composition tests (`len` and `sum` consuming the result) so the returned NanVal is verified as a real list on every backend. Removes the two `_undefined` expectation tests from `regression_flat.rs`. Updates `examples/flat.ilo` to drop its tree-only engine-skip markers and adds a `sum (flat ...)` composition row so the engines harness round-trips it cross-backend.

## Test plan

- [x] `cargo test --release --features cranelift --test regression_flat --test regression_flat_cross_engine`, 16/16 pass
- [x] `cargo test --release --features cranelift --test examples_engines`, pass (picks up `examples/flat.ilo` cross-backend)
- [x] `cargo test --release --features cranelift --lib`, pass on default target dir (the seven AOT tests that look for `libilo.a` need the default target, same pre-existing constraint as #295)
- [x] `cargo test --release --features cranelift --test regression_aot_wrapper_strip`, pass
- [x] Manual repro across all three engines (tree, VM, cranelift) for: basic nested, empty outer, scalar pass-through, mixed, wrong-type, composition with `sum` and `len`
- [x] `cargo fmt --check` clean

## Follow-ups

None for this fix. The OP_FLAT dispatch in the VM has the same inline shape as OP_SETUNION; the helper-call+codegen pattern in Cranelift is the same as OP_SUM minus the F64 shadow refresh. No further cleanup needed.