### PR TITLE
rsrt fn xs and rsrt fn ctx xs overloads, mirroring srt

### DIFF
--- a/examples/rsrt-by-key.ilo
+++ b/examples/rsrt-by-key.ilo
@@ -1,0 +1,26 @@
+-- rsrt fn xs: descending sort by key. Mirrors `srt fn xs` but reverses
+-- the comparator, so the largest key comes first.
+-- One-step alternative to `rev (srt fn xs)` or `srt (-0 key) xs`.
+-- Signature: rsrt fn:F a k xs:L a > L a
+
+-- Key: absolute value, largest first.
+absv n:n>n;?<n 0 (-0 n) n
+
+worst-by-abs xs:L n>L n;rsrt absv xs
+
+-- Key: string length, longest first — the canonical persona case for
+-- "top-N by some derived score".
+slen s:t>n;len s
+
+longest-words ws:L t>L t;rsrt slen ws
+
+-- 3-arg closure-bind form: fn receives (elem, ctx).
+score-with x:n c:n>n;*x c
+top-scaled xs:L n>L n;rsrt score-with 2 xs
+
+-- run: worst-by-abs [-3,1,-2,4,-1]
+-- out: [4, -3, -2, 1, -1]
+-- run: longest-words ["fig","banana","apple"]
+-- out: [banana, apple, fig]
+-- run: top-scaled [1,3,2,5,4]
+-- out: [5, 4, 3, 2, 1]

--- a/src/codegen/python.rs
+++ b/src/codegen/python.rs
@@ -681,6 +681,11 @@ fn emit_expr(out: &mut String, level: usize, expr: &Expr) -> String {
                 let xs = emit_expr(out, level, &args[1]);
                 return format!("sorted({}, key={})", xs, key_fn);
             }
+            if function == "rsrt" && args.len() == 2 {
+                let key_fn = emit_expr(out, level, &args[0]);
+                let xs = emit_expr(out, level, &args[1]);
+                return format!("sorted({}, key={}, reverse=True)", xs, key_fn);
+            }
             if function == "trm" && args.len() == 1 {
                 return format!("{}.strip()", emit_expr(out, level, &args[0]));
             }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1939,6 +1939,59 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             )),
         };
     }
+    if builtin == Some(Builtin::Rsrt) && (args.len() == 2 || args.len() == 3) {
+        // rsrt fn xs / rsrt fn ctx xs — descending sort by key function.
+        // Mirrors the srt 2/3-arg path: compute keys for each element, then
+        // sort by key using the REVERSED comparator (b.cmp(a) for text,
+        // b.partial_cmp(a) for numbers). Element type is preserved.
+        let fn_name = resolve_fn_ref(&args[0]).ok_or_else(|| {
+            RuntimeError::new(
+                "ILO-R009",
+                format!(
+                    "rsrt: key arg must be a function reference, got {:?}",
+                    args[0]
+                ),
+            )
+        })?;
+        let captures = closure_captures(&args[0]);
+        let (ctx, list_arg) = if args.len() == 3 {
+            (Some(args[1].clone()), &args[2])
+        } else {
+            (None, &args[1])
+        };
+        let items = match list_arg {
+            Value::List(l) => l.clone(),
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!("rsrt: list arg must be a list, got {:?}", other),
+                ));
+            }
+        };
+        let owned_items: Vec<Value> = Arc::try_unwrap(items).unwrap_or_else(|arc| (*arc).clone());
+        let mut keyed: Vec<(Value, Value)> = owned_items
+            .into_iter()
+            .map(|item| {
+                let mut call_args = match &ctx {
+                    Some(c) => vec![item.clone(), c.clone()],
+                    None => vec![item.clone()],
+                };
+                call_args.extend(captures.iter().cloned());
+                let key = call_function(env, &fn_name, call_args)?;
+                Ok((key, item))
+            })
+            .collect::<Result<_>>()?;
+        keyed.sort_by(|(ka, _), (kb, _)| match (ka, kb) {
+            (Value::Number(a), Value::Number(b)) => {
+                b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal)
+            }
+            (Value::Text(a), Value::Text(b)) => b.cmp(a),
+            _ => std::cmp::Ordering::Equal,
+        });
+        return Ok(Value::List(Arc::new(
+            keyed.into_iter().map(|(_, v)| v).collect(),
+        )));
+    }
     if builtin == Some(Builtin::Slc) && args.len() == 3 {
         // Both bounds accept negative integers Python-style:
         // `slc xs -1 0` is empty, `slc xs 0 -1` drops the last element,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3201,6 +3201,10 @@ fn builtin_arity_tables() -> (HashMap<String, usize>, HashMap<String, Vec<bool>>
         // follows. The 0th slot is a fn-ref position so `srt xs` keeps
         // `xs` as a bare ref and doesn't try to expand it.
         ("srt", 2, &[0]),
+        // rsrt mirrors srt: 1-arg descending sort plus `rsrt fn xs` and
+        // `rsrt fn ctx xs` closure-bind variant. Slot 0 is a fn-ref so the
+        // bare `rsrt xs` form keeps `xs` as a ref and doesn't try to expand.
+        ("rsrt", 2, &[0]),
         // Higher-order
         ("map", 2, &[0]),
         ("flt", 2, &[0]),

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -364,6 +364,7 @@ const BUILTINS: &[(&str, &[&str], &str)] = &[
     ("srt", &["list_or_text"], "list_or_text"),
     ("srt", &["fn", "list"], "list"),
     ("rsrt", &["list_or_text"], "list_or_text"),
+    ("rsrt", &["fn", "list"], "list"),
     ("unq", &["list_or_text"], "list_or_text"),
     ("slc", &["list_or_text", "n", "n"], "list_or_text"),
     ("lst", &["list", "n", "any"], "list"),
@@ -1191,6 +1192,61 @@ fn builtin_check_args(
             (Ty::Unknown, errors)
         }
         "rsrt" => {
+            if arg_types.len() == 3 {
+                // rsrt key-fn ctx xs — closure-bind variant: fn takes (elem, ctx)
+                if let Some(fn_ty) = arg_types.first()
+                    && !matches!(fn_ty, Ty::Fn(_, _) | Ty::Unknown)
+                {
+                    errors.push(VerifyError {
+                        code: "ILO-T013",
+                        function: func_ctx.to_string(),
+                        message: format!("'rsrt' key arg must be a function (F ...), got {fn_ty}"),
+                        hint: Some("pass a function name: rsrt key-fn ctx xs".to_string()),
+                        span,
+                        is_warning: false,
+                    });
+                }
+                if let Some(Ty::Fn(params, _)) = arg_types.first()
+                    && params.len() != 2
+                {
+                    errors.push(VerifyError {
+                        code: "ILO-T013",
+                        function: func_ctx.to_string(),
+                        message: format!(
+                            "'rsrt' key fn must take 2 args (elem, ctx) for closure-bind variant, got {} args",
+                            params.len()
+                        ),
+                        hint: Some("for rsrt fn ctx xs, fn must be: F a c b".to_string()),
+                        span,
+                        is_warning: false,
+                    });
+                }
+                let ret = match arg_types.get(2) {
+                    Some(ty @ Ty::List(_)) => ty.clone(),
+                    _ => Ty::Unknown,
+                };
+                return (ret, errors);
+            }
+            if arg_types.len() == 2 {
+                // rsrt key-fn xs — descending sort by key function
+                if let Some(fn_ty) = arg_types.first()
+                    && !matches!(fn_ty, Ty::Fn(_, _) | Ty::Unknown)
+                {
+                    errors.push(VerifyError {
+                        code: "ILO-T013",
+                        function: func_ctx.to_string(),
+                        message: format!("'rsrt' key arg must be a function (F ...), got {fn_ty}"),
+                        hint: Some("pass a function name: rsrt key-fn xs".to_string()),
+                        span,
+                        is_warning: false,
+                    });
+                }
+                let ret = match arg_types.get(1) {
+                    Some(ty @ Ty::List(_)) => ty.clone(),
+                    _ => Ty::Unknown,
+                };
+                return (ret, errors);
+            }
             if let Some(arg) = arg_types.first() {
                 match arg {
                     Ty::List(inner) => return (Ty::List(inner.clone()), errors),
@@ -3148,8 +3204,8 @@ impl VerifyContext {
                         builtin_arity(callee).expect("is_builtin guarantees arity exists");
                     let arity_ok = if callee == "rnd" {
                         args.is_empty() || args.len() == 2
-                    } else if callee == "srt" {
-                        // srt xs / srt fn xs / srt fn ctx xs
+                    } else if callee == "srt" || callee == "rsrt" {
+                        // srt xs / srt fn xs / srt fn ctx xs (and rsrt mirrors)
                         args.len() == 1 || args.len() == 2 || args.len() == 3
                     } else if callee == "min" || callee == "max" {
                         // min xs (list form, returns min element) / min a b (number pair)
@@ -3179,7 +3235,7 @@ impl VerifyContext {
                     if !arity_ok {
                         let arity_desc = if callee == "rnd" {
                             "0 or 2".to_string()
-                        } else if callee == "srt" {
+                        } else if callee == "srt" || callee == "rsrt" {
                             "1, 2, or 3".to_string()
                         } else if callee == "map" || callee == "flt" {
                             "2 or 3".to_string()

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -417,6 +417,10 @@ pub(crate) fn is_tree_bridge_eligible(b: crate::builtins::Builtin, argc: usize) 
         (Builtin::Uniqby, 2) => true,
         (Builtin::Partition, 2) => true,
         (Builtin::Srt, 2) => true,
+        // rsrt fn xs — descending sort by key. Same bridge contract as
+        // srt 2-arg: tree interpreter does the user-fn callback, bridge
+        // round-trips the result list. Cross-engine parity with srt.
+        (Builtin::Rsrt, 2) => true,
         // mapr fn xs: short-circuit Result-aware map. Tree bridge routes
         // through the tree interpreter's Mapr arm, which handles the
         // ~v/^e dispatch and ACTIVE_AST_PROGRAM user-fn callbacks the same
@@ -430,6 +434,9 @@ pub(crate) fn is_tree_bridge_eligible(b: crate::builtins::Builtin, argc: usize) 
         (Builtin::Flt, 3) => true,
         (Builtin::Fld, 4) => true,
         (Builtin::Srt, 3) => true,
+        // rsrt fn ctx xs — closure-bind descending sort. Same bridge
+        // contract as srt 3-arg.
+        (Builtin::Rsrt, 3) => true,
         _ => false,
     }
 }

--- a/tests/regression_rsrt_keyfn.rs
+++ b/tests/regression_rsrt_keyfn.rs
@@ -1,0 +1,125 @@
+// Regression tests for the `rsrt fn xs` and `rsrt fn ctx xs` overloads.
+//
+// `rsrt` mirrors `srt`'s 1/2/3-arg pattern. The 1-arg form (descending sort
+// of a list-or-text by natural order) shipped in #196. The 2-arg key-fn form
+// and 3-arg closure-bind form were a 4-release standing ask from
+// qa-tester / security-researcher / logs-forensics / content-mod personas:
+// descending-by-key previously required `rev (srt fn xs)` or a negating
+// key fn (`-0 v`) wrapped around `srt`.
+//
+// Routing: like `srt 2`/`srt 3`, the new `rsrt 2`/`rsrt 3` paths go through
+// the tree bridge (`is_tree_bridge_eligible`) so VM and Cranelift share the
+// tree interpreter's user-fn callback dispatch. These tests pin that the
+// three engines agree on output for every form.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn check_stdout(engine: &str, src: &str, expected: &str) {
+    let out = ilo()
+        .args([src, engine, "f"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "engine={engine}: expected success for `{src}`, got stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&out.stdout).trim(),
+        expected,
+        "engine={engine}: stdout mismatch for `{src}`"
+    );
+}
+
+fn check_all(src: &str, expected: &str) {
+    check_stdout("--run-tree", src, expected);
+    check_stdout("--run-vm", src, expected);
+    #[cfg(feature = "cranelift")]
+    check_stdout("--run-cranelift", src, expected);
+}
+
+// ── 2-arg rsrt fn xs ──────────────────────────────────────────────────────
+
+#[test]
+fn rsrt_numeric_key_desc_cross_engine() {
+    // sort numbers descending by themselves (identity key)
+    check_all(
+        "idk x:n>n;x f>L n;rsrt idk [1,3,2,5,4]",
+        "[5, 4, 3, 2, 1]",
+    );
+}
+
+#[test]
+fn rsrt_text_by_length_desc_cross_engine() {
+    // sort strings by length, longest first — the canonical persona case
+    check_all(
+        "ln s:t>n;len s f>L t;rsrt ln [\"a\",\"bbb\",\"cc\",\"dddd\"]",
+        "[dddd, bbb, cc, a]",
+    );
+}
+
+#[test]
+fn rsrt_negated_key_inverts_to_ascending_cross_engine() {
+    // rsrt with a negating key fn is equivalent to ascending sort — pins
+    // the comparator direction is genuinely reversed vs srt's.
+    check_all(
+        "neg x:n>n;-0 x f>L n;rsrt neg [1,3,2,5,4]",
+        "[1, 2, 3, 4, 5]",
+    );
+}
+
+#[test]
+fn rsrt_preserves_element_type_via_key_cross_engine() {
+    // The element type (text) is preserved; only the key (number) drives
+    // ordering. Mirrors srt's contract — return list element type = input
+    // list element type.
+    check_all(
+        "ln s:t>n;len s f>L t;rsrt ln [\"ab\",\"x\",\"qrst\",\"\"]",
+        "[qrst, ab, x, ]",
+    );
+}
+
+#[test]
+fn rsrt_empty_list_cross_engine() {
+    check_all("idk x:n>n;x f>L n;rsrt idk []", "[]");
+}
+
+// ── 3-arg rsrt fn ctx xs (closure-bind) ───────────────────────────────────
+
+#[test]
+fn rsrt_closure_bind_ctx_cross_engine() {
+    // 3-arg form: fn receives (elem, ctx). The ctx is the same for every
+    // element so it doesn't change ordering, just confirms the bridge
+    // threads the extra arg through without dropping it.
+    check_all(
+        "addk x:n c:n>n;+x c f>L n;rsrt addk 10 [1,3,2,5,4]",
+        "[5, 4, 3, 2, 1]",
+    );
+}
+
+#[test]
+fn rsrt_closure_bind_ctx_inverting_cross_engine() {
+    // Negate-with-ctx: the ctx supplies the scale. Identical result-shape
+    // to `rsrt neg xs` — exercises the closure-bind dispatch path on each
+    // engine.
+    check_all(
+        "scl x:n c:n>n;*x c f>L n;rsrt scl -1 [1,3,2,5,4]",
+        "[1, 2, 3, 4, 5]",
+    );
+}
+
+// ── 1-arg rsrt xs still works (regression guard) ──────────────────────────
+
+#[test]
+fn rsrt_one_arg_descending_unchanged_cross_engine() {
+    check_all("f>L n;rsrt [1,3,2,5,4]", "[5, 4, 3, 2, 1]");
+}
+
+#[test]
+fn rsrt_one_arg_text_unchanged_cross_engine() {
+    check_all("f>t;rsrt \"cab\"", "cba");
+}

--- a/tests/regression_rsrt_keyfn.rs
+++ b/tests/regression_rsrt_keyfn.rs
@@ -47,10 +47,7 @@ fn check_all(src: &str, expected: &str) {
 #[test]
 fn rsrt_numeric_key_desc_cross_engine() {
     // sort numbers descending by themselves (identity key)
-    check_all(
-        "idk x:n>n;x f>L n;rsrt idk [1,3,2,5,4]",
-        "[5, 4, 3, 2, 1]",
-    );
+    check_all("idk x:n>n;x f>L n;rsrt idk [1,3,2,5,4]", "[5, 4, 3, 2, 1]");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds the 2-arg `rsrt fn xs` and 3-arg `rsrt fn ctx xs` overloads, mirroring `srt`'s 1/2/3-arg pattern. Descending-by-key was previously a two-step pipeline (`rev (srt fn xs)` or a `-0 v` negating-key wrapper around `srt`); now it's one builtin call.

This is a 4-release standing ask from four personas: qa-tester, security-researcher, logs-forensics, content-mod. Manifesto framing: one shorter call instead of a two-line workaround, per element-type-preserving HOF rules, with no new opcodes (Cranelift inherits via the existing tree bridge).

## Repro before/after

Before:
```
$ ilo 'neg p:L _>n;-0 p.0 f>L (L _);rsrt neg [[3 "a"][1 "b"][2 "c"]]' f
ILO-T013: 'rsrt' expects a list or text, got n
```

After:
```
$ ilo 'fst p:L _>n;p.0 f>L (L _);rsrt fst [[3 "a"][1 "b"][2 "c"]]' f
[[3, a], [2, c], [1, b]]
```

## What's in the diff (per-commit)

1. **verify**: accept rsrt 2/3-arg forms — new `(fn, list)` candidate sig, T006 arity branch accepts srt OR rsrt for 1/2/3, full key-fn / closure-bind typing arm mirroring srt with rsrt-specific error messages and hints.
2. **parser**: arity-table entry `("rsrt", 2, &[0])` so the parser expands fn-ref slot 0 the same way srt does. Bare `rsrt xs` still parses because the loop stops on no further operand.
3. **interpreter**: new arm for `Builtin::Rsrt` at arity 2 or 3. Threads optional ctx, calls user fn per element, sorts by key with reversed comparator (`b.partial_cmp(a)` / `b.cmp(a)`). Element type preserved.
4. **vm**: `is_tree_bridge_eligible` returns true for `(Rsrt, 2)` and `(Rsrt, 3)`. Tree interpreter handles user-fn dispatch; VM and Cranelift get cross-engine parity for free. The existing 1-arg `OP_SRTDESC` arm is untouched.
5. **codegen/python**: `rsrt fn xs` emits `sorted(xs, key=fn, reverse=True)`, mirroring the existing srt arm so transpiled output stays faithful.
6. **test + example**: 9 cross-engine integration tests in `tests/regression_rsrt_keyfn.rs` covering numeric key, text-by-length, negated-key (proves the comparator is genuinely reversed), element-type preservation, empty list, both closure-bind variants, plus 1-arg regression guards. Plus `examples/rsrt-by-key.ilo` with three run/out blocks that `tests/examples_engines.rs` exercises on every engine.

## Test plan

- [x] `cargo test --release --features cranelift --test regression_rsrt_keyfn` — 9 passed
- [x] `cargo test --release --features cranelift --test examples_engines` — 1 passed (new example included)
- [x] Manual CLI smoke across `--run-tree`, `--run-vm`, `--run-cranelift` for all three overload shapes — all engines agree
- [x] 1-arg `rsrt xs` and `rsrt "cba"` unchanged
- [ ] CI green on push

## Follow-ups

None identified for this PR. The standing 🟡 entry in `ilo_assessment_feedback.md` (line ~3096, ~3644, ~4164, ~4180) gets moved to ✅ Addressed on merge.