### PR TITLE
parser: hint at `at xs (expr)` when `xs.(expr)` is written

### DIFF
--- a/examples/dot-paren-hint.ilo
+++ b/examples/dot-paren-hint.ilo
@@ -1,0 +1,23 @@
+-- `xs.(expr)` (parenthesised expression after `.`) is not valid ilo syntax,
+-- but it's a common reach for variable-position indexing when the index is a
+-- computed expression rather than a bare name. PR #298 desugars `xs.i` to
+-- `at xs i` when `i` is a bound variable, so the natural extension to
+-- `xs.(i+1)` is a reasonable guess, hence the friendly parser hint
+-- pointing at `at xs (expr)` or the bind-first idiom.
+--
+-- This example demonstrates the two correct shapes the hint suggests.
+
+-- Shape 1: `at xs (expr)` — the direct form. Three tokens plus the parens.
+plus1 xs:L n i:n>n;at xs (+i 1)
+
+-- Shape 2: bind to a name first, then use `xs.i` (PR #298 desugar path).
+plus1bind xs:L n i:n>n;j=+i 1;xs.j
+
+-- run: plus1 [10,20,30] 0
+-- out: 20
+-- run: plus1 [10,20,30] 1
+-- out: 30
+-- run: plus1bind [10,20,30] 0
+-- out: 20
+-- run: plus1bind [10,20,30] 1
+-- out: 30

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2741,7 +2741,7 @@ or write `({fmt_name} \"...\" ...)` so its args are grouped."
                     });
                 }
                 // Check for field access chain: ident.field.field...
-                let mut expr = Expr::Ref(name);
+                let mut expr = Expr::Ref(name.clone());
                 while matches!(self.peek(), Some(Token::Dot) | Some(Token::DotQuestion)) {
                     let safe = self.peek() == Some(&Token::DotQuestion);
                     self.advance();
@@ -2753,6 +2753,25 @@ or write `({fmt_name} \"...\" ...)` so its args are grouped."
                                 index: n as usize,
                                 safe,
                             };
+                        }
+                        // `xs.(expr)` — parenthesised expression after `.`
+                        // is a common reach for variable-position indexing
+                        // (ml-engineer rerun4). PR #298 desugars `xs.i` to
+                        // `at xs i` when `i` is bound, but `xs.(i+1)` never
+                        // even parses. Emit a hint pointing at the correct
+                        // shape rather than the bare "expected identifier"
+                        // error from expect_ident().
+                        Some(Token::LParen) => {
+                            return Err(self.error_hint(
+                                "ILO-P005",
+                                "expected identifier, got LParen".into(),
+                                format!(
+                                    "field access requires an identifier after `.`. \
+For variable-position list indexing use `at {n} (expr)`, \
+or bind the index to a name first: `i:expr;{n}.i`.",
+                                    n = name
+                                ),
+                            ));
                         }
                         _ => {
                             let field = self.expect_ident()?;
@@ -3742,6 +3761,30 @@ mod tests {
             panic!("expected index access")
         };
         assert_eq!(*index, 0);
+    }
+
+    #[test]
+    fn dot_followed_by_paren_emits_at_hint() {
+        // `xs.(expr)` is a common reach for variable-position indexing
+        // (ml-engineer rerun4). PR #298 desugars `xs.i` to `at xs i` when
+        // `i` is bound, but `xs.(i+1)` never parses. The parser should
+        // emit a friendly hint pointing at `at xs (expr)` rather than the
+        // bare ILO-P005 "expected identifier" with no suggestion.
+        let (_, errors) = parse_str_errors("f xs:L n i:n>n;xs.(i + 1)");
+        assert!(!errors.is_empty(), "expected parse error");
+        let err = errors
+            .iter()
+            .find(|e| e.code == "ILO-P005")
+            .expect("expected ILO-P005 error");
+        let hint = err.hint.as_deref().unwrap_or("");
+        assert!(
+            hint.contains("at xs (expr)"),
+            "hint should point at `at xs (expr)`; got: {hint:?}"
+        );
+        assert!(
+            hint.contains("bind") || hint.contains("xs.i"),
+            "hint should suggest binding the index to a name first; got: {hint:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`xs.i` already desugars to `at xs i` when `i` is a bound variable (PR #298), so reaching for `xs.(i+1)` to index a list by a computed expression is a natural extension. It just doesn't parse - the field-access loop in `parse_field` hits `expect_ident()` on the `LParen` and throws a bare `ILO-P005 expected identifier, got LParen` with no hint. ml-engineer rerun4 hit this and burned a retry working out the right shape. Cheap diagnostic add, manifesto-aligned: one extra hint string saves a retry per agent that ever reaches for the dot-paren form.

## Repro

```
nth xs:L n i:n>n;xs.(i + 1)
```

Before:
```
{"code":"ILO-P005","message":"expected identifier, got LParen", ...}
```
No hint, no suggestion. Agent guesses.

After:
```
{"code":"ILO-P005","message":"expected identifier, got LParen",
 "suggestion":"field access requires an identifier after `.`. For variable-position list indexing use `at xs (expr)`, or bind the index to a name first: `i:expr;xs.i`."}
```
Two correct shapes spelled out, base name interpolated.

## What's in the diff

- `src/parser/mod.rs`: explicit `Some(Token::LParen)` arm in the field-access loop ahead of the `expect_ident()` fall-through. Emits `ILO-P005` with a hint that interpolates the original base name so the user sees `at xs (expr)` rather than a generic placeholder. Doesn't touch the `Number` or normal-ident arms, so every other dot-form (`xs.0`, `p.name`, `p.?x`) parses unchanged.
- `src/parser/mod.rs` tests: `dot_followed_by_paren_emits_at_hint` pins the hint text contains `at xs (expr)` plus a bind suggestion.
- `examples/dot-paren-hint.ilo`: demonstrates the two suggested shapes (`at xs (+i 1)` and `j=+i 1;xs.j`) and runs across every engine via the existing examples harness.

## Test plan

- [x] `cargo test --release dot_followed_by_paren` passes
- [x] Manual repro: ml-engineer-style snippet now emits the hint
- [x] Manual smoke: `at xs (expr)` shape returns the expected element on tree and VM
- [x] Existing field-access tests (`parse_field_access`, `parse_index_access`, `parse_safe_field_access`) unchanged
- [ ] CI green

## Follow-ups

None. This is parse-time-only; runtime is untouched.