### PR TITLE
cli: error on unknown subcommand in multi-fn files

### DIFF
--- a/examples/unknown-subcommand-listing.ilo
+++ b/examples/unknown-subcommand-listing.ilo
@@ -1,0 +1,21 @@
+-- Multi-fn file with `main` plus helpers. Pins that:
+--   * `ilo file.ilo`          auto-runs `main`
+--   * `ilo file.ilo dbl 21`   dispatches to the named function
+--   * `ilo file.ilo trp 4`    dispatches to the named function
+--
+-- The CLI-level guard for the unknown-subcommand case (e.g.
+-- `ilo file.ilo wibble x` should error with "no such function" and
+-- list available functions instead of silently routing to the first
+-- declared fn) is covered by tests/regression_cli_default.rs — the
+-- examples harness only exercises happy-path dispatch.
+
+dbl x:n>n;*x 2
+trp x:n>n;*x 3
+main>n;+(dbl 7)(trp 4)
+
+-- run: main
+-- out: 26
+-- run: dbl 21
+-- out: 42
+-- run: trp 4
+-- out: 12

--- a/src/main.rs
+++ b/src/main.rs
@@ -2744,6 +2744,35 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
                     if func_names.contains(&first.as_str()) {
                         let fn_ref = Some(first.as_str());
                         (fn_ref, parse_cli_args_typed(&program, fn_ref, &rest[1..]))
+                    } else if is_file && func_names.len() > 1 && looks_like_subcommand_name(first) {
+                        // Multi-function file with an unknown leading
+                        // positional that LOOKS like an identifier
+                        // (alphabetic / underscore start, ident-shaped
+                        // tail): this is almost certainly a mistyped
+                        // subcommand, not a literal arg to the first
+                        // function. Silently routing to the first
+                        // declared function with `[unknown, ...]` as
+                        // args produced a misleading arity error far
+                        // from the cause (interactive-cli rerun5 P1).
+                        //
+                        // The ident-shaped guard preserves the existing
+                        // pass-through for numeric / sigil-shaped
+                        // leading args, which are clearly data, not a
+                        // subcommand attempt (e.g. `ilo file.ilo 42`
+                        // still routes `42` to the first fn — see
+                        // `tests/eval_inline.rs` unwrap_*_inline).
+                        //
+                        // Synthetic `__lit_*` decls are already filtered
+                        // out of `func_names` above (see #307), so the
+                        // listing here only shows user functions.
+                        eprintln!("error: no such function '{}' in {}", first, source_arg);
+                        eprintln!("available functions:");
+                        for n in &func_names {
+                            eprintln!("  {}", n);
+                        }
+                        eprintln!();
+                        eprintln!("  ilo {} <func> [args...]   run a function", source_arg);
+                        return 1;
                     } else {
                         (None, rest.iter().map(|a| parse_cli_arg(a)).collect())
                     }
@@ -3782,6 +3811,34 @@ fn split_top_level_commas(s: &str) -> Vec<&str> {
     parts
 }
 
+/// True iff `s` is shaped like an ilo function identifier (could plausibly
+/// have been intended as a subcommand name).
+///
+/// Used in the Default-engine CLI dispatch to distinguish `ilo f.ilo wibble`
+/// (a mistyped subcommand — should error with "no such function") from
+/// `ilo f.ilo 42` or `ilo f.ilo "hello"` (clearly a literal arg to the
+/// entry function — should pass through as before).
+///
+/// Rule: starts with an ASCII letter or underscore, and every subsequent
+/// char is alphanumeric or underscore. Anything else (a digit-prefixed
+/// number, a sigil, a quoted string, a bracketed list) is treated as data.
+///
+/// Reserved literal words (`true`, `false`, `nil`) are also exempt — they
+/// match the ident shape but `parse_cli_arg` already turns them into the
+/// corresponding `Bool` / `Nil` values, and passing them through to the
+/// entry function is the long-standing intent.
+fn looks_like_subcommand_name(s: &str) -> bool {
+    if matches!(s, "true" | "false" | "nil") {
+        return false;
+    }
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
 fn parse_cli_arg(s: &str) -> interpreter::Value {
     // Bracketed list: [1,2,3], ["apple","ant"], [[1,2],[3,4]] or [] — split
     // top-level commas, honoring quoted strings so commas inside strings don't
@@ -3937,6 +3994,45 @@ fn coerce_cli_args(
 mod tests {
     use super::*;
     use std::sync::Arc;
+
+    // ── looks_like_subcommand_name ────────────────────────────────────────────
+
+    #[test]
+    fn subcommand_shape_accepts_idents() {
+        assert!(looks_like_subcommand_name("wibble"));
+        assert!(looks_like_subcommand_name("helper"));
+        assert!(looks_like_subcommand_name("a"));
+        assert!(looks_like_subcommand_name("_priv"));
+        assert!(looks_like_subcommand_name("foo_bar"));
+        assert!(looks_like_subcommand_name("fn2"));
+    }
+
+    #[test]
+    fn subcommand_shape_rejects_data() {
+        // Numbers and number-looking strings
+        assert!(!looks_like_subcommand_name("42"));
+        assert!(!looks_like_subcommand_name("-1"));
+        assert!(!looks_like_subcommand_name("3.14"));
+        // Quoted strings, brackets, sigils
+        assert!(!looks_like_subcommand_name("\"hi\""));
+        assert!(!looks_like_subcommand_name("[1,2,3]"));
+        assert!(!looks_like_subcommand_name("--flag"));
+        // Empty and edge cases
+        assert!(!looks_like_subcommand_name(""));
+        assert!(!looks_like_subcommand_name("2x"));
+        assert!(!looks_like_subcommand_name("foo-bar"));
+    }
+
+    #[test]
+    fn subcommand_shape_exempts_reserved_literals() {
+        // `true` / `false` / `nil` are ident-shaped but `parse_cli_arg`
+        // already maps them to Bool/Nil values. Passing them through
+        // to the entry function on a multi-fn file is the long-standing
+        // intent, so they must not trip the unknown-subcommand error.
+        assert!(!looks_like_subcommand_name("true"));
+        assert!(!looks_like_subcommand_name("false"));
+        assert!(!looks_like_subcommand_name("nil"));
+    }
 
     // ── test helpers ──────────────────────────────────────────────────────────
 

--- a/tests/regression_cli_default.rs
+++ b/tests/regression_cli_default.rs
@@ -272,3 +272,156 @@ fn synthetic_lambda_decls_hidden_from_multi_fn_listing() {
         "real fn names should still be listed; stderr: {stderr}"
     );
 }
+
+// ── unknown subcommand: friendly error, not silent first-fn dispatch ──────────
+//
+// Originating bug: `ilo file.ilo wibble x` on a multi-fn file used to
+// silently route to the FIRST declared function with `["wibble", "x"]`
+// as positional args. The user saw a misleading arity error
+// (`helper: expected 1 args, got 2`) far from the cause. Reported as
+// interactive-cli rerun5 P1.
+//
+// New behaviour: when the leading positional doesn't match any user
+// function in a multi-fn file, emit `no such function '<name>' in
+// <file>` plus the available-function listing, exit 1. Single-fn
+// files and inline programs keep their existing pass-through
+// semantics so the unknown leading token is treated as a literal arg.
+
+#[test]
+fn unknown_subcommand_errors_with_available_listing() {
+    // Two user functions, neither matches `wibble`. Pre-fix this
+    // produced `helper: expected 1 args, got 2` from the first
+    // declared function. Now it must produce a "no such function"
+    // diagnostic listing both `helper` and `main`.
+    let (_dir, path) = write_temp("helper a:n>n;+a 1\nmain>n;helper 41\n");
+    let (ok, _stdout, stderr) = run(&[path.to_str().unwrap(), "wibble", "x"]);
+    assert!(!ok, "unknown subcommand should exit non-zero");
+    assert!(
+        stderr.contains("no such function 'wibble'"),
+        "expected 'no such function' error; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("available functions"),
+        "expected available-functions listing; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("helper") && stderr.contains("main"),
+        "expected both fn names listed; stderr: {stderr}"
+    );
+    // The pre-fix arity error must not appear: that was the misleading
+    // symptom the fix is replacing.
+    assert!(
+        !stderr.contains("expected 1 args, got 2"),
+        "must not leak first-fn arity error; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn known_subcommand_still_routes_correctly_in_multi_fn_file() {
+    // Companion check: the fix must not break the happy path. With a
+    // valid function name as the leading positional, it should still
+    // dispatch to that function with the remaining args.
+    let (_dir, path) = write_temp("helper a:n>n;+a 1\nmain>n;helper 41\n");
+    let (ok, stdout, stderr) = run(&[path.to_str().unwrap(), "helper", "5"]);
+    assert!(ok, "known subcommand should succeed; stderr: {stderr}");
+    assert_eq!(stdout.trim(), "6");
+}
+
+#[test]
+fn unknown_subcommand_does_not_list_synthetic_lit_decls() {
+    // Same #307 guarantee that the multi-fn-no-main listing has,
+    // applied to the unknown-subcommand path. Inline-lambda HOF use
+    // emits `__lit_N` synthetic top-level decls; they must not appear
+    // in the "available functions" listing the user sees.
+    let (_dir, path) =
+        write_temp("sq xs:L n>L n;map (x:n>n;*x x) xs\nother xs:L n>L n;flt (x:n>b;>x 0) xs\n");
+    let (ok, _stdout, stderr) = run(&[path.to_str().unwrap(), "wibble"]);
+    assert!(!ok, "unknown subcommand should exit non-zero");
+    assert!(
+        stderr.contains("no such function 'wibble'"),
+        "expected no-such-function error; stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("__lit"),
+        "synthetic __lit_N names must not leak to user listing; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("sq") && stderr.contains("other"),
+        "real fn names should still be listed; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn single_fn_file_treats_unknown_leading_token_as_arg() {
+    // For single-fn files (one user function, no `main`), the
+    // pre-existing convention is that any positional args are passed
+    // through to that sole function. The unknown-subcommand check
+    // must NOT fire here — otherwise `ilo dbl.ilo 21` would refuse to
+    // run `dbl 21` and demand an explicit subcommand name. This is
+    // the auto-run contract from #307 / the SKILL.md "Inline programs
+    // and single-function files" rule.
+    let (_dir, path) = write_temp("dbl x:n>n;*x 2\n");
+    let (ok, stdout, stderr) = run(&[path.to_str().unwrap(), "21"]);
+    assert!(ok, "single-fn auto-run should succeed; stderr: {stderr}");
+    assert_eq!(stdout.trim(), "42");
+}
+
+#[test]
+fn inline_program_treats_unknown_leading_token_as_arg() {
+    // Inline programs (`ilo '<code>'`) also auto-run their entry fn
+    // with remaining args, per the same SKILL.md convention. The
+    // unknown-subcommand check is file-only — inline keeps its
+    // existing pass-through.
+    let (ok, stdout, stderr) = run(&["dbl x:n>n;*x 2", "21"]);
+    assert!(ok, "inline auto-run should succeed; stderr: {stderr}");
+    assert_eq!(stdout.trim(), "42");
+}
+
+#[test]
+fn multi_fn_file_numeric_leading_arg_passes_through_to_entry_fn() {
+    // The unknown-subcommand check is shape-aware: only ident-shaped
+    // tokens (alphabetic / underscore start) trigger the error. A
+    // numeric leading arg is clearly data, not a typoed subcommand, so
+    // it must still pass through to the first declared function — the
+    // long-standing contract that `tests/eval_inline.rs`
+    // unwrap_*_inline pins (`ilo file.ilo 42` where the multi-fn file
+    // defines an `outer x:n>R n t` entry routes `42` to `outer`).
+    //
+    // Without the shape guard, the unknown-subcommand error fired on
+    // every numeric-arg invocation, breaking those existing tests.
+    let (_dir, path) = write_temp("outer x:n>n;+x 1\ninner x:n>n;*x 2\n");
+    let (ok, stdout, stderr) = run(&[path.to_str().unwrap(), "41"]);
+    assert!(
+        ok,
+        "numeric leading arg should pass through to entry fn; stderr: {stderr}"
+    );
+    assert_eq!(stdout.trim(), "42");
+}
+
+#[test]
+fn multi_fn_file_quoted_string_leading_arg_passes_through() {
+    // Companion to the numeric pass-through: a quoted-string leading
+    // arg is also clearly data. Same guard, same outcome — first
+    // declared fn receives the literal.
+    let (_dir, path) = write_temp("greet s:t>t;s\nother s:t>t;s\n");
+    let (ok, stdout, stderr) = run(&[path.to_str().unwrap(), "\"hi\""]);
+    assert!(
+        ok,
+        "quoted-string leading arg should pass through; stderr: {stderr}"
+    );
+    assert_eq!(stdout.trim().trim_matches('"'), "hi");
+}
+
+#[test]
+fn multi_fn_file_bracketed_list_leading_arg_passes_through() {
+    // A bracketed-list leading arg is also data (starts with `[`,
+    // not a letter), so it must pass through to the entry fn rather
+    // than tripping the unknown-subcommand error.
+    let (_dir, path) = write_temp("first xs:L n>n;hd xs\nother xs:L n>n;hd xs\n");
+    let (ok, stdout, stderr) = run(&[path.to_str().unwrap(), "[7,8,9]"]);
+    assert!(
+        ok,
+        "bracketed-list leading arg should pass through; stderr: {stderr}"
+    );
+    assert_eq!(stdout.trim(), "7");
+}


### PR DESCRIPTION
## Summary

`ilo file.ilo wibble x` on a multi-function file used to silently route to the FIRST declared function with `["wibble", "x"]` as positional args, producing a misleading arity error like `helper: expected 1 args, got 2` far from the cause. Filed as interactive-cli rerun5 P1.

Default-engine dispatch now checks the leading positional against the known function names and, when it doesn't match AND looks like an identifier, emits a friendly diagnostic listing the available functions instead.

The token-cost framing: silently routing an unknown subcommand wastes follow-up turns on an arity error the agent then has to chase back through the file. A direct "no such function 'wibble'; available: main, helper, ..." closes the loop in one read.

## Repro

Before:

```
$ ilo file.ilo wibble x
{"code":"ILO-R004","message":"helper: expected 1 args, got 2",...}
```

After:

```
$ ilo file.ilo wibble x
error: no such function 'wibble' in file.ilo
available functions:
  helper
  main

  ilo file.ilo <func> [args...]   run a function
```

## What's in the diff

- **cli: error on unknown subcommand in multi-fn files** — adds `looks_like_subcommand_name` (ASCII ident-shape check, exempts `true`/`false`/`nil`) and a new branch in the Default-engine dispatch that fires when the file has 2+ user functions and the leading positional is ident-shaped but unknown. Synthetic `__lit_*` decls are already filtered out of the listing per #307.
- **test: regression coverage for unknown-subcommand error** — eight new integration tests in `tests/regression_cli_default.rs` covering ident-shaped unknown subcommand, known subcommand happy path, `__lit_*` filtering, single-fn and inline pass-through, and numeric / quoted-string / bracketed-list leading-arg pass-through (the last three pin the shape guard so `tests/eval_inline.rs` unwrap_*_inline don't regress).
- **examples: exercise subcommand dispatch across engines** — `examples/unknown-subcommand-listing.ilo` with `main` + two helpers and `-- run: / -- out:` annotations, pinning the happy-path dispatch contracts across every engine via the examples harness.

Three new unit tests in `src/main.rs` also cover `looks_like_subcommand_name` directly.

## Test plan

- [x] Full test suite green: `cargo test --release --features cranelift` — 138 test binaries pass, 0 failures
- [x] Clippy clean: `cargo clippy --release --features cranelift --tests -- -D warnings`
- [x] `cargo fmt --check` clean
- [x] Manual repro: `ilo /tmp/repro.ilo wibble x` produces the new error, `ilo /tmp/repro.ilo helper 5` still works, `ilo /tmp/repro.ilo` still auto-runs main
- [x] Single-fn file `ilo dbl.ilo 21` still pass-throughs as before
- [x] Inline `ilo 'dbl x:n>n;*x 2' 21` still pass-throughs

## Follow-ups

- VM, Tree, and Cranelift engines (when explicitly selected with `--vm` / `--tree` / `--cranelift`) still emit their backend-native "undefined function" error rather than the friendly listing. Default-engine covers the agent default-path which is the common case; lifting the guard to all engines would be a small follow-up if it surfaces.