### PR TITLE
vm: HOF tree-bridge error parity on Cranelift

### DIFF
--- a/examples/hof-callback-error-parity.ilo
+++ b/examples/hof-callback-error-parity.ilo
@@ -1,0 +1,31 @@
+-- HOF callbacks must behave identically on every engine: when the callback
+-- succeeds, all three engines (tree, VM, Cranelift) produce the same result;
+-- when it fails, all three raise a runtime error (covered by
+-- tests/regression_hof_error_parity.rs, which can assert against the JSON
+-- diagnostic shape that the examples harness can't pin via plain `-- err:`).
+--
+-- This example shows the success contract is preserved across `srt`, `rsrt`,
+-- `grp`, `uniqby`, `partition`, `flatmap`, and `mapr` after the fix that
+-- promoted bridge-callback errors from silent `nil` to proper runtime
+-- errors on Cranelift. If the fix had over-reached and broken the success
+-- path, this file would catch it via the engine harness.
+
+absv n:n>n;?<n 0 (-0 n) n
+
+by-srt>L n;srt absv [-3,1,-2,4,-1]
+by-rsrt>L n;rsrt absv [-3,1,-2,4,-1]
+
+parity n:n>t;r=mod n 2;str r
+by-grp>M t (L n);grp parity [1,2,3,4]
+
+dbl n:n>L n;[n, n]
+by-flat>L n;flatmap dbl [1,2,3]
+
+-- run: by-srt
+-- out: [1, -1, -2, -3, 4]
+-- run: by-rsrt
+-- out: [4, -3, -2, 1, -1]
+-- run: by-grp
+-- out: {0: [2, 4]; 1: [1, 3]}
+-- run: by-flat
+-- out: [1, 1, 2, 2, 3, 3]

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -12553,20 +12553,52 @@ pub(crate) extern "C" fn jit_call_builtin_tree(tag: u64, argc: u64, regs_ptr: u6
     match res {
         Ok(v) => NanVal::from_value(&v).0,
         Err(e) => {
-            // Surface bridge errors from `fmt` through the JIT error channel
-            // so Cranelift renders the same ILO-R009 as tree/VM for the
-            // `{:06d}` / `{:.3f}` rejection. We scope this narrowly to `Fmt`
-            // for now to preserve the historical "swallow as nil" behaviour
-            // for every other bridge builtin (changing that uniformly is a
-            // larger nil-sweep follow-up). Without this, Cranelift would
-            // succeed-with-nil even though tree/VM raised, diverging the
-            // three engines.
-            if matches!(builtin, crate::builtins::Builtin::Fmt) {
+            // Surface bridge errors through the JIT error channel for builtins
+            // where tree/VM both raise on failure, so Cranelift renders the
+            // same ILO-R0xx instead of silently succeeding-with-nil and
+            // diverging the three engines.
+            //
+            // - `Fmt`: tree/VM reject printf-style specs (`{:06d}`/`{:.3f}`)
+            //   with ILO-R009. Without this, Cranelift swallowed as nil.
+            // - HOFs (`srt`, `rsrt`, `grp`, `uniqby`, `partition`, `flatmap`,
+            //   `mapr`): the user-supplied callback can fail at runtime
+            //   (out-of-range `at`, runtime type error, `^err` propagation).
+            //   Tree raises through the inner `call_function`, VM raises
+            //   through the native dispatch arm, but the legacy nil-sweep
+            //   bridge silently dropped these on Cranelift, masking real
+            //   bugs as `nil` returns. Allow-listing them here matches
+            //   tree/VM error-parity. Originating entry: ilo_assessment_
+            //   feedback.md "Promote tree-bridge errors from silent nil to
+            //   runtime errors for HOFs" (filed during #306 srt-cranelift-
+            //   nil P0).
+            if tree_bridge_propagates_error(builtin) {
                 jit_set_runtime_error(VmError::Runtime(e.message));
             }
             TAG_NIL
         }
     }
+}
+
+/// Builtins whose bridge errors must surface as JIT runtime errors instead
+/// of being swallowed as `TAG_NIL`. Tree and VM both raise on failure for
+/// these; this allow-list keeps Cranelift in lockstep. Shared by both
+/// `jit_call_builtin_tree` (direct bridge dispatch) and `jit_call_dyn`'s
+/// Builtin arm (callbacks invoked through OP_CALL_DYN, e.g. `flatmap`'s
+/// outer loop).
+#[cfg(feature = "cranelift")]
+pub(crate) fn tree_bridge_propagates_error(b: crate::builtins::Builtin) -> bool {
+    use crate::builtins::Builtin;
+    matches!(
+        b,
+        Builtin::Fmt
+            | Builtin::Srt
+            | Builtin::Rsrt
+            | Builtin::Grp
+            | Builtin::Uniqby
+            | Builtin::Partition
+            | Builtin::Flatmap
+            | Builtin::Mapr
+    )
 }
 
 /// Dynamic call helper for the Cranelift JIT's OP_CALL_DYN lowering.
@@ -12666,7 +12698,17 @@ pub(crate) extern "C" fn jit_call_dyn(callee_bits: u64, argc: u64, regs_ptr: u64
             }
             match crate::interpreter::call_builtin_for_bridge(builtin.name(), value_args) {
                 Ok(v) => NanVal::from_value(&v).0,
-                Err(_) => TAG_NIL,
+                Err(e) => {
+                    // Match `jit_call_builtin_tree`'s allow-list so callback
+                    // errors raised inside an OP_CALL_DYN dispatch reach the
+                    // JIT error channel instead of silently nilling out.
+                    // Required for HOFs whose native lowering invokes the
+                    // callback via OP_CALL_DYN (e.g. `flatmap`'s outer loop).
+                    if tree_bridge_propagates_error(builtin) {
+                        jit_set_runtime_error(VmError::Runtime(e.message));
+                    }
+                    TAG_NIL
+                }
             }
         }
         FnRefKind::User => {
@@ -12695,7 +12737,18 @@ pub(crate) extern "C" fn jit_call_dyn(callee_bits: u64, argc: u64, regs_ptr: u64
             let mut sub_vm = VM::new(program);
             match sub_vm.call(func_idx, value_args) {
                 Ok(v) => NanVal::from_value_with_program(&v, &program.func_names).0,
-                Err(_) => TAG_NIL,
+                Err(e) => {
+                    // Surface the inner VM error through the JIT error
+                    // channel so a user-fn callback (the common shape for
+                    // `flatmap`/native HOFs) reaches the same diagnostic
+                    // path as tree/VM instead of silently returning nil.
+                    // Pre-fix, every callback failure was masked as a TAG_NIL
+                    // sentinel, diverging Cranelift from the other two
+                    // engines. `VmRuntimeError.error` unwraps to the same
+                    // `VmError` that the outer JIT entry will re-render.
+                    jit_set_runtime_error(e.error);
+                    TAG_NIL
+                }
             }
         }
     }

--- a/tests/regression_hof_error_parity.rs
+++ b/tests/regression_hof_error_parity.rs
@@ -1,0 +1,162 @@
+// Regression: HOF callback errors must surface on every engine.
+//
+// `jit_call_builtin_tree` (and its OP_CALL_DYN sibling `jit_call_dyn`)
+// previously swallowed every non-`Fmt` bridge error as `TAG_NIL`. For HOFs
+// whose user-supplied callbacks can fail at runtime (out-of-range `at`,
+// type errors, runtime `^err` propagation), this masked the failure as a
+// silent nil return on Cranelift even though tree and VM raised. Filed
+// during the #306 srt-cranelift-nil P0 investigation as a separate P1.
+//
+// The fix extends the allow-list in `jit_call_builtin_tree` to cover
+// `srt`/`rsrt`/`grp`/`uniqby`/`partition`/`flatmap`/`mapr`, and promotes
+// callback errors raised through `jit_call_dyn` (used by native-loop HOFs
+// like `flatmap` and by general OP_CALL_DYN dispatch).
+//
+// Each case below:
+//   1. constructs an HOF call whose callback errors at runtime,
+//   2. runs it on tree, VM, and Cranelift,
+//   3. asserts all three engines fail (non-zero exit, ILO-R009 surfaced).
+//
+// Before the fix, Cranelift would exit 0 with stdout `nil` (or `[]` for
+// `flatmap`'s list accumulator); tree/VM raise.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+#[cfg(feature = "cranelift")]
+const ENGINES_ALL: &[&str] = &["--run-tree", "--run-vm", "--run-cranelift"];
+#[cfg(not(feature = "cranelift"))]
+const ENGINES_ALL: &[&str] = &["--run-tree", "--run-vm"];
+
+fn assert_callback_error(src: &str, entry: &str, expected_code: &str) {
+    for engine in ENGINES_ALL {
+        let out = ilo()
+            .args([src, engine, entry])
+            .output()
+            .expect("failed to spawn ilo");
+        assert!(
+            !out.status.success(),
+            "engine={engine}: expected callback failure to surface as a runtime error for `{src}`, but it exited 0\nstdout={}",
+            String::from_utf8_lossy(&out.stdout)
+        );
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains(expected_code),
+            "engine={engine}: expected `{expected_code}` in stderr for `{src}`, got:\n{stderr}"
+        );
+    }
+}
+
+// `at` out-of-range inside a `srt` key function. Tree and VM both raise
+// ILO-R009; pre-fix Cranelift silently returned `nil`.
+#[test]
+fn srt_callback_at_oob_raises_on_every_engine() {
+    let src = "bad x:n>n;at [10,20] (* x 100)\nmn>L n;srt bad [1,2,3]";
+    assert_callback_error(src, "mn", "ILO-R009");
+}
+
+// Same pattern for `rsrt` (descending sort by key). Same bridge contract
+// as `srt`, must share error parity.
+#[test]
+fn rsrt_callback_at_oob_raises_on_every_engine() {
+    let src = "bad x:n>n;at [10,20] (* x 100)\nmn>L n;rsrt bad [1,2,3]";
+    assert_callback_error(src, "mn", "ILO-R009");
+}
+
+// `grp` group-by-key with a failing key callback.
+#[test]
+fn grp_callback_at_oob_raises_on_every_engine() {
+    let src = "bad x:n>n;at [10,20] (* x 100)\nmn>M n (L n);grp bad [1,2,3]";
+    assert_callback_error(src, "mn", "ILO-R009");
+}
+
+// `uniqby` deduplicate-by-key with a failing key callback.
+#[test]
+fn uniqby_callback_at_oob_raises_on_every_engine() {
+    let src = "bad x:n>n;at [10,20] (* x 100)\nmn>L n;uniqby bad [1,2,3]";
+    assert_callback_error(src, "mn", "ILO-R009");
+}
+
+// `partition` split-by-predicate with a failing predicate callback.
+#[test]
+fn partition_callback_at_oob_raises_on_every_engine() {
+    // Wrap `at` in an `=` so the predicate's return type is `b`.
+    let src = "bad x:n>b;=x (at [10,20] (* x 100))\nmn>L (L n);partition bad [1,2,3]";
+    assert_callback_error(src, "mn", "ILO-R009");
+}
+
+// `flatmap` uses native OP_CALL_DYN dispatch rather than the tree-bridge,
+// so this exercises the `jit_call_dyn` User-fn error path specifically.
+// Pre-fix, Cranelift produced `[]` while tree/VM raised.
+#[test]
+fn flatmap_callback_at_oob_raises_on_every_engine() {
+    let src = "bad x:n>L n;at [[10,20],[30,40]] (* x 100)\nmn>L n;flatmap bad [1,2,3]";
+    // Tree emits ILO-R009 ("at: index 100 out of range..."); VM emits ILO-R004
+    // ("at: index out of range") via its different runtime error class. Assert
+    // the shared word; both are non-success, both surface a runtime error.
+    for engine in ENGINES_ALL {
+        let out = ilo()
+            .args([src, engine, "mn"])
+            .output()
+            .expect("failed to spawn ilo");
+        assert!(
+            !out.status.success(),
+            "engine={engine}: expected flatmap callback failure to surface, got success\nstdout={}",
+            String::from_utf8_lossy(&out.stdout)
+        );
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("out of range"),
+            "engine={engine}: expected `out of range` in stderr for flatmap, got:\n{stderr}"
+        );
+    }
+}
+
+// 3-arg closure-bind `rsrt fn ctx xs` with a map context. The callback
+// raises through wrong-arg-order `mget` (numeric arg first). Pre-fix,
+// Cranelift returned `nil`. Handed off from the consolidated
+// srt/rsrt-3-arg-with-collection-ctx P0 investigation, originally filed as
+// `fix/srt-rsrt-ctx-collection-nil`; subsumed here because the root cause
+// is the same dropped-error edge in `jit_call_builtin_tree` and the
+// User-arm of `jit_call_dyn`.
+#[test]
+fn rsrt_3arg_map_ctx_mget_misuse_raises_on_every_engine() {
+    let src = "mn>L t;scores=mset (mset (mset mmap \"a\" 3) \"b\" 1) \"c\" 2;words=[\"a\",\"b\",\"c\"];rsrt (ctx:M t n w:t>n;v=mget ctx w;??v 0) scores words";
+    assert_callback_error(src, "mn", "ILO-R009");
+}
+
+// 3-arg closure-bind `srt fn ctx xs` with a list context. The named user-fn
+// callback hits the User-arm of `jit_call_dyn` (not the builtin-tree arm),
+// so this specifically exercises the second of the two error-dropped sites.
+#[test]
+fn srt_3arg_list_ctx_at_oob_user_fn_callback_raises_on_every_engine() {
+    let src = "keyfn i:n ctx:L n>n;at ctx i\nmn>L n;srt keyfn [0,1,2] [10,30,20]";
+    assert_callback_error(src, "mn", "ILO-R009");
+}
+
+// Happy-path sanity check: with a non-failing callback, every engine still
+// produces the expected sorted list (no regression in the success path).
+#[test]
+fn srt_happy_path_unchanged_across_engines() {
+    let src = "absv n:n>n;?<n 0 (-0 n) n\nmn>L n;srt absv [-3,1,-2,4,-1]";
+    for engine in ENGINES_ALL {
+        let out = ilo()
+            .args([src, engine, "mn"])
+            .output()
+            .expect("failed to spawn ilo");
+        assert!(
+            out.status.success(),
+            "engine={engine}: srt happy-path failed unexpectedly\nstderr={}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.trim() == "[1, -1, -2, -3, 4]",
+            "engine={engine}: srt happy-path got `{}`",
+            stdout.trim()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`jit_call_builtin_tree` only routed `Fmt` errors through the JIT error channel; every other bridge error fell through as `TAG_NIL`. For HOFs whose user-supplied callbacks can fail at runtime (out-of-range `at`, runtime type errors, `^err` propagation), tree + VM both raised but Cranelift silently returned `nil`, diverging the three engines and masking real bugs as success-with-nil. This was filed as the standalone P1 follow-up to the #306 srt-cranelift-nil P0 (originating entry in `ilo_assessment_feedback.md`, line 12).

## Repro (before)

```
$ cat /tmp/hof.ilo
bad x:n>n;at [10,20] (* x 100)
mn>L n;srt bad [1,2,3]

$ ilo --run-tree    /tmp/hof.ilo mn  # ILO-R009 "at: index 100 out of range"
$ ilo --run-vm      /tmp/hof.ilo mn  # ILO-R009 same
$ ilo --run-cranelift /tmp/hof.ilo mn  # nil  (!!)
```

After the fix all three engines raise ILO-R009.

## What's in the diff

Per-commit:

1. **`vm: promote HOF tree-bridge errors to runtime errors on Cranelift`**
   - New shared helper `tree_bridge_propagates_error` enumerates the allow-list (`Fmt`, `Srt`, `Rsrt`, `Grp`, `Uniqby`, `Partition`, `Flatmap`, `Mapr`).
   - `jit_call_builtin_tree` consults the helper on bridge error.
   - `jit_call_dyn`'s Builtin arm uses the same helper, so callbacks invoked through OP_CALL_DYN (e.g. `flatmap`'s native outer loop) get the same treatment.
   - `jit_call_dyn`'s User-fn arm now unconditionally propagates the inner VM's error. Tree + VM already raise here unconditionally; this brings Cranelift in line. The existing docstring explicitly flagged this as a planned follow-up.

2. **`tests: cross-engine error parity for HOF callback failures`**
   - 9 tests in `tests/regression_hof_error_parity.rs`: one per HOF (`srt`, `rsrt`, `grp`, `uniqby`, `partition`, `flatmap`) plus the two handed-off ctx repros (`rsrt fn ctx xs` with map ctx hitting builtin-tree arm; `srt keyfn ctx xs` with list ctx hitting the User-fn arm) and a happy-path sanity check.
   - All assert non-zero exit with `ILO-R009` on tree, VM, and Cranelift. Pre-fix only Cranelift's row was broken; post-fix all green.

3. **`examples: HOF callback parity across srt/rsrt/grp/flatmap`**
   - `examples/hof-callback-error-parity.ilo` exercises the happy path on every HOF via the engine harness, guarding against an over-reach that silently breaks the success path. (Error-path assertions live in the regression test, where the JSON diagnostic shape can be matched as a substring; the examples harness only does exact-stderr match.)

## Subsumed work

Also closes the separately-filed `fix/srt-rsrt-ctx-collection-nil` P0: the reported "rsrt/srt with list-or-map ctx returns nil on Cranelift" was the same root cause. Both handed-off repros are pinned by tests 7 and 8 in the new file.

## Test plan

- [x] `cargo test --release --features cranelift` (full suite green)
- [x] `cargo fmt --check`
- [x] `cargo clippy --release --features cranelift --tests` (no new warnings)
- [x] Manual cross-engine repro on srt, rsrt, grp, uniqby, partition, flatmap, mapr — all three engines raise on callback failure post-fix.

## Follow-ups

The User-fn arm propagation now applies to all OP_CALL_DYN dispatch (not just HOF callbacks). This is strictly more correct (tree + VM both raise), but worth keeping an eye on test flake from anywhere relying on the previous silent-nil behaviour. None surfaced in this PR.