### PR TITLE
parser: accept brace-block function bodies, show both shapes in multi-line hint

### DIFF
--- a/examples/fn-body-forms.ilo
+++ b/examples/fn-body-forms.ilo
@@ -1,0 +1,25 @@
+-- ilo function bodies come in two valid shapes: single-line `;`-separated
+-- (`foo p:t>r;body1;body2`) and brace-block (`foo p:t>r;{body1;body2}`). The
+-- brace-block form survives indented continuations cleanly, which matters
+-- when personas reach for python/swift-style indented bodies. This file
+-- pins both shapes across every engine.
+
+-- Single-line `;`-separated form.
+suma xs:Ln>n;s=0;@k xs{s=+s k};s
+
+-- Brace-block form, same body, written on one line.
+sumb xs:Ln>n;{s=0;@k xs{s=+s k};s}
+
+-- Brace-block form with indented continuations inside the braces.
+sumc xs:Ln>n;{
+  s=0
+  @k xs{s=+s k}
+  s
+}
+
+-- run: suma [1,2,3]
+-- out: 6
+-- run: sumb [1,2,3]
+-- out: 6
+-- run: sumc [1,2,3]
+-- out: 6

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -183,8 +183,14 @@ impl Parser {
                     // body statements are collapsed to `;` by the lexer,
                     // so `@k kws\n  body` becomes `@k kws;body` and the
                     // foreach's required `{` lands on a `;` instead.
+                    //
+                    // Personas reach for python/swift-style indented bodies
+                    // and have learned to dense-pack single-line forms as a
+                    // workaround. Surface BOTH valid shapes (brace-block and
+                    // single-line `;`-separated) so the next attempt picks
+                    // one rather than re-trying indentation.
                     Some(
-                        "ilo bodies are single-line, `;`-separated. If you broke the body across lines, collapse it onto one line or wrap with `{ ... }`. For example `@k kws{body};...` not `@k kws;body`.".to_string()
+                        "ilo bodies are single-line, `;`-separated — not python/swift-style indented. Use either the brace-block form `name p:t>r;{body1;body2}` or the single-line form `name p:t>r;body1;body2`. For statements that require a block (`@k xs{...}`, `wh cond{...}`, `?subj{...}`), the `{...}` must be on the same line as the head.".to_string()
                     )
                 } else {
                     None
@@ -740,7 +746,21 @@ impl Parser {
         if self.peek() == Some(&Token::Semi) {
             self.advance();
         }
-        let body = self.parse_body_with(true)?;
+        // Two valid body shapes after the header:
+        //   (a) `;`-separated single-line / indented-continuation form
+        //   (b) brace-block form `{body1;body2}` — explicit braces wrap the
+        //       whole function body. This mirrors the brace-block grammar
+        //       already accepted by `=cond{block}`, match arms (`~v:{block}`)
+        //       and braced-conditional headings; surfacing it at fn-decl
+        //       position gives personas a python/swift-friendly escape from
+        //       the dense single-line workaround they've been settling for.
+        // Skip the brace-block path when the leading `{` is a destructure
+        // pattern (`f p:pt>n;{x}=p;...`) — that's a statement, not a wrap.
+        let body = if self.peek() == Some(&Token::LBrace) && !self.is_destructure_pattern() {
+            self.parse_brace_body()?
+        } else {
+            self.parse_body_with(true)?
+        };
         let end = self.prev_span();
         Ok(Decl::Function {
             name,
@@ -8259,7 +8279,9 @@ mod tests {
     #[test]
     fn lbrace_expected_got_semi_emits_multiline_body_hint() {
         // Foreach body without explicit `{`: `@k xs;+k 1` triggers
-        // `expected LBrace, got Semi`.
+        // `expected LBrace, got Semi`. The hint should mention both
+        // valid body shapes so personas pick one instead of re-trying
+        // python/swift-style indented bodies.
         let source = "main>n;xs=[1 2 3];@k xs;+k 1";
         let (_, errors) = parse_str_errors(source);
         let e = errors
@@ -8268,9 +8290,70 @@ mod tests {
             .expect("expected ILO-P003 LBrace error");
         let hint = e.hint.as_ref().expect("expected hint");
         assert!(
-            hint.contains("single-line") && hint.contains("`{ ... }`"),
+            hint.contains("single-line") && hint.contains("brace-block"),
             "hint: {}",
             hint
+        );
+        // Both alternative function-syntax forms should appear so the
+        // persona's next attempt picks one.
+        assert!(
+            hint.contains("name p:t>r;{body1;body2}"),
+            "brace-block form missing; hint: {}",
+            hint
+        );
+        assert!(
+            hint.contains("name p:t>r;body1;body2"),
+            "single-line `;`-separated form missing; hint: {}",
+            hint
+        );
+    }
+
+    #[test]
+    fn multiline_function_body_with_indented_foreach_emits_hint() {
+        // Repro: python-style indented body inside a function. After
+        // normalize_newlines: `foo xs:Ln>n;s=0;@k xs;s=+s k;s`.
+        // The foreach's expected `{` lands on a `;`.
+        let source = "foo xs:Ln>n\n  s=0\n  @k xs\n    s=+s k\n  s\n";
+        let (_, errors) = parse_str_errors(source);
+        let e = errors
+            .iter()
+            .find(|e| e.code == "ILO-P003" && e.message.contains("expected LBrace"))
+            .expect("expected ILO-P003 LBrace error");
+        let hint = e.hint.as_ref().expect("expected hint");
+        assert!(
+            hint.contains("name p:t>r;{body1;body2}"),
+            "expected brace-block form in hint; got: {}",
+            hint
+        );
+        assert!(
+            hint.contains("name p:t>r;body1;body2"),
+            "expected single-line form in hint; got: {}",
+            hint
+        );
+    }
+
+    #[test]
+    fn single_line_function_body_parses_without_hint() {
+        // Regression: the `;`-separated single-line form must still
+        // parse cleanly with no diagnostic.
+        let source = "foo xs:Ln>n;s=0;@k xs{s=+s k};s\nmain>n;foo lst 1 2 3";
+        let (_, errors) = parse_str_errors(source);
+        assert!(
+            errors.is_empty(),
+            "single-line body should parse cleanly; errors: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn braced_function_body_parses_without_hint() {
+        // Regression: the brace-block form must still parse cleanly.
+        let source = "foo xs:Ln>n;{s=0;@k xs{s=+s k};s}\nmain>n;foo lst 1 2 3";
+        let (_, errors) = parse_str_errors(source);
+        assert!(
+            errors.is_empty(),
+            "braced body should parse cleanly; errors: {:?}",
+            errors
         );
     }
 


### PR DESCRIPTION
## Summary

Personas reaching for python/swift-style indented function bodies have been hitting `ILO-P003 expected LBrace, got Semi` and learning to dense-pack everything onto one line as a workaround. That's "working around the language" smell, flagged across multiple persona reruns.

Two changes:

1. The existing `expected LBrace, got Semi` hint now shows both valid function-body shapes explicitly, instead of only the foreach example. So a persona sees:

   > ilo bodies are single-line, `;`-separated — not python/swift-style indented. Use either the brace-block form `name p:t>r;{body1;body2}` or the single-line form `name p:t>r;body1;body2`. For statements that require a block (`@k xs{...}`, `wh cond{...}`, `?subj{...}`), the `{...}` must be on the same line as the head.

2. The brace-block form for function decls is now grammar (it wasn't before — `parse_body_with(true)` rejected a leading `{`). It mirrors the brace-block grammar already accepted by `=cond{block}`, match arms (`~v:{...}`), and braced-conditional bodies. The big ergonomic win: braces survive indented continuations cleanly, so a python-style author can write the brace form and indent inside without the lexer's `;`-collapse fighting them.

Destructure statements at body start (`f p:pt>n;{x}=p;...`) are unaffected — the brace-block path is gated on `!is_destructure_pattern()`.

## Repro before/after

Source:

```
foo xs:Ln>n
  s=0
  @k xs
    s=+s k
  s

main>n;foo (lst 1 2 3)
```

**Before:** `ILO-P003 expected LBrace, got Semi` with a foreach-only hint (`@k kws{body};...`) — no mention of the alternative function-body forms.

**After:** same error code (the indented form is still invalid), but the hint now spells out both `name p:t>r;{body1;body2}` and `name p:t>r;body1;body2`. AND the persona can now actually use the brace-block form to keep their indentation:

```
foo xs:Ln>n;{
  s=0
  @k xs{s=+s k}
  s
}
```

That parses cleanly across tree / VM / Cranelift.

## What's in the diff (per-commit)

- **parser: accept brace-block function bodies and update multi-line hint** — single grammar change in `parse_fn_decl` (check for `LBrace` after header, fall through to `parse_brace_body` when it's not a destructure pattern), broader hint text at the `expect(LBrace)` site, and four new regression tests: hint shows both forms, indented foreach inside fn body fires the hint, single-line body still parses, brace-block body parses.
- **examples: pin both function-body shapes across every engine** — `examples/fn-body-forms.ilo` exercises single-line / one-line brace / indented-inside-brace, with `-- run` / `-- out` assertions so the engine harness catches grammar regressions on every backend.

## Test plan

- [x] `cargo test --release --features cranelift` — 3089 lib tests + integration green
- [x] `cargo test --release --features cranelift --test examples_engines` — new example runs on tree / VM / Cranelift
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --release --features cranelift -- -D warnings` clean
- [x] Manual repro before/after confirmed

## Follow-ups

None — the diagnostic and the grammar change are scoped and self-contained.