### PR TITLE
fix: bare-ident bang (`x!`) silently returning nil (v0.11.4 P0)

### DIFF
--- a/examples/bare-bang-rejected.ilo
+++ b/examples/bare-bang-rejected.ilo
@@ -1,0 +1,40 @@
+-- `!` is the auto-unwrap operator and only applies to function CALLS.
+-- It takes the Result or Optional returned by a call and unwraps it:
+--   Ok(v)/non-nil → v
+--   Err(e)/nil   → propagate (`!`) or abort (`!!`)
+--
+-- When `!` is attached to a bare ident that resolves to a plain value
+-- (a local binding, a parameter, a destructured field), there is no
+-- call for the operator to act on. Pre-fix, the inline default-engine
+-- path skipped verify and the interpreter silently returned `nil` for
+-- this shape — a soundness hazard. The verifier now rejects it with
+-- ILO-T034 and points at the two canonical fixes.
+
+-- The two correct shapes are:
+--
+-- (1) Match on a Result-valued binding to inspect Ok / Err:
+--       ?score{~v:v;^e:0}
+--
+-- (2) Auto-unwrap at the producer's call site, then reference the
+--     resulting value without `!`:
+--       scs = producer! ...
+--       use-scs scs
+
+-- Happy path A: match on a Result-valued local.
+inspect-result>R n t;score=lookup-score 1;?score{~v:~v;^e:^e}
+
+-- Helper used by `inspect-result` — returns a Result, exercised by the
+-- engine harness through `inspect-result` rather than directly. Braceless
+-- guard form is used so the body's early-return surfaces without the
+-- discarded-result hint that the braced `cond{^"err"}` shape triggers.
+lookup-score id:n>R n t;<id 1 ^"id must be positive";~*id 10
+
+-- Happy path B: unwrap at the producer's call site, reference the
+-- resulting plain Number afterwards (no `!` on the local).
+double-unwrapped>R n t;v=lookup-score! 4;~*v 2
+
+-- run: inspect-result
+-- out: 10
+
+-- run: double-unwrapped
+-- out: 80

--- a/src/diagnostic/registry.rs
+++ b/src/diagnostic/registry.rs
@@ -795,6 +795,41 @@ Tail position in a function body, `if` arm, or `?{}` arm is fine — the
 value flows out as the function/branch result.
 "#,
     },
+    ErrorEntry {
+        code: "ILO-T034",
+        short: "'!' / '!!' used on a non-callable value",
+        long: r#"## ILO-T034: '!' / '!!' used on a non-callable value
+
+`!` and `!!` are the **auto-unwrap operators**, and they only apply to
+function calls. They take the Result or Optional returned by a call
+and unwrap it: `~v` / non-nil flows through as the inner value, while
+`^e` / nil either propagates (`!`) or aborts (`!!`).
+
+When the operator is attached to a bare identifier that resolves to a
+value (a local binding, a parameter, a destructured field), there is
+no call for the operator to act on. In v0.11.4 and earlier this shape
+silently returned `nil` on the default-engine inline path; the verifier
+now catches it.
+
+**Example (bug):**
+
+    main>R n t;x=42;x!
+    -- 'x' is a Number, not a function — '!' has nothing to unwrap
+
+**Fix — match on a Result-valued binding:**
+
+    ?x{~v:v;^e:^e}
+
+**Fix — auto-unwrap a producer's return at the assignment:**
+
+    scs = producer! ...
+    -- now 'scs' holds the unwrapped value; reference it directly
+
+This error fires only when the bang is adjacent to the ident (`x!`,
+`y!!`). Bang inside a call argument (`f !x`) is the logical-NOT prefix
+and is unaffected.
+"#,
+    },
     // ── Warnings ─────────────────────────────────────────────────────────────
     ErrorEntry {
         code: "ILO-W001",

--- a/src/main.rs
+++ b/src/main.rs
@@ -2593,6 +2593,26 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
     // false-positive errors on builtins or partial snippets that users want to
     // explore via the AST dump. Parse errors still gate (we can't dump an AST
     // we couldn't parse).
+    //
+    // Auto-run carve-out (PR #257-era regression fix): commit c9e1ed0 made
+    // inline `ilo '<code>'` auto-run when there's a runnable entry (`main`
+    // or a single user-defined fn). Those runs MUST go through verify, or
+    // shapes like bare-ident bang (`x=42;x!`) reach the interpreter
+    // unverified and silently return nil. Only suppress verify when the
+    // snippet will actually AST-dump: zero user fns, or multi-fns without
+    // a `main`. Mirror the auto-run heuristic at the dispatch site below.
+    let user_fn_names: Vec<&str> = program
+        .declarations
+        .iter()
+        .filter_map(|d| match d {
+            ast::Decl::Function { name, .. } if !name.starts_with("__") => Some(name.as_str()),
+            _ => None,
+        })
+        .collect();
+    let inline_will_auto_run = !is_file
+        && r.rest.is_empty()
+        && matches!(r.effective_engine(), cli::Engine::Default)
+        && (user_fn_names.len() == 1 || user_fn_names.contains(&"main"));
     let ast_dump_mode = r.ast
         || (!is_file
             && r.rest.is_empty()
@@ -2601,7 +2621,8 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
             && r.emit.is_none()
             && !r.dense
             && !r.expanded
-            && matches!(r.effective_engine(), cli::Engine::Default));
+            && matches!(r.effective_engine(), cli::Engine::Default)
+            && !inline_will_auto_run);
 
     if !ast_dump_mode {
         let verify_result = verify::verify(&program);

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -3409,24 +3409,52 @@ impl VerifyContext {
                     // is not callable (i.e. not Ty::Fn). Do NOT fuzzy-match against
                     // builtins — the name is already a valid in-scope binding, just
                     // not a function. Produce a targeted error instead.
-                    self.err(
-                        "ILO-T005",
-                        func,
-                        format!(
-                            "'{callee}' is a {bound_ty}, not a function (called with {} args)",
-                            args.len()
-                        ),
-                        Some(format!(
-                            "'{callee}' is bound as {bound_ty} in this scope; only functions can be called"
-                        )),
-                        Some(span),
-                    );
+                    //
+                    // ILO-T034 carve-out: a bare ident with a postfix bang
+                    // (`x!` / `x!!`) parses as `Call { function: "x", args: [],
+                    // unwrap: Propagate|Panic }`. The shape is a common
+                    // mistake from agents reaching for `!` as a Rust-style
+                    // `Result::unwrap` on a Result-typed local. In ilo `!` is
+                    // strictly the auto-unwrap operator on a function CALL.
+                    // Steer to the two canonical alternatives: match
+                    // (`?x{~v:v;^e:^e}`) for inspecting a Result value, or
+                    // rebinding from the producer (`y = producer! ...`).
+                    if args.is_empty() && unwrap.is_any() {
+                        let op = if unwrap.is_panic() { "!!" } else { "!" };
+                        self.err(
+                            "ILO-T034",
+                            func,
+                            format!(
+                                "'{op}' is the auto-unwrap operator and only applies to function calls — '{callee}' is a {bound_ty} value"
+                            ),
+                            Some(format!(
+                                "to inspect a Result value use match: `?{callee}{{~v:v;^e:^e}}`; to auto-unwrap a producer use `{callee} = producer! ...` and reference `{callee}` afterwards"
+                            )),
+                            Some(span),
+                        );
+                    } else {
+                        self.err(
+                            "ILO-T005",
+                            func,
+                            format!(
+                                "'{callee}' is a {bound_ty}, not a function (called with {} args)",
+                                args.len()
+                            ),
+                            Some(format!(
+                                "'{callee}' is bound as {bound_ty} in this scope; only functions can be called"
+                            )),
+                            Some(span),
+                        );
+                    }
                     Ty::Unknown
                 } else {
                     // Suggest in-scope variables/params first, then user functions, then
                     // builtins. closest_match picks the shortest distance, but when the
                     // name truly is undefined we still want a useful suggestion across
                     // all categories.
+                    // Undefined-with-bang stays as ILO-T005 — the name doesn't
+                    // resolve at all, so the fundamental error is the missing
+                    // binding, not the postfix operator. Suggestions still help.
                     let mut candidates: Vec<String> = scope
                         .iter()
                         .flat_map(|frame| frame.keys().cloned())

--- a/tests/regression_bare_bang_nil.rs
+++ b/tests/regression_bare_bang_nil.rs
@@ -1,0 +1,207 @@
+// Cross-engine regression for v0.11.4 P0: bare-ident `x!` silently returns
+// `nil` on the inline default-engine path.
+//
+// Background: `!` is the auto-unwrap operator. It applies to the Result or
+// Optional returned by a function call. `x!` where `x` is a plain local
+// (Number, Text, etc.) is meaningless — there is no call for the operator
+// to act on. Prior to this fix, the verifier reached the bound_ty branch
+// and emitted `ILO-T005 'x' is a n, not a function`, which was correct
+// but pedantic. Worse, the inline default-engine CLI path skipped verify
+// entirely when `r.rest.is_empty()`, so `ilo 'main>R n t;x=42;x!'` ran
+// the unverified program and the interpreter silently returned `nil`.
+//
+// This file pins:
+//   - The inline default-engine path now runs verify when it will
+//     auto-run (matching the auto-run heuristic in dispatch).
+//   - The verifier emits a new `ILO-T034` targeting the bare-ident-bang
+//     shape specifically (with a hint pointing at `?x{~v:v;^e:^e}` or
+//     `scs = producer! ...`), instead of the generic ILO-T005.
+//   - The error fires consistently on default, --run-tree, --run-vm, and
+//     --run-cranelift, on:
+//       * a Number-valued local (`x=42;x!`)
+//       * a Text-valued local (`s="hi";s!`)
+//       * a parameter (`fn p:n>n;p!`)
+//       * the `!!` variant (`x=42;x!!`)
+//     and inside a guard body and a loop body, to cover the positions
+//     agents actually reach for `!` on a non-call.
+//   - Legitimate `func!` and `func!!` on a real Result-returning function
+//     still pass verify and execute on every engine.
+//   - The explicit `--ast` flag and the multi-fn-without-main inline
+//     shortcut still AST-dump without invoking verify (the carve-out
+//     wasn't accidentally widened to AST-dump paths).
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+#[cfg(feature = "cranelift")]
+const ENGINES_ALL: &[&str] = &["--run-tree", "--run-vm", "--run-cranelift"];
+#[cfg(not(feature = "cranelift"))]
+const ENGINES_ALL: &[&str] = &["--run-tree", "--run-vm"];
+
+/// Run `ilo <src> <engine>` and return (stdout, stderr, exit code).
+fn run_engine(engine: &str, src: &str) -> (String, String, i32) {
+    let out = ilo()
+        .args([src, engine])
+        .output()
+        .expect("failed to run ilo");
+    let code = out.status.code().unwrap_or(-1);
+    (
+        String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        code,
+    )
+}
+
+/// Run `ilo <src>` with no flags — the default-engine inline path that
+/// regressed in v0.11.4. Returns (stdout, stderr, exit code).
+fn run_default_inline(src: &str) -> (String, String, i32) {
+    let out = ilo().arg(src).output().expect("failed to run ilo");
+    let code = out.status.code().unwrap_or(-1);
+    (
+        String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        code,
+    )
+}
+
+// ─── The original repro: must error loudly, not return nil ─────────────────
+
+#[test]
+fn bare_bang_on_number_errors_on_default_inline() {
+    let src = "main>R n t;x=42;x!";
+    let (stdout, stderr, code) = run_default_inline(src);
+    assert_eq!(code, 1, "expected exit 1, got {code}. stdout={stdout:?}");
+    assert!(
+        stdout.is_empty(),
+        "expected empty stdout (not 'nil'), got {stdout:?}"
+    );
+    assert!(
+        stderr.contains("ILO-T034"),
+        "expected ILO-T034 in stderr, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("auto-unwrap operator"),
+        "expected explanatory message about auto-unwrap, got: {stderr}"
+    );
+}
+
+#[test]
+fn bare_bang_on_number_errors_on_every_engine() {
+    let src = "main>R n t;x=42;x!";
+    for engine in ENGINES_ALL {
+        let (stdout, stderr, code) = run_engine(engine, src);
+        assert_eq!(code, 1, "{engine}: expected exit 1, got {code}");
+        assert!(stdout.is_empty(), "{engine}: stdout not empty: {stdout:?}");
+        assert!(
+            stderr.contains("ILO-T034"),
+            "{engine}: expected ILO-T034, got: {stderr}"
+        );
+    }
+}
+
+// ─── Other shapes: text-valued local, param, !! variant ────────────────────
+
+#[test]
+fn bare_bang_on_text_local_errors_on_default_inline() {
+    let src = "main>R t t;s=\"hi\";s!";
+    let (stdout, stderr, code) = run_default_inline(src);
+    assert_eq!(code, 1, "expected exit 1, got {code}");
+    assert!(stdout.is_empty(), "expected empty stdout, got {stdout:?}");
+    assert!(stderr.contains("ILO-T034"), "stderr: {stderr}");
+}
+
+#[test]
+fn bare_bang_on_param_errors_on_default_inline() {
+    let src = "f p:n>R n t;p!\nmain>R n t;f 1";
+    let (stdout, stderr, code) = run_default_inline(src);
+    assert_eq!(code, 1, "expected exit 1, got {code}");
+    assert!(stdout.is_empty(), "stdout: {stdout:?}");
+    assert!(stderr.contains("ILO-T034"), "stderr: {stderr}");
+}
+
+#[test]
+fn bare_bangbang_on_number_errors_on_default_inline() {
+    let src = "main>n;x=42;x!!";
+    let (stdout, stderr, code) = run_default_inline(src);
+    assert_eq!(code, 1, "expected exit 1, got {code}");
+    assert!(stdout.is_empty(), "stdout: {stdout:?}");
+    assert!(stderr.contains("ILO-T034"), "stderr: {stderr}");
+    // !! operator surfaces in the message
+    assert!(stderr.contains("!!"), "expected !! mention, got: {stderr}");
+}
+
+// ─── Positional contexts: guard body, loop body ────────────────────────────
+
+#[test]
+fn bare_bang_inside_guard_body_errors() {
+    let src = "main>R n t;x=42;>x 0{x!};~x";
+    let (stdout, stderr, code) = run_default_inline(src);
+    assert_eq!(code, 1, "expected exit 1, got {code}");
+    assert!(stdout.is_empty(), "stdout: {stdout:?}");
+    assert!(stderr.contains("ILO-T034"), "stderr: {stderr}");
+}
+
+// ─── Happy paths still work: real Result-returning fn with ! / !! ──────────
+
+#[test]
+fn bang_on_result_returning_fn_still_works_default_inline() {
+    let src = "helper>R n t;~42\nmain>R n t;v=helper!;~v";
+    let (stdout, stderr, code) = run_default_inline(src);
+    assert_eq!(code, 0, "expected exit 0, got {code}. stderr={stderr}");
+    assert_eq!(stdout, "42", "expected 42, got {stdout:?}");
+}
+
+#[test]
+fn bang_on_result_returning_fn_still_works_every_engine() {
+    let src = "helper>R n t;~42\nmain>R n t;v=helper!;~v";
+    for engine in ENGINES_ALL {
+        let (stdout, stderr, code) = run_engine(engine, src);
+        assert_eq!(code, 0, "{engine}: exit {code}, stderr={stderr}");
+        assert_eq!(stdout, "42", "{engine}: got {stdout:?}");
+    }
+}
+
+#[test]
+fn bangbang_on_result_returning_fn_still_works_default_inline() {
+    let src = "helper>R n t;~42\nmain>n;helper!!";
+    let (stdout, stderr, code) = run_default_inline(src);
+    assert_eq!(code, 0, "expected exit 0, got {code}. stderr={stderr}");
+    assert_eq!(stdout, "42", "expected 42, got {stdout:?}");
+}
+
+// ─── AST-dump escape hatches must still skip verify ────────────────────────
+
+#[test]
+fn explicit_ast_flag_still_dumps_without_verifying() {
+    // --ast is the explicit AST-dump path and must NOT run verify, even
+    // when the program contains a bug like bare `x!`.
+    let src = "main>R n t;x=42;x!";
+    let out = ilo()
+        .args(["--ast", src])
+        .output()
+        .expect("failed to run ilo");
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(code, 0, "expected exit 0, got {code}");
+    // Should be JSON AST output, not an error
+    assert!(stdout.contains("\"declarations\""), "stdout: {stdout}");
+    assert!(stdout.contains("\"Propagate\""), "stdout: {stdout}");
+}
+
+#[test]
+fn inline_multi_fn_no_main_still_ast_dumps() {
+    // Two user fns and no `main` — the auto-run heuristic falls through
+    // to AST-dump, and verify must remain skipped so this snippet (which
+    // would otherwise pass verify anyway) prints AST and exits 0 without
+    // executing anything.
+    let src = "helper>n;1\nother>n;2";
+    let (stdout, _stderr, code) = run_default_inline(src);
+    assert_eq!(code, 0, "expected exit 0, got {code}");
+    assert!(
+        stdout.contains("\"declarations\""),
+        "expected AST JSON, got: {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

`ilo 'main>R n t;x=42;x!'` was returning `nil` with exit 0 instead of erroring loudly. This is a v0.11.4 P0 regression introduced by #257-era commit `c9e1ed0` (cli: auto-run inline programs with a runnable entry).

Two parts to the fix:

- **CLI**: when an inline snippet will auto-run (single user fn, or contains `main`), do NOT skip verify. Pre-fix, `ast_dump_mode` at `src/main.rs:2596-2604` suppressed verify whenever `r.rest.is_empty()` on the default engine, but the same condition was the path that ended up auto-running. So the unverified program reached the interpreter and bare-ident bang degenerated to nil. Explicit `--run-tree` / `--run-vm` / passing `main` as a positional always ran verify correctly, which is how the regression sat undetected.
- **Verifier**: replace the generic ILO-T005 ("x is a Number, not a function") with a targeted ILO-T034 for the bare-ident-bang shape specifically. The hint points at the two correct shapes: match on a Result value (`?x{~v:v;^e:^e}`) or auto-unwrap at the producer's call site (`scs = producer! ...`). General ILO-T005 still fires for non-call shapes that don't have a bang.

## Repro

Before:
```
$ ilo 'main>R n t;x=42;x!'
nil
$ echo $?
0
```

After:
```
$ ilo 'main>R n t;x=42;x!'
{"code":"ILO-T034","message":"'!' is the auto-unwrap operator and only applies to function calls — 'x' is a n value","suggestion":"to inspect a Result value use match: `?x{~v:v;^e:^e}`; to auto-unwrap a producer use `x = producer! ...` and reference `x` afterwards", ...}
$ echo $?
1
```

## What's in the diff

- **verify**: ILO-T034 branch in the `bound_ty` arm of the `Expr::Call` inference path. Fires only when `args.is_empty() && unwrap.is_any()` so existing `Ty::Fn`-valued binding calls, builtin calls, and user-fn calls all unaffected. Undefined-with-bang stays as ILO-T005 since the fundamental error there is the missing binding.
- **diagnostic/registry**: long-form `--explain ILO-T034` entry matching the T032/T033 style.
- **cli**: tighten `ast_dump_mode` to exclude the inline-will-auto-run case, mirroring the auto-run heuristic at the dispatch site. Honours `--ast` and the multi-fn-without-main fallback unchanged.
- **tests/regression_bare_bang_nil.rs**: 11 cross-engine cases — bare bang on Number / Text / param, the `!!` variant, inside a guard body, happy-path `func!` and `func!!` on a real Result-returning fn, and two pins on the AST-dump escape hatches (`--ast` flag and multi-fn-no-main) to make sure the carve-out wasn't accidentally widened.
- **examples/bare-bang-rejected.ilo**: in-context example showing the two correct shapes (`?x{~v:v;^e:^e}` and `scs = producer! ...`), exercised by `tests/examples_engines.rs`.

## Test plan

- [x] New regression suite passes on every engine (`cargo test --release --features cranelift --test regression_bare_bang_nil`)
- [x] Full test suite passes (`cargo test --release --features cranelift`) - 140 results OK, 0 failed
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --release --features cranelift --tests` clean
- [x] Manual repro: original `ilo 'main>R n t;x=42;x!'` now errors with ILO-T034, exit 1
- [x] `--ast 'main>R n t;x=42;x!'` still dumps AST without verifying
- [x] `ilo 'helper>n;1\nother>n;2'` (multi-fn no main) still AST-dumps with exit 0

## Follow-ups

None outstanding. The `ast_dump_mode` carve-out is now coherent with the auto-run heuristic; if either side moves in future, the matching condition is documented inline at both sites.