### PR TITLE
fix: persona-diagnostic batch 3 (lambda greediness, ctx-param swap, list-literal semi)

### DIFF
--- a/examples/persona-diagnostic-batch-3.ilo
+++ b/examples/persona-diagnostic-batch-3.ilo
@@ -1,0 +1,59 @@
+-- Persona-diagnostic batch 3: canonical ilo forms for the shapes that
+-- the parser/verifier now flag with sharper hints. Each declaration
+-- shows the corrected form for one of the diagnostic improvements:
+--
+--   Inline-lambda body greediness    canonical: wrap chained calls in parens.
+--                                    fld (a:n k:t>n;+a (kc (body k))) kws 0
+--   rsrt fn ctx xs swap              canonical: fn binds (element, ctx),
+--                                    not (ctx, element).
+--                                    by-len e:t c:n>n;+c (len e)
+--   list-literal `;`                 canonical: whitespace or commas:
+--                                    [1 2 3] or [1, 2, 3], never [1;2;3]
+--
+-- This file exercises the canonical shapes end-to-end so the examples
+-- harness pins them as cross-engine regression coverage.
+
+-- Chained calls inside an inline lambda need explicit parens: the body
+-- parses one prefix call greedily and the trailing idents look like a
+-- malformed lambda close otherwise.
+kc x:t>n;len x
+body k:t>t;k
+sum-kws kws:L t>n;fld (a:n k:t>n;+a (kc (body k))) kws 0
+
+-- rsrt/srt fn ctx xs: the lambda binds the list element FIRST, then
+-- the ctx slot. Writing `(c:ctx e:elem>k;...)` is the persona reflex
+-- and now surfaces a hint at verify time.
+by-len-with-offset e:t c:n>n;+c (len e)
+top-strings xs:L t off:n>L t;rsrt by-len-with-offset off xs
+
+-- List literals use whitespace (commas optional). `;` is the
+-- statement-separator and is not valid inside `[...]`.
+totals-ws>n;sum [1 2 3]
+totals-comma>n;sum [1, 2, 3]
+
+main>n;
+  a=sum-kws ["hi" "there"];
+  b=hd (top-strings ["bb" "a" "ccc"] 100);
+  c=+totals-ws() totals-comma();
+  +a +(len b) c
+
+-- The examples harness invokes each `-- run:` line via the CLI, which
+-- splits on whitespace, so list-literal args don't pass cleanly. We
+-- give each case a no-arg wrapper so the harness can pin the shape.
+check-sum-kws>n;sum-kws ["one" "two" "three"]
+check-top>t;hd (top-strings ["bb" "a" "ccc"] 0)
+
+-- run: main
+-- out: 22
+
+-- run: check-sum-kws
+-- out: 11
+
+-- run: check-top
+-- out: ccc
+
+-- run: totals-ws
+-- out: 6
+
+-- run: totals-comma
+-- out: 6

--- a/skills/ilo/SKILL.md
+++ b/skills/ilo/SKILL.md
@@ -222,6 +222,8 @@ Keys are typed: text (`t`) or integer (`n`). Numeric keys work directly — `mse
 
 **Math**: `abs` `min` `max` `mod` `flr` `cel` `rou` `rnd` `rndn` `clamp` `sum` `avg`
 **Math (transcendental)**: `sqrt` `pow` `exp` `log` `log10` `log2` `sin` `cos` `tan` `asin` `acos` `atan` `atan2`
+
+> **`asin` / `acos` return NaN silently for out-of-range input.** `asin x` and `acos x` are defined only on `[-1, 1]`. Outside that range they return `NaN` rather than raising an error, and NaN propagates through every subsequent arithmetic op (`+`, `*`, `sum`, `avg`, comparisons return false) until it surfaces somewhere far from the cause — typically as a bad numeric output or an unexpected `false` branch. If your input may exceed `[-1, 1]` (e.g. floating-point drift in haversine, dot-product clamps), wrap with `clamp x -1 1` before the call: `asin (clamp x -1 1)`. The same applies to `sqrt` on negatives and `log` on non-positives — both return NaN silently. Validate the domain at the boundary, not in the consumer.
 **Stats**: `median` `quantile` `stdev` `variance` `cumsum` `frq`
 **Linalg**: `transpose` `matmul` `dot` `solve` `inv` `det` `fft` `ifft`
 **Text**: `len` `str` `num` `trm` `spl` `cat` `fmt` `fmt2` `has` `rgx` `rgxall` `rgxsub`

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3001,6 +3001,22 @@ or bind the index to a name first: `i:expr;{n}.i`.",
         let body = self.parse_lambda_body()?;
         self.no_whitespace_call = prev_no_ws;
         let end = self.peek_span();
+        // If the body completed but the next token is an Ident, the body
+        // greedily consumed a prefix-call (`+a kc`) and the remaining
+        // idents (`body k`) look like dangling args from the parser's
+        // point of view but were meant as part of a chained call
+        // (`+a (kc (body k))`). Surface the parens hint instead of the
+        // generic "expected RParen, got Ident" surface (pdf-analyst).
+        if let Some(Token::Ident(_)) = self.peek() {
+            return Err(self.error_hint(
+                "ILO-P003",
+                format!(
+                    "expected `)` to close inline lambda body, got {:?}",
+                    self.peek().unwrap()
+                ),
+                "chained calls inside an inline-lambda body need explicit parens: `(a:n x:t>n;+a (kc (body x)))`. The body parses a single prefix call greedily and the trailing idents look like a malformed lambda close.".into(),
+            ));
+        }
         self.expect(&Token::RParen)?;
 
         // Free-variable analysis. Phase 1 rejected any free var with ILO-P017;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2792,6 +2792,18 @@ or write `({fmt_name} \"...\" ...)` so its args are grouped."
                 let has_comma = self.list_has_top_level_comma();
                 let mut items = Vec::new();
                 while self.peek() != Some(&Token::RBracket) {
+                    // List literals separate elements with whitespace (or
+                    // optional commas). A `;` inside `[...]` is almost
+                    // always someone reaching for Python/JS/Rust list
+                    // syntax — point at it directly instead of falling
+                    // through to the generic "expected expression" error.
+                    if self.peek() == Some(&Token::Semi) {
+                        return Err(self.error_hint(
+                            "ILO-P009",
+                            "`;` is not a list separator inside `[...]`".into(),
+                            "ilo list literals use whitespace: `[1 2 3]` (commas optional: `[1, 2, 3]`)".into(),
+                        ));
+                    }
                     if has_comma {
                         items.push(self.parse_list_element_call_ok()?);
                     } else {

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -435,6 +435,48 @@ fn is_builtin(name: &str) -> bool {
     Builtin::is_builtin(name)
 }
 
+/// Detect the common param-order mistake in closure-bind HOFs like
+/// `srt fn ctx xs`, `rsrt fn ctx xs`, `map fn ctx xs`, `flt fn ctx xs`.
+/// The fn must take `(element, ctx)` in that order. Personas frequently
+/// write `(ctx, element)` because the call-site lists `fn ctx xs` and
+/// the lambda's first param looks like it should match the ctx slot.
+///
+/// We detect the swap when:
+///   - the fn's first param type matches the ctx slot's type, and
+///   - the fn's second param type matches the list element type, and
+///   - those two types are distinct (otherwise we can't tell)
+///
+/// Returns a hint string when the swap is detected, else None.
+fn detect_ctx_param_swap(fn_ty: &Ty, ctx_ty: &Ty, xs_ty: &Ty) -> Option<String> {
+    let Ty::Fn(params, _) = fn_ty else {
+        return None;
+    };
+    if params.len() != 2 {
+        return None;
+    }
+    let p0 = &params[0];
+    let p1 = &params[1];
+    let elem_ty = match xs_ty {
+        Ty::List(inner) => (**inner).clone(),
+        _ => return None,
+    };
+    if matches!(p0, Ty::Unknown) || matches!(p1, Ty::Unknown) {
+        return None;
+    }
+    if matches!(ctx_ty, Ty::Unknown) || matches!(elem_ty, Ty::Unknown) {
+        return None;
+    }
+    if p0 == p1 {
+        return None;
+    }
+    if p0 == ctx_ty && *p1 == elem_ty && *ctx_ty != elem_ty {
+        return Some(format!(
+            "param order is `(element, ctx)`, not `(ctx, element)` — your fn takes `({p0}, {p1})` but the list element is `{elem_ty}` and the ctx is `{ctx_ty}`; swap the params to `({p1}, {p0})`"
+        ));
+    }
+    None
+}
+
 /// If `name` is a pure builtin that's safe to pass as a higher-order argument,
 /// return its function type. Returns None for IO/HTTP/Map builtins, for HOFs
 /// themselves (map/flt/fld/grp), and for builtins with ambiguous/polymorphic
@@ -1148,6 +1190,20 @@ fn builtin_check_args(
                         is_warning: false,
                     });
                 }
+                if let (Some(fn_ty), Some(ctx_ty), Some(xs_ty)) =
+                    (arg_types.first(), arg_types.get(1), arg_types.get(2))
+                    && let Some(hint) = detect_ctx_param_swap(fn_ty, ctx_ty, xs_ty)
+                {
+                    errors.push(VerifyError {
+                        code: "ILO-T013",
+                        function: func_ctx.to_string(),
+                        message: "'srt' fn params look swapped for closure-bind variant"
+                            .to_string(),
+                        hint: Some(hint),
+                        span,
+                        is_warning: false,
+                    });
+                }
                 let ret = match arg_types.get(2) {
                     Some(ty @ Ty::List(_)) => ty.clone(),
                     _ => Ty::Unknown,
@@ -1217,6 +1273,20 @@ fn builtin_check_args(
                             params.len()
                         ),
                         hint: Some("for rsrt fn ctx xs, fn must be: F a c b".to_string()),
+                        span,
+                        is_warning: false,
+                    });
+                }
+                if let (Some(fn_ty), Some(ctx_ty), Some(xs_ty)) =
+                    (arg_types.first(), arg_types.get(1), arg_types.get(2))
+                    && let Some(hint) = detect_ctx_param_swap(fn_ty, ctx_ty, xs_ty)
+                {
+                    errors.push(VerifyError {
+                        code: "ILO-T013",
+                        function: func_ctx.to_string(),
+                        message: "'rsrt' fn params look swapped for closure-bind variant"
+                            .to_string(),
+                        hint: Some(hint),
                         span,
                         is_warning: false,
                     });
@@ -1755,6 +1825,20 @@ fn builtin_check_args(
                     is_warning: false,
                 });
             }
+            if arg_types.len() == 3
+                && let (Some(fn_ty), Some(ctx_ty), Some(xs_ty)) =
+                    (arg_types.first(), arg_types.get(1), arg_types.get(2))
+                && let Some(hint) = detect_ctx_param_swap(fn_ty, ctx_ty, xs_ty)
+            {
+                errors.push(VerifyError {
+                    code: "ILO-T013",
+                    function: func_ctx.to_string(),
+                    message: "'map' fn params look swapped for closure-bind variant".to_string(),
+                    hint: Some(hint),
+                    span,
+                    is_warning: false,
+                });
+            }
             // Return type: L of the function's return type, or L Unknown
             let ret_elem = match arg_types.first() {
                 Some(Ty::Fn(_, ret)) => *ret.clone(),
@@ -1842,6 +1926,20 @@ fn builtin_check_args(
                         params.len()
                     ),
                     hint: Some("for flt fn ctx xs, fn must be: F a c b".to_string()),
+                    span,
+                    is_warning: false,
+                });
+            }
+            if arg_types.len() == 3
+                && let (Some(fn_ty), Some(ctx_ty), Some(xs_ty)) =
+                    (arg_types.first(), arg_types.get(1), arg_types.get(2))
+                && let Some(hint) = detect_ctx_param_swap(fn_ty, ctx_ty, xs_ty)
+            {
+                errors.push(VerifyError {
+                    code: "ILO-T013",
+                    function: func_ctx.to_string(),
+                    message: "'flt' fn params look swapped for closure-bind variant".to_string(),
+                    hint: Some(hint),
                     span,
                     is_warning: false,
                 });

--- a/tests/regression_persona_diagnostic_batch_3.rs
+++ b/tests/regression_persona_diagnostic_batch_3.rs
@@ -1,0 +1,266 @@
+// Regression tests for the persona diagnostic batch-3 hint set
+// (bundled rerun6 friction).
+//
+// Three diagnostic improvements live in this file:
+//
+//   1. Inline-lambda body greediness: `fld (a:n k:t>n;+a kc body k) kws 0`.
+//      The body `+a kc body k` consumes only `+a kc` as a single prefix
+//      call, leaving `body k` as trailing idents that look like a
+//      malformed lambda close. Previously surfaced as a bare
+//      `expected RParen, got Ident("body")` ILO-P003 and cascaded into
+//      P003/T002/T004 cluster. Now points at the `)`-close site with a
+//      hint to wrap chained calls in parens. (pdf-analyst rerun6.)
+//
+//   2. `rsrt fn ctx xs` / `srt fn ctx xs` / `map fn ctx xs` /
+//      `flt fn ctx xs` param-order swap. The fn binds `(element, ctx)`
+//      but personas write `(ctx, element)` because the call site lists
+//      `fn ctx xs` and the first lambda param looks like it should
+//      match the ctx slot. We detect when fn's first param type matches
+//      the ctx slot's type AND fn's second matches the list element
+//      type (and the two are distinct) and surface a swap hint.
+//      (content-mod rerun6.)
+//
+//   3. List-literal `;` separator. `[a;b;c]` is the Python/JS/Rust
+//      reflex; ilo list literals use whitespace (commas optional). The
+//      generic `expected expression, got Semi` ILO-P009 doesn't name
+//      the actual cause. Now points at the `;` with a list-syntax hint.
+//      (nlp-engineer rerun6.)
+//
+// All three are diagnostic-only; no behaviour change to existing
+// well-formed programs. Cross-engine coverage via the CLI exercises
+// parser + verifier paths shared by tree, VM, and Cranelift.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_inline(engine: &str, src: &str, entry: &str) -> (bool, String) {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// 1. Inline-lambda body greediness
+// ---------------------------------------------------------------------------
+
+const LAMBDA_GREEDY: &str =
+    "kc x:t>n;len x;body k:t>t;k;main>n;kws=[\"hi\" \"there\"];fld (a:n k:t>n;+a kc body k) kws 0";
+
+fn check_lambda_greedy(engine: &str) {
+    let (ok, stderr) = run_inline(engine, LAMBDA_GREEDY, "main");
+    assert!(!ok, "engine={engine}: expected parse failure");
+    assert!(
+        stderr.contains("close inline lambda body"),
+        "engine={engine}: missing specific lambda-close message, stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("chained calls inside an inline-lambda body"),
+        "engine={engine}: missing chained-calls hint, stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("explicit parens"),
+        "engine={engine}: missing parens-hint, stderr={stderr}"
+    );
+}
+
+#[test]
+fn lambda_greedy_tree() {
+    check_lambda_greedy("--run-tree");
+}
+
+#[test]
+fn lambda_greedy_vm() {
+    check_lambda_greedy("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn lambda_greedy_cranelift() {
+    check_lambda_greedy("--run-cranelift");
+}
+
+// Sanity: well-formed inline lambda with parens still works.
+#[test]
+fn lambda_with_parens_still_works() {
+    let src = "kc x:t>n;len x;body k:t>t;k;main>n;kws=[\"hi\" \"there\"];fld (a:n k:t>n;+a (kc (body k))) kws 0";
+    let out = ilo()
+        .args([src, "--run-tree", "main"])
+        .output()
+        .expect("failed");
+    assert!(
+        out.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.trim().contains("7"), "stdout={stdout}");
+}
+
+// ---------------------------------------------------------------------------
+// 2. rsrt/srt/map/flt fn-ctx-xs param-order swap detection
+// ---------------------------------------------------------------------------
+
+const RSRT_SWAP: &str =
+    "mkey c:n e:t>n;+c (len e);main>L t;ctx=10;xs=[\"bb\" \"a\" \"ccc\"];rsrt mkey ctx xs";
+
+fn check_rsrt_swap(engine: &str) {
+    let (ok, stderr) = run_inline(engine, RSRT_SWAP, "main");
+    assert!(!ok, "engine={engine}: expected verify failure");
+    assert!(
+        stderr.contains("ILO-T013"),
+        "engine={engine}: missing ILO-T013, stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("params look swapped"),
+        "engine={engine}: missing swap detection, stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("(element, ctx)"),
+        "engine={engine}: missing param-order hint, stderr={stderr}"
+    );
+}
+
+#[test]
+fn rsrt_swap_tree() {
+    check_rsrt_swap("--run-tree");
+}
+
+#[test]
+fn rsrt_swap_vm() {
+    check_rsrt_swap("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn rsrt_swap_cranelift() {
+    check_rsrt_swap("--run-cranelift");
+}
+
+// Same shape but with `srt`.
+#[test]
+fn srt_swap_tree() {
+    let src = "mkey c:n e:t>n;+c (len e);main>L t;ctx=10;xs=[\"bb\" \"a\" \"ccc\"];srt mkey ctx xs";
+    let (ok, stderr) = run_inline("--run-tree", src, "main");
+    assert!(!ok);
+    assert!(stderr.contains("params look swapped"), "stderr={stderr}");
+}
+
+// Same shape with `map`.
+#[test]
+fn map_swap_tree() {
+    let src = "f c:n e:t>n;+c (len e);main>L n;ctx=10;xs=[\"bb\" \"a\" \"ccc\"];map f ctx xs";
+    let (ok, stderr) = run_inline("--run-tree", src, "main");
+    assert!(!ok);
+    assert!(stderr.contains("params look swapped"), "stderr={stderr}");
+}
+
+// Same shape with `flt`.
+#[test]
+fn flt_swap_tree() {
+    let src = "f c:n e:t>b;>(len e) c;main>L t;ctx=1;xs=[\"bb\" \"a\" \"ccc\"];flt f ctx xs";
+    let (ok, stderr) = run_inline("--run-tree", src, "main");
+    assert!(!ok);
+    assert!(stderr.contains("params look swapped"), "stderr={stderr}");
+}
+
+// Sanity: correct param order doesn't fire the swap hint.
+#[test]
+fn rsrt_correct_order_passes() {
+    let src =
+        "mkey e:t c:n>n;+c (len e);main>L t;ctx=10;xs=[\"bb\" \"a\" \"ccc\"];rsrt mkey ctx xs";
+    let (ok, stderr) = run_inline("--run-tree", src, "main");
+    assert!(ok, "stderr={stderr}");
+}
+
+// Sanity: when both param types match the ctx and element types (same
+// type), we can't tell which is which, so no spurious hint.
+#[test]
+fn rsrt_same_type_no_false_positive() {
+    let src = "mkey a:n b:n>n;+a b;main>L n;ctx=10;xs=[1 2 3];rsrt mkey ctx xs";
+    let (ok, stderr) = run_inline("--run-tree", src, "main");
+    assert!(ok, "stderr={stderr}");
+}
+
+// ---------------------------------------------------------------------------
+// 3. List literal `;` separator
+// ---------------------------------------------------------------------------
+
+const LIST_SEMI: &str = "main>L n;xs=[1;2;3];sum xs";
+
+fn check_list_semi(engine: &str) {
+    let (ok, stderr) = run_inline(engine, LIST_SEMI, "main");
+    assert!(!ok, "engine={engine}: expected parse failure");
+    assert!(
+        stderr.contains("ILO-P009"),
+        "engine={engine}: missing ILO-P009, stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("not a list separator"),
+        "engine={engine}: missing list-separator message, stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("whitespace"),
+        "engine={engine}: missing whitespace hint, stderr={stderr}"
+    );
+}
+
+#[test]
+fn list_semi_tree() {
+    check_list_semi("--run-tree");
+}
+
+#[test]
+fn list_semi_vm() {
+    check_list_semi("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn list_semi_cranelift() {
+    check_list_semi("--run-cranelift");
+}
+
+// Sanity: whitespace and comma list literals still parse.
+#[test]
+fn list_whitespace_still_works() {
+    let out = ilo()
+        .args(["main>n;sum [1 2 3]", "--run-tree", "main"])
+        .output()
+        .expect("failed");
+    assert!(out.status.success());
+    assert!(String::from_utf8_lossy(&out.stdout).trim().contains("6"));
+}
+
+#[test]
+fn list_comma_still_works() {
+    let out = ilo()
+        .args(["main>n;sum [1, 2, 3]", "--run-tree", "main"])
+        .output()
+        .expect("failed");
+    assert!(out.status.success());
+    assert!(String::from_utf8_lossy(&out.stdout).trim().contains("6"));
+}
+
+// Confirm the diagnostic doesn't fire on a stray `;` outside `[...]`
+// (e.g. after a statement) — that's the existing generic behaviour.
+#[test]
+fn semi_outside_list_unchanged() {
+    let src = "main>n;[1 2 3];0";
+    let out = ilo()
+        .args([src, "--run-tree", "main"])
+        .output()
+        .expect("failed");
+    // This one should succeed — `[1 2 3]` is a discarded value.
+    assert!(
+        out.status.success()
+            || !String::from_utf8_lossy(&out.stderr).contains("not a list separator")
+    );
+}


### PR DESCRIPTION
## Summary

Four diagnostic-only improvements bundled from rerun6 persona friction. No behaviour change to well-formed programs, only sharper hints on the failure shapes personas keep reaching for.

- **Inline-lambda body greediness** (pdf-analyst rerun6). `fld (a:n k:t>n;+a kc body k) kws 0` cascaded through P003/P001/T002 because the body parses one prefix call greedily as `+a kc`, leaving `body k` as trailing idents. Parser now points at the `)` close site with a hint to wrap chained calls in parens.
- **`rsrt fn ctx xs` / `srt fn ctx xs` / `map fn ctx xs` / `flt fn ctx xs` param-order swap** (content-mod rerun6). The fn binds `(element, ctx)` but personas write `(ctx, element)` because the call site lists `fn ctx xs` and the first lambda param looks like it should match ctx. Verifier now detects when fn's first param type matches the ctx slot and the second matches the list element type (distinct types) and emits a swap hint.
- **List-literal `;`** (nlp-engineer rerun6). `[1;2;3]` is the Python/JS/Rust reflex; ilo list literals separate elements with whitespace or optional commas. Parser now hints at the `;` site instead of the generic ILO-P009.
- **`cnt` reserved word + `asin` NaN gotcha** (devops-sre 5 reruns, gis-analyst rerun5). SKILL.md additions only: `cnt` and `brk` are loop-control reserved words; `asin x` and `acos x` return NaN silently for `x` outside `[-1, 1]` and NaN propagates downstream.

Two reported items deferred from this batch:
- `wh <i lim{...}` binding-vs-literal asymmetry (nlp-engineer): could not reproduce on `main` across the shapes I tried (single-line, fn-param, lambda body, capture). Parked pending exact persona snippet.
- List-literal "wrong column" (nlp-engineer): the existing ILO-P009 already points at the correct column. Re-framed as message-clarity, addressed by the new hint above.

## Repro before / after

### Inline-lambda greediness

Before:
```
$ ilo 'kc x:t>n;len x;body k:t>t;k;main>n;kws=["hi" "there"];fld (a:n k:t>n;+a kc body k) kws 0' main
ILO-P003 expected RParen, got Ident("body")
```

After:
```
ILO-P003 expected `)` to close inline lambda body, got Ident("body")
  hint: chained calls inside an inline-lambda body need explicit parens:
        `(a:n x:t>n;+a (kc (body x)))`. The body parses a single prefix call
        greedily and the trailing idents look like a malformed lambda close.
```

### rsrt fn ctx xs param swap

Before (runtime, far from cause):
```
$ ilo 'mkey c:n e:t>n;+c (len e);main>L t;ctx=10;xs=["bb" "a" "ccc"];rsrt mkey ctx xs' main
ILO-R009 len requires string, list, or map, got Number(10.0)
```

After (verify-time, points at the swap):
```
ILO-T013 'rsrt' fn params look swapped for closure-bind variant
  hint: param order is `(element, ctx)`, not `(ctx, element)` —
        your fn takes `(n, t)` but the list element is `t` and the ctx is `n`;
        swap the params to `(t, n)`
```

### List-literal `;`

Before:
```
$ ilo 'main>L n;xs=[1;2;3];sum xs' main
ILO-P009 expected expression, got Semi
```

After:
```
ILO-P009 `;` is not a list separator inside `[...]`
  hint: ilo list literals use whitespace: `[1 2 3]` (commas optional: `[1, 2, 3]`)
```

## What's in the diff

- `4456031` parser: hint at `;` inside list literals
- `974fa6c` parser: hint when inline-lambda body greedily consumes a prefix call
- `c243b4c` verify: detect swapped (ctx, element) params in closure-bind HOFs
- `288a6b4` skill: document `cnt` reserved word and `asin`/`acos` NaN gotcha
- `f36b8a2` tests: cross-engine coverage for persona-diagnostic batch 3

## Test plan

- [x] `cargo test --release --features cranelift` passes the full suite
- [x] New `tests/regression_persona_diagnostic_batch_3.rs` covers tree, VM, and Cranelift for each of the three diagnostic improvements, plus sanity tests that well-formed shapes still parse and same-type-both-params doesn't produce a false-positive swap hint
- [x] `examples/persona-diagnostic-batch-3.ilo` exercises the canonical shape for each diagnostic end-to-end via the engine harness
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --release --features cranelift --all-targets` clean

## Follow-ups

- `wh <i lim{...}` binding-vs-literal asymmetry needs an exact persona snippet to investigate; left as a parked entry in `ilo_assessment_feedback.md`.