### PR TITLE
cli: hyphenated subcommands + non-ident positionals route to main (#320 follow-up)

### DIFF
--- a/examples/unknown-subcommand-listing.ilo
+++ b/examples/unknown-subcommand-listing.ilo
@@ -1,16 +1,21 @@
 -- Multi-fn file with `main` plus helpers. Pins that:
---   * `ilo file.ilo`          auto-runs `main`
---   * `ilo file.ilo dbl 21`   dispatches to the named function
---   * `ilo file.ilo trp 4`    dispatches to the named function
+--   * `ilo file.ilo`             auto-runs `main`
+--   * `ilo file.ilo dbl 21`      dispatches to the named function
+--   * `ilo file.ilo trp 4`       dispatches to the named function
+--   * `ilo file.ilo list-pair 3` dispatches to a hyphenated function
+--     (per SPEC ident shape `[a-z][a-z0-9]*(-[a-z0-9]+)*`)
 --
 -- The CLI-level guard for the unknown-subcommand case (e.g.
 -- `ilo file.ilo wibble x` should error with "no such function" and
 -- list available functions instead of silently routing to the first
 -- declared fn) is covered by tests/regression_cli_default.rs — the
--- examples harness only exercises happy-path dispatch.
+-- examples harness only exercises happy-path dispatch. The same file
+-- also pins the hyphenated-ident error case (`list-orders` typo) and
+-- the bug-2 main-routing case (`ilo file.ilo top200.csv`).
 
 dbl x:n>n;*x 2
 trp x:n>n;*x 3
+list-pair x:n>L n;[x,*x 2]
 main>n;+(dbl 7)(trp 4)
 
 -- run: main
@@ -19,3 +24,5 @@ main>n;+(dbl 7)(trp 4)
 -- out: 42
 -- run: trp 4
 -- out: 12
+-- run: list-pair 3
+-- out: [3, 6]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2835,6 +2835,26 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
                         eprintln!();
                         eprintln!("  ilo {} <func> [args...]   run a function", source_arg);
                         return 1;
+                    } else if is_file && func_names.contains(&"main") {
+                        // Multi-function file with an unknown leading
+                        // positional that does NOT look ident-shaped (a
+                        // path like `top200.csv`, a digit-prefixed
+                        // string, a sigil, etc.) and the file defines
+                        // `main`: route to `main` with the positional as
+                        // arg #1. Previously this fell through to the
+                        // "first declared function" path, so
+                        // `ilo main_v5.ilo top200.csv` ran the first
+                        // alphabetical/declared function (e.g. `hav`)
+                        // with `top200.csv` as its first arg — a
+                        // misleading silent mis-dispatch when the user
+                        // clearly intended `main` as the entry point
+                        // (gis-analyst rerun6, devops-sre rerun6 —
+                        // independent personas, same root cause). The
+                        // presence of `main` is the strong intent
+                        // signal; we use it wherever the user has not
+                        // explicitly named a different function.
+                        let fn_ref = Some("main");
+                        (fn_ref, parse_cli_args_typed(&program, fn_ref, rest))
                     } else {
                         (None, rest.iter().map(|a| parse_cli_arg(a)).collect())
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3924,8 +3924,17 @@ fn split_top_level_commas(s: &str) -> Vec<&str> {
 /// entry function — should pass through as before).
 ///
 /// Rule: starts with an ASCII letter or underscore, and every subsequent
-/// char is alphanumeric or underscore. Anything else (a digit-prefixed
-/// number, a sigil, a quoted string, a bracketed list) is treated as data.
+/// char is alphanumeric, underscore, or `-`. `-` is legal mid-ident per
+/// the SPEC's canonical `[a-z][a-z0-9]*(-[a-z0-9]+)*` shape (so
+/// `list-orders`, `wibble-x`, `parse-csv` all read as plausible
+/// subcommand names rather than mystery data) but must not appear at the
+/// very end of the string, and may not be doubled — `foo-` and `foo--bar`
+/// fall through as data, as does anything starting with `-` (which is
+/// already excluded by the alpha/underscore first-char rule and keeps
+/// `--flag` and `-1` out).
+///
+/// Anything else (a digit-prefixed number, a sigil, a quoted string, a
+/// bracketed list, a path with a dot) is treated as data.
 ///
 /// Reserved literal words (`true`, `false`, `nil`) are also exempt — they
 /// match the ident shape but `parse_cli_arg` already turns them into the
@@ -3935,12 +3944,28 @@ fn looks_like_subcommand_name(s: &str) -> bool {
     if matches!(s, "true" | "false" | "nil") {
         return false;
     }
-    let mut chars = s.chars();
-    match chars.next() {
-        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+    let bytes = s.as_bytes();
+    match bytes.first() {
+        Some(&c) if c.is_ascii_alphabetic() || c == b'_' => {}
         _ => return false,
     }
-    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+    // No trailing `-` (e.g. `foo-`).
+    if bytes.last() == Some(&b'-') {
+        return false;
+    }
+    let mut prev_dash = false;
+    for &c in &bytes[1..] {
+        let ok = c.is_ascii_alphanumeric() || c == b'_' || c == b'-';
+        if !ok {
+            return false;
+        }
+        // No doubled `-` (e.g. `foo--bar`).
+        if c == b'-' && prev_dash {
+            return false;
+        }
+        prev_dash = c == b'-';
+    }
+    true
 }
 
 fn parse_cli_arg(s: &str) -> interpreter::Value {
@@ -4109,6 +4134,16 @@ mod tests {
         assert!(looks_like_subcommand_name("_priv"));
         assert!(looks_like_subcommand_name("foo_bar"));
         assert!(looks_like_subcommand_name("fn2"));
+        // Hyphenated idents — SPEC canonical shape
+        // `[a-z][a-z0-9]*(-[a-z0-9]+)*`. Used to be rejected, which
+        // routed `ilo file.ilo list-orders` to the first declared
+        // function with `["list-orders", ...]` as args and produced
+        // misleading arity errors (interactive-cli rerun6 P1).
+        assert!(looks_like_subcommand_name("list-orders"));
+        assert!(looks_like_subcommand_name("wibble-x"));
+        assert!(looks_like_subcommand_name("parse-csv"));
+        assert!(looks_like_subcommand_name("a-b-c"));
+        assert!(looks_like_subcommand_name("foo-bar"));
     }
 
     #[test]
@@ -4124,7 +4159,17 @@ mod tests {
         // Empty and edge cases
         assert!(!looks_like_subcommand_name(""));
         assert!(!looks_like_subcommand_name("2x"));
-        assert!(!looks_like_subcommand_name("foo-bar"));
+        // File-shaped args (a dot is not a legal ident char) still fall
+        // through as data — this is what routes `ilo main.ilo data.csv`
+        // to `main` with `data.csv` as its first positional rather than
+        // erroring with `no such function 'data.csv'`.
+        assert!(!looks_like_subcommand_name("top200.csv"));
+        assert!(!looks_like_subcommand_name("data.csv"));
+        assert!(!looks_like_subcommand_name("path/to/file"));
+        // `-` is legal mid-ident but not at the end or doubled.
+        assert!(!looks_like_subcommand_name("foo-"));
+        assert!(!looks_like_subcommand_name("foo--bar"));
+        assert!(!looks_like_subcommand_name("-foo"));
     }
 
     #[test]

--- a/tests/regression_cli_default.rs
+++ b/tests/regression_cli_default.rs
@@ -580,3 +580,181 @@ fn run_vm_flag_single_fn_no_args_still_runs() {
 fn run_cranelift_flag_single_fn_no_args_still_runs() {
     run_engine_single_fn_no_args_still_runs("--run-cranelift");
 }
+
+// ── hyphenated unknown subcommand: friendly error (PR #320 follow-up) ─────────
+//
+// Originating bug (interactive-cli rerun6 P1): `ilo file.ilo list-orders`
+// on a multi-fn file silently routed to the FIRST declared function with
+// `["list-orders"]` as positional args, producing a misleading
+// `load: expected 0 args` error. PR #320 added the unknown-subcommand
+// error but its `looks_like_subcommand_name` helper rejected anything
+// containing `-`, so hyphenated idents fell through to the old greedy
+// dispatch.
+//
+// Per SPEC the canonical ilo ident shape is
+// `[a-z][a-z0-9]*(-[a-z0-9]+)*` so `-` is a legal mid-ident character
+// and `list-orders` / `wibble-x` / `parse-csv` are all plausible
+// subcommand names.
+
+#[test]
+fn hyphenated_unknown_subcommand_errors_with_listing() {
+    // Pre-fix: routed to `load` (first declared) with `["list-orders"]`
+    // as args, producing a misleading type / arity error. Post-fix: the
+    // helper accepts `-` as a tail char so `list-orders` is recognised
+    // as an ident shape, falls into the unknown-subcommand branch, and
+    // emits the friendly "no such function" listing.
+    let (_dir, path) = write_temp("load x:n>n;*x 2\nmain>n;load 21\n");
+    let (ok, _stdout, stderr) = run(&[path.to_str().unwrap(), "list-orders"]);
+    assert!(!ok, "unknown hyphenated subcommand should exit non-zero");
+    assert!(
+        stderr.contains("no such function 'list-orders'"),
+        "expected 'no such function' error for hyphenated name; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("available functions"),
+        "expected available-functions listing; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("load") && stderr.contains("main"),
+        "expected both fn names listed; stderr: {stderr}"
+    );
+    // The dispatch must NOT have invoked the first-declared `load` with
+    // the typo as a positional. If it had, we'd see a `load` arity/type
+    // error rather than the listing.
+    assert!(
+        !stderr.contains("'load' arg"),
+        "must not leak first-fn dispatch; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn hyphenated_unknown_subcommand_wibble_x() {
+    // Tail-hyphenated form (`wibble-x`) from the bug report. Same
+    // diagnostic shape as the `list-orders` case.
+    let (_dir, path) = write_temp("helper a:n>n;+a 1\nmain>n;helper 41\n");
+    let (ok, _stdout, stderr) = run(&[path.to_str().unwrap(), "wibble-x"]);
+    assert!(!ok);
+    assert!(
+        stderr.contains("no such function 'wibble-x'"),
+        "expected no-such-function for `wibble-x`; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn trailing_dash_falls_through_as_data() {
+    // `-` is legal mid-ident but not at the end. `foo-` is not a valid
+    // ident shape, so it must NOT trip the unknown-subcommand error;
+    // it routes to `main` if defined, otherwise passes through to the
+    // first declared function.
+    let (_dir, path) = write_temp("first s:t>t;s\nother s:t>t;s\n");
+    let (ok, stdout, stderr) = run(&[path.to_str().unwrap(), "foo-"]);
+    assert!(
+        ok,
+        "trailing-dash positional should pass through, not error; stderr: {stderr}"
+    );
+    assert_eq!(stdout.trim().trim_matches('"'), "foo-");
+}
+
+// ── non-ident leading arg with `main` defined: route to `main` ─────────────────
+//
+// Originating bug (gis-analyst rerun6): `ilo main_v5.ilo top200.csv` on
+// a multi-fn file used to silently route the non-ident-shaped arg
+// `top200.csv` to the FIRST declared function (e.g. `hav`) rather than
+// to `main`. The presence of `main` is a strong intent signal that the
+// user wants `main` as the entry point; positional args after the file
+// path should flow into `main`'s arg list, not into whichever function
+// happens to be declared first.
+
+#[test]
+fn non_ident_arg_routes_to_main_when_main_exists() {
+    // First-declared function is `hav` (3 args), `main` is the real
+    // entry. Pre-fix: `top200.csv` routed to `hav` and produced an
+    // arity error (`hav: expected 3 args, got 1`). Post-fix: `main`
+    // receives `top200.csv` as its sole arg and echoes it back.
+    let (_dir, path) = write_temp("hav lat:n lon:n r:n>n;+lat lon\nmain path:t>t;path\n");
+    let (ok, stdout, stderr) = run(&[path.to_str().unwrap(), "top200.csv"]);
+    assert!(ok, "non-ident arg should route to main; stderr: {stderr}");
+    assert_eq!(stdout.trim().trim_matches('"'), "top200.csv");
+    // The pre-fix arity error from the first declared function must
+    // not appear.
+    assert!(
+        !stderr.contains("hav:"),
+        "must not invoke `hav` (first declared); stderr: {stderr}"
+    );
+}
+
+#[test]
+fn non_ident_arg_routes_to_main_with_multiple_positionals() {
+    // Same routing rule must extend to multi-positional invocations:
+    // every positional flows into `main`'s arg list, in order.
+    let (_dir, path) = write_temp("hav lat:n lon:n>n;+lat lon\nmain a:t b:t>L t;[a,b]\n");
+    let (ok, stdout, stderr) = run(&[path.to_str().unwrap(), "data.csv", "out.txt"]);
+    assert!(ok, "expected success; stderr: {stderr}");
+    // Both positionals routed to main, in order.
+    assert!(stdout.contains("data.csv"), "stdout: {stdout}");
+    assert!(stdout.contains("out.txt"), "stdout: {stdout}");
+}
+
+#[test]
+fn non_ident_arg_routes_to_main_numeric() {
+    // A numeric leading positional is also non-ident-shaped (`42`
+    // starts with a digit). When `main` exists it should route to
+    // `main`, not to whichever function happens to be declared first.
+    let (_dir, path) = write_temp("hav x:n>n;+x 1\nmain x:n>n;*x 2\n");
+    let (ok, stdout, stderr) = run(&[path.to_str().unwrap(), "21"]);
+    assert!(ok, "expected success; stderr: {stderr}");
+    assert_eq!(stdout.trim(), "42");
+}
+
+#[test]
+fn non_ident_arg_without_main_keeps_legacy_passthrough() {
+    // Companion check: when there is NO `main`, the legacy
+    // pass-through-to-first-fn behaviour is preserved. This is the
+    // contract `multi_fn_file_numeric_leading_arg_passes_through_to_entry_fn`
+    // already pins; restated here as an explicit guard against the
+    // new bug-2 branch over-firing.
+    let (_dir, path) = write_temp("outer x:n>n;+x 1\ninner x:n>n;*x 2\n");
+    let (ok, stdout, stderr) = run(&[path.to_str().unwrap(), "41"]);
+    assert!(ok, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "42");
+}
+
+#[test]
+fn non_ident_path_arg_routes_to_main_devops_sre_shape() {
+    // devops-sre rerun6: same root cause as gis-analyst rerun6,
+    // independently surfaced via a different persona workload. A
+    // multi-fn file with a named-helper field-access (`gs i:_>...`
+    // taking a struct/record and reading `i.field`) and a `main` taking
+    // a JSON path. Pre-fix: `ilo probe.ilo /tmp/inc.json` routed the
+    // path positional (`/` + `.` make it non-ident-shaped) to the
+    // first-declared `gs`, hitting a field-access type mismatch on a
+    // raw text arg. Post-fix: the path flows into `main` as intended.
+    let (_dir, path) = write_temp("gs i:_>t;i.host\nmain p:t>t;p\n");
+    let (ok, stdout, stderr) = run(&[path.to_str().unwrap(), "/tmp/inc.json"]);
+    assert!(
+        ok,
+        "non-ident path arg should route to main, not gs; stderr: {stderr}"
+    );
+    assert_eq!(stdout.trim().trim_matches('"'), "/tmp/inc.json");
+    // Pre-fix symptom: invoking `gs` on the text arg would surface a
+    // field-access type error referencing `gs` or `i.host`.
+    assert!(
+        !stderr.contains("'gs'"),
+        "must not invoke first-declared `gs`; stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("i.host"),
+        "must not surface gs's field-access path; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn known_func_name_overrides_main_routing() {
+    // Bug-2 fix must NOT shadow explicit function selection: when the
+    // leading positional matches a declared function name, that
+    // function still wins even if `main` is defined.
+    let (_dir, path) = write_temp("hav x:n>n;+x 1\nmain x:n>n;*x 2\n");
+    let (ok, stdout, stderr) = run(&[path.to_str().unwrap(), "hav", "41"]);
+    assert!(ok, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "42");
+}


### PR DESCRIPTION
## Summary

Two related gaps in PR #320's `looks_like_subcommand_name` helper, both surfaced via persona reruns and both fixed under one diff.

**Bug 1, interactive-cli rerun6**: hyphenated idents like `wibble-x` / `list-orders` fell through to the old greedy first-fn dispatch and produced misleading errors (`load: expected 0 args`). Per SPEC the canonical ilo ident shape is `[a-z][a-z0-9]*(-[a-z0-9]+)*`, so `-` must be a legal tail char.

**Bug 2, gis-analyst rerun6 + devops-sre rerun6 (same root cause, two personas)**: `ilo main_v5.ilo top200.csv` routed the non-ident positional `top200.csv` to the FIRST declared function rather than to `main`. devops-sre saw the same shape with a JSON-path arg (`/tmp/inc.json`) hitting a named-helper field access. The presence of `main` is the strong intent signal; positionals should flow into `main`'s arg list when the user didn't pick a different fn.

Manifesto framing: both bugs cost the user an extra round trip on what should be a first-try happy path. Routing to `main` when `main` exists is also the symmetric counterpart to the existing no-args rule (`_ if func_names.contains(&"main")` already auto-runs `main` when `rest` is empty).

## Repro

**Bug 1** (`list-orders` typo on a multi-fn file with `main`):

Before:
```
$ ilo file.ilo list-orders
{"code":"ILO-T013","message":"'load' arg 1 expects n, got t",...}
```

After:
```
$ ilo file.ilo list-orders
error: no such function 'list-orders' in file.ilo
available functions:
  load
  main

  ilo file.ilo <func> [args...]   run a function
```

**Bug 2** (`top200.csv` positional, multi-fn file with `hav` first-declared and `main`):

Before:
```
$ ilo main_v5.ilo top200.csv
{"code":"ILO-T013","message":"'hav' arg 1 expects n, got t",...}
```

After:
```
$ ilo main_v5.ilo top200.csv
# main runs with path = "top200.csv"
```

## What's in the diff (per commit)

1. **`cli: extend subcommand-name helper to accept hyphenated idents`** - `looks_like_subcommand_name` now allows `-` as a tail character per the SPEC ident shape. Trailing dash, doubled dash, and leading dash remain rejected. File-shaped args (with `.` or `/`) keep falling through as data. Five new accept-cases and seven new reject-cases in the unit tests.
2. **`cli: route non-ident positionals to main when main exists`** - new dispatch branch in `dispatch_run` (src/main.rs ~2797): when `is_file && func_names.contains(&"main")` and the leading positional is neither a known fn nor ident-shaped, route to `main` with type-aware arg parsing.
3. **`tests: hyphenated-ident and non-ident main-routing coverage`** - 8 new integration tests in `regression_cli_default.rs` covering both bugs plus the legacy-passthrough guard (no-main files keep first-fn dispatch) and the explicit-fn-name-wins guard.
4. **`examples: hyphenated function name dispatch via examples harness`** - extend `examples/unknown-subcommand-listing.ilo` with a `list-pair` function, exercised across every engine by `tests/examples_engines.rs`.

## Test plan

- [x] `cargo test --release --features cranelift --test regression_cli_default` - 34 passed
- [x] `cargo test --release --features cranelift --test examples` - example harness happy
- [x] `cargo test --release --features cranelift` - full suite green
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --release --features cranelift --all-targets -- -D warnings` clean
- [ ] CI green on push

## Follow-ups

None. The helper is symmetric with the SPEC ident shape now, and the main-routing rule mirrors the no-args auto-run case.