### PR TITLE
cli: auto-pick main on --run-tree / --run-vm / --run-cranelift

### DIFF
--- a/examples/engine-flag-automain.ilo
+++ b/examples/engine-flag-automain.ilo
@@ -1,0 +1,17 @@
+-- `ilo --run-tree file.ilo`, `--run-vm`, `--run-cranelift`, and the
+-- default engine all auto-run `main` on a multi-fn file when no func
+-- name is supplied. Before the fix, only the default engine did:
+--   * --run-tree     -> arity error (`helper: expected 1 args, got 0`)
+--   * --run-vm       -> silent `nil`, exit 0
+--   * --run-cranelift-> bare "Cranelift JIT: compilation failed"
+-- All four are now consistent with the documented auto-pick-main
+-- behaviour (SKILL.md: "Multi-function files require either a
+-- function name argument or a function called `main`.").
+
+helper a:n>n;+a 1
+main>n;helper 41
+
+-- run: main
+-- out: 42
+-- run: helper 9
+-- out: 10

--- a/src/main.rs
+++ b/src/main.rs
@@ -2453,6 +2453,49 @@ fn dispatch_bare_args(raw_args: Vec<String>, global: &cli::Global) -> i32 {
     dispatch_run(run_args, mode, explicit_json, no_hints)
 }
 
+/// Resolve the function name + remaining args for an explicit engine flag
+/// (`--run-tree`, `--run-vm`, `--run-cranelift`).
+///
+/// Mirrors the auto-pick-main heuristic from the Default engine branch
+/// (PR #307): when no positional func arg is supplied, prefer a function
+/// called `main` so multi-fn files don't surface as misleading arity
+/// errors (Tree), silent `nil` results (VM), or bare
+/// "Cranelift JIT: compilation failed" strings (Cranelift). Reported by
+/// the ml-engineer / routing-tsp / devops-sre / html-scraper personas in
+/// rerun6 P1.
+///
+/// Synthetic `__lit_N` decls emitted by inline-lambda lifting are
+/// filtered out — same convention as the Default branch — so they
+/// never become a default entry point.
+///
+/// Scope is deliberately narrow: only the no-positional case gets the
+/// auto-pick treatment. When `rest` has any positional, we preserve
+/// the long-standing "first arg is the func name" contract verbatim —
+/// the engine then errors with `undefined function: <name>` if the
+/// caller mistyped a subcommand (pinned by
+/// `tests/cli_integration.rs::cli_cov_run_vm_fn_not_found` and
+/// friends). Tightening that pass-through is a separate, larger
+/// follow-up; this change is the minimal fix for the rerun6 P1 repro.
+fn resolve_engine_func_name<'a>(
+    program: &ast::Program,
+    rest: &'a [String],
+) -> (Option<&'a str>, &'a [String]) {
+    if let Some(first) = rest.first() {
+        return (Some(first.as_str()), &rest[1..]);
+    }
+
+    let has_main = program.declarations.iter().any(|d| {
+        matches!(
+            d,
+            ast::Decl::Function { name, .. } if !name.starts_with("__") && name == "main"
+        )
+    });
+    if has_main {
+        return (Some("main"), &[][..]);
+    }
+    (None, &[][..])
+}
+
 /// Dispatch the `run` subcommand via parsed RunArgs.  Returns exit code.
 fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints: bool) -> i32 {
     let source_arg = &r.source;
@@ -2691,8 +2734,7 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
             }
             cli::Engine::Llvm => run_llvm_engine(&program, rest),
             cli::Engine::Vm => {
-                let func_name = rest.first().map(|s| s.as_str());
-                let raw = if rest.len() > 1 { &rest[1..] } else { &[][..] };
+                let (func_name, raw) = resolve_engine_func_name(&program, rest);
                 let run_args = parse_cli_args_typed(&program, func_name, raw);
                 let compiled = match vm::compile(&program) {
                     Ok(c) => c,
@@ -2718,8 +2760,7 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
                 )
             }
             cli::Engine::Tree => {
-                let func_name = rest.first().map(|s| s.as_str());
-                let raw = if rest.len() > 1 { &rest[1..] } else { &[][..] };
+                let (func_name, raw) = resolve_engine_func_name(&program, rest);
                 let run_args = parse_cli_args_typed(&program, func_name, raw);
                 run_interp_with_provider(
                     &program,
@@ -2876,8 +2917,7 @@ fn run_cranelift_engine(
     mode: OutputMode,
     explicit_json: bool,
 ) -> i32 {
-    let func_name = rest.first().map(|s| s.as_str());
-    let raw = if rest.len() > 1 { &rest[1..] } else { &[][..] };
+    let (func_name, raw) = resolve_engine_func_name(program, rest);
     let run_args = parse_cli_args_typed(program, func_name, raw);
     let suppress = program_result_should_suppress(program, func_name);
 

--- a/tests/regression_cli_default.rs
+++ b/tests/regression_cli_default.rs
@@ -425,3 +425,158 @@ fn multi_fn_file_bracketed_list_leading_arg_passes_through() {
     );
     assert_eq!(stdout.trim(), "7");
 }
+
+// ── engine-flag auto-pick-main (rerun6 P1) ────────────────────────────────────
+//
+// PR #307 fixed the Default-engine branch to auto-run `main` on a
+// multi-fn file when no func arg is given. The explicit-engine paths
+// (`--run-tree`, `--run-vm`, `--run-cranelift`) kept the pre-307
+// behaviour of treating the first declared fn as the entry, which
+// surfaced as:
+//   * Tree     → misleading arity error (`helper: expected 1 args, got 0`)
+//   * VM       → silent `nil` result, exit 0
+//   * Cranelift→ bare "Cranelift JIT: compilation failed" string
+// Reported across four rerun6 personas (ml-engineer, routing-tsp,
+// devops-sre, html-scraper). Fix mirrors the #307 heuristic in
+// `resolve_engine_func_name`, exercised here across all four engines.
+
+fn run_engine_picks_main(engine_flag: &str) {
+    let (_dir, path) = write_temp("helper a:n>n;+a 1\nmain>n;helper 41\n");
+    let (ok, stdout, stderr) = run(&[engine_flag, path.to_str().unwrap()]);
+    assert!(
+        ok,
+        "{engine_flag}: expected main to auto-run; stderr: {stderr}"
+    );
+    assert_eq!(
+        stdout.trim(),
+        "42",
+        "{engine_flag}: expected main result 42; stdout: {stdout}"
+    );
+    assert!(
+        !stderr.contains("expected 1 args, got 0"),
+        "{engine_flag}: must not leak helper arity error; stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Cranelift JIT: compilation failed"),
+        "{engine_flag}: must not leak bare JIT-failed string; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn run_tree_flag_auto_picks_main_on_multi_fn_file() {
+    run_engine_picks_main("--run-tree");
+}
+
+#[test]
+fn run_vm_flag_auto_picks_main_on_multi_fn_file() {
+    run_engine_picks_main("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn run_cranelift_flag_auto_picks_main_on_multi_fn_file() {
+    run_engine_picks_main("--run-cranelift");
+}
+
+#[test]
+fn run_default_flag_auto_picks_main_on_multi_fn_file() {
+    // Pin the pre-existing #307 behaviour here too, so all four engines
+    // are exercised in one place. If the default-branch heuristic ever
+    // drifts, this test will catch it alongside the engine-flag set.
+    let (_dir, path) = write_temp("helper a:n>n;+a 1\nmain>n;helper 41\n");
+    let (ok, stdout, stderr) = run(&[path.to_str().unwrap()]);
+    assert!(ok, "default: expected main to auto-run; stderr: {stderr}");
+    assert_eq!(stdout.trim(), "42");
+}
+
+fn run_engine_explicit_func_overrides_main(engine_flag: &str) {
+    let (_dir, path) = write_temp("helper>n;7\nmain>n;42\n");
+    let (ok, stdout, stderr) = run(&[engine_flag, path.to_str().unwrap(), "helper"]);
+    assert!(
+        ok,
+        "{engine_flag}: expected explicit helper to run; stderr: {stderr}"
+    );
+    assert_eq!(stdout.trim(), "7");
+}
+
+#[test]
+fn run_tree_flag_explicit_func_overrides_main() {
+    run_engine_explicit_func_overrides_main("--run-tree");
+}
+
+#[test]
+fn run_vm_flag_explicit_func_overrides_main() {
+    run_engine_explicit_func_overrides_main("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn run_cranelift_flag_explicit_func_overrides_main() {
+    run_engine_explicit_func_overrides_main("--run-cranelift");
+}
+
+fn run_engine_undefined_func_arg_still_errors(engine_flag: &str) {
+    // Companion regression: when the caller passes an explicit
+    // positional that doesn't match any function, the engine must
+    // still surface `undefined function: <name>` (or an equivalent
+    // diagnostic). This pins the pre-existing contract that the
+    // narrow auto-pick-main fix did NOT touch — we only auto-pick
+    // `main` when `rest` is empty, so positional pass-through (and
+    // its typo-detection) is preserved verbatim.
+    let (_dir, path) = write_temp("helper a:n>n;+a 1\nmain>n;helper 41\n");
+    let (ok, _stdout, stderr) = run(&[engine_flag, path.to_str().unwrap(), "wibble"]);
+    assert!(!ok, "{engine_flag}: undefined fn arg must fail");
+    assert!(
+        stderr.contains("undefined")
+            || stderr.contains("no such function")
+            || stderr.contains("wibble"),
+        "{engine_flag}: expected fn-not-found-style error; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn run_tree_flag_undefined_func_arg_still_errors() {
+    run_engine_undefined_func_arg_still_errors("--run-tree");
+}
+
+#[test]
+fn run_vm_flag_undefined_func_arg_still_errors() {
+    run_engine_undefined_func_arg_still_errors("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn run_cranelift_flag_undefined_func_arg_still_errors() {
+    run_engine_undefined_func_arg_still_errors("--run-cranelift");
+}
+
+fn run_engine_single_fn_no_args_still_runs(engine_flag: &str) {
+    // Auto-run contract for single-fn files with no positional args
+    // must keep working under every engine flag — the single-fn
+    // dispatch path already handles `func_name = None` by running
+    // the sole declared fn. The fix preserves that path unchanged.
+    // (Single-fn + positional-args on engine flags is a pre-existing
+    // limitation: positional args are still parsed as the func name
+    // first, so `--run-tree file.ilo 21` errors with `undefined
+    // function: 21` on main. Out of scope for this fix.)
+    let (_dir, path) = write_temp("entry>n;42\n");
+    let (ok, stdout, stderr) = run(&[engine_flag, path.to_str().unwrap()]);
+    assert!(ok, "{engine_flag}: expected success; stderr: {stderr}");
+    assert_eq!(stdout.trim(), "42");
+}
+
+#[test]
+fn run_tree_flag_single_fn_no_args_still_runs() {
+    run_engine_single_fn_no_args_still_runs("--run-tree");
+}
+
+#[test]
+fn run_vm_flag_single_fn_no_args_still_runs() {
+    run_engine_single_fn_no_args_still_runs("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn run_cranelift_flag_single_fn_no_args_still_runs() {
+    run_engine_single_fn_no_args_still_runs("--run-cranelift");
+}


### PR DESCRIPTION
## Summary

PR #307 fixed the default engine to auto-run \`main\` on a multi-fn file when no func arg is given. The explicit engine flags kept the pre-#307 behaviour of treating the first declared fn as the entry, which surfaced as three different symptoms for the same root cause:

- \`--run-tree\` → misleading arity error (\`helper: expected 1 args, got 0\`)
- \`--run-vm\` → silent \`nil\` result with exit 0
- \`--run-cranelift\` → bare \`Cranelift JIT: compilation failed\` string with no error code

Reported by ml-engineer, routing-tsp, devops-sre, and html-scraper in rerun6 P1.

Manifesto framing: each persona burned a retry investigating an arity error, a nil result, or a JIT failure that was actually just "I forgot to pass \`main\`". One auto-pick rule, applied consistently to every backend, removes that whole class of first-touch surprise.

## Repro

\`\`\`
$ cat multifn.ilo
helper x:n>n;*x 2
main>n;42

# before
$ ilo --run-tree multifn.ilo
{"code":"ILO-R004","message":"helper: expected 1 args, got 0",...}
$ ilo --run-vm multifn.ilo
nil
$ ilo --run-cranelift multifn.ilo
Cranelift JIT: compilation failed

# after
$ ilo --run-tree multifn.ilo
42
$ ilo --run-vm multifn.ilo
42
$ ilo --run-cranelift multifn.ilo
42
\`\`\`

## What's in the diff

- **\`cli: auto-pick main on --run-tree / --run-vm / --run-cranelift\`** — extract \`resolve_engine_func_name\` mirroring the #307 heuristic, wire it into the Tree, VM, and Cranelift engine branches. Scope deliberately narrow: only the no-positional case auto-picks main, so mistyped subcommand args still surface \`undefined function: <name>\` as before.
- **\`test: pin auto-pick-main across all four engine flags\`** — cross-engine regression coverage in \`tests/regression_cli_default.rs\` (auto-pick + override + typo-detection + single-fn-no-args guard) plus \`examples/engine-flag-automain.ilo\` so the engine-harness test (\`tests/examples_engines.rs\`) exercises the program through every backend on every test run.

## Test plan

- [x] \`cargo build --release --features cranelift\` clean
- [x] \`cargo test --release --features cranelift\` — full suite green, 50+ test buckets, 0 failed
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --release --features cranelift --no-deps\` clean
- [x] Manual cross-engine repro on the multi-fn case returns 42 on all four engines
- [x] Manual repro that mistyped subcommand still errors with \`undefined function: ...\` on each engine flag

## Follow-ups

- Single-fn engine-flag invocation with positional args (\`ilo --run-tree single.ilo 21\`) still errors with \`undefined function: 21\` because the first positional is unconditionally parsed as a func name. Same pre-existing behaviour as on main; out of scope here. The Default branch's \`func_names.contains(&first)\` check could be extended to the engine flags as a follow-up if the personas hit it.