### PR TITLE
parser: bare-bool prefix ternary `?h a b`

### DIFF
--- a/examples/bool-ternary.ilo
+++ b/examples/bool-ternary.ilo
@@ -27,6 +27,20 @@ pick h:b>n;v=?h{10}{20};v
 -- want the symmetry of `true:` / `false:` arm labels.
 arms h:b>n;?h{true:10;false:20}
 
+-- Unbraced prefix form on a bare-bool subject: `?h a b`.
+-- Symmetric with the existing `?=cond a b` prefix ternary (which
+-- requires a comparison op after `?`). Cheapest shape when both
+-- arms are bare atoms — 6 chars for `?h 1 0` vs 8 for `?h{1}{0}`
+-- vs 12 for the older workaround `?=h true 1 0`.
+unbraced h:b>n;?h 1 0
+unbraced-t h:b>t;?h "yes" "no"
+
+-- Unbraced form in expression position (let RHS).
+unbraced-pick h:b>n;v=?h 10 20;v
+
+-- Unbraced form with prefix-op arms (`+1 2` / `*3 4`).
+unbraced-calc h:b>n;?h +1 2 *3 4
+
 -- run: basic true
 -- out: 1
 
@@ -62,3 +76,27 @@ arms h:b>n;?h{true:10;false:20}
 
 -- run: arms false
 -- out: 20
+
+-- run: unbraced true
+-- out: 1
+
+-- run: unbraced false
+-- out: 0
+
+-- run: unbraced-t true
+-- out: yes
+
+-- run: unbraced-t false
+-- out: no
+
+-- run: unbraced-pick true
+-- out: 10
+
+-- run: unbraced-pick false
+-- out: 20
+
+-- run: unbraced-calc true
+-- out: 3
+
+-- run: unbraced-calc false
+-- out: 12

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1294,6 +1294,25 @@ impl Parser {
             let ternary = self.parse_brace_ternary_after_subject(subj.clone())?;
             return Ok(Stmt::Expr(ternary));
         }
+        // Bare-bool prefix ternary: `?h a b` on a bool subject, symmetric
+        // with the existing `?=cond a b` comparison-led prefix ternary. After
+        // the subject is consumed, if the next token is not `{` but can start
+        // an operand, parse two operands and desugar to `Expr::Ternary`. The
+        // brace-form `?h{a}{b}` is handled above; this closes the asymmetry
+        // for the unbraced shape (the cheapest token cost on a bool subject:
+        // `?h 1 0` is 6 chars vs `?=h true 1 0` at 12 or `?h{1}{0}` at 8).
+        if let Some(subj) = &subject
+            && self.peek() != Some(&Token::LBrace)
+            && self.can_start_operand()
+        {
+            let then_expr = self.parse_operand()?;
+            let else_expr = self.parse_operand()?;
+            return Ok(Stmt::Expr(Expr::Ternary {
+                condition: Box::new(subj.clone()),
+                then_expr: Box::new(then_expr),
+                else_expr: Box::new(else_expr),
+            }));
+        }
         self.expect(&Token::LBrace)?;
         // Friendly hint: `?cond{body}` on a bare bool is a common slip — the
         // user reaches for braced-conditional execution but gets match syntax
@@ -2101,6 +2120,20 @@ impl Parser {
             && self.looks_like_brace_ternary()
         {
             return self.parse_brace_ternary_after_subject((**subj).clone());
+        }
+        // Bare-bool prefix ternary in expr position: `?h a b` symmetric with
+        // `?=cond a b`. See `parse_match_stmt` for the rationale.
+        if let Some(subj) = &subject
+            && self.peek() != Some(&Token::LBrace)
+            && self.can_start_operand()
+        {
+            let then_expr = self.parse_operand()?;
+            let else_expr = self.parse_operand()?;
+            return Ok(Expr::Ternary {
+                condition: Box::new((**subj).clone()),
+                then_expr: Box::new(then_expr),
+                else_expr: Box::new(else_expr),
+            });
         }
         self.expect(&Token::LBrace)?;
         let arms = self.parse_match_arms()?;
@@ -3761,6 +3794,96 @@ mod tests {
         };
         assert_eq!(name, "v");
         assert!(matches!(value, Expr::Ternary { .. }));
+    }
+
+    #[test]
+    fn parse_bare_bool_prefix_ternary_stmt() {
+        // `?h 1 0` on a bool subject — symmetric with `?=cond a b`.
+        let prog = parse_str("f h:b>n;?h 1 0");
+        let Decl::Function { body, .. } = &prog.declarations[0] else {
+            panic!("expected function")
+        };
+        let Stmt::Expr(Expr::Ternary {
+            condition,
+            then_expr,
+            else_expr,
+        }) = &body[0].node
+        else {
+            panic!("expected ternary, got {:?}", body[0])
+        };
+        assert!(matches!(condition.as_ref(), Expr::Ref(n) if n == "h"));
+        assert!(matches!(then_expr.as_ref(), Expr::Literal(Literal::Number(n)) if *n == 1.0));
+        assert!(matches!(else_expr.as_ref(), Expr::Literal(Literal::Number(n)) if *n == 0.0));
+    }
+
+    #[test]
+    fn parse_bare_bool_prefix_ternary_in_let() {
+        // `v=?h 10 20` — bare-bool ternary in expression position.
+        let prog = parse_str("f h:b>n;v=?h 10 20;v");
+        let Decl::Function { body, .. } = &prog.declarations[0] else {
+            panic!("expected function")
+        };
+        let Stmt::Let { name, value, .. } = &body[0].node else {
+            panic!("expected let, got {:?}", body[0])
+        };
+        assert_eq!(name, "v");
+        let Expr::Ternary {
+            condition,
+            then_expr,
+            else_expr,
+        } = value
+        else {
+            panic!("expected ternary, got {:?}", value)
+        };
+        assert!(matches!(condition.as_ref(), Expr::Ref(n) if n == "h"));
+        assert!(matches!(then_expr.as_ref(), Expr::Literal(Literal::Number(n)) if *n == 10.0));
+        assert!(matches!(else_expr.as_ref(), Expr::Literal(Literal::Number(n)) if *n == 20.0));
+    }
+
+    #[test]
+    fn parse_bare_bool_prefix_ternary_does_not_break_match() {
+        // `?h{true:1;false:0}` — explicit-arm match still parses as match.
+        let prog = parse_str("f h:b>n;?h{true:1;false:0}");
+        let Decl::Function { body, .. } = &prog.declarations[0] else {
+            panic!("expected function")
+        };
+        let Stmt::Match { subject, arms } = &body[0].node else {
+            panic!("expected match, got {:?}", body[0])
+        };
+        assert!(subject.is_some());
+        assert_eq!(arms.len(), 2);
+    }
+
+    #[test]
+    fn parse_bare_bool_prefix_ternary_does_not_break_brace_sugar() {
+        // `?h{1}{0}` — brace sugar from #323 still parses as ternary.
+        let prog = parse_str("f h:b>n;?h{1}{0}");
+        let Decl::Function { body, .. } = &prog.declarations[0] else {
+            panic!("expected function")
+        };
+        let Stmt::Expr(Expr::Ternary { condition, .. }) = &body[0].node else {
+            panic!("expected ternary, got {:?}", body[0])
+        };
+        assert!(matches!(condition.as_ref(), Expr::Ref(n) if n == "h"));
+    }
+
+    #[test]
+    fn parse_bare_bool_prefix_ternary_with_paren_subject() {
+        // `?(=>x 0) 1 0` — paren-grouped comparison as bool subject.
+        let prog = parse_str("f x:n>n;?(=x 0) 1 0");
+        let Decl::Function { body, .. } = &prog.declarations[0] else {
+            panic!("expected function")
+        };
+        let Stmt::Expr(Expr::Ternary { condition, .. }) = &body[0].node else {
+            panic!("expected ternary, got {:?}", body[0])
+        };
+        assert!(matches!(
+            condition.as_ref(),
+            Expr::BinOp {
+                op: BinOp::Equals,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/tests/regression_bool_ternary_prefix.rs
+++ b/tests/regression_bool_ternary_prefix.rs
@@ -93,7 +93,11 @@ fn bool_prefix_ternary_assign_cross_engine() {
     let src = "f h:b>n;v=?h 10 20;v";
     for engine in ENGINES_ALL {
         assert_eq!(run_ok(engine, src, &["f", "true"]), "10", "{engine}: true");
-        assert_eq!(run_ok(engine, src, &["f", "false"]), "20", "{engine}: false");
+        assert_eq!(
+            run_ok(engine, src, &["f", "false"]),
+            "20",
+            "{engine}: false"
+        );
     }
 }
 

--- a/tests/regression_bool_ternary_prefix.rs
+++ b/tests/regression_bool_ternary_prefix.rs
@@ -1,0 +1,188 @@
+// Cross-engine regression tests for the bare-bool prefix ternary
+// `?subj a b`.
+//
+// Before this fix, `?h a b` parsed `h` as a match subject, then
+// expected `{` for arms and errored with `ILO-P003 expected LBrace,
+// got Number(1.0)`. The brace form `?h{a}{b}` worked after #323 and
+// the comparison-led prefix form `?=h true a b` always worked, but
+// the unbraced bare-bool shape was asymmetric and forced the user
+// into one of the longer workarounds, costing extra tokens on every
+// conditional with a bare-bool subject.
+//
+// The fix extends `parse_match_stmt` / `parse_match_expr`: after the
+// subject is consumed and the brace-ternary shape detector misses,
+// if the next token is not `LBrace` but `can_start_operand()`, two
+// operands are parsed and the result is `Expr::Ternary { subj, a, b }`.
+// All three backends already handle `Expr::Ternary` from the existing
+// `?=cond a b` and `?h{a}{b}` paths, so no engine-level changes were
+// needed, but cross-engine pinning catches future drift.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_ok(engine: &str, src: &str, args: &[&str]) -> String {
+    let mut cmd = ilo();
+    cmd.arg(src).arg(engine);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} {src:?} {args:?} unexpectedly failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+#[cfg(feature = "cranelift")]
+const ENGINES_ALL: &[&str] = &["--run-tree", "--run-vm", "--run-cranelift"];
+#[cfg(not(feature = "cranelift"))]
+const ENGINES_ALL: &[&str] = &["--run-tree", "--run-vm"];
+
+// ── Bare-bool prefix ternary as tail expression ──────────────────────
+
+#[test]
+fn bool_prefix_ternary_true_cross_engine() {
+    let src = "f h:b>n;?h 1 0";
+    for engine in ENGINES_ALL {
+        assert_eq!(
+            run_ok(engine, src, &["f", "true"]),
+            "1",
+            "{engine}: ?h 1 0 on true"
+        );
+    }
+}
+
+#[test]
+fn bool_prefix_ternary_false_cross_engine() {
+    let src = "f h:b>n;?h 1 0";
+    for engine in ENGINES_ALL {
+        assert_eq!(
+            run_ok(engine, src, &["f", "false"]),
+            "0",
+            "{engine}: ?h 1 0 on false"
+        );
+    }
+}
+
+#[test]
+fn bool_prefix_ternary_string_branches_cross_engine() {
+    let src = "f h:b>t;?h \"yes\" \"no\"";
+    for engine in ENGINES_ALL {
+        assert_eq!(
+            run_ok(engine, src, &["f", "true"]),
+            "yes",
+            "{engine}: string then-branch"
+        );
+        assert_eq!(
+            run_ok(engine, src, &["f", "false"]),
+            "no",
+            "{engine}: string else-branch"
+        );
+    }
+}
+
+// ── Bare-bool prefix ternary in expression position (RHS) ────────────
+
+#[test]
+fn bool_prefix_ternary_assign_cross_engine() {
+    let src = "f h:b>n;v=?h 10 20;v";
+    for engine in ENGINES_ALL {
+        assert_eq!(run_ok(engine, src, &["f", "true"]), "10", "{engine}: true");
+        assert_eq!(run_ok(engine, src, &["f", "false"]), "20", "{engine}: false");
+    }
+}
+
+// ── Arms can be prefix-binop expressions ─────────────────────────────
+
+#[test]
+fn bool_prefix_ternary_prefix_op_branches_cross_engine() {
+    // Operands use `parse_operand`, so prefix-binop forms work directly:
+    // `?h +1 2 *3 4` reads as ternary with then=`+1 2` (3), else=`*3 4` (12).
+    let src = "f h:b>n;?h +1 2 *3 4";
+    for engine in ENGINES_ALL {
+        assert_eq!(run_ok(engine, src, &["f", "true"]), "3", "{engine}: +1 2");
+        assert_eq!(run_ok(engine, src, &["f", "false"]), "12", "{engine}: *3 4");
+    }
+}
+
+// ── Subject can be a comparison result bound to a local ──────────────
+
+#[test]
+fn bool_prefix_ternary_comparison_subject_cross_engine() {
+    let src = "f x:n>t;c=>x 0;?c \"pos\" \"nonpos\"";
+    for engine in ENGINES_ALL {
+        assert_eq!(
+            run_ok(engine, src, &["f", "5"]),
+            "pos",
+            "{engine}: pos branch"
+        );
+        assert_eq!(
+            run_ok(engine, src, &["f", "0"]),
+            "nonpos",
+            "{engine}: nonpos branch"
+        );
+    }
+}
+
+// ── Symmetry: same result as the brace form and the `?=cond` form ────
+
+#[test]
+fn bool_prefix_ternary_matches_brace_form_cross_engine() {
+    // Both shapes should produce identical results, since both desugar
+    // to the same `Expr::Ternary` node.
+    let bare = "f h:b>n;?h 7 9";
+    let brace = "g h:b>n;?h{7}{9}";
+    for engine in ENGINES_ALL {
+        assert_eq!(run_ok(engine, bare, &["f", "true"]), "7");
+        assert_eq!(run_ok(engine, brace, &["g", "true"]), "7");
+        assert_eq!(run_ok(engine, bare, &["f", "false"]), "9");
+        assert_eq!(run_ok(engine, brace, &["g", "false"]), "9");
+    }
+}
+
+#[test]
+fn bool_prefix_ternary_matches_eq_prefix_form_cross_engine() {
+    // `?h 1 0` on bool h is semantically `?=h true 1 0`.
+    let bare = "f h:b>n;?h 1 0";
+    let eqp = "g h:b>n;?=h true 1 0";
+    for engine in ENGINES_ALL {
+        assert_eq!(run_ok(engine, bare, &["f", "true"]), "1");
+        assert_eq!(run_ok(engine, eqp, &["g", "true"]), "1");
+        assert_eq!(run_ok(engine, bare, &["f", "false"]), "0");
+        assert_eq!(run_ok(engine, eqp, &["g", "false"]), "0");
+    }
+}
+
+// ── Existing match shapes must keep parsing as match ─────────────────
+
+#[test]
+fn match_on_int_arms_still_work_cross_engine() {
+    // The new prefix-ternary path triggers only when the next token is
+    // NOT `LBrace`; the match-arm form is unchanged.
+    let src = "f x:n>t;?x{1:\"a\";2:\"b\";_:\"c\"}";
+    for engine in ENGINES_ALL {
+        assert_eq!(run_ok(engine, src, &["f", "1"]), "a", "{engine}: arm 1");
+        assert_eq!(run_ok(engine, src, &["f", "2"]), "b", "{engine}: arm 2");
+        assert_eq!(run_ok(engine, src, &["f", "9"]), "c", "{engine}: wildcard");
+    }
+}
+
+#[test]
+fn eq_prefix_ternary_unchanged_cross_engine() {
+    // `?=x 0 a b` is unaffected by the new path because `?` followed by
+    // a comparison operator routes via `is_prefix_ternary` directly.
+    let src = "f x:n>t;?=x 0 \"zero\" \"nonzero\"";
+    for engine in ENGINES_ALL {
+        assert_eq!(run_ok(engine, src, &["f", "0"]), "zero", "{engine}: zero");
+        assert_eq!(
+            run_ok(engine, src, &["f", "5"]),
+            "nonzero",
+            "{engine}: nonzero"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`?h a b` on a bool subject errored with `expected LBrace, got Number` because the parser unconditionally routed the shape to match-arm parsing once `?` was followed by anything other than a comparison op. Three forms of the same conditional shape were available, with one notably absent:

- `?=h true a b` (prefix ternary, comparison-led) - works
- `?h{a}{b}` (brace sugar from #323) - works
- `?h a b` (bare-bool prefix ternary) - failed

Streaming-tail rerun6 flagged the asymmetry as a P1 papercut: the cheapest shape on a bool subject (6 chars for `?h 1 0` vs 8 for the brace form and 12 for the eq-prefix form) was the one shape that didn't parse.

## Repro

Before:

```
$ ilo file.ilo basic true       # basic h:b>n;?h 1 0
{"code":"ILO-P003", "message":"expected LBrace, got Number(1.0)", ...}
```

After:

```
$ ilo file.ilo basic true
1
$ ilo file.ilo basic false
0
```

## What's in the diff

- **`parser: sugar ?bool a b as bare-bool prefix ternary`** - in `parse_match_stmt` and `parse_match_expr`, after subject is consumed and the brace-ternary shape detector misses, check whether the next token is not `LBrace` but can start an operand. On match, parse two operands via `parse_operand` (same path as the existing `?=cond a b` ternary) and produce `Expr::Ternary`. On mismatch, fall through to existing `expect(LBrace)` so `?h` alone still errors the same way and `?h{1:a;_:b}` still parses as match. Five inline unit tests pin stmt/let-RHS positions, match-vs-ternary disambiguation, brace coexistence, and paren-grouped comparison subjects.
- **`tests: cross-engine coverage`** - 10 regression tests in `tests/regression_bool_ternary_prefix.rs` covering happy paths, branch-type variants (n / t), let-RHS, prefix-binop operands, bound-comparison subjects, result-parity with the brace and eq-prefix forms, plus negative shape pins so existing match parses and `?=cond a b` are unaffected.
- **`examples: pin unbraced shape`** - extends `examples/bool-ternary.ilo` with four new `-- run:` cases so the examples_engines harness exercises the shape across tree, VM, and Cranelift. The same example file now documents all three valid forms in one place, so future personas reach for the cheapest shape that fits.

All three backends already handle `Expr::Ternary` from the existing prefix-ternary and `?h{a}{b}` paths, so no engine-level changes are required.

## Test plan

- [x] 5 new inline parser unit tests pass
- [x] 10 new cross-engine regression tests pass (tree, VM, Cranelift)
- [x] examples_engines harness picks up the four new `-- run:` cases and passes on every engine
- [x] Full suite: `cargo test --release --features cranelift --no-fail-fast` - 145 test binaries, 0 failures
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --release --features cranelift --all-targets` clean

## Follow-ups

None. The shape is now symmetric with `?=cond a b` and `?h{a}{b}`; all three desugar to the same `Expr::Ternary` node, so backends stay untouched.