### PR TITLE
fix: reject double-minus prefix-binop trap (ILO-P021)

### DIFF
--- a/examples/double-minus-trap.ilo
+++ b/examples/double-minus-trap.ilo
@@ -1,0 +1,24 @@
+-- Double-minus prefix-binop trap (ILO-P021).
+-- The intuitive transcription of `-g*s - b*om` into prefix form is
+--   - -*gl s *b om
+-- but that parses as `-((g*s) - (b*om)) = -g*s + b*om` — the sign of the
+-- second product gets flipped. The parser now rejects that shape outright
+-- with ILO-P021 so the silent miscompile can't happen. Two safe forms:
+
+-- Form 1: subtract the SUM of both products from zero. Cheapest.
+--   = 0 - (g*s + b*om) = -g*s - b*om
+damped-a gl:n s:n b:n om:n>n;- 0 +*gl s *b om
+
+-- Form 2: bind each product, then subtract one from the negation of the
+-- other (or any other unambiguous combination).
+--   nbom = -b*om ; result = -g*s + nbom = -g*s - b*om
+damped-b gl:n s:n b:n om:n>n;p=*gl s;q=*b om;- 0 +p q
+
+-- run: damped-a 1 1 0.5 1
+-- out: -1.5
+-- run: damped-b 1 1 0.5 1
+-- out: -1.5
+-- run: damped-a 2 1 0.25 3
+-- out: -2.75
+-- run: damped-b 2 1 0.25 3
+-- out: -2.75

--- a/src/diagnostic/registry.rs
+++ b/src/diagnostic/registry.rs
@@ -342,6 +342,50 @@ This diagnostic exists so the error span lands on the function whose
 header is incomplete, not on the next function in the file.
 "#,
     },
+    ErrorEntry {
+        code: "ILO-P021",
+        short: "ambiguous double-minus prefix-binop chain",
+        long: r#"## ILO-P021: ambiguous double-minus prefix-binop chain
+
+A statement of the shape `- -<op> a b <op> c d`, where each `<op>` is a
+prefix binop in `{+, *, /}` and is followed by two atoms, is rejected
+because it parses in a way that almost always disagrees with the
+intuitive reading.
+
+**Example that triggers this (damped pendulum, natural form):**
+
+    f gl:n s:n b:n om:n>n;- -*gl s *b om
+
+The author wants `-g*s - b*om`. The parser instead reads it as:
+
+1. Inner `-` is a binary subtract: `(g*s) - (b*om)`.
+2. Outer `-` has only one operand left, so it becomes unary negate.
+3. Final expression: `-((g*s) - (b*om)) = -g*s + b*om`.
+
+The sign of the second product is flipped. The verifier sees a valid
+expression and the evaluator runs it, so the bug is silent — only
+domain knowledge surfaces it.
+
+**Fixes**
+
+Negate the sum of both products (cheapest):
+
+    - 0 +*gl s *b om            -- = 0 - (g*s + b*om) = -g*s - b*om
+
+Or bind first, then operate:
+
+    p=*gl s; q=*b om; - 0 +p q  -- = -(p + q)
+
+If you really do want `-((a OP1 b) - (c OP2 d))`, bind the inner
+subtract and negate it explicitly:
+
+    p=*a b; q=*c d; r=- p q; - 0 r
+
+This diagnostic exists to catch a specific silent-miscompile shape;
+single-atom variants like `- -a b` (negate of subtract over atoms) are
+unambiguous and remain accepted.
+"#,
+    },
     // ── Type / Verifier ──────────────────────────────────────────────────────
     ErrorEntry {
         code: "ILO-T001",

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2111,6 +2111,12 @@ impl Parser {
     /// Parse `-`: unary negation (`-x`) when one atom follows,
     /// binary subtract (`-a b`) when two atoms follow.
     fn parse_minus(&mut self) -> Result<Expr> {
+        // Reject the double-minus prefix-binop trap before consuming anything:
+        //   `- -*a b *c d`  parses as `-(a*b - c*d) = -a*b + c*d`,
+        // not the intuitive `-a*b - c*d`. Verifier sees a valid expression,
+        // evaluator produces a sign-flipped second term — silent miscompile.
+        // Surface it as a hard error with a bind-first suggestion. See ILO-P021.
+        self.check_double_minus_trap()?;
         self.advance(); // consume `-`
         let first = self.parse_operand()?;
         if self.can_start_operand() {
@@ -2126,6 +2132,79 @@ impl Parser {
                 operand: Box::new(first),
             })
         }
+    }
+
+    /// Detect the `- -<op> a b <op> c d` shape where both inner `<op>`s are
+    /// prefix binops in `{+, *, /}` and each is followed by two atoms. This
+    /// shape parses as `-((a OP1 b) - (c OP2 d))`, flipping the sign of the
+    /// second product vs the natural reading `-(a OP1 b) - (c OP2 d)`. It's a
+    /// silent miscompile from the agent's point of view (e.g. damped-pendulum
+    /// `-g*s - b*om` written as `- -*gl s *b om`).
+    ///
+    /// We deliberately do NOT trip on shapes that aren't this trap:
+    /// - `- -a b`  (negate of subtract — single atoms, well-defined)
+    /// - `- -a b c` (no inner prefix-binop — well-defined)
+    /// - `+*a b c`, `-+a b c` (single leading `-` family, documented)
+    /// - `- - -*a b *c d` (triple leading minus — different shape)
+    fn check_double_minus_trap(&self) -> Result<()> {
+        // pos: `-`, pos+1: `-`, pos+2: one of {+,*,/}, pos+3..4: atoms,
+        // pos+5: one of {+,*,/}, pos+6..7: atoms.
+        let is_prefix_arith = |t: Option<&Token>| {
+            matches!(
+                t,
+                Some(Token::Plus) | Some(Token::Star) | Some(Token::Slash)
+            )
+        };
+        let is_atom_start = |t: Option<&Token>| {
+            matches!(
+                t,
+                Some(Token::Ident(_))
+                    | Some(Token::Number(_))
+                    | Some(Token::Text(_))
+                    | Some(Token::True)
+                    | Some(Token::False)
+                    | Some(Token::Nil)
+                    | Some(Token::Underscore)
+                    | Some(Token::LParen)
+                    | Some(Token::LBracket)
+            )
+        };
+        if !matches!(self.token_at(self.pos), Some(Token::Minus)) {
+            return Ok(());
+        }
+        if !matches!(self.token_at(self.pos + 1), Some(Token::Minus)) {
+            return Ok(());
+        }
+        if !is_prefix_arith(self.token_at(self.pos + 2)) {
+            return Ok(());
+        }
+        if !is_atom_start(self.token_at(self.pos + 3)) {
+            return Ok(());
+        }
+        if !is_atom_start(self.token_at(self.pos + 4)) {
+            return Ok(());
+        }
+        if !is_prefix_arith(self.token_at(self.pos + 5)) {
+            return Ok(());
+        }
+        if !is_atom_start(self.token_at(self.pos + 6)) {
+            return Ok(());
+        }
+        if !is_atom_start(self.token_at(self.pos + 7)) {
+            return Ok(());
+        }
+        Err(self.error_hint(
+            "ILO-P021",
+            "ambiguous double-minus prefix-binop chain: parses as \
+             `-((a OP1 b) - (c OP2 d))`, sign-flipping the second product \
+             vs the natural reading `-(a OP1 b) - (c OP2 d)`"
+                .to_string(),
+            "to negate the sum of both products write `- 0 +OP1 a b OP2 c d` \
+             (subtract the sum from zero); to subtract them write \
+             `p=OP1 a b; q=OP2 c d; - p q`. \
+             e.g. `-g*s - b*om` becomes `- 0 +*gl s *b om`"
+                .to_string(),
+        ))
     }
 
     fn parse_prefix_binop(&mut self) -> Result<Expr> {

--- a/tests/regression_double_minus_trap.rs
+++ b/tests/regression_double_minus_trap.rs
@@ -172,6 +172,69 @@ fn accepts_bind_first_workaround() {
     assert_eq!(out.trim(), "-1.5");
 }
 
+// ─── Near-miss shapes — exercise each early-return in the detector ─────────
+//
+// Each of these probes one specific bail-out in `check_double_minus_trap` so
+// the detector's negative branches all have direct coverage. We don't pin
+// outputs (the parser's behaviour on the surrounding shapes isn't what's
+// under test); we only assert the trap diagnostic does NOT fire.
+
+fn assert_no_p021(src: &str, args: &[&str]) {
+    let mut cmd = ilo();
+    cmd.arg("--json").arg(src);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("ILO-P021"),
+        "ILO-P021 should NOT fire for {src:?}, stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn near_miss_no_second_minus() {
+    // pos+1 is not `-` → first bail-out
+    assert_no_p021("f a:n b:n>n;-+a b", &["1", "2"]);
+}
+
+#[test]
+fn near_miss_inner_op_is_comparison() {
+    // pos+2 is not in {+, *, /} (it's `>`) → second bail-out
+    assert_no_p021("f a:n b:n>b;- ->a b", &["1", "2"]);
+}
+
+#[test]
+fn near_miss_third_token_not_atom() {
+    // pos+3 is another prefix op, not an atom → third bail-out
+    assert_no_p021("f a:n b:n c:n>n;- -*+a b c", &["1", "2", "3"]);
+}
+
+#[test]
+fn near_miss_fourth_token_not_atom() {
+    // pos+4 is another prefix op, not an atom → fourth bail-out
+    assert_no_p021("f a:n b:n c:n>n;- -*a +b c", &["1", "2", "3"]);
+}
+
+#[test]
+fn near_miss_second_op_missing() {
+    // pos+5 is not a prefix-arith op (just runs out of tokens) → fifth bail-out
+    assert_no_p021("f a:n b:n>n;- -*a b", &["3", "4"]);
+}
+
+#[test]
+fn near_miss_second_op_followed_by_op_not_atom() {
+    // pos+6 is not an atom → sixth bail-out
+    assert_no_p021("f a:n b:n c:n d:n>n;- -*a b *+c d", &["1", "2", "3", "4"]);
+}
+
+#[test]
+fn near_miss_second_op_only_one_atom() {
+    // pos+7 is not an atom (we run out, or hit another op) → seventh bail-out
+    assert_no_p021("f a:n b:n c:n>n;- -*a b *c", &["1", "2", "3"]);
+}
+
 // ─── Cross-engine coverage ──────────────────────────────────────────────────
 //
 // The fix is in the parser, which all three engines share. To be defensive

--- a/tests/regression_double_minus_trap.rs
+++ b/tests/regression_double_minus_trap.rs
@@ -1,0 +1,206 @@
+//! Regression: the double-minus prefix-binop trap.
+//!
+//! The shape `- -<op> a b <op> c d`, with each `<op>` a prefix binop in
+//! `{+, *, /}` and each followed by two atoms, parses as
+//! `-((a OP1 b) - (c OP2 d))` — that is, the inner `-` consumes both
+//! prefix-binop groups as its operands, then the outer `-` has nothing
+//! left and becomes a unary negate. Algebraically that equals
+//! `-(a OP1 b) + (c OP2 d)`: the sign of the second product is flipped
+//! relative to the natural reading `-(a OP1 b) - (c OP2 d)`.
+//!
+//! The verifier sees a valid expression and the evaluator runs it, so the
+//! bug is silent — only domain knowledge surfaces it (e.g. a
+//! damped-pendulum natural-form transcription `-g*s - b*om` rendered as
+//! `- -*gl s *b om`, which evaluates with `+b*om` rather than `-b*om`).
+//!
+//! Fix: parser rejects this exact shape at parse time with ILO-P021 and a
+//! bind-first suggestion. The check is intentionally narrow — single-atom
+//! variants like `- -a b` (legitimate negate-of-subtract) and the
+//! documented `+*a b c` / `-+a b c` families remain accepted.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_err_json(src: &str, args: &[&str]) -> String {
+    let mut cmd = ilo();
+    cmd.arg("--json").arg(src);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "expected failure for {src:?}, stdout: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+fn run_ok(src: &str, args: &[&str]) -> String {
+    let mut cmd = ilo();
+    cmd.arg(src);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "expected success for {src:?}, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+fn first_error_code(stderr: &str) -> String {
+    let key = "\"code\":\"";
+    let idx = stderr
+        .find(key)
+        .unwrap_or_else(|| panic!("no code field in stderr:\n{stderr}"));
+    let tail = &stderr[idx + key.len()..];
+    let end = tail.find('"').expect("unterminated code field");
+    tail[..end].to_string()
+}
+
+// ─── Trap shapes — must reject with ILO-P021 ────────────────────────────────
+
+#[test]
+fn rejects_double_minus_star_star() {
+    // The originating shape from the rerun6 damped-pendulum repro:
+    //   `-g*s - b*om` written as `- -*gl s *b om`.
+    let src = "f gl:n s:n b:n om:n>n;- -*gl s *b om";
+    let err = run_err_json(src, &["1", "1", "0.5", "1"]);
+    assert_eq!(first_error_code(&err), "ILO-P021");
+    assert!(
+        err.contains("sign-flipping"),
+        "expected sign-flipping wording in:\n{err}"
+    );
+    assert!(
+        err.contains("- 0 +*gl s *b om"),
+        "expected concrete bind-first suggestion in:\n{err}"
+    );
+}
+
+#[test]
+fn rejects_double_minus_slash_slash() {
+    let src = "f a:n b:n c:n d:n>n;- -/a b /c d";
+    let err = run_err_json(src, &["4", "2", "6", "3"]);
+    assert_eq!(first_error_code(&err), "ILO-P021");
+}
+
+#[test]
+fn rejects_double_minus_plus_plus() {
+    let src = "f a:n b:n c:n d:n>n;- -+a b +c d";
+    let err = run_err_json(src, &["1", "2", "3", "4"]);
+    assert_eq!(first_error_code(&err), "ILO-P021");
+}
+
+#[test]
+fn rejects_double_minus_star_slash_mixed() {
+    let src = "f a:n b:n c:n d:n>n;- -*a b /c d";
+    let err = run_err_json(src, &["1", "2", "6", "3"]);
+    assert_eq!(first_error_code(&err), "ILO-P021");
+}
+
+#[test]
+fn rejects_double_minus_plus_star_mixed() {
+    let src = "f a:n b:n c:n d:n>n;- -+a b *c d";
+    let err = run_err_json(src, &["1", "2", "3", "4"]);
+    assert_eq!(first_error_code(&err), "ILO-P021");
+}
+
+#[test]
+fn rejects_double_minus_with_number_atoms() {
+    // Atom-start tokens include numbers, not just idents.
+    let src = "main>n;- -*2 3 *4 5";
+    let err = run_err_json(src, &[]);
+    assert_eq!(first_error_code(&err), "ILO-P021");
+}
+
+// ─── Non-trap shapes — must still parse cleanly ─────────────────────────────
+
+#[test]
+fn accepts_negate_of_subtract_single_atoms() {
+    // `- -a b` is negate-of-subtract over two atoms — unambiguous, leave it.
+    // `-(5 - 3) = -2`.
+    let out = run_ok("f a:n b:n>n;- -a b", &["5", "3"]);
+    assert_eq!(out.trim(), "-2");
+}
+
+#[test]
+fn accepts_minus_minus_three_atoms() {
+    // `- -a b c` has no inner prefix-binop. The inner `-` is negate-of-`a`
+    // and the outer `-` then subtracts the rest. Don't trip.
+    let out = run_ok("f a:n b:n c:n>n;- -a b c", &["5", "3", "2"]);
+    // -(-5) - 3 ... actually evaluates per current parser: inner `-a` is
+    // unary, outer `- (-a) b` is binary subtract — but `c` is still in scope
+    // and gets consumed... just assert it runs successfully without
+    // ILO-P021. The exact value is whatever the parser produces today.
+    assert!(!out.is_empty());
+}
+
+#[test]
+fn accepts_single_minus_plus_family() {
+    // `-+a b c` is the documented "inner prefix-op binds first" family.
+    let out = run_ok("f a:n b:n c:n>n;-+a b c", &["1", "2", "3"]);
+    assert_eq!(out.trim(), "0");
+}
+
+#[test]
+fn accepts_plus_star_family() {
+    // `+*a b c` — single leading prefix-op, not the trap.
+    let out = run_ok("f a:n b:n c:n>n;+*a b c", &["1", "2", "3"]);
+    assert_eq!(out.trim(), "5");
+}
+
+#[test]
+fn accepts_unary_negation() {
+    let out = run_ok("f a:n>n;-a", &["5"]);
+    assert_eq!(out.trim(), "-5");
+}
+
+#[test]
+fn accepts_bind_first_workaround() {
+    // The suggested fix in the error hint must itself parse and produce
+    // the value the agent originally wanted.
+    let out = run_ok(
+        "f gl:n s:n b:n om:n>n;- 0 +*gl s *b om",
+        &["1", "1", "0.5", "1"],
+    );
+    assert_eq!(out.trim(), "-1.5");
+}
+
+// ─── Cross-engine coverage ──────────────────────────────────────────────────
+//
+// The fix is in the parser, which all three engines share. To be defensive
+// against a future engine-specific re-parse path, exercise each engine
+// explicitly and confirm the trap is rejected before any engine runs.
+
+#[test]
+fn rejects_trap_on_all_engines() {
+    let src = "f gl:n s:n b:n om:n>n;- -*gl s *b om";
+    for backend in ["--run-tree", "--run-vm", "--run-cranelift"] {
+        let out = ilo()
+            .arg("--json")
+            .arg(backend)
+            .arg(src)
+            .arg("1")
+            .arg("1")
+            .arg("0.5")
+            .arg("1")
+            .output()
+            .expect("failed to run ilo");
+        assert!(
+            !out.status.success(),
+            "expected failure on {backend}, stdout: {}",
+            String::from_utf8_lossy(&out.stdout)
+        );
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("ILO-P021"),
+            "expected ILO-P021 on {backend}, stderr:\n{stderr}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`- -*gl s *b om` parses as `-((g*s) - (b*om)) = -g*s + b*om` — the inner `-` greedily consumes both prefix-binop groups as its operands and the outer `-` falls back to unary negate. The sign of the second product is flipped vs the natural reading `-g*s - b*om`. The verifier sees a valid expression and the evaluator runs it, so it's a silent miscompile — only domain knowledge surfaces it. Scientific-researcher rerun6 hit this on the damped-pendulum natural form.

Manifesto framing: a wrong numeric answer costs the agent N retries to chase. A loud parse-time rejection with a concrete suggestion costs zero retries. Killing the silent-miscompile shape dead is a token win.

## Repro before / after

Before:

```
$ ilo 'f gl:n s:n b:n om:n>n;- -*gl s *b om' 1 1 0.5 1
-0.5            -- silently wrong; correct answer is -1.5
```

After:

```
$ ilo 'f gl:n s:n b:n om:n>n;- -*gl s *b om' 1 1 0.5 1
error[ILO-P021]: ambiguous double-minus prefix-binop chain: parses as
  `-((a OP1 b) - (c OP2 d))`, sign-flipping the second product vs the
  natural reading `-(a OP1 b) - (c OP2 d)`
  hint: to negate the sum of both products write `- 0 +OP1 a b OP2 c d`
  (subtract the sum from zero); to subtract them write
  `p=OP1 a b; q=OP2 c d; - p q`. e.g. `-g*s - b*om` becomes
  `- 0 +*gl s *b om`

$ ilo 'f gl:n s:n b:n om:n>n;- 0 +*gl s *b om' 1 1 0.5 1
-1.5            -- correct
```

## What's in the diff (per commit)

- `parser: register ILO-P021 for double-minus prefix-binop trap` — registry entry with long-form explanation, two safe replacement forms, and the deliberate carve-out that single-atom variants like `- -a b` stay accepted.
- `parser: reject the double-minus prefix-binop trap` — `check_double_minus_trap` at the entry to `parse_minus`, a cheap 8-token lookahead matching `- - <op> a b <op> c d` where each `<op>` is in `{+, *, /}` and each is followed by two atom-starts. Returns the new diagnostic with a concrete `- 0 +*gl s *b om`-style suggestion. No semantic change to any accepted shape.
- `tests: regression coverage for the double-minus trap` — 13 tests covering every `{+,*,/}` op-pair plus mixed pairs, number-literal atoms, and a cross-backend check that all three engines (tree / vm / cranelift) reject the trap before evaluating. Non-trap shapes (`- -a b`, `-+a b c`, `+*a b c`, unary `-a`, `- -a b c` with no inner binop) are pinned to keep parsing. Plus `examples/double-minus-trap.ilo` showing the two safe forms with `-- run` / `-- out` assertions so `tests/examples_engines.rs` exercises them across every engine and future agents have an in-context learning example.

## Test plan

- [x] Trap repro from rerun6 now errors with ILO-P021
- [x] Fixed form `- 0 +*gl s *b om` produces `-1.5`
- [x] All four `{+,*,/}` op-pair shapes plus mixed pairs reject
- [x] Single-atom and single-leading-op variants still parse
- [x] Cross-backend: trap rejected on `--run-tree`, `--run-vm`, `--run-cranelift`
- [x] New `examples/double-minus-trap.ilo` runs cleanly through `examples_engines.rs`
- [x] Full suite green: `cargo test --release --features cranelift` — 0 failed across all binaries
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --release --features cranelift --tests -- -D warnings` clean

## Follow-ups

None blocking. Possible future tightening if a similar silent-miscompile shape surfaces from another rerun, but I'd want a real repro first rather than speculate.