### PR TITLE
fix: prefix-binop operand expands known-arity calls

### DIFF
--- a/examples/wh-prefix-call.ilo
+++ b/examples/wh-prefix-call.ilo
@@ -1,0 +1,36 @@
+-- wh >len q 0{...} — prefix-binop condition with a known-arity call on the
+-- left operand. Six-rerun standing P1: pre-fix this errored on first
+-- attempt across every persona, forcing bind-first or paren workarounds.
+-- Post-fix, the natural shape parses directly because parse_prefix_binop
+-- expands known-arity idents into calls (mirroring the prefix-`??` fix
+-- in #310).
+
+-- drain-tail: shrink a list until empty, count the iterations.
+drain-tail xs:L n>n;c=0;wh >len xs 0{xs=tl xs;c=+c 1};c
+
+-- bound-by-other: shrink until length matches a reference list's length.
+bound-by-other xs:L n ys:L n>n;wh >len xs len ys{xs=tl xs};len xs
+
+-- guard form: `>len q 1{...}` — the same prefix-call shape in a guard
+-- header (not just `wh`).
+guard-len q:L n>n;>len q 1{ret 42};0
+
+-- prefix-ternary form: `?>len q 0 a b` — condition is a prefix-call.
+ternary-len q:L n>n;?>len q 0 100 0
+
+-- run: drain-tail [1,2,3]
+-- out: 3
+-- run: drain-tail []
+-- out: 0
+-- run: bound-by-other [1,2,3,4,5] [1,2]
+-- out: 2
+-- run: bound-by-other [1] [1,2,3]
+-- out: 1
+-- run: guard-len [1,2]
+-- out: 42
+-- run: guard-len []
+-- out: 0
+-- run: ternary-len [1,2,3]
+-- out: 100
+-- run: ternary-len []
+-- out: 0

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2183,13 +2183,77 @@ impl Parser {
             Some(Token::PlusEq) => BinOp::Append,
             _ => unreachable!(),
         };
-        let left = self.parse_operand()?;
-        let right = self.parse_operand()?;
+        // Prefer `parse_call_arg` over `parse_operand` so a known-arity ident
+        // followed by enough operands expands into a call expression,
+        // consuming exactly its declared arity. Without this, `>len q 0`
+        // parses as `BinOp(>, Ref(len), Ref(q))` and orphans `0` — fatal in
+        // a `wh` header where the surrounding context immediately expects
+        // `{`. Mirrors the prefix-`??` fix in #310 (parse_expr_inner
+        // NilCoalesce arm) which made the same swap for the same reason.
+        //
+        // Guard: only opt in when the next token after the ident is itself
+        // operand-startable. A bare ident-then-terminator (e.g. `&e f{...}`
+        // where `f` is a local that shadows a user fn named `f`) must stay
+        // a bare `Ref` so the local resolves at runtime — otherwise
+        // `parse_call_arg` would expand the shadowed name into a zero-arg
+        // call and trigger ILO-T006 (regression caught by
+        // `vm_and_does_not_clobber_left_operand`'s FizzBuzz fixture).
+        let left = self.parse_prefix_binop_operand()?;
+        let right = self.parse_prefix_binop_operand()?;
         Ok(Expr::BinOp {
             op,
             left: Box::new(left),
             right: Box::new(right),
         })
+    }
+
+    /// Parse one operand of a prefix-binary operator (`>a b`, `&a b`, etc.).
+    ///
+    /// Dispatches to `parse_call_arg` when the ident at `self.pos` is a
+    /// known-arity function AND the next token can start another operand —
+    /// so `>len q 0` expands `len q` into a call and leaves `0` as the
+    /// right operand. Falls back to `parse_operand` otherwise, preserving
+    /// bare-ident semantics for locals that shadow user fn names
+    /// (`&e f{...}` where `f` is a local — must stay `Ref(f)`).
+    fn parse_prefix_binop_operand(&mut self) -> Result<Expr> {
+        if let Some(Token::Ident(name)) = self.peek()
+            && let Some(&arity) = self.fn_arity.get(name)
+            && arity > 0
+        {
+            // Mirror the suppression set in `parse_call_arg`'s expansion
+            // arm: record-construction, field access, zero-arg paren-call,
+            // and postfix-bang adjacency all turn the ident into something
+            // other than a plain call and must take the `parse_operand`
+            // path.
+            let next = self.token_at(self.pos + 1);
+            let is_record = matches!(next, Some(Token::Ident(_)))
+                && self.token_at(self.pos + 2) == Some(&Token::Colon);
+            let is_field = matches!(next, Some(Token::Dot) | Some(Token::DotQuestion));
+            let is_zero_arg_call =
+                next == Some(&Token::LParen) && self.token_at(self.pos + 2) == Some(&Token::RParen);
+            let is_unwrap = matches!(next, Some(&Token::Bang) | Some(&Token::BangBang)) && {
+                let ident_span = self.peek_span();
+                let bang_span = self
+                    .tokens
+                    .get(self.pos + 1)
+                    .map(|(_, s)| *s)
+                    .unwrap_or(Span::UNKNOWN);
+                ident_span.end > 0 && bang_span.start == ident_span.end
+            };
+            // Probe whether the ident is followed by another operand without
+            // consuming anything. `can_start_operand` is a pure peek.
+            let next_starts_operand = {
+                let saved = self.pos;
+                self.pos = saved + 1;
+                let result = self.can_start_operand();
+                self.pos = saved;
+                result
+            };
+            if !(is_record || is_field || is_zero_arg_call || is_unwrap) && next_starts_operand {
+                return self.parse_call_arg(false, None);
+            }
+        }
+        self.parse_operand()
     }
 
     /// Register a user function's arity and per-param fn-ref flags so that

--- a/tests/regression_prefix_binop_call.rs
+++ b/tests/regression_prefix_binop_call.rs
@@ -1,0 +1,165 @@
+// Regression tests for prefix-binop where an operand is a known-arity call.
+//
+// Previously `parse_prefix_binop` parsed both operands via `parse_operand`
+// (atom-only), so `>len q 0` mis-parsed as `BinOp(>, Ref(len), Ref(q))` with
+// `0` left orphaned. This was a 6-rerun P1 standing item across personas —
+// `wh` header, guard, let-RHS, and prefix-ternary all failed on first
+// attempt when the prefix-binop operand was a call expression, forcing
+// every persona to retry with bind-first or parens.
+//
+// Fix mirrors the prefix-`??` precedent (#310): swap `parse_operand` →
+// `parse_call_arg(false, None)` for both operands so a known-arity ident
+// expands into a call expression, consuming exactly its declared arity.
+// Bare locals (no fn_arity entry) fall through to `parse_operand`
+// unchanged, so the historical `wh >v 0` shape keeps working.
+//
+// Cross-engine: parses are pure parser-side so tree/VM/Cranelift all see
+// the same AST, but we exercise every backend anyway to catch any
+// downstream codegen surprise from the new call nodes.
+//
+// Note: `+f g` where `f` is a 1-arity user-defined fn now parses as
+// `BinOp(+, Call(f, [g]), <next>)` instead of `BinOp(+, Ref(f), Ref(g))`,
+// matching the manifesto-aligned arity-cap behaviour. The bare-ref shape
+// was never meaningful (you can't add two function references) so this
+// is a clean upgrade. Consistent with the same trade `??` makes.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str) -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let seq = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let path = std::env::temp_dir().join(format!(
+        "ilo_prefix_binop_call_{}_{}.ilo",
+        std::process::id(),
+        seq
+    ));
+    std::fs::write(&path, src).unwrap();
+    let out = ilo()
+        .args([path.to_str().unwrap(), engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+// The originating shape from gis-analyst: `wh >len q 0{...}`. Tail-shrinks
+// a list with a prefix-call condition. Pre-fix this errored
+// `ILO-P003 expected LBrace, got Number(0.0)`; post-fix it parses cleanly
+// and runs to completion (q drained, len reaches 0).
+const WH_HEAD_LEN_GT: &str = "main>n;q=[1,2,3];wh >len q 0{q=tl q};len q";
+
+// Same family with `<` (less-than) — `wh <len q 3` shrinks while the
+// list is shorter than 3 elements (always false here, body never runs).
+const WH_HEAD_LEN_LT: &str = "main>n;q=[1,2,3];wh <len q 3{q=tl q};len q";
+
+// `<i (len xs)` — call wrapped in parens on the RIGHT operand. Should
+// already have worked (parens are a separate code path) but pin it as a
+// no-regression check.
+const WH_HEAD_PAREN_RIGHT: &str = "main>n;xs=[10,20,30];i=0;s=0;wh <i (len xs){s=+s xs.i;i=+i 1};s";
+
+// Guard with prefix-call condition: `=>len q 1{...}` should parse the
+// `>` as a comparison (not a return-type arrow). Tests the guard path
+// since it routes through `parse_expr_or_guard` not the `wh` arm.
+const GUARD_PREFIX_CALL: &str = "main>n;q=[1,2,3];>len q 1{ret 42};0";
+
+// Assignment RHS: `v = >len q 0` binds a bool. Tests `parse_let` path.
+const LET_RHS_PREFIX_CALL: &str = "main>n;q=[1,2,3];v=>len q 0;?v{1}{0}";
+
+// Prefix-ternary on prefix-call: `?>len q 0 a b`. The prefix-ternary
+// helper parses the condition via `parse_prefix_binop`, so the fix here
+// flows through automatically.
+const PREFIX_TERNARY_CALL: &str = "main>n;q=[1,2,3];?>len q 0 100 0";
+const PREFIX_TERNARY_CALL_EMPTY: &str = "main>n;q=[];?>len q 0 100 0";
+
+// Negative regression: `wh >v 0` with a bare local `v` (no fn_arity
+// entry) must still work — falls through to `parse_operand` unchanged.
+// Exact shape from the historic `examples/wh-gt-condition.ilo`.
+const WH_BARE_LOCAL: &str = "main>n;v=3;wh >v 0{v=- v 1};v";
+
+// Builtin in left-operand slot via prefix `=`: `==len xs 3` (equality
+// against a call). Different from `>`/`<` since `=` is the comparison
+// op. Confirms the fix isn't `>`-specific.
+const WH_EQ_LEN: &str = "main>n;xs=[1,2];i=0;wh ==len xs 2{i=+i 1;xs=tl xs};i";
+
+// Both operands as calls: `>len xs len ys`. Each `len` is arity-1 so
+// `parse_call_arg` consumes `len xs` then `len ys`, leaving nothing
+// orphaned. Pin this in case anyone later assumes only left is a call.
+const WH_BOTH_CALLS: &str = "main>n;xs=[1,2,3];ys=[1,2];n=0;wh >len xs len ys{xs=tl xs;n=+n 1};n";
+
+fn check_all(engine: &str) {
+    assert_eq!(
+        run(engine, WH_HEAD_LEN_GT, "main"),
+        "0",
+        "wh >len q 0 engine={engine}"
+    );
+    assert_eq!(
+        run(engine, WH_HEAD_LEN_LT, "main"),
+        "3",
+        "wh <len q 3 engine={engine}"
+    );
+    assert_eq!(
+        run(engine, WH_HEAD_PAREN_RIGHT, "main"),
+        "60",
+        "wh <i (len xs) engine={engine}"
+    );
+    assert_eq!(
+        run(engine, GUARD_PREFIX_CALL, "main"),
+        "42",
+        "guard >len q 1 engine={engine}"
+    );
+    assert_eq!(
+        run(engine, LET_RHS_PREFIX_CALL, "main"),
+        "1",
+        "let RHS >len q 0 engine={engine}"
+    );
+    assert_eq!(
+        run(engine, PREFIX_TERNARY_CALL, "main"),
+        "100",
+        "prefix-ternary >len q 0 engine={engine}"
+    );
+    assert_eq!(
+        run(engine, PREFIX_TERNARY_CALL_EMPTY, "main"),
+        "0",
+        "prefix-ternary >len []=0 engine={engine}"
+    );
+    assert_eq!(
+        run(engine, WH_BARE_LOCAL, "main"),
+        "0",
+        "wh >v 0 bare local engine={engine}"
+    );
+    assert_eq!(
+        run(engine, WH_EQ_LEN, "main"),
+        "1",
+        "wh ==len xs 2 engine={engine}"
+    );
+    assert_eq!(
+        run(engine, WH_BOTH_CALLS, "main"),
+        "1",
+        "wh >len xs len ys engine={engine}"
+    );
+}
+
+#[test]
+fn prefix_binop_call_tree() {
+    check_all("--run-tree");
+}
+
+#[test]
+fn prefix_binop_call_vm() {
+    check_all("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn prefix_binop_call_cranelift() {
+    check_all("--run-cranelift");
+}


### PR DESCRIPTION
## Summary

Six-rerun P1 standing: `wh >len q 0{...}` failed on first attempt across every persona (gis-analyst, nlp-engineer, others), forcing a bind-first or paren retry every time.

Root cause: `parse_prefix_binop` parsed both operands via `parse_operand` (atom-only), so `>len q 0` parsed as `BinOp(>, Ref(len), Ref(q))` and orphaned `0` — fatal in a `wh` header where the surrounding context immediately expects `{` and emits ILO-P003.

Fix mirrors the prefix-`??` swap from #310: new `parse_prefix_binop_operand` helper dispatches to `parse_call_arg` when the ident at the cursor is a known-arity function AND the next token can start another operand. Falls back to `parse_operand` otherwise, so bare locals that shadow user fn names (`&e f{...}` where `f` is a local) keep resolving via `Ref` instead of expanding into a zero-arg call. The shadow-safety guard is what kept the FizzBuzz regression (`vm_and_does_not_clobber_left_operand`) green.

Manifesto win: the natural shape parses on first try. No more "wh prefix-cond" retries chewing through tokens.

## Repro

Before:
```
$ echo 'main>n;q=[1,2,3];wh >len q 0{q=tl q};len q' | ilo run /dev/stdin
{"code":"ILO-P003","message":"expected LBrace, got Number(0.0)",...}
```

After:
```
$ echo 'main>n;q=[1,2,3];wh >len q 0{q=tl q};len q' | ilo run /dev/stdin
0
```

## What's in the diff

- **parser: prefix-binop operand expands known-arity calls** (commit 1) — `parse_prefix_binop` now delegates each operand to `parse_prefix_binop_operand`, which opts into `parse_call_arg` only when the next ident is known-arity AND followed by an operand-startable token. Suppression set (records, field access, zero-arg paren, postfix-bang) mirrors the existing one in `parse_call_arg`.
- **tests: cross-engine regression for prefix-binop with call operands** (commit 2) — `tests/regression_prefix_binop_call.rs` covers the originating `wh >len q 0` shape plus guard form, let-RHS, prefix-ternary, equality, both-operands-as-calls, parenthesised right operand. Pins the bare-local fallback (`wh >v 0` keeps working). Tree + VM + Cranelift.
- **examples: wh-prefix-call shapes for the engine harness** (commit 3) — `examples/wh-prefix-call.ilo` runs through `examples_engines.rs` so the working shapes are in-context examples for future agents and the example harness catches any regression independently of the parser-specific test.

## Notable behaviour change

`+f g` where `f` is a 1-arity user fn now parses as `BinOp(+, Call(f, [g]), <next>)` instead of `BinOp(+, Ref(f), Ref(g))`. The bare-ref shape was never meaningful (you can't add two function references), so this is a clean upgrade — consistent with the same trade `??` made in #310. If a real program breaks it's an easy bind-first rewrite.

## Test plan

- [x] `cargo test --release --features cranelift` — full suite green
- [x] New `regression_prefix_binop_call` tree/VM/Cranelift all pass
- [x] `examples_engines` harness picks up the new example
- [x] Previously-failing `vm_and_does_not_clobber_left_operand` (FizzBuzz fixture) still green after the shadow-safe guard
- [x] `regression_wh_gt_trap` (existing `wh >v 0` cases) still green
- [x] `regression_prefix_nil_coalesce` (the precedent fix from #310) still green

## Follow-ups

None for this PR. The analogous prefix-ternary (`?>len q 0 a b`) is already covered by the new tests and works because prefix-ternary's condition flows through `parse_prefix_binop`. `parse_prefix_ternary`'s then/else operands still use `parse_operand` — that's a separate trade-off worth opening only if a persona hits it.