### PR TITLE
cli: engine flags share non-ident positional -> main heuristic with default

### DIFF
--- a/examples/engine-flag-non-ident-positional.ilo
+++ b/examples/engine-flag-non-ident-positional.ilo
@@ -1,0 +1,24 @@
+-- Engine flags (--run-tree / --run-vm / --run-cranelift) now mirror the
+-- default engine's #328 heuristic: when the first positional after the
+-- source path is NOT ident-shaped (e.g. `paper.txt`, `/tmp/x.json`, a
+-- number, anything with a `.` or `/` in it) and `main` is defined, the
+-- engine routes to `main` and passes the positional through as arg #1.
+--
+-- Before the fix, `ilo --run-tree main.ilo paper.txt` errored with
+-- `ILO-R002: undefined function: paper.txt` while default-engine
+-- `ilo main.ilo paper.txt` correctly ran `main "paper.txt"`. Three
+-- rerun7 personas (pdf-analyst, devops-sre, qa-tester) flagged it
+-- independently. PR follow-up to #329, which only covered the
+-- no-positional case.
+
+helper a:n>n;+a 1
+main p:t>n;+(len p) 1
+
+-- run: main paper.txt
+-- out: 10
+-- run: paper.txt
+-- out: 10
+-- run: /tmp/x.json
+-- out: 12
+-- run: helper 41
+-- out: 42

--- a/src/main.rs
+++ b/src/main.rs
@@ -2480,16 +2480,36 @@ fn resolve_engine_func_name<'a>(
     program: &ast::Program,
     rest: &'a [String],
 ) -> (Option<&'a str>, &'a [String]) {
-    if let Some(first) = rest.first() {
-        return (Some(first.as_str()), &rest[1..]);
-    }
-
     let has_main = program.declarations.iter().any(|d| {
         matches!(
             d,
             ast::Decl::Function { name, .. } if !name.starts_with("__") && name == "main"
         )
     });
+
+    if let Some(first) = rest.first() {
+        // Mirror the default-engine non-ident-positional -> main heuristic
+        // (PR #328 / src/main.rs ~2838). If the first positional does NOT
+        // look like a subcommand name (e.g. `paper.txt`, `/tmp/x.json`, `42`)
+        // and the program defines `main`, route to `main` and pass the whole
+        // `rest` slice through as call args. Without this, the engine sees
+        // `paper.txt` as a function name and emits `ILO-R002: undefined
+        // function: paper.txt` while the default engine on the same
+        // invocation runs `main` correctly.
+        //
+        // Ident-shaped first positionals are still treated as the function
+        // name, so typo detection ("undefined function: helpr") and explicit
+        // routing (`--run-tree file.ilo main path`) are preserved verbatim.
+        //
+        // Originating reports: pdf-analyst rerun7 P2 (assessment doc line
+        // 6736), devops-sre rerun7 P2 (line 7009), qa-tester rerun7 P2
+        // (line 6961, inline variant).
+        if has_main && !looks_like_subcommand_name(first) {
+            return (Some("main"), rest);
+        }
+        return (Some(first.as_str()), &rest[1..]);
+    }
+
     if has_main {
         return (Some("main"), &[][..]);
     }

--- a/tests/regression_cli_default.rs
+++ b/tests/regression_cli_default.rs
@@ -758,3 +758,222 @@ fn known_func_name_overrides_main_routing() {
     assert!(ok, "stderr: {stderr}");
     assert_eq!(stdout.trim(), "42");
 }
+
+// ── engine-flag non-ident-positional -> main (rerun7 P2, three personas) ──────
+//
+// PR #329 wired `resolve_engine_func_name` to auto-pick `main` when there
+// is NO positional after the engine flag, mirroring half of #328. The
+// other half (#328: non-ident first positional routes to `main` with the
+// positional as arg #1) didn't get propagated, so the default-engine path
+// `ilo main.ilo paper.txt` correctly runs `main "paper.txt"` but every
+// explicit-engine variant (`--run-tree`, `--run-vm`, `--run-cranelift`)
+// hard-failed with `ILO-R002: undefined function: paper.txt`.
+//
+// Reported in rerun7 by three independent personas:
+//   * pdf-analyst (assessment doc line 6736)
+//   * devops-sre  (line 7009)
+//   * qa-tester   (line 6961, inline variant — `--run-tree '...' 10 0`)
+//
+// This block locks the asymmetry shut across every engine.
+
+fn run_engine_non_ident_positional_routes_to_main(engine_flag: &str) {
+    // `paper.txt` contains a `.` so `looks_like_subcommand_name` rejects
+    // it. With `main` defined, the engine flag should route to `main`
+    // and pass `paper.txt` through as the first positional arg.
+    let (_dir, path) = write_temp("helper>n;7\nmain p:t>n;+(len p) 1\n");
+    let (ok, stdout, stderr) = run(&[engine_flag, path.to_str().unwrap(), "paper.txt"]);
+    assert!(
+        ok,
+        "{engine_flag}: expected main to absorb non-ident positional; stderr: {stderr}"
+    );
+    assert_eq!(
+        stdout.trim(),
+        "10",
+        "{engine_flag}: expected len('paper.txt')+1 = 10; stdout: {stdout}"
+    );
+    assert!(
+        !stderr.contains("undefined function"),
+        "{engine_flag}: must not leak undefined-function diagnostic; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn run_tree_flag_non_ident_positional_routes_to_main() {
+    run_engine_non_ident_positional_routes_to_main("--run-tree");
+}
+
+#[test]
+fn run_vm_flag_non_ident_positional_routes_to_main() {
+    run_engine_non_ident_positional_routes_to_main("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn run_cranelift_flag_non_ident_positional_routes_to_main() {
+    run_engine_non_ident_positional_routes_to_main("--run-cranelift");
+}
+
+#[test]
+fn run_default_non_ident_positional_routes_to_main_pin() {
+    // Pin the default-engine behaviour alongside the engine flags so a
+    // future drift between default and explicit engines is caught in one
+    // file, the same way the #329 set pins all four engines.
+    let (_dir, path) = write_temp("helper>n;7\nmain p:t>n;+(len p) 1\n");
+    let (ok, stdout, stderr) = run(&[path.to_str().unwrap(), "paper.txt"]);
+    assert!(ok, "default: stderr: {stderr}");
+    assert_eq!(stdout.trim(), "10");
+}
+
+fn run_engine_path_shaped_positional_routes_to_main(engine_flag: &str) {
+    // Repro from devops-sre rerun7: `/tmp/x.json` as a literal CLI arg.
+    // `/` is not a legal ident char so the heuristic must catch it.
+    let (_dir, path) = write_temp("helper>n;7\nmain p:t>n;len p\n");
+    let (ok, stdout, stderr) = run(&[engine_flag, path.to_str().unwrap(), "/tmp/x.json"]);
+    assert!(
+        ok,
+        "{engine_flag}: expected main to absorb path-shaped positional; stderr: {stderr}"
+    );
+    assert_eq!(
+        stdout.trim(),
+        "11",
+        "{engine_flag}: len('/tmp/x.json') = 11"
+    );
+}
+
+#[test]
+fn run_tree_flag_path_shaped_positional_routes_to_main() {
+    run_engine_path_shaped_positional_routes_to_main("--run-tree");
+}
+
+#[test]
+fn run_vm_flag_path_shaped_positional_routes_to_main() {
+    run_engine_path_shaped_positional_routes_to_main("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn run_cranelift_flag_path_shaped_positional_routes_to_main() {
+    run_engine_path_shaped_positional_routes_to_main("--run-cranelift");
+}
+
+fn run_engine_numeric_positional_routes_to_main(engine_flag: &str) {
+    // Numbers are non-ident-shaped (looks_like_subcommand_name rejects
+    // "42") so they should also route to `main`. This exercises the
+    // same code path as the qa-tester rerun7 case, where positional
+    // numeric args were swallowed as a function-name attempt.
+    let (_dir, path) = write_temp("helper>n;7\nmain a:n b:n>n;+a b\n");
+    let (ok, stdout, stderr) = run(&[engine_flag, path.to_str().unwrap(), "10", "32"]);
+    assert!(
+        ok,
+        "{engine_flag}: expected main to absorb numeric positionals; stderr: {stderr}"
+    );
+    assert_eq!(stdout.trim(), "42");
+}
+
+#[test]
+fn run_tree_flag_numeric_positional_routes_to_main() {
+    run_engine_numeric_positional_routes_to_main("--run-tree");
+}
+
+#[test]
+fn run_vm_flag_numeric_positional_routes_to_main() {
+    run_engine_numeric_positional_routes_to_main("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn run_cranelift_flag_numeric_positional_routes_to_main() {
+    run_engine_numeric_positional_routes_to_main("--run-cranelift");
+}
+
+fn run_engine_explicit_main_keyword_still_works(engine_flag: &str) {
+    // Explicit `main` before the non-ident positional must still route
+    // to `main` and produce the same result — the heuristic must not
+    // double-consume the positional or otherwise re-shape the args.
+    let (_dir, path) = write_temp("helper>n;7\nmain p:t>n;+(len p) 1\n");
+    let (ok, stdout, stderr) = run(&[engine_flag, path.to_str().unwrap(), "main", "paper.txt"]);
+    assert!(
+        ok,
+        "{engine_flag}: explicit `main` + non-ident positional; stderr: {stderr}"
+    );
+    assert_eq!(stdout.trim(), "10");
+}
+
+#[test]
+fn run_tree_flag_explicit_main_with_non_ident_arg() {
+    run_engine_explicit_main_keyword_still_works("--run-tree");
+}
+
+#[test]
+fn run_vm_flag_explicit_main_with_non_ident_arg() {
+    run_engine_explicit_main_keyword_still_works("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn run_cranelift_flag_explicit_main_with_non_ident_arg() {
+    run_engine_explicit_main_keyword_still_works("--run-cranelift");
+}
+
+fn run_engine_explicit_helper_overrides_main_heuristic(engine_flag: &str) {
+    // Even when `main` exists, passing an explicit ident-shaped helper
+    // name still routes to that helper. The non-ident heuristic must
+    // only fire when the first positional is itself non-ident — it must
+    // NOT override the user's explicit function selection.
+    let (_dir, path) = write_temp("helper p:t>n;len p\nmain p:t>n;+(len p) 100\n");
+    let (ok, stdout, stderr) = run(&[engine_flag, path.to_str().unwrap(), "helper", "paper.txt"]);
+    assert!(
+        ok,
+        "{engine_flag}: explicit helper override; stderr: {stderr}"
+    );
+    assert_eq!(
+        stdout.trim(),
+        "9",
+        "{engine_flag}: expected len('paper.txt') = 9 from helper, not 109 from main; stdout: {stdout}"
+    );
+}
+
+#[test]
+fn run_tree_flag_explicit_helper_overrides_main_heuristic() {
+    run_engine_explicit_helper_overrides_main_heuristic("--run-tree");
+}
+
+#[test]
+fn run_vm_flag_explicit_helper_overrides_main_heuristic() {
+    run_engine_explicit_helper_overrides_main_heuristic("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn run_cranelift_flag_explicit_helper_overrides_main_heuristic() {
+    run_engine_explicit_helper_overrides_main_heuristic("--run-cranelift");
+}
+
+fn run_engine_unknown_ident_no_main_still_errors(engine_flag: &str) {
+    // No `main` defined + ident-shaped unknown positional must still
+    // surface a clear `undefined function` diagnostic. The heuristic
+    // is gated on `has_main`, so this path is unchanged.
+    let (_dir, path) = write_temp("helper a:n>n;+a 1\n");
+    let (ok, _stdout, stderr) = run(&[engine_flag, path.to_str().unwrap(), "wibble"]);
+    assert!(!ok, "{engine_flag}: unknown ident must fail");
+    assert!(
+        stderr.contains("undefined") || stderr.contains("wibble"),
+        "{engine_flag}: expected fn-not-found diagnostic; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn run_tree_flag_unknown_ident_no_main_still_errors() {
+    run_engine_unknown_ident_no_main_still_errors("--run-tree");
+}
+
+#[test]
+fn run_vm_flag_unknown_ident_no_main_still_errors() {
+    run_engine_unknown_ident_no_main_still_errors("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn run_cranelift_flag_unknown_ident_no_main_still_errors() {
+    run_engine_unknown_ident_no_main_still_errors("--run-cranelift");
+}


### PR DESCRIPTION
## Summary

PR #329 propagated half of the default-engine entry-point heuristic to the explicit-engine flags (`--run-tree` / `--run-vm` / `--run-cranelift`): when there's no positional after the source path, auto-pick `main`. It didn't propagate PR #328's other half: when the first positional doesn't look like a function name (`paper.txt`, `/tmp/x.json`, `42`, anything with a `.` or `/` or leading digit) and `main` is defined, route to `main` with the positional as arg #1.

Three rerun7 personas (pdf-analyst, devops-sre, qa-tester) hit the same asymmetry independently:

```
$ ilo main.ilo paper.txt                # default engine: works
42
$ ilo --run-tree main.ilo paper.txt     # tree: fails
{"code":"ILO-R002","message":"undefined function: paper.txt", ...}
$ ilo --run-vm main.ilo /tmp/x.json     # vm: same
$ ilo --run-cranelift main.ilo paper.txt # cranelift: same
```

This PR extends `resolve_engine_func_name` (src/main.rs) to share the same `looks_like_subcommand_name` check the default-engine path uses. Surgical fix, mirrors a check that's already documented and well-tested elsewhere.

## Repro before/after

`/tmp/repro.ilo`:
```
helper x:n>n;+x 1
main path:t>n;helper 41
```

Before:
```
$ ilo --run-tree /tmp/repro.ilo /tmp/paper.txt
{"code":"ILO-R002","message":"undefined function: /tmp/paper.txt", ...}
$ ilo --run-vm /tmp/repro.ilo /tmp/paper.txt
{"code":"ILO-R002","message":"undefined function: /tmp/paper.txt", ...}
$ ilo --run-cranelift /tmp/repro.ilo /tmp/paper.txt
undefined function: /tmp/paper.txt
```

After:
```
$ ilo --run-tree /tmp/repro.ilo /tmp/paper.txt        → 42
$ ilo --run-vm /tmp/repro.ilo /tmp/paper.txt          → 42
$ ilo --run-cranelift /tmp/repro.ilo /tmp/paper.txt   → 42
$ ilo /tmp/repro.ilo /tmp/paper.txt                   → 42  (unchanged)
```

## What's in the diff

- **`cli: engine flags route non-ident first positional to main`** (1cd81db) — the four-line guard in `resolve_engine_func_name`. Identical predicate to the default-engine branch at src/main.rs ~2838-2857, so future drift between the two paths is easier to spot.
- **`tests: cross-engine regression for non-ident positional dispatch`** (89bed33) — 24 new tests in `regression_cli_default.rs` mirroring the PR #329 block: one helper per scenario, fanned out across `--run-tree` / `--run-vm` / `--run-cranelift` plus a default-engine pin. Covers non-ident positional, path-shaped positional, numeric positional, explicit `main` keyword + non-ident arg, explicit helper override (must NOT be shadowed by the heuristic), and ident-shaped-unknown-no-main (must still error).
- **`examples: pin non-ident positional routing across engines`** (8b04f63) — `examples/engine-flag-non-ident-positional.ilo` runs through the engine harness on every backend, so a future regression here fails at cross-engine parity rather than waiting for another persona to file it.

## Test plan

- [x] cargo test --release --features cranelift (full suite green, all 3000+ tests)
- [x] cargo fmt --check clean
- [x] cargo clippy --release --features cranelift --tests -- -D warnings clean
- [x] Manual repro across all four engines confirms 42
- [x] Examples harness exercises `paper.txt`, `/tmp/x.json`, explicit `main`, and explicit `helper` on every backend

## Follow-ups

- qa-tester rerun7 inline variant (`ilo --run-tree 'f a:n b:n>n;/a b' 10 0` with one fn, no main) is NOT covered here. The narrow brief was "share #328's non-ident -> main heuristic", and that case has no `main` to route to. Worth a follow-up to consider a single-fn inline auto-run on the explicit-engine paths, but it's a wider design call than this PR.