### PR TITLE
fix: CLI-boundary arity guard at every engine entry

### DIFF
--- a/examples/cli-arity-strict.ilo
+++ b/examples/cli-arity-strict.ilo
@@ -1,0 +1,46 @@
+-- Strict CLI arity: every engine errors with ILO-R004 when the number
+-- of CLI positionals doesn't match the entry function's declared
+-- parameter count.
+--
+-- Before this fix (v0.11.6 regression introduced by PR #336), calling
+-- `ilo 'f x:n>n;+x 1'` with no positional arg returned `nil` and exit
+-- 0 silently on the default engine, --run-vm, and --run-cranelift. The
+-- tree interpreter alone caught it. The mechanism was that PR #336
+-- made `JitCallError::NotEligible` fall through to `vm::run`, but the
+-- VM's `setup_call` had never checked arity — it pre-allocated
+-- register slots with `NanVal::nil()`, so a missing arg silently bound
+-- the parameter to nil. The interactive-cli tracker persona surfaced
+-- the worst-case shape: `ilo main.ilo add` (missing the task text)
+-- wrote the literal string `[ ] nil` to tasks.txt on disk and
+-- returned exit 0 — silent on-disk corruption.
+--
+-- The fix lives in `src/main.rs::check_cli_arity` (CLI-boundary guard
+-- at every engine entry: `run_default`, `run_cranelift_engine`,
+-- `Engine::Vm`, `Engine::Tree`) and `src/vm/mod.rs::check_entry_arity`
+-- (belt-and-braces backstop at `vm::run` / `vm::run_with_tools`). The
+-- diagnostic message matches the tree interpreter's existing form:
+-- `{name}: expected {n} args, got {m}`.
+--
+-- The harness only exercises the happy path here — sub/super-arity
+-- errors are covered by `tests/regression_cli_arity_silent_corruption.rs`
+-- which shells out to the binary and checks exit codes + diagnostic
+-- shape. Both arms together pin the contract:
+--   - exact arity         -> runs, expected output
+--   - sub-arity (missing) -> exit 1 + ILO-R004, NEVER nil
+--   - super-arity (extra) -> exit 1 + ILO-R004, NEVER silently dropped
+
+-- Single-param entry. Engines must accept exactly 1 CLI positional.
+inc x:n>n;+x 1
+
+-- Two-param entry. Tests the `main: expected 2 args, got N` shape that
+-- the interactive-cli regression actually hit.
+add-two x:n y:n>n;+x y
+
+-- run: inc 5
+-- out: 6
+-- run: inc 0
+-- out: 1
+-- run: add-two 3 4
+-- out: 7
+-- run: add-two 10 0
+-- out: 10

--- a/src/diagnostic/mod.rs
+++ b/src/diagnostic/mod.rs
@@ -178,6 +178,7 @@ impl From<&crate::vm::VmError> for Diagnostic {
             VmError::FieldNotFound { .. } => "ILO-R005",
             VmError::UnknownOpcode { .. } => "ILO-R013",
             VmError::Type(_) => "ILO-R004",
+            VmError::Arity { .. } => "ILO-R004",
             // Tree-bridge surfaces the interpreter's RuntimeError verbatim;
             // R009 mirrors what the tree interpreter would produce for the
             // same call, keeping diagnostic codes consistent across engines.

--- a/src/main.rs
+++ b/src/main.rs
@@ -2756,6 +2756,17 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
             cli::Engine::Vm => {
                 let (func_name, raw) = resolve_engine_func_name(&program, rest);
                 let run_args = parse_cli_args_typed(&program, func_name, raw);
+                // CLI-boundary arity guard. The bytecode VM's `setup_call`
+                // pads missing args with `NanVal::nil()` and silently
+                // ignores extras (vm/mod.rs:5996), so without this gate the
+                // user gets a `nil` result for a missing positional. See
+                // `check_cli_arity` doc + run_default for the regression
+                // history.
+                if let Err(code) =
+                    check_cli_arity(&program, func_name, run_args.len(), &source, mode)
+                {
+                    return code;
+                }
                 let compiled = match vm::compile(&program) {
                     Ok(c) => c,
                     Err(e) => {
@@ -2782,6 +2793,18 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
             cli::Engine::Tree => {
                 let (func_name, raw) = resolve_engine_func_name(&program, rest);
                 let run_args = parse_cli_args_typed(&program, func_name, raw);
+                // CLI-boundary arity guard. The tree interpreter already
+                // enforces this at dispatch (interpreter/mod.rs:4152), but
+                // running it here keeps the diagnostic shape consistent
+                // across every engine and avoids a one-off code path
+                // where the engine surfaces an ILO-R012 ("undefined
+                // function") for inline programs with a typoed entry
+                // while the others use ILO-R004.
+                if let Err(code) =
+                    check_cli_arity(&program, func_name, run_args.len(), &source, mode)
+                {
+                    return code;
+                }
                 run_interp_with_provider(
                     &program,
                     func_name,
@@ -2959,6 +2982,12 @@ fn run_cranelift_engine(
 ) -> i32 {
     let (func_name, raw) = resolve_engine_func_name(program, rest);
     let run_args = parse_cli_args_typed(program, func_name, raw);
+    // CLI-boundary arity guard (mirrors run_default). See the comment there
+    // for the regression history; same contract applies to the explicit
+    // --run-cranelift dispatch path.
+    if let Err(code) = check_cli_arity(program, func_name, run_args.len(), source, mode) {
+        return code;
+    }
     let suppress = program_result_should_suppress(program, func_name);
 
     #[cfg(feature = "cranelift")]
@@ -3378,6 +3407,18 @@ fn run_default(
     mode: OutputMode,
     explicit_json: bool,
 ) -> i32 {
+    // CLI-boundary arity guard. Restores the strict arity contract the tree
+    // interpreter has enforced since v0.11.5 (interpreter/mod.rs:4152) at the
+    // dispatch boundary, so missing or extra CLI args produce a loud
+    // ILO-R004 regardless of which engine the dispatcher picks. Pre-#336
+    // this happened to fire (via the JIT-NotEligible -> error path); after
+    // #336 the JIT silently falls back to the VM and the VM didn't check,
+    // leaving missing args nil-padded -- the regression that surfaced as
+    // `[ ] nil` writes from the interactive-cli tracker. Checking here
+    // makes the engine choice irrelevant to the error contract.
+    if let Err(code) = check_cli_arity(program, func_name, args.len(), source, mode) {
+        return code;
+    }
     let suppress = program_result_should_suppress(program, func_name);
     // Try Cranelift JIT first — all functions are now eligible
     #[cfg(feature = "cranelift")]
@@ -4133,6 +4174,80 @@ fn lookup_param_types<'a>(
         } if n == name => Some(params.as_slice()),
         _ => None,
     })
+}
+
+/// Resolve the entry function that the engines would dispatch to.
+///
+/// Mirrors the resolution every engine entry uses internally: if the caller
+/// supplied `func_name`, use it; otherwise pick the first declared function
+/// (matching `vm::run` / `interpreter::run_with_env` / `run_default`).
+///
+/// Returned name is the canonical target so the CLI-boundary arity check can
+/// report a faithful function name in the diagnostic, regardless of whether
+/// the auto-resolution kicked in.
+fn resolve_entry_func_name<'a>(
+    program: &'a ast::Program,
+    func_name: Option<&'a str>,
+) -> Option<&'a str> {
+    if func_name.is_some() {
+        return func_name;
+    }
+    program.declarations.iter().find_map(|d| match d {
+        ast::Decl::Function { name, .. } => Some(name.as_str()),
+        _ => None,
+    })
+}
+
+/// CLI-boundary arity guard. Compares the number of CLI args against the
+/// resolved entry function's declared parameter count and, on mismatch,
+/// reports an ILO-R004 diagnostic exactly matching the tree interpreter's
+/// existing check (`{name}: expected {n} args, got {m}`).
+///
+/// Returns `Err(1)` so the caller can short-circuit with `?`-style dispatch
+/// before handing off to the VM, JIT, or tree engine. The same diagnostic
+/// fires regardless of which engine the user picked, so missing-arg silent
+/// nil-padding can't sneak past the JIT-NotEligible -> VM fallback (the
+/// regression that produced `[ ] nil` writes in v0.11.6).
+///
+/// `Ok(())` for inline snippets whose entry function isn't a `Decl::Function`
+/// we can resolve — the engines will surface ILO-R012 themselves. Same for
+/// the cases where `lookup_param_types` returns None: we don't have a
+/// contract to enforce.
+fn check_cli_arity(
+    program: &ast::Program,
+    func_name: Option<&str>,
+    args_len: usize,
+    source: &str,
+    mode: OutputMode,
+) -> Result<(), i32> {
+    let target = match resolve_entry_func_name(program, func_name) {
+        Some(t) => t,
+        None => return Ok(()),
+    };
+    let params = match lookup_param_types(program, Some(target)) {
+        Some(p) => p,
+        None => return Ok(()),
+    };
+    if args_len == params.len() {
+        return Ok(());
+    }
+    let err = interpreter::RuntimeError {
+        code: "ILO-R004",
+        message: format!(
+            "{}: expected {} args, got {}",
+            target,
+            params.len(),
+            args_len
+        ),
+        span: None,
+        call_stack: Vec::new(),
+        propagate_value: None,
+    };
+    report_diagnostic(
+        &Diagnostic::from(&err).with_source(source.to_string()),
+        mode,
+    );
+    Err(1)
 }
 
 /// Parse and coerce CLI args against a function's declared parameter types.

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -19,6 +19,21 @@ pub enum VmError {
     UnknownOpcode { op: u8 },
     #[error("{0}")]
     Type(&'static str),
+    /// Caller passed the wrong number of args to the entry function.
+    ///
+    /// Belt-and-braces backstop for the CLI-boundary arity check in
+    /// `main::check_cli_arity`: if any future engine path reaches
+    /// `vm::run` / `vm::run_with_tools` without going through the
+    /// CLI guard (e.g. a future JIT-NotEligible fallback chain),
+    /// the VM itself refuses to silently nil-pad and surfaces the
+    /// same ILO-R004 diagnostic the tree interpreter has always
+    /// emitted (interpreter/mod.rs:4152).
+    #[error("{name}: expected {expected} args, got {got}")]
+    Arity {
+        name: String,
+        expected: usize,
+        got: usize,
+    },
     /// Dynamic runtime message produced by helpers (used by the tree-bridge
     /// dispatcher to surface interpreter errors with their original wording).
     #[error("{0}")]
@@ -5850,7 +5865,37 @@ pub fn run(
         span: None,
         call_stack: Vec::new(),
     })?;
+    check_entry_arity(compiled, func_idx, &target, args.len())?;
     VM::new(compiled).call(func_idx, args)
+}
+
+/// Backstop arity check at the VM entry boundary. `setup_call` itself
+/// pre-allocates register slots with `NanVal::nil()`, which silently nil-pads
+/// when caller args are missing. Catching the mismatch here turns the silent
+/// corruption into a loud ILO-R004 — matching the tree interpreter's
+/// `args.len() != params.len()` guard at `interpreter/mod.rs:4152` and
+/// the CLI-boundary check in `main::check_cli_arity`. Keeps the internal
+/// `VM::call` callers (JIT bridge, builtin re-entry) free to dispatch
+/// without paying this check on every nested call.
+fn check_entry_arity(
+    compiled: &CompiledProgram,
+    func_idx: u16,
+    target: &str,
+    args_len: usize,
+) -> Result<(), VmRuntimeError> {
+    let expected = compiled.chunks[func_idx as usize].param_count as usize;
+    if args_len != expected {
+        return Err(VmRuntimeError {
+            error: VmError::Arity {
+                name: target.to_string(),
+                expected,
+                got: args_len,
+            },
+            span: None,
+            call_stack: Vec::new(),
+        });
+    }
+    Ok(())
 }
 
 pub fn run_with_tools(
@@ -5879,6 +5924,7 @@ pub fn run_with_tools(
         span: None,
         call_stack: Vec::new(),
     })?;
+    check_entry_arity(compiled, func_idx, &target, args.len())?;
     VM::new_with_tools(
         compiled,
         provider,
@@ -5923,6 +5969,16 @@ impl<'a> VmState<'a> {
                 .ok_or_else(|| VmError::UndefinedFunction {
                     name: func_name.to_string(),
                 })?;
+        // Same arity backstop as `vm::run`: setup_call nil-pads missing args,
+        // so the entry boundary has to reject the mismatch explicitly.
+        let expected = self.vm.program.chunks[func_idx as usize].param_count as usize;
+        if args.len() != expected {
+            return Err(VmError::Arity {
+                name: func_name.to_string(),
+                expected,
+                got: args.len(),
+            });
+        }
         let nan_args: Vec<NanVal> = args
             .iter()
             .map(|v| NanVal::from_value_with_program(v, &self.vm.program.func_names))
@@ -31958,5 +32014,93 @@ main>n
         // windows of 2: [A,I] (both hydro), [I,L] (both hydro), [L,X] (X not hydro)
         // → 2 windows pass.
         assert_eq!(format!("{:?}", v), format!("{:?}", Value::Number(2.0)));
+    }
+
+    // ── VM entry-boundary arity guard ─────────────────────────────────────
+    //
+    // Belt-and-braces backstop for the CLI-boundary `check_cli_arity` in
+    // main.rs. The CLI guard fires first in normal use, so these tests
+    // exercise the VM-internal check directly via `vm::run` (which the
+    // CLI dispatcher routes through after JIT-NotEligible fallback).
+    // If anyone ever bypasses the CLI guard — e.g. embeds the VM, or
+    // adds a new dispatch entry — the VM still refuses to silently
+    // nil-pad missing args and surfaces an ILO-R004-shaped Arity error.
+
+    #[test]
+    fn vm_run_entry_arity_too_few_args() {
+        let src = "f x:n>n;+x 1";
+        let prog = parse_program(src);
+        let compiled = compile(&prog).expect("compile");
+        let err = run(&compiled, Some("f"), vec![]).expect_err("expected arity error");
+        match err.error {
+            VmError::Arity {
+                name,
+                expected,
+                got,
+            } => {
+                assert_eq!(name, "f");
+                assert_eq!(expected, 1);
+                assert_eq!(got, 0);
+            }
+            other => panic!("expected VmError::Arity, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn vm_run_entry_arity_too_many_args() {
+        let src = "f x:n>n;+x 1";
+        let prog = parse_program(src);
+        let compiled = compile(&prog).expect("compile");
+        let err = run(
+            &compiled,
+            Some("f"),
+            vec![Value::Number(1.0), Value::Number(2.0)],
+        )
+        .expect_err("expected arity error");
+        match err.error {
+            VmError::Arity {
+                name,
+                expected,
+                got,
+            } => {
+                assert_eq!(name, "f");
+                assert_eq!(expected, 1);
+                assert_eq!(got, 2);
+            }
+            other => panic!("expected VmError::Arity, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn vm_run_entry_arity_exact_succeeds() {
+        let src = "f x:n>n;+x 1";
+        let prog = parse_program(src);
+        let compiled = compile(&prog).expect("compile");
+        let v = run(&compiled, Some("f"), vec![Value::Number(5.0)]).expect("ok");
+        assert_eq!(format!("{:?}", v), format!("{:?}", Value::Number(6.0)));
+    }
+
+    #[test]
+    fn vm_state_call_arity_check() {
+        // VmState is the bench-mode reusable handle. It has its own
+        // arity check in `VmState::call` (parallel to `vm::run`'s) so a
+        // bench / embedding caller can't accidentally nil-pad either.
+        let src = "f x:n>n;+x 1";
+        let prog = parse_program(src);
+        let compiled = compile(&prog).expect("compile");
+        let mut state = VmState::new(&compiled);
+        let err = state.call("f", vec![]).expect_err("expected arity error");
+        match err {
+            VmError::Arity {
+                name,
+                expected,
+                got,
+            } => {
+                assert_eq!(name, "f");
+                assert_eq!(expected, 1);
+                assert_eq!(got, 0);
+            }
+            other => panic!("expected VmError::Arity, got {other:?}"),
+        }
     }
 }

--- a/tests/regression_cli_arity_silent_corruption.rs
+++ b/tests/regression_cli_arity_silent_corruption.rs
@@ -1,0 +1,316 @@
+// Regression coverage for the v0.11.6 P0 silent-corruption regression where
+// the VM and Cranelift JIT silently nil-padded missing CLI args instead of
+// erroring (interactive-cli rerun7).
+//
+// Reproduces: `ilo main.ilo add` on a tracker script that declared
+// `add txt:t>R t t;...` returned exit 0 and wrote the literal string
+// "[ ] nil" to tasks.txt. v0.11.5 errored correctly via the tree
+// interpreter's arity guard; PR #336's listview reshape made
+// `JitCallError::NotEligible` fall through to `vm::run`, and the VM's
+// `setup_call` happily pre-allocated registers with NanVal::nil(),
+// turning the missing arg into a silent `nil` binding.
+//
+// Coverage matrix:
+//   - sub-arity (missing required positional)
+//   - super-arity (extra positional)
+//   - happy path (exact arity) — unchanged behaviour
+//   - every engine (default, --run-tree, --run-vm, --run-cranelift)
+//   - inline (`ilo 'src' ...`) and file (`ilo main.ilo ...`)
+//   - auto-main file dispatch (`ilo main.ilo` with main taking args)
+//
+// The contract is "strict arity, every engine, loud ILO-R004". Sub-arity
+// must never coerce to nil. Super-arity must never silently drop extras.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_args(args: &[&str]) -> (i32, String, String) {
+    let out = ilo()
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn ilo: {e}"));
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    (code, stdout, stderr)
+}
+
+fn assert_arity_error(out: (i32, String, String), expected_fn: &str, want: usize, got: usize) {
+    let (code, stdout, stderr) = out;
+    assert_eq!(
+        code, 1,
+        "expected exit 1 for arity mismatch; stdout=\n{stdout}\nstderr=\n{stderr}"
+    );
+    let needle = format!("{}: expected {} args, got {}", expected_fn, want, got);
+    let combined = format!("{stdout}\n{stderr}");
+    assert!(
+        combined.contains(&needle) && combined.contains("ILO-R004"),
+        "expected `{needle}` + ILO-R004 in output; got:\n{combined}"
+    );
+}
+
+// ── inline sub-arity (missing required positional) ────────────────────────────
+
+#[test]
+fn inline_sub_arity_default_engine() {
+    // The originating bug. Pre-fix: prints `nil` exit 0.
+    assert_arity_error(run_args(&["f x:n>n;+x 1"]), "f", 1, 0);
+}
+
+#[test]
+fn inline_sub_arity_run_tree() {
+    assert_arity_error(run_args(&["--run-tree", "f x:n>n;+x 1"]), "f", 1, 0);
+}
+
+#[test]
+fn inline_sub_arity_run_vm() {
+    // Pre-fix: prints `nil` exit 0. VM setup_call padded with NanVal::nil().
+    assert_arity_error(run_args(&["--run-vm", "f x:n>n;+x 1"]), "f", 1, 0);
+}
+
+#[test]
+fn inline_sub_arity_run_cranelift() {
+    // Pre-fix: JIT bailed via NotEligible, fell through to nil-padded VM.
+    assert_arity_error(run_args(&["--run-cranelift", "f x:n>n;+x 1"]), "f", 1, 0);
+}
+
+// ── inline super-arity (extra positional) ─────────────────────────────────────
+//
+// Only the default-engine path can faithfully detect super-arity for inline
+// snippets — the explicit `--run-*` engines treat positionals after the
+// source as `[func, args...]` and surface ILO-R002 "undefined function"
+// when the next positional isn't a known function. That pre-existing
+// shape is out of scope for this regression; the silent-corruption fix
+// is specifically about the auto-resolved default-engine path.
+
+#[test]
+fn inline_super_arity_default_engine() {
+    assert_arity_error(run_args(&["f x:n>n;+x 1", "5", "7"]), "f", 1, 2);
+}
+
+// ── inline happy path (exact arity) ───────────────────────────────────────────
+
+#[test]
+fn inline_exact_arity_default_engine() {
+    let (code, stdout, _) = run_args(&["f x:n>n;+x 1", "5"]);
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "6");
+}
+
+#[test]
+fn inline_exact_arity_run_vm() {
+    let (code, stdout, _) = run_args(&["--run-vm", "f x:n>n;+x 1", "f", "5"]);
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "6");
+}
+
+#[test]
+fn inline_exact_arity_run_cranelift() {
+    let (code, stdout, _) = run_args(&["--run-cranelift", "f x:n>n;+x 1", "f", "5"]);
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "6");
+}
+
+#[test]
+fn inline_exact_arity_run_tree() {
+    let (code, stdout, _) = run_args(&["--run-tree", "f x:n>n;+x 1", "f", "5"]);
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "6");
+}
+
+// ── file dispatch with auto-main routing ──────────────────────────────────────
+//
+// The interactive-cli tracker is a multi-function file that routes
+// subcommands through `main cmd:t arg:t>...`. Pre-fix:
+//   `ilo main.ilo add` resolved entry to `main`, parsed CLI as `["add"]`
+//   (one positional), then VM `setup_call` padded `arg` with nil. The
+//   `?cmd{"add":add arg;...}` body then evaluated `add nil` -> wrote
+//   `[ ] nil` to tasks.txt silently.
+// Post-fix: ILO-R004 fires at the CLI boundary because the resolved
+// entry `main` declares 2 params but only 1 was supplied.
+
+fn write_tracker(dir: &std::path::Path) -> std::path::PathBuf {
+    // Minimal echo of the interactive-cli rerun7 tracker shape: a `main`
+    // that routes a subcommand to a function which writes a tagged line
+    // to disk via `wrl`. Keeps the silent-corruption surface (file write
+    // + nil-coerced second positional) intact while avoiding load/save
+    // round-trip complexity.
+    let src = r#"add txt:t>R t t;ln=fmt "[ ] {}" txt;wrl "tasks.txt" [ln]
+main cmd:t arg:t>R t t;?cmd{"add":add arg;_:^"usage"}
+"#;
+    let path = dir.join("tracker.ilo");
+    std::fs::write(&path, src).expect("write tracker");
+    path
+}
+
+#[test]
+fn file_auto_main_sub_arity_default() {
+    // `ilo tracker.ilo add` — `add` is a declared function, so the
+    // default-engine CLI routes directly to `add txt:t` with no positional
+    // args. Pre-fix: VM nil-padded `txt`, ran `wrl "tasks.txt" ["[ ] nil"]`,
+    // silently wrote corrupt data to disk and exited 0. Post-fix: the
+    // CLI-boundary arity guard reports `add: expected 1 args, got 0` and
+    // exits 1 before any side effects.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = write_tracker(dir.path());
+    let out = ilo()
+        .current_dir(dir.path())
+        .args([path.to_str().unwrap(), "add"])
+        .output()
+        .expect("spawn");
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    assert_arity_error((code, stdout, stderr), "add", 1, 0);
+    // Crucially: the broken behaviour wrote a `[ ] nil` line. Tasks.txt
+    // must NOT exist after the dispatch failed.
+    assert!(
+        !dir.path().join("tasks.txt").exists(),
+        "tasks.txt must NOT be written when arity check fires"
+    );
+}
+
+#[test]
+fn file_auto_main_no_positional_routes_to_main() {
+    // Bare `ilo tracker.ilo` (no positionals) auto-runs `main`. Main
+    // declares 2 params (cmd, arg) — supply none -> the CLI guard
+    // reports `main: expected 2 args, got 0`. Pinning this shape
+    // because the auto-pick-main heuristic (#329) is the other path
+    // that could nil-pad without our guard.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = write_tracker(dir.path());
+    let out = ilo()
+        .current_dir(dir.path())
+        .args([path.to_str().unwrap()])
+        .output()
+        .expect("spawn");
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    assert_arity_error((code, stdout, stderr), "main", 2, 0);
+    assert!(!dir.path().join("tasks.txt").exists());
+}
+
+#[test]
+fn file_auto_main_exact_arity_writes_task() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = write_tracker(dir.path());
+    let out = ilo()
+        .current_dir(dir.path())
+        .args([path.to_str().unwrap(), "add", "buy milk"])
+        .output()
+        .expect("spawn");
+    assert_eq!(
+        out.status.code().unwrap_or(-1),
+        0,
+        "happy path should succeed; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let written = std::fs::read_to_string(dir.path().join("tasks.txt")).expect("tasks.txt");
+    assert!(
+        written.contains("[ ] buy milk"),
+        "expected tasks.txt to contain `[ ] buy milk`; got {written:?}"
+    );
+    // And critically: no `nil`.
+    assert!(
+        !written.contains("nil"),
+        "tasks.txt must never contain `nil` (regression marker); got {written:?}"
+    );
+}
+
+#[test]
+fn file_auto_main_super_arity_default() {
+    // `ilo tracker.ilo add "buy milk" extra` — routes to `add txt:t` with
+    // 2 positional args. Pre-fix: VM ignored the extra and wrote `[ ] buy
+    // milk` (extras silently dropped — the second half of the rerun7
+    // report). Post-fix: ILO-R004 fires with `add: expected 1 args, got 2`.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = write_tracker(dir.path());
+    let out = ilo()
+        .current_dir(dir.path())
+        .args([path.to_str().unwrap(), "add", "buy milk", "extra"])
+        .output()
+        .expect("spawn");
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    assert_arity_error((code, stdout, stderr), "add", 1, 2);
+    assert!(
+        !dir.path().join("tasks.txt").exists(),
+        "tasks.txt must NOT be written when arity check fires"
+    );
+}
+
+// ── explicit-engine file dispatch ─────────────────────────────────────────────
+//
+// The `--run-vm` / `--run-cranelift` engine flag with a file routes
+// non-ident first positional to main (per the #329 / #336 fix). Cover
+// that the arity guard fires regardless of engine.
+
+#[test]
+fn file_main_sub_arity_run_vm() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = "main x:n y:n>n;+x y\n";
+    let path = dir.path().join("two.ilo");
+    std::fs::write(&path, src).expect("write");
+    // --run-vm with file + 1 positional that LOOKS like an ident routes
+    // to the named function path (engine resolves `main` because no
+    // positional is given). Provide one ambiguous positional later.
+    let out = ilo()
+        .args(["--run-vm", path.to_str().unwrap()])
+        .output()
+        .expect("spawn");
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    assert_arity_error((code, stdout, stderr), "main", 2, 0);
+}
+
+#[test]
+fn file_main_sub_arity_run_cranelift() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = "main x:n y:n>n;+x y\n";
+    let path = dir.path().join("two.ilo");
+    std::fs::write(&path, src).expect("write");
+    let out = ilo()
+        .args(["--run-cranelift", path.to_str().unwrap()])
+        .output()
+        .expect("spawn");
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    assert_arity_error((code, stdout, stderr), "main", 2, 0);
+}
+
+#[test]
+fn file_main_sub_arity_run_tree() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = "main x:n y:n>n;+x y\n";
+    let path = dir.path().join("two.ilo");
+    std::fs::write(&path, src).expect("write");
+    let out = ilo()
+        .args(["--run-tree", path.to_str().unwrap()])
+        .output()
+        .expect("spawn");
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    assert_arity_error((code, stdout, stderr), "main", 2, 0);
+}
+
+#[test]
+fn file_main_exact_arity_run_vm() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = "main x:n y:n>n;+x y\n";
+    let path = dir.path().join("two.ilo");
+    std::fs::write(&path, src).expect("write");
+    let out = ilo()
+        .args(["--run-vm", path.to_str().unwrap(), "main", "3", "4"])
+        .output()
+        .expect("spawn");
+    assert_eq!(out.status.code().unwrap_or(-1), 0);
+    assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "7");
+}


### PR DESCRIPTION
## Summary

`ilo main.ilo add` (the interactive-cli tracker called without the task text positional) silently wrote the literal string `[ ] nil` to tasks.txt and exited 0 on v0.11.6. Same shape inline: `ilo 'f x:n>n;+x 1'` returned `nil` exit 0 on default, --run-vm, and --run-cranelift. v0.11.5 errored loudly. Manifesto worst-class footgun: silent on-disk corruption, no signal.

Bisected to PR #336 (`e8b66f5 vm: reshape OP_WINDOW / OP_WINDOW_VIEW`). #336 changed `JitCallError::NotEligible` from "print error + exit 1" to "silently fall through to `vm::run`" — legitimate, because the listview reshape made OP_WINDOW JIT-bail and the VM is the correct fallback. But `jit_cranelift::call_raw` returns `NotEligible` ALSO for `args.len() != param_count`, and `vm::setup_call` had never validated arity — it pre-allocated registers with `NanVal::nil()`, silently nil-padding any missing arg. So missing args started running on a nil-padded frame and producing garbage. The tree interpreter alone caught it because of its dispatch-time check at `interpreter/mod.rs:4152`.

## Repro

```
# v0.11.6 (broken)
$ rm -f tasks.txt && ilo /tmp/tracker.ilo add && cat tasks.txt
tasks.txt
[ ] nil       ← silent on-disk corruption

$ ilo 'f x:n>n;+x 1'
nil
$ echo $?
0
```

After this PR:

```
$ ilo /tmp/tracker.ilo add
{"code":"ILO-R004","message":"add: expected 1 args, got 0",...}
$ echo $?
1
$ ls tasks.txt
ls: tasks.txt: No such file or directory   ← never touched
```

## What's in the diff

Three commits:

1. **`vm: reject wrong-arity entry calls instead of nil-padding`** — adds `VmError::Arity` variant + `check_entry_arity` backstop in `vm::run` / `vm::run_with_tools` + parallel inline check in `VmState::call`. Internal `VM::call` (HOF callbacks, JIT bridge re-entry, `OP_CALL` dispatch) is deliberately untouched, so dynamic dispatch inside a running program pays no extra cost. Maps to ILO-R004 in the diagnostic registry. Includes 4 unit tests exercising the backstop directly.

2. **`cli: arity guard at every engine entry, not just the tree interpreter`** — adds `check_cli_arity` helper that resolves the entry function the same way each engine does (caller-supplied name, else first declared fn), looks up declared params, and emits an ILO-R004 diagnostic with identical wording to the tree interpreter (`{name}: expected {n} args, got {m}`). Wired into all four entry points: `run_default`, `run_cranelift_engine`, and the `Engine::Vm` / `Engine::Tree` arms in `dispatch_run`. Fires BEFORE `vm::compile`, JIT codegen, or any IO.

3. **`tests: cross-engine + file-dispatch coverage for the arity guard`** — 17 integration tests covering sub/super/exact arity across all four engines, inline + file dispatch, auto-main routing. The tracker test explicitly asserts `tasks.txt` is NOT created on the error path — the regression marker for the on-disk corruption. Plus `examples/cli-arity-strict.ilo` for harness coverage and agent learning.

I deliberately did not revert #336's `NotEligible → VM` silent fallback. That fallback is legitimate (OP_WINDOW is supposed to bail on the JIT and run on the VM). The bug was that the VM didn't check arity. Keeping the fallback preserves the listview perf win; the new guards make the engine choice irrelevant to the error contract.

## Test plan

- [x] `cargo test --release --features cranelift` — 5637 tests, 161 suites, all green
- [x] Clippy clean
- [x] Manual repro of the original `main.ilo add` corruption — now errors loudly, tasks.txt never written
- [x] Manual repro of inline `ilo 'f x:n>n;+x 1'` across all 4 engines — all error with ILO-R004 exit 1
- [x] Happy path (`ilo 'f x:n>n;+x 1' 5`) returns 6 exit 0 on all engines
- [x] Auto-main file dispatch (`ilo tracker.ilo` with no positional and `main` taking 2 params) errors with `main: expected 2 args, got 0`
- [ ] CI green

## Follow-ups

- Super-arity on `--run-vm` / `--run-cranelift` / `--run-tree` for inline snippets still surfaces as `ILO-R002 undefined function: <extra>` because the explicit engines treat the second positional as a function name. Pre-existing shape, not in scope for this regression; the silent-corruption surface is specifically the auto-resolved default-engine path.
- LLVM JIT (`--run-llvm`) has its own numeric-only arg parser path that wasn't part of the regression and didn't get the new guard. Worth a follow-up if anyone is using it.