### PR TITLE
lexer: skip blank lines inside indented function bodies

### DIFF
--- a/examples/blank-line-in-fn-body.ilo
+++ b/examples/blank-line-in-fn-body.ilo
@@ -1,0 +1,16 @@
+-- Blank lines inside an indented function body are treated as continuation,
+-- not declaration boundary. Paragraph-separated multi-line bodies parse
+-- cleanly across every engine. Before this fix, the blank line below would
+-- emit a literal `\n` mid-body, the parser would see the next statement as
+-- a new top-level declaration, and bail with ILO-P009 plus a cascade of
+-- misleading T002/T004 errors.
+sum-with-blanks>n;
+  x=10;
+
+  y=20;
+
+  z=12;
+  +x +y z
+
+-- run: sum-with-blanks
+-- out: 42

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -306,6 +306,33 @@ pub fn normalize_newlines_with_map(source: &str) -> (String, Vec<u32>) {
                 }
                 continue;
             }
+            // Skip blank lines (lines that are empty or whitespace-only)
+            // before deciding declaration-boundary vs continuation. Without
+            // this, a blank line between two indented statements inside a
+            // function body emits a literal `\n` that the parser interprets
+            // as a top-level declaration boundary, breaking parsing with a
+            // misleading ILO-P009 cascade. Scan ahead through any run of
+            // whitespace-only lines; the *next* non-blank line's indentation
+            // is what determines whether this `\n` boundary continues the
+            // current block or starts a new declaration.
+            loop {
+                let mut probe = iter.clone();
+                // Skip whitespace on the current candidate "next" line.
+                while matches!(probe.peek().map(|(_, ch)| *ch), Some(' ') | Some('\t')) {
+                    probe.next();
+                }
+                // If the line is empty (immediate `\n`), consume the
+                // whitespace + the trailing `\n` from the real iterator
+                // and continue scanning. Otherwise stop.
+                if probe.peek().map(|(_, ch)| *ch) == Some('\n') {
+                    while matches!(iter.peek().map(|(_, ch)| *ch), Some(' ') | Some('\t')) {
+                        iter.next();
+                    }
+                    iter.next(); // consume the trailing `\n`
+                } else {
+                    break;
+                }
+            }
             // Check if next line is indented (starts with space or tab)
             if matches!(iter.peek().map(|(_, ch)| *ch), Some(' ') | Some('\t')) {
                 // Peek past indent at the first real char on the next line
@@ -1960,6 +1987,121 @@ mod tests {
             tokens.iter().any(|(t, _)| matches!(t, Token::OptType)),
             "expected OptType in tokens: {:?}",
             tokens
+        );
+    }
+
+    // --- blank-line continuation tests (nlp-engineer rerun7 P0) ---
+    //
+    // A blank line between indented statements inside a function body must
+    // be treated as a continuation, not a declaration boundary. Without the
+    // fix, a literal `\n` is emitted mid-body and the parser interprets the
+    // next indented statement as a new top-level declaration, producing a
+    // misleading ILO-P009 / T002 / T004 cascade.
+
+    #[test]
+    fn normalize_blank_line_between_indented_statements_is_continuation() {
+        let src = "main>n;\n  x=42;\n\n  prnt x;\n  0\n";
+        let got = normalize_newlines(src);
+        // Must NOT contain a `\n` mid-body — that would be a declaration
+        // boundary. All statements collapse to a single `main>n;...` line.
+        assert!(
+            !got.trim_end_matches('\n').contains('\n'),
+            "blank line should not produce mid-body newline: {:?}",
+            got
+        );
+        assert_eq!(got, "main>n;x=42;prnt x;0\n");
+    }
+
+    #[test]
+    fn normalize_multiple_consecutive_blank_lines_collapse() {
+        let src = "main>n;\n  x=42;\n\n\n\n  prnt x;\n  0\n";
+        let got = normalize_newlines(src);
+        assert_eq!(got, "main>n;x=42;prnt x;0\n");
+    }
+
+    #[test]
+    fn normalize_blank_line_with_trailing_whitespace_is_continuation() {
+        // Blank lines that contain only spaces/tabs must also be treated
+        // as continuation, not declaration boundary.
+        let src = "main>n;\n  x=42;\n   \n\t\n  prnt x;\n  0\n";
+        let got = normalize_newlines(src);
+        assert_eq!(got, "main>n;x=42;prnt x;0\n");
+    }
+
+    #[test]
+    fn normalize_blank_line_before_non_indented_keeps_decl_boundary() {
+        // Blank line followed by a NON-indented line is still a declaration
+        // boundary (the blank lines just separate top-level declarations).
+        let src = "f>n;1\n\ng>n;2\n";
+        let got = normalize_newlines(src);
+        assert!(
+            got.contains('\n'),
+            "blank line before top-level decl must keep newline: {:?}",
+            got
+        );
+        // The two declarations must end up separated by a single `\n`.
+        assert_eq!(got, "f>n;1\ng>n;2\n");
+    }
+
+    #[test]
+    fn normalize_blank_lines_at_start_of_function_body() {
+        // Blank line *immediately* after the function header, before the
+        // first indented statement, must be tolerated.
+        let src = "main>n;\n\n  x=42;\n  prnt x;\n  0\n";
+        let got = normalize_newlines(src);
+        assert_eq!(got, "main>n;x=42;prnt x;0\n");
+    }
+
+    #[test]
+    fn normalize_trailing_blank_lines_at_eof() {
+        // Trailing blank lines must not crash and must not corrupt the
+        // final declaration boundary.
+        let src = "main>n;\n  x=42;\n  0\n\n\n";
+        let got = normalize_newlines(src);
+        assert!(got.starts_with("main>n;x=42;0"));
+    }
+
+    #[test]
+    fn normalize_prnt_fmt_then_blank_line_parses() {
+        // The exact nlp-engineer rerun7 repro shape: `prnt fmt "tmpl" arg;`
+        // followed by a blank line and another statement. The variadic
+        // arg-list must NOT swallow tokens across the blank line.
+        let src = "main>n;\n  x=42;\n  prnt fmt \"x={}\" x;\n\n  y=99;\n  prnt y;\n  0\n";
+        let got = normalize_newlines(src);
+        assert!(
+            !got.trim_end_matches('\n').contains('\n'),
+            "prnt fmt + blank line + next stmt must collapse: {:?}",
+            got
+        );
+        // End-to-end parse + lex sanity check on the same shape.
+        let tokens = lex(src).unwrap();
+        assert!(!tokens.is_empty(), "lex must produce tokens");
+    }
+
+    #[test]
+    fn normalize_blank_line_offset_map_preserves_span_fidelity() {
+        // Span integrity: an error on a line that comes *after* a blank
+        // line must remap to its original-source byte offset, not to
+        // wherever the normalized rewrite landed. Without a faithful map,
+        // ILO-P009 (and any other diagnostic emitted on post-blank lines)
+        // would anchor at the wrong column.
+        let src = "main>n;\n  x=42;\n\n  y=99;\n  prnt y;\n  0\n";
+        let (normalized, map) = normalize_newlines_with_map(src);
+        // The sentinel +1 byte at the end of map covers one-past-end.
+        assert_eq!(map.len(), normalized.len() + 1);
+        // Every map entry must point inside the original source.
+        let src_len = src.len() as u32;
+        for &off in &map {
+            assert!(off <= src_len, "map offset {} > src.len() {}", off, src_len);
+        }
+        // The first `y` in the normalized output must remap to the `y` on
+        // line 4 of the original source (after the blank line on line 3).
+        let y_pos_normalized = normalized.find("y=99").expect("y=99 in normalized");
+        let y_pos_original = map[y_pos_normalized] as usize;
+        assert_eq!(
+            &src[y_pos_original..y_pos_original + 4],
+            "y=99",
+            "span remap landed at wrong original byte"
         );
     }
 }


### PR DESCRIPTION
## Summary

A blank line between two indented statements inside a function body broke parsing with `ILO-P009 expected expression, got Semi` plus a cascade of T002 duplicate-fn / T004 undefined-variable noise that looked exactly like the #326 inline-lambda type-var bug it isn't. nlp-engineer rerun7 lost 15 minutes investigating the wrong code region; the persona report calls this "actively dangerous" because the headline error points the agent at lambdas while the actual root cause was a `prnt fmt` line several statements upstream.

Investigation surfaced a broader bug than the persona thought: **any** blank line inside a fn body breaks parsing, not just `prnt fmt`. And it's latent since v0.11.0, not a v0.11.5→v0.11.6 regression. The PMI script was just the first persona to write paragraph-separated multi-line bodies at scale.

Manifesto frame: every persona naturally writes paragraph-separated readable code. Stripping blank lines is the kind of cosmetic-friction-becomes-real-tax pattern the manifesto warns about. Closing this trap is a release-blocker for any program over ~15 lines.

## Repro before/after

```
main>n;
  x=42;
  prnt fmt "x={}" x;

  y=99;
  prnt y;
  0
```

Before: `{"code":"ILO-P009","message":"expected expression, got Semi", ...}` at line 4.
After: `x=42\n99\n0`.

The full nlp-engineer rerun7 PMI script (`/tmp/ilo-persona-nlp-engineer-rerun7/main.ilo`, 67 lines, 8 paragraph separators) now runs end-to-end in 1.4s on Cranelift, output linguistically correct (`moby dick` PMI 7.85, `sperm whale` 4.88).

## What's in the diff

- **lexer: skip blank lines inside indented function bodies** — `normalize_newlines_with_map` now scans ahead past consecutive blank lines (whitespace-only + `\n`) before deciding declaration-boundary vs continuation. The next non-blank line's indentation is what determines the call. Span fidelity preserved; #318's anchoring win on dangling-token diagnostics is unaffected. 8 new unit tests cover paragraph-separated bodies, multiple consecutive blanks, blanks with trailing whitespace, blank at start of body, trailing blank at EOF, the exact `prnt fmt` repro shape, the top-level-decl-boundary case that must NOT regress, and explicit byte-offset-map preservation.
- **examples: blank-line continuation across every engine** — `examples/blank-line-in-fn-body.ilo` exercises the fix through `examples_engines` (tree + VM + Cranelift parity).

## Test plan

- [x] `cargo test --release --features cranelift --lib` — 3134 passed / 0 failed
- [x] `cargo test --release --features cranelift` (all suites) — 0 failures
- [x] `cargo test --release --features cranelift --test examples_engines` — new example green on tree, VM, Cranelift
- [x] `cargo clippy --release --features cranelift --lib -- -W clippy::all` — clean
- [x] nlp-engineer rerun7 artifact (`/tmp/ilo-persona-nlp-engineer-rerun7/main.ilo`) runs end-to-end with correct PMI output
- [x] Existing top-level declaration boundary case (`f>n;1\n\ng>n;2\n`) still emits a `\n` between declarations
- [x] Span fidelity test: error byte offsets on post-blank-line tokens remap to correct original-source bytes
- [x] Bracket-depth short-circuit unaffected: blank lines inside `(...)` / `[...]` still go through the early-return whitespace path

## Follow-ups

None. This is a behaviour-restoration fix; no new syntax, no new keyword, no CLI change, no doc updates required.