### PR TITLE
chore: bump version to 0.11.7

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ilo",
       "source": "./",
       "description": "Write, run, debug, and explain programs in ilo — a token-optimised programming language for AI agents",
-      "version": "0.11.6",
+      "version": "0.11.7",
       "author": {
         "name": "Daniel Morris"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ilo",
   "description": "Write, run, debug, and explain programs in ilo — a token-optimised programming language for AI agents",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "author": {
     "name": "Daniel Morris"
   },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "ilo"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ilo"
-version = "0.11.6"
+version = "0.11.7"
 edition = "2024"
 rust-version = "1.85"
 description = "ilo — a programming language for AI agents"


### PR DESCRIPTION
## Summary

v0.11.7 ships five rerun7 fixes:

- [#341](https://github.com/ilo-lang/ilo/pull/341) engine flags auto-pick `main` on non-ident positionals
- [#343](https://github.com/ilo-lang/ilo/pull/343) reserved namespaces forecast + 3+ char convention for new builtins
- [#344](https://github.com/ilo-lang/ilo/pull/344) CLI arg-arity silent corruption P0 (interactive-cli)
- [#345](https://github.com/ilo-lang/ilo/pull/345) blank line in fn body breaks parsing (nlp-engineer)
- [#346](https://github.com/ilo-lang/ilo/pull/346) fused len(flt p xs) + nested-closure inline Phase 1+2 — bio canonical 10.16s -> 8.5s (-16.3%); 5.6s gate not closed yet

## Test plan

- [x] cargo build --release --features cranelift
- [x] cargo install --path . --features cranelift --force
- [x] ilo --version reports 0.11.7