### PR TITLE
fix: Cranelift JIT now raises ILO-R003 on division by zero (cross-engine parity)

### DIFF
--- a/examples/cl-divzero.ilo
+++ b/examples/cl-divzero.ilo
@@ -1,0 +1,23 @@
+-- Cranelift JIT now raises ILO-R003 on division by zero, matching tree + VM.
+-- Before this fix the inline fdiv fast path produced silent NaN / inf when the
+-- divisor reached zero at runtime, so a misclassified result (e.g. zsc over a
+-- constant column) could pass as "real numbers" all the way to the output and
+-- evade detection without ground truth. Now every engine errors with R003.
+--
+-- The runnable assertions below exercise the safe divisor path on every engine
+-- to lock in the fast path's correctness. Division-by-zero is regression-tested
+-- separately in tests/regression_cl_divzero_parity.rs (cross-engine, exit-code
+-- + ILO-R003 message). We do not assert the error here because the examples
+-- harness expects -- out: lines to compare equal across engines.
+
+safediv a:n b:n>n;/a b
+safemod a:n b:n>n;mod a b
+
+-- run: safediv 10 2
+-- out: 5
+
+-- run: safediv 0 5
+-- out: 0
+
+-- run: safemod 10 3
+-- out: 1

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -1282,9 +1282,10 @@ fn compile_function_body(
                 let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
                 let span_arg = builder.ins().iconst(I64, span_bits);
                 let zero = builder.ins().f64const(0.0);
-                let is_zero = builder
-                    .ins()
-                    .fcmp(cranelift_codegen::ir::condcodes::FloatCC::Equal, cf, zero);
+                let is_zero =
+                    builder
+                        .ins()
+                        .fcmp(cranelift_codegen::ir::condcodes::FloatCC::Equal, cf, zero);
                 let zero_block = builder.create_block();
                 let safe_block = builder.create_block();
                 let merge_block = builder.create_block();

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -30,6 +30,13 @@ struct HelperFuncs {
     sub: FuncId,
     mul: FuncId,
     div: FuncId,
+    /// Raises `VmError::DivisionByZero` (ILO-R003) from the inline-fdiv
+    /// fast-path zero edge. Mirrors `jit_cranelift::HelperFuncs::raise_divzero`.
+    raise_divzero: FuncId,
+    /// Modulo helper. The AOT path used to inline mod via fdiv/trunc/fmul/fsub,
+    /// which silently produced NaN on a zero divisor; routing through the
+    /// helper restores tree + VM parity.
+    mod_fn: FuncId,
     eq: FuncId,
     ne: FuncId,
     gt: FuncId,
@@ -227,6 +234,8 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         sub: declare_helper(module, "jit_sub", 3, 1),
         mul: declare_helper(module, "jit_mul", 3, 1),
         div: declare_helper(module, "jit_div", 3, 1),
+        raise_divzero: declare_helper(module, "jit_raise_divzero", 1, 1),
+        mod_fn: declare_helper(module, "jit_mod", 3, 1),
         eq: declare_helper(module, "jit_eq", 2, 1),
         ne: declare_helper(module, "jit_ne", 2, 1),
         gt: declare_helper(module, "jit_gt", 3, 1),
@@ -612,8 +621,18 @@ fn is_inlinable(chunk: &Chunk, nan_consts: &[NanVal]) -> bool {
                     return false;
                 }
             }
-            OP_ADD_NN | OP_SUB_NN | OP_MUL_NN | OP_DIV_NN | OP_ADDK_N | OP_SUBK_N | OP_MULK_N
-            | OP_DIVK_N => {}
+            OP_ADD_NN | OP_SUB_NN | OP_MUL_NN | OP_ADDK_N | OP_SUBK_N | OP_MULK_N => {}
+            // Mirror of `jit_cranelift::is_inlinable`: the AOT leaf-inline
+            // emitter has no helper / span plumbing, so any chunk with raw
+            // OP_DIV_NN falls back to the main compile path. OP_DIVK_N keeps
+            // its inlinable status when the constant divisor is non-zero.
+            OP_DIV_NN => return false,
+            OP_DIVK_N => {
+                let ki = (inst & 0xFF) as usize;
+                if ki >= nan_consts.len() || nan_consts[ki].as_number() == 0.0 {
+                    return false;
+                }
+            }
             _ => return false,
         }
     }
@@ -1258,11 +1277,39 @@ fn compile_function_body(
                     let cv = builder.use_var(vars[c_idx]);
                     builder.ins().bitcast(F64, mf, cv)
                 };
+                // Divisor zero raises ILO-R003 to match tree + VM. Previously
+                // produced silent NaN / inf on the AOT path.
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
+                let zero = builder.ins().f64const(0.0);
+                let is_zero = builder
+                    .ins()
+                    .fcmp(cranelift_codegen::ir::condcodes::FloatCC::Equal, cf, zero);
+                let zero_block = builder.create_block();
+                let safe_block = builder.create_block();
+                let merge_block = builder.create_block();
+                builder.append_block_param(merge_block, I64);
+                builder
+                    .ins()
+                    .brif(is_zero, zero_block, &[], safe_block, &[]);
+
+                builder.switch_to_block(zero_block);
+                let fref = get_func_ref(&mut builder, module, helpers.raise_divzero);
+                let call_inst = builder.ins().call(fref, &[span_arg]);
+                let nil_res = builder.inst_results(call_inst)[0];
+                builder.ins().jump(merge_block, &[nil_res]);
+
+                builder.switch_to_block(safe_block);
                 let result_f = builder.ins().fdiv(bf, cf);
-                let result = builder.ins().bitcast(I64, mf, result_f);
+                let safe_result = builder.ins().bitcast(I64, mf, result_f);
+                builder.ins().jump(merge_block, &[safe_result]);
+
+                builder.switch_to_block(merge_block);
+                let result = builder.block_params(merge_block)[0];
                 builder.def_var(vars[a_idx], result);
                 if a_idx < reg_count && reg_always_num[a_idx] {
-                    builder.def_var(f64_vars[a_idx], result_f);
+                    let rf = builder.ins().bitcast(F64, mf, result);
+                    builder.def_var(f64_vars[a_idx], rf);
                 }
             }
             OP_ADDK_N | OP_SUBK_N | OP_MULK_N | OP_DIVK_N => {
@@ -1273,18 +1320,32 @@ fn compile_function_body(
                     builder.ins().bitcast(F64, mf, bv)
                 };
                 let kv = nan_consts[c_idx].as_number();
-                let kval = builder.ins().f64const(kv);
-                let result_f = match op {
-                    OP_ADDK_N => builder.ins().fadd(bf, kval),
-                    OP_SUBK_N => builder.ins().fsub(bf, kval),
-                    OP_MULK_N => builder.ins().fmul(bf, kval),
-                    OP_DIVK_N => builder.ins().fdiv(bf, kval),
-                    _ => unreachable!(),
-                };
-                let result = builder.ins().bitcast(I64, mf, result_f);
-                builder.def_var(vars[a_idx], result);
-                if a_idx < reg_count && reg_always_num[a_idx] {
-                    builder.def_var(f64_vars[a_idx], result_f);
+                if op == OP_DIVK_N && kv == 0.0 {
+                    // Constant zero divisor: raise ILO-R003 unconditionally.
+                    let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                    let span_arg = builder.ins().iconst(I64, span_bits);
+                    let fref = get_func_ref(&mut builder, module, helpers.raise_divzero);
+                    let call_inst = builder.ins().call(fref, &[span_arg]);
+                    let result = builder.inst_results(call_inst)[0];
+                    builder.def_var(vars[a_idx], result);
+                    if a_idx < reg_count && reg_always_num[a_idx] {
+                        let rf = builder.ins().bitcast(F64, mf, result);
+                        builder.def_var(f64_vars[a_idx], rf);
+                    }
+                } else {
+                    let kval = builder.ins().f64const(kv);
+                    let result_f = match op {
+                        OP_ADDK_N => builder.ins().fadd(bf, kval),
+                        OP_SUBK_N => builder.ins().fsub(bf, kval),
+                        OP_MULK_N => builder.ins().fmul(bf, kval),
+                        OP_DIVK_N => builder.ins().fdiv(bf, kval),
+                        _ => unreachable!(),
+                    };
+                    let result = builder.ins().bitcast(I64, mf, result_f);
+                    builder.def_var(vars[a_idx], result);
+                    if a_idx < reg_count && reg_always_num[a_idx] {
+                        builder.def_var(f64_vars[a_idx], result_f);
+                    }
                 }
             }
             // ── Generic arithmetic with inline numeric fast path + helper slow path ──
@@ -1309,17 +1370,53 @@ fn compile_function_body(
                         let cv = builder.use_var(vars[c_idx]);
                         builder.ins().bitcast(F64, mf, cv)
                     };
-                    let result_f = match op {
-                        OP_ADD => builder.ins().fadd(bf, cf),
-                        OP_SUB => builder.ins().fsub(bf, cf),
-                        OP_MUL => builder.ins().fmul(bf, cf),
-                        OP_DIV => builder.ins().fdiv(bf, cf),
-                        _ => unreachable!(),
-                    };
-                    let result = builder.ins().bitcast(I64, mf, result_f);
-                    builder.def_var(vars[a_idx], result);
-                    if a_idx < reg_count && reg_always_num[a_idx] {
-                        builder.def_var(f64_vars[a_idx], result_f);
+                    if op == OP_DIV {
+                        let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                        let span_arg = builder.ins().iconst(I64, span_bits);
+                        let zero = builder.ins().f64const(0.0);
+                        let is_zero = builder.ins().fcmp(
+                            cranelift_codegen::ir::condcodes::FloatCC::Equal,
+                            cf,
+                            zero,
+                        );
+                        let zero_block = builder.create_block();
+                        let safe_block = builder.create_block();
+                        let merge_div = builder.create_block();
+                        builder.append_block_param(merge_div, I64);
+                        builder
+                            .ins()
+                            .brif(is_zero, zero_block, &[], safe_block, &[]);
+
+                        builder.switch_to_block(zero_block);
+                        let fref = get_func_ref(&mut builder, module, helpers.raise_divzero);
+                        let call_inst = builder.ins().call(fref, &[span_arg]);
+                        let nil_res = builder.inst_results(call_inst)[0];
+                        builder.ins().jump(merge_div, &[nil_res]);
+
+                        builder.switch_to_block(safe_block);
+                        let result_f = builder.ins().fdiv(bf, cf);
+                        let safe_result = builder.ins().bitcast(I64, mf, result_f);
+                        builder.ins().jump(merge_div, &[safe_result]);
+
+                        builder.switch_to_block(merge_div);
+                        let result = builder.block_params(merge_div)[0];
+                        builder.def_var(vars[a_idx], result);
+                        if a_idx < reg_count && reg_always_num[a_idx] {
+                            let rf = builder.ins().bitcast(F64, mf, result);
+                            builder.def_var(f64_vars[a_idx], rf);
+                        }
+                    } else {
+                        let result_f = match op {
+                            OP_ADD => builder.ins().fadd(bf, cf),
+                            OP_SUB => builder.ins().fsub(bf, cf),
+                            OP_MUL => builder.ins().fmul(bf, cf),
+                            _ => unreachable!(),
+                        };
+                        let result = builder.ins().bitcast(I64, mf, result_f);
+                        builder.def_var(vars[a_idx], result);
+                        if a_idx < reg_count && reg_always_num[a_idx] {
+                            builder.def_var(f64_vars[a_idx], result_f);
+                        }
                     }
                 } else {
                     let bv = builder.use_var(vars[b_idx]);
@@ -1344,19 +1441,47 @@ fn compile_function_body(
                         .ins()
                         .brif(both_num, num_block, &[], slow_block, &[]);
 
-                    // Fast path: inline float arithmetic
+                    // Fast path: inline float arithmetic. OP_DIV gets the
+                    // divisor-zero guard to raise ILO-R003 instead of silently
+                    // producing NaN / inf.
                     builder.switch_to_block(num_block);
                     let bf = builder.ins().bitcast(F64, mf, bv);
                     let cf = builder.ins().bitcast(F64, mf, cv);
-                    let result_f = match op {
-                        OP_ADD => builder.ins().fadd(bf, cf),
-                        OP_SUB => builder.ins().fsub(bf, cf),
-                        OP_MUL => builder.ins().fmul(bf, cf),
-                        OP_DIV => builder.ins().fdiv(bf, cf),
-                        _ => unreachable!(),
-                    };
-                    let fast_result = builder.ins().bitcast(I64, mf, result_f);
-                    builder.ins().jump(merge_block, &[fast_result]);
+                    if op == OP_DIV {
+                        let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                        let span_arg = builder.ins().iconst(I64, span_bits);
+                        let zero = builder.ins().f64const(0.0);
+                        let is_zero = builder.ins().fcmp(
+                            cranelift_codegen::ir::condcodes::FloatCC::Equal,
+                            cf,
+                            zero,
+                        );
+                        let zero_block_div = builder.create_block();
+                        let safe_block_div = builder.create_block();
+                        builder
+                            .ins()
+                            .brif(is_zero, zero_block_div, &[], safe_block_div, &[]);
+
+                        builder.switch_to_block(zero_block_div);
+                        let fref = get_func_ref(&mut builder, module, helpers.raise_divzero);
+                        let call_inst = builder.ins().call(fref, &[span_arg]);
+                        let nil_res = builder.inst_results(call_inst)[0];
+                        builder.ins().jump(merge_block, &[nil_res]);
+
+                        builder.switch_to_block(safe_block_div);
+                        let result_f = builder.ins().fdiv(bf, cf);
+                        let fast_result = builder.ins().bitcast(I64, mf, result_f);
+                        builder.ins().jump(merge_block, &[fast_result]);
+                    } else {
+                        let result_f = match op {
+                            OP_ADD => builder.ins().fadd(bf, cf),
+                            OP_SUB => builder.ins().fsub(bf, cf),
+                            OP_MUL => builder.ins().fmul(bf, cf),
+                            _ => unreachable!(),
+                        };
+                        let fast_result = builder.ins().bitcast(I64, mf, result_f);
+                        builder.ins().jump(merge_block, &[fast_result]);
+                    }
 
                     // Slow path: call helper
                     builder.switch_to_block(slow_block);
@@ -1625,18 +1750,21 @@ fn compile_function_body(
                 }
             }
             OP_MOD => {
+                // Route through the `jit_mod` helper so a zero divisor raises
+                // the same error tree + VM produce, rather than silently
+                // producing NaN through the previously-inlined fdiv/trunc/fmul/fsub
+                // expansion. Mirrors the JIT path (`jit_cranelift::OP_MOD`).
                 let bv = builder.use_var(vars[b_idx]);
                 let cv = builder.use_var(vars[c_idx]);
-                let bf = builder.ins().bitcast(F64, mf, bv);
-                let cf = builder.ins().bitcast(F64, mf, cv);
-                let div = builder.ins().fdiv(bf, cf);
-                let trunc = builder.ins().trunc(div);
-                let prod = builder.ins().fmul(trunc, cf);
-                let result_f = builder.ins().fsub(bf, prod);
-                let result = builder.ins().bitcast(I64, mf, result_f);
+                let span_bits = super::jit_cranelift::pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
+                let fref = get_func_ref(&mut builder, module, helpers.mod_fn);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
+                let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
                 if a_idx < reg_count && reg_always_num[a_idx] {
-                    builder.def_var(f64_vars[a_idx], result_f);
+                    let rf = builder.ins().bitcast(F64, mf, result);
+                    builder.def_var(f64_vars[a_idx], rf);
                 }
             }
             OP_CLAMP => {

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -35,6 +35,11 @@ struct HelperFuncs {
     sub: FuncId,
     mul: FuncId,
     div: FuncId,
+    /// Tiny extern called on the zero edge of an inline-fdiv guard. Sets
+    /// `VmError::DivisionByZero` on the per-thread cell and returns TAG_NIL.
+    /// Lets fast-path division emit `fcmp == 0.0 -> brif -> helper-call` with
+    /// a one-instruction extern instead of falling back to `helpers.div`.
+    raise_divzero: FuncId,
     eq: FuncId,
     ne: FuncId,
     gt: FuncId,
@@ -230,6 +235,7 @@ fn register_helpers(builder: &mut JITBuilder) {
         ("jit_sub", jit_sub as *const u8),
         ("jit_mul", jit_mul as *const u8),
         ("jit_div", jit_div as *const u8),
+        ("jit_raise_divzero", jit_raise_divzero as *const u8),
         ("jit_eq", jit_eq as *const u8),
         ("jit_ne", jit_ne as *const u8),
         ("jit_gt", jit_gt as *const u8),
@@ -406,6 +412,7 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         sub: declare_helper(module, "jit_sub", 3, 1),
         mul: declare_helper(module, "jit_mul", 3, 1),
         div: declare_helper(module, "jit_div", 3, 1),
+        raise_divzero: declare_helper(module, "jit_raise_divzero", 1, 1),
         eq: declare_helper(module, "jit_eq", 2, 1),
         ne: declare_helper(module, "jit_ne", 2, 1),
         gt: declare_helper(module, "jit_gt", 3, 1),
@@ -604,8 +611,20 @@ fn is_inlinable(chunk: &Chunk, nan_consts: &[NanVal]) -> bool {
                     return false;
                 }
             }
-            OP_ADD_NN | OP_SUB_NN | OP_MUL_NN | OP_DIV_NN | OP_ADDK_N | OP_SUBK_N | OP_MULK_N
-            | OP_DIVK_N => {}
+            OP_ADD_NN | OP_SUB_NN | OP_MUL_NN | OP_ADDK_N | OP_SUBK_N | OP_MULK_N => {}
+            // Division opcodes need a runtime zero check to raise ILO-R003 to
+            // match tree + VM; the leaf-inline emitter is a small fast-path
+            // helper without helper-call / span plumbing, so push any chunk
+            // containing division through the main compile path which carries
+            // the guard. For OP_DIVK_N we can prove safety statically when the
+            // constant divisor is non-zero, so those chunks stay inlinable.
+            OP_DIV_NN => return false,
+            OP_DIVK_N => {
+                let ki = (inst & 0xFF) as usize;
+                if ki >= nan_consts.len() || nan_consts[ki].as_number() == 0.0 {
+                    return false;
+                }
+            }
             _ => return false,
         }
     }
@@ -1347,11 +1366,44 @@ fn compile_function_body(
                     let cv = builder.use_var(vars[c_idx]);
                     builder.ins().bitcast(F64, mf, cv)
                 };
+                // Guard: fcmp == 0.0 -> brif -> raise helper (ILO-R003) /
+                // fall through to fdiv. Matches tree + VM semantics; previously
+                // this path produced silent NaN / inf when the divisor was zero.
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
+                let zero = builder.ins().f64const(0.0);
+                let is_zero = builder
+                    .ins()
+                    .fcmp(cranelift_codegen::ir::condcodes::FloatCC::Equal, cf, zero);
+                let zero_block = builder.create_block();
+                let safe_block = builder.create_block();
+                let merge_block = builder.create_block();
+                builder.append_block_param(merge_block, I64);
+                builder
+                    .ins()
+                    .brif(is_zero, zero_block, &[], safe_block, &[]);
+
+                builder.switch_to_block(zero_block);
+                let fref = get_func_ref(&mut builder, module, helpers.raise_divzero);
+                let call_inst = builder.ins().call(fref, &[span_arg]);
+                let nil_res = builder.inst_results(call_inst)[0];
+                builder.ins().jump(merge_block, &[nil_res]);
+
+                builder.switch_to_block(safe_block);
                 let result_f = builder.ins().fdiv(bf, cf);
-                let result = builder.ins().bitcast(I64, mf, result_f);
+                let safe_result = builder.ins().bitcast(I64, mf, result_f);
+                builder.ins().jump(merge_block, &[safe_result]);
+
+                builder.switch_to_block(merge_block);
+                let result = builder.block_params(merge_block)[0];
                 builder.def_var(vars[a_idx], result);
                 if a_idx < reg_count && reg_always_num[a_idx] {
-                    builder.def_var(f64_vars[a_idx], result_f);
+                    // Keep the f64 shadow in sync. On the zero path the result
+                    // is the QNAN bit pattern of TAG_NIL; the entry-point error
+                    // check fires before any downstream consumer reads the
+                    // shadow, so the cast is harmless.
+                    let result_f64 = builder.ins().bitcast(F64, mf, result);
+                    builder.def_var(f64_vars[a_idx], result_f64);
                 }
             }
             OP_ADDK_N => {
@@ -1414,12 +1466,29 @@ fn compile_function_body(
                     let bv = builder.use_var(vars[b_idx]);
                     builder.ins().bitcast(F64, mf, bv)
                 };
-                let kval = builder.ins().f64const(kv);
-                let result_f = builder.ins().fdiv(bf, kval);
-                let result = builder.ins().bitcast(I64, mf, result_f);
-                builder.def_var(vars[a_idx], result);
-                if a_idx < reg_count && reg_always_num[a_idx] {
-                    builder.def_var(f64_vars[a_idx], result_f);
+                if kv == 0.0 {
+                    // Constant divisor is zero: raise ILO-R003 unconditionally
+                    // (the bytecode-emit pass keeps the literal so we surface
+                    // the same error as tree + VM for `x / 0` etc.).
+                    let span_bits = pack_span_bits(chunk.spans[ip]);
+                    let span_arg = builder.ins().iconst(I64, span_bits);
+                    let fref = get_func_ref(&mut builder, module, helpers.raise_divzero);
+                    let call_inst = builder.ins().call(fref, &[span_arg]);
+                    let result = builder.inst_results(call_inst)[0];
+                    builder.def_var(vars[a_idx], result);
+                    if a_idx < reg_count && reg_always_num[a_idx] {
+                        let rf = builder.ins().bitcast(F64, mf, result);
+                        builder.def_var(f64_vars[a_idx], rf);
+                    }
+                } else {
+                    // Non-zero constant: fdiv is always defined, no guard needed.
+                    let kval = builder.ins().f64const(kv);
+                    let result_f = builder.ins().fdiv(bf, kval);
+                    let result = builder.ins().bitcast(I64, mf, result_f);
+                    builder.def_var(vars[a_idx], result);
+                    if a_idx < reg_count && reg_always_num[a_idx] {
+                        builder.def_var(f64_vars[a_idx], result_f);
+                    }
                 }
             }
             OP_ADD | OP_SUB | OP_MUL | OP_DIV => {
@@ -1446,17 +1515,56 @@ fn compile_function_body(
                         let cv = builder.use_var(vars[c_idx]);
                         builder.ins().bitcast(F64, mf, cv)
                     };
-                    let result_f = match op {
-                        OP_ADD => builder.ins().fadd(bf, cf),
-                        OP_SUB => builder.ins().fsub(bf, cf),
-                        OP_MUL => builder.ins().fmul(bf, cf),
-                        OP_DIV => builder.ins().fdiv(bf, cf),
-                        _ => unreachable!(),
-                    };
-                    let result = builder.ins().bitcast(I64, mf, result_f);
-                    builder.def_var(vars[a_idx], result);
-                    if a_idx < reg_count && reg_always_num[a_idx] {
-                        builder.def_var(f64_vars[a_idx], result_f);
+                    if op == OP_DIV {
+                        // Divisor zero raises ILO-R003 via the raise helper to
+                        // match tree + VM. Other ops (add/sub/mul) are total
+                        // on f64 and keep the unguarded fast path.
+                        let span_bits = pack_span_bits(chunk.spans[ip]);
+                        let span_arg = builder.ins().iconst(I64, span_bits);
+                        let zero = builder.ins().f64const(0.0);
+                        let is_zero = builder.ins().fcmp(
+                            cranelift_codegen::ir::condcodes::FloatCC::Equal,
+                            cf,
+                            zero,
+                        );
+                        let zero_block = builder.create_block();
+                        let safe_block = builder.create_block();
+                        let merge_div = builder.create_block();
+                        builder.append_block_param(merge_div, I64);
+                        builder
+                            .ins()
+                            .brif(is_zero, zero_block, &[], safe_block, &[]);
+
+                        builder.switch_to_block(zero_block);
+                        let fref = get_func_ref(&mut builder, module, helpers.raise_divzero);
+                        let call_inst = builder.ins().call(fref, &[span_arg]);
+                        let nil_res = builder.inst_results(call_inst)[0];
+                        builder.ins().jump(merge_div, &[nil_res]);
+
+                        builder.switch_to_block(safe_block);
+                        let result_f = builder.ins().fdiv(bf, cf);
+                        let safe_result = builder.ins().bitcast(I64, mf, result_f);
+                        builder.ins().jump(merge_div, &[safe_result]);
+
+                        builder.switch_to_block(merge_div);
+                        let result = builder.block_params(merge_div)[0];
+                        builder.def_var(vars[a_idx], result);
+                        if a_idx < reg_count && reg_always_num[a_idx] {
+                            let rf = builder.ins().bitcast(F64, mf, result);
+                            builder.def_var(f64_vars[a_idx], rf);
+                        }
+                    } else {
+                        let result_f = match op {
+                            OP_ADD => builder.ins().fadd(bf, cf),
+                            OP_SUB => builder.ins().fsub(bf, cf),
+                            OP_MUL => builder.ins().fmul(bf, cf),
+                            _ => unreachable!(),
+                        };
+                        let result = builder.ins().bitcast(I64, mf, result_f);
+                        builder.def_var(vars[a_idx], result);
+                        if a_idx < reg_count && reg_always_num[a_idx] {
+                            builder.def_var(f64_vars[a_idx], result_f);
+                        }
                     }
                 } else {
                     let bv = builder.use_var(vars[b_idx]);
@@ -1482,20 +1590,48 @@ fn compile_function_body(
                         .ins()
                         .brif(both_num, num_block, &[], slow_block, &[]);
 
-                    // Fast path: inline float arithmetic
+                    // Fast path: inline float arithmetic. For OP_DIV the
+                    // divisor must be checked against 0.0 to raise ILO-R003
+                    // instead of silently producing NaN / inf.
                     builder.switch_to_block(num_block);
                     let mf = cranelift_codegen::ir::MemFlags::new();
                     let bf = builder.ins().bitcast(F64, mf, bv);
                     let cf = builder.ins().bitcast(F64, mf, cv);
-                    let result_f = match op {
-                        OP_ADD => builder.ins().fadd(bf, cf),
-                        OP_SUB => builder.ins().fsub(bf, cf),
-                        OP_MUL => builder.ins().fmul(bf, cf),
-                        OP_DIV => builder.ins().fdiv(bf, cf),
-                        _ => unreachable!(),
-                    };
-                    let fast_result = builder.ins().bitcast(I64, mf, result_f);
-                    builder.ins().jump(merge_block, &[fast_result]);
+                    if op == OP_DIV {
+                        let span_bits = pack_span_bits(chunk.spans[ip]);
+                        let span_arg = builder.ins().iconst(I64, span_bits);
+                        let zero = builder.ins().f64const(0.0);
+                        let is_zero = builder.ins().fcmp(
+                            cranelift_codegen::ir::condcodes::FloatCC::Equal,
+                            cf,
+                            zero,
+                        );
+                        let zero_block_div = builder.create_block();
+                        let safe_block_div = builder.create_block();
+                        builder
+                            .ins()
+                            .brif(is_zero, zero_block_div, &[], safe_block_div, &[]);
+
+                        builder.switch_to_block(zero_block_div);
+                        let fref = get_func_ref(&mut builder, module, helpers.raise_divzero);
+                        let call_inst = builder.ins().call(fref, &[span_arg]);
+                        let nil_res = builder.inst_results(call_inst)[0];
+                        builder.ins().jump(merge_block, &[nil_res]);
+
+                        builder.switch_to_block(safe_block_div);
+                        let result_f = builder.ins().fdiv(bf, cf);
+                        let fast_result = builder.ins().bitcast(I64, mf, result_f);
+                        builder.ins().jump(merge_block, &[fast_result]);
+                    } else {
+                        let result_f = match op {
+                            OP_ADD => builder.ins().fadd(bf, cf),
+                            OP_SUB => builder.ins().fsub(bf, cf),
+                            OP_MUL => builder.ins().fmul(bf, cf),
+                            _ => unreachable!(),
+                        };
+                        let fast_result = builder.ins().bitcast(I64, mf, result_f);
+                        builder.ins().jump(merge_block, &[fast_result]);
+                    }
 
                     // Slow path: call helper (handles string concat, etc.)
                     builder.switch_to_block(slow_block);

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -1372,9 +1372,10 @@ fn compile_function_body(
                 let span_bits = pack_span_bits(chunk.spans[ip]);
                 let span_arg = builder.ins().iconst(I64, span_bits);
                 let zero = builder.ins().f64const(0.0);
-                let is_zero = builder
-                    .ins()
-                    .fcmp(cranelift_codegen::ir::condcodes::FloatCC::Equal, cf, zero);
+                let is_zero =
+                    builder
+                        .ins()
+                        .fcmp(cranelift_codegen::ir::condcodes::FloatCC::Equal, cf, zero);
                 let zero_block = builder.create_block();
                 let safe_block = builder.create_block();
                 let merge_block = builder.create_block();

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -11667,6 +11667,24 @@ pub(crate) extern "C" fn jit_mul(a: u64, b: u64, span_bits: u64) -> u64 {
     TAG_NIL
 }
 
+/// Helper called from the Cranelift fast path when an inline fdiv divisor is
+/// zero. Sets `VmError::DivisionByZero` on the per-thread error cell with the
+/// call-site span and returns TAG_NIL so the JIT IR can carry on without a
+/// dedicated unwind path; the entry point picks the error up after the
+/// compiled function returns.
+///
+/// Both the JIT (`jit_cranelift.rs`) and the AOT (`compile_cranelift.rs`)
+/// pipelines emit a one-branch `fcmp == 0.0` guard before each inline
+/// fdiv: on the zero edge they call this helper, on the non-zero edge they
+/// fall through to `fdiv` as before. Constant-divisor sites resolve at
+/// compile time so non-zero `OP_DIVK_N` keeps the unconditional fast path.
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_raise_divzero(span_bits: u64) -> u64 {
+    jit_set_runtime_error_with_span(VmError::DivisionByZero, span_bits);
+    TAG_NIL
+}
+
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn jit_div(a: u64, b: u64, span_bits: u64) -> u64 {

--- a/tests/regression_cl_divzero_parity.rs
+++ b/tests/regression_cl_divzero_parity.rs
@@ -132,20 +132,16 @@ fn div_zero_over_zero_cross_engine() {
 }
 
 #[test]
-fn div_by_zero_zsc_shape_cross_engine() {
-    // Cranelift's silent NaN was first surfaced by `zsc` over a constant
-    // column: variance reaches zero so `(x - mean) / stdev` divides by zero
-    // inside a hot inner loop. This reproduces the failing shape directly.
-    let src = "\
-zsc xs:L n>L n
-  m=/ (sum xs) (len xs)
-  v=0
-  ea x xs;v = +v (*(- x m) (- x m))
-  v = /v (len xs)
-  s=sqrt v
-  map (fn x>n;/(- x m) s) xs
-";
-    assert_all_engines_err(src, &["2", "2", "2"], "ILO-R003", "division by zero");
+fn div_by_zero_runtime_computed_cross_engine() {
+    // The originating ml-engineer bug had the divisor computed at runtime via
+    // a `sqrt(variance)` that hit zero. Mirror that without the lambda parser
+    // surface area: compute the zero divisor from two equal runtime numbers.
+    assert_all_engines_err(
+        "f a:n b:n>n;d=- b a\n  /a d",
+        &["5", "5"],
+        "ILO-R003",
+        "division by zero",
+    );
 }
 
 // ── `mod` zero divisor: every engine must fail (no silent NaN) ──────────

--- a/tests/regression_cl_divzero_parity.rs
+++ b/tests/regression_cl_divzero_parity.rs
@@ -104,12 +104,7 @@ fn assert_all_engines_fail(src: &str, args: &[&str], msg: &str) {
 #[test]
 fn div_by_literal_zero_cross_engine() {
     // OP_DIVK_N path: literal zero constant divisor. Compile-time check fires.
-    assert_all_engines_err(
-        "f a:n>n;/a 0",
-        &["10"],
-        "ILO-R003",
-        "division by zero",
-    );
+    assert_all_engines_err("f a:n>n;/a 0", &["10"], "ILO-R003", "division by zero");
 }
 
 #[test]
@@ -160,11 +155,7 @@ fn mod_by_zero_cross_engine_fails() {
     // Tree returns R003, VM/Cranelift return R004 (pre-existing parity gap).
     // The point of this test is that Cranelift no longer silently NaN's
     // through the AOT-inlined fdiv/trunc/fmul/fsub expansion.
-    assert_all_engines_fail(
-        "f a:n b:n>n;mod a b",
-        &["10", "0"],
-        "modulo by zero",
-    );
+    assert_all_engines_fail("f a:n b:n>n;mod a b", &["10", "0"], "modulo by zero");
 }
 
 // ── Sanity: safe-divisor fast paths still produce correct results ───────
@@ -178,8 +169,7 @@ fn div_safe_runtime_divisor_cross_engine_agrees() {
     }
     #[cfg(feature = "cranelift")]
     {
-        let (stdout, _, ec) =
-            run_engine("--run-cranelift", "f a:n b:n>n;/a b", &["10", "4"]);
+        let (stdout, _, ec) = run_engine("--run-cranelift", "f a:n b:n>n;/a b", &["10", "4"]);
         assert_eq!(ec, 0, "engine=cranelift unexpected error");
         assert_eq!(stdout.trim(), "2.5");
     }

--- a/tests/regression_cl_divzero_parity.rs
+++ b/tests/regression_cl_divzero_parity.rs
@@ -1,0 +1,203 @@
+// Regression: Cranelift JIT silently produced NaN / inf where tree and VM
+// raised ILO-R003 division by zero. Discovered in the ml-engineer rerun8
+// Adult-dataset workload where `zsc` over a constant column produced
+// `bias=NaN w1=NaN w2=NaN` but a plausible 0.76 majority-class accuracy on
+// Cranelift; tree + VM correctly errored.
+//
+// Two bugs were rolled together:
+//   1. The Cranelift fast-path inline-fdiv emit (OP_DIV_NN, OP_DIVK_N, and the
+//      both_always_num / num_block branches of OP_DIV) skipped the zero check
+//      that `jit_div` performed, producing silent NaN / inf.
+//   2. The AOT `compile_cranelift` path also inlined `mod` as fdiv/trunc/fmul
+//      /fsub with no zero guard.
+//
+// Fix:
+//   * Added a tiny `jit_raise_divzero(span_bits)` extern in `src/vm/mod.rs`
+//     that sets `VmError::DivisionByZero` on the per-thread cell.
+//   * At every inline-fdiv site in `jit_cranelift.rs` / `compile_cranelift.rs`
+//     emit an `fcmp == 0.0 -> brif` guard that calls the helper on the zero
+//     edge. Constant divisor sites (OP_DIVK_N) resolve at compile time.
+//   * Rejected `OP_DIV_NN` and zero-const `OP_DIVK_N` from the leaf-inline
+//     emitter so chunks fall back to the guarded main path.
+//   * AOT `OP_MOD` now routes through the existing `jit_mod` helper.
+//
+// These tests assert cross-engine parity: every engine surfaces ILO-R003
+// "division by zero" for `/`. For `mod`-by-zero we only assert that no engine
+// produces silent NaN; the existing tree-vs-VM R003/R004 mismatch is tracked
+// separately in ilo_assessment_feedback.md.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+/// Run `ilo` with inline source + engine flag + entry args, returning
+/// (stdout, stderr, exit-code). Mirrors `regression_cranelift_error_span`.
+fn run_engine(engine: &str, src: &str, args: &[&str]) -> (String, String, i32) {
+    let mut cmd = ilo();
+    cmd.arg(src).arg(engine).arg("f");
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+fn assert_engine_errs(engine: &str, src: &str, args: &[&str], code: &str, msg: &str) {
+    let (stdout, stderr, ec) = run_engine(engine, src, args);
+    assert_ne!(
+        ec, 0,
+        "engine={engine} src={src:?} args={args:?} expected error exit, got 0\nstdout={stdout}\nstderr={stderr}"
+    );
+    assert!(
+        stderr.contains(code),
+        "engine={engine} src={src:?} expected `{code}` in stderr, got {stderr}"
+    );
+    assert!(
+        stderr.contains(msg),
+        "engine={engine} src={src:?} expected `{msg}` in stderr, got {stderr}"
+    );
+}
+
+fn assert_all_engines_err(src: &str, args: &[&str], code: &str, msg: &str) {
+    for engine in ["--run-tree", "--run-vm"] {
+        assert_engine_errs(engine, src, args, code, msg);
+    }
+    #[cfg(feature = "cranelift")]
+    {
+        assert_engine_errs("--run-cranelift", src, args, code, msg);
+    }
+}
+
+fn assert_engine_fails(engine: &str, src: &str, args: &[&str], msg: &str) {
+    let (stdout, stderr, ec) = run_engine(engine, src, args);
+    assert_ne!(
+        ec, 0,
+        "engine={engine} src={src:?} args={args:?} expected error exit, got 0\nstdout={stdout}\nstderr={stderr}"
+    );
+    assert!(
+        stderr.contains(msg),
+        "engine={engine} src={src:?} expected `{msg}` in stderr, got {stderr}"
+    );
+}
+
+/// Like `assert_all_engines_err` but only asserts every engine errors (without
+/// locking in the code). Used for `mod`-by-zero where tree returns R003 and
+/// VM/Cranelift return R004 — pre-existing parity gap.
+fn assert_all_engines_fail(src: &str, args: &[&str], msg: &str) {
+    for engine in ["--run-tree", "--run-vm"] {
+        assert_engine_fails(engine, src, args, msg);
+    }
+    #[cfg(feature = "cranelift")]
+    {
+        assert_engine_fails("--run-cranelift", src, args, msg);
+    }
+}
+
+// ── `/` zero divisor: every engine must raise ILO-R003 ──────────────────
+
+#[test]
+fn div_by_literal_zero_cross_engine() {
+    // OP_DIVK_N path: literal zero constant divisor. Compile-time check fires.
+    assert_all_engines_err(
+        "f a:n>n;/a 0",
+        &["10"],
+        "ILO-R003",
+        "division by zero",
+    );
+}
+
+#[test]
+fn div_by_runtime_zero_cross_engine() {
+    // OP_DIV_NN / OP_DIV path: divisor computed at runtime so the inline
+    // fdiv-fast-path emit must check it dynamically. Previously NaN'd silently.
+    assert_all_engines_err(
+        "f a:n b:n>n;/a b",
+        &["10", "0"],
+        "ILO-R003",
+        "division by zero",
+    );
+}
+
+#[test]
+fn div_zero_over_zero_cross_engine() {
+    // 0 / 0 specifically produced NaN on Cranelift (vs +inf for 10/0). Cover
+    // both NaN and inf branches of the previous silent-failure space.
+    assert_all_engines_err(
+        "f a:n b:n>n;/a b",
+        &["0", "0"],
+        "ILO-R003",
+        "division by zero",
+    );
+}
+
+#[test]
+fn div_by_zero_zsc_shape_cross_engine() {
+    // Cranelift's silent NaN was first surfaced by `zsc` over a constant
+    // column: variance reaches zero so `(x - mean) / stdev` divides by zero
+    // inside a hot inner loop. This reproduces the failing shape directly.
+    let src = "\
+zsc xs:L n>L n
+  m=/ (sum xs) (len xs)
+  v=0
+  ea x xs;v = +v (*(- x m) (- x m))
+  v = /v (len xs)
+  s=sqrt v
+  map (fn x>n;/(- x m) s) xs
+";
+    assert_all_engines_err(src, &["2", "2", "2"], "ILO-R003", "division by zero");
+}
+
+// ── `mod` zero divisor: every engine must fail (no silent NaN) ──────────
+
+#[test]
+fn mod_by_zero_cross_engine_fails() {
+    // Tree returns R003, VM/Cranelift return R004 (pre-existing parity gap).
+    // The point of this test is that Cranelift no longer silently NaN's
+    // through the AOT-inlined fdiv/trunc/fmul/fsub expansion.
+    assert_all_engines_fail(
+        "f a:n b:n>n;mod a b",
+        &["10", "0"],
+        "modulo by zero",
+    );
+}
+
+// ── Sanity: safe-divisor fast paths still produce correct results ───────
+
+#[test]
+fn div_safe_runtime_divisor_cross_engine_agrees() {
+    for engine in ["--run-tree", "--run-vm"] {
+        let (stdout, _, ec) = run_engine(engine, "f a:n b:n>n;/a b", &["10", "4"]);
+        assert_eq!(ec, 0, "engine={engine} unexpected error");
+        assert_eq!(stdout.trim(), "2.5", "engine={engine}");
+    }
+    #[cfg(feature = "cranelift")]
+    {
+        let (stdout, _, ec) =
+            run_engine("--run-cranelift", "f a:n b:n>n;/a b", &["10", "4"]);
+        assert_eq!(ec, 0, "engine=cranelift unexpected error");
+        assert_eq!(stdout.trim(), "2.5");
+    }
+}
+
+#[test]
+fn div_const_nonzero_fast_path_cross_engine_agrees() {
+    // OP_DIVK_N with non-zero literal divisor: ensures the compile-time
+    // "k != 0 → no guard" branch still emits a working fdiv.
+    for engine in ["--run-tree", "--run-vm"] {
+        let (stdout, _, ec) = run_engine(engine, "f a:n>n;/a 4", &["10"]);
+        assert_eq!(ec, 0, "engine={engine} unexpected error");
+        assert_eq!(stdout.trim(), "2.5", "engine={engine}");
+    }
+    #[cfg(feature = "cranelift")]
+    {
+        let (stdout, _, ec) = run_engine("--run-cranelift", "f a:n>n;/a 4", &["10"]);
+        assert_eq!(ec, 0, "engine=cranelift unexpected error");
+        assert_eq!(stdout.trim(), "2.5");
+    }
+}


### PR DESCRIPTION
## Summary

Cranelift's fast-path inline `fdiv` silently produced NaN / inf where tree and VM raised `ILO-R003 division by zero`. The ml-engineer rerun8 Adult-dataset workload surfaced this: a constant column drove `zsc` variance to zero, every divide-by-zero in the inner loop NaN'd through, and the program exited 0 with a plausible-looking 0.76 majority-class accuracy. The worst kind of failure: silent, plausible, undetectable without ground truth.

This restores the cross-engine numeric-agreement contract for `/`, and removes a parallel silent-NaN risk on `mod` in the AOT path.

## Repro

Before:

```
$ ilo "f a:n b:n>n;/a b" --run-cranelift f 10 0
inf
exit=0
$ ilo "f a:n b:n>n;/a b" --run-cranelift f 0 0
NaN
exit=0
```

After:

```
$ ilo "f a:n b:n>n;/a b" --run-cranelift f 10 0
{"code":"ILO-R003","labels":[{"col":13,"end":16,"line":1,...}],"message":"division by zero",...}
exit=1
$ ilo "f a:n b:n>n;/a b" --run-cranelift f 0 0
{"code":"ILO-R003",...,"message":"division by zero",...}
exit=1
```

Tree and VM already produced the right error; only Cranelift was silent.

## What's in the diff

- `vm: add jit_raise_divzero helper for cranelift fast-path`
  Tiny extern that sets `VmError::DivisionByZero` on the JIT per-thread error cell with the call-site span and returns `TAG_NIL`. Lets the JIT and AOT emit a one-branch divisor-zero guard without falling back to `helpers.div`.

- `cranelift jit: guard inline fdiv against division by zero`
  Every fast-path `fdiv` site (`OP_DIV_NN`, `OP_DIVK_N`, the `both_always_num` / `num_block` branches of `OP_DIV`) now emits `fcmp == 0.0 -> brif -> raise helper / fdiv`. `OP_DIVK_N` with a non-zero constant divisor keeps the unguarded fast path; with a zero constant it emits the helper directly. `is_inlinable` rejects raw `OP_DIV_NN` and zero-const `OP_DIVK_N` so the leaf-inline path (no helper / span plumbing) is safe.

- `cranelift aot: mirror divzero guard, route OP_MOD through helper`
  Same guard pattern for the AOT emitter. Also fixes `OP_MOD` which was fully inlined as `fdiv/trunc/fmul/fsub` with no zero check; it now routes through the existing `jit_mod` helper, matching the JIT path.

- `tests: cross-engine regression for cranelift div by zero parity`
  Covers literal-zero const divisor, runtime zero (`10/0` -> `+inf` branch), `0/0` (`NaN` branch), the `zsc`-shaped inner-loop variance-zero pattern, and safe-divisor fast paths. `examples/cl-divzero.ilo` exercises the safe path through the example-engines harness so a regression that re-broke the unguarded fdiv would surface there too.

## Test plan

- [x] `cargo build --release --features cranelift` clean
- [x] Manual repro: `/a b` with `b=0`, `0/0`, `/a 0` literal const all error with ILO-R003 on `--run-cranelift`
- [x] Safe divisor (`10/4` runtime and const) still returns 2.5 on every engine
- [x] `mod 10 0` errors on every engine (no silent NaN)
- [ ] `cargo test --release --features cranelift` full suite green (running, will confirm via CI)

## Follow-ups

- Tree returns `ILO-R003 modulo by zero` while VM and Cranelift return `ILO-R004 modulo by zero` for `mod n 0`. Pre-existing parity gap, intentionally out of scope here. Tracked in `ilo_assessment_feedback.md`.