### PR TITLE
fix: cross-engine error parity for OOB messages and call-stack notes

### DIFF
--- a/examples/cross-engine-error-parity.ilo
+++ b/examples/cross-engine-error-parity.ilo
@@ -1,0 +1,40 @@
+-- Cross-engine error parity: at-OOB now reports the same rich message,
+-- code (ILO-R009), and call-stack notes on tree, VM, and Cranelift.
+--
+-- Pre-fix (v0.11.7 db-analyst rerun8):
+--   tree:      ILO-R009 "at: index 99 out of range for list of length 3"
+--              notes: ["called from 'main'", "called from 'g'"]
+--   VM:        ILO-R004 "at: index out of range" (no values)
+--              notes: ["called from 'main'", "called from 'g'"]
+--   Cranelift: ILO-R004 "at: index out of range" (no values)
+--              notes: []   <-- empty
+--
+-- Post-fix: all three engines produce the tree shape bit-equal. An agent
+-- that filters by code (e.g. retry-on-R009-only) now sees consistent
+-- behaviour regardless of which engine the runner picked.
+--
+-- This file only exercises the *positive* paths so the examples harness
+-- can pin against `-- out:` directly. The cross-engine error-shape
+-- contracts (rich message, R009, call-stack notes) are asserted in
+-- tests/regression_cross_engine_error_parity.rs which spawns the binary
+-- and inspects --json stderr on every engine.
+
+-- Safe `at`: positive index inside bounds works the same way on every engine.
+safe-at>n;at [10,20,30] 1
+
+-- Safe `lst`: replacing an in-bounds element works the same way too.
+safe-lst>L n;lst [10,20,30] 1 99
+
+-- Nested call: when this errors, all three engines now report
+-- ["called from 'main'", "called from 'g'"] in notes. We don't assert
+-- the error path here (harness limitation), but the test in
+-- regression_cross_engine_error_parity.rs covers it.
+g xs:L n>n;at xs 0
+deepest>n;g [42]
+
+-- run: safe-at
+-- out: 20
+-- run: safe-lst
+-- out: [10, 99, 30]
+-- run: deepest
+-- out: 42

--- a/src/main.rs
+++ b/src/main.rs
@@ -3785,14 +3785,15 @@ fn run_bench(program: &ast::Program, func_name: Option<&str>, args: &[interprete
         let nan_args: Vec<u64> = args.iter().map(|v| vm::NanVal::from_value(v).0).collect();
         vm::with_active_registry(&compiled, || {
             if let Some(jit_func) = vm::jit_cranelift::compile(chunk, nan_consts, &compiled) {
+                let entry_name = compiled.func_names.get(fi).map(|s| s.as_str());
                 for _ in 0..100 {
-                    let _ = vm::jit_cranelift::call(&jit_func, &nan_args);
+                    let _ = vm::jit_cranelift::call(&jit_func, &nan_args, entry_name);
                 }
 
                 let start = Instant::now();
                 let mut jit_result_bits = 0u64;
                 for _ in 0..iterations {
-                    jit_result_bits = vm::jit_cranelift::call(&jit_func, &nan_args)
+                    jit_result_bits = vm::jit_cranelift::call(&jit_func, &nan_args, entry_name)
                         .expect("Cranelift JIT error during benchmark");
                 }
                 let jit_dur = start.elapsed();

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -193,6 +193,9 @@ struct HelperFuncs {
     call_builtin_tree: FuncId,
     // Dynamic-dispatch bridge for OP_CALL_DYN (HOF callbacks: `map`, ...)
     call_dyn: FuncId,
+    // Per-thread call-stack tracking for cross-engine error parity.
+    push_call_frame: FuncId,
+    pop_call_frame: FuncId,
 }
 
 /// Pack a `Span { start, end }` into a single i64 immediate for passing to
@@ -391,6 +394,17 @@ fn register_helpers(builder: &mut JITBuilder) {
         ("jit_dtparse", jit_dtparse as *const u8),
         ("jit_call_builtin_tree", jit_call_builtin_tree as *const u8),
         ("jit_call_dyn", jit_call_dyn as *const u8),
+        // Call-stack tracking for VmRuntimeError.call_stack parity with
+        // VM/tree. See `jit_push_call_frame` / `jit_pop_call_frame` in
+        // src/vm/mod.rs for the rationale.
+        (
+            "jit_push_call_frame",
+            crate::vm::jit_push_call_frame as *const u8,
+        ),
+        (
+            "jit_pop_call_frame",
+            crate::vm::jit_pop_call_frame as *const u8,
+        ),
     ];
     for &(name, ptr) in helpers {
         builder.symbol(name, ptr);
@@ -565,6 +579,8 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         dtparse: declare_helper(module, "jit_dtparse", 3, 1),
         call_builtin_tree: declare_helper(module, "jit_call_builtin_tree", 4, 1),
         call_dyn: declare_helper(module, "jit_call_dyn", 4, 1),
+        push_call_frame: declare_helper(module, "jit_push_call_frame", 2, 1),
+        pop_call_frame: declare_helper(module, "jit_pop_call_frame", 0, 1),
     }
 }
 
@@ -4146,9 +4162,46 @@ fn compile_function_body(
                         for i in 0..n_args {
                             call_args.push(builder.use_var(vars[a_idx_call + 1 + i]));
                         }
+
+                        // Push the callee's name onto the per-thread JIT
+                        // call stack so a runtime error surfaced from
+                        // inside the callee carries call_stack notes
+                        // matching VM/tree output. We only push for
+                        // non-inlined calls because inlined callees fuse
+                        // into the caller's IR — they do not constitute
+                        // a separate frame in the VM/tree model either
+                        // (the inliner mirrors what the tree walker
+                        // would have called the caller, not the
+                        // callee).
+                        let push_call_emitted = if let Some(name) = program.func_names.get(func_idx)
+                            && !name.is_empty()
+                        {
+                            let name_ptr = builder.ins().iconst(I64, name.as_ptr() as i64);
+                            let name_len = builder.ins().iconst(I64, name.len() as i64);
+                            let push_fref =
+                                get_func_ref(&mut builder, module, helpers.push_call_frame);
+                            builder.ins().call(push_fref, &[name_ptr, name_len]);
+                            true
+                        } else {
+                            false
+                        };
+
                         let call_inst = builder.ins().call(target_fref, &call_args);
                         call_result = builder.inst_results(call_inst)[0];
                         builder.def_var(vars[a_idx_call], call_result);
+
+                        // Pop on the success path. On the error path the
+                        // post-call check in `jit_cranelift::call` will
+                        // snapshot the stack before unwinding, so we do
+                        // not need to pop in that case. (The callee
+                        // returned normally here: any helper-set error
+                        // is the *caller's* responsibility to propagate
+                        // via its own RET sequence.)
+                        if push_call_emitted {
+                            let pop_fref =
+                                get_func_ref(&mut builder, module, helpers.pop_call_frame);
+                            builder.ins().call(pop_fref, &[]);
+                        }
                     } // end else (not inlined)
                 } else {
                     // Fallback: use jit_call helper for out-of-range func indices
@@ -4804,8 +4857,22 @@ fn check_force_panic_env() {
 /// cleared on drop even if Rust-side code panics later. Returns `Runtime`
 /// when a helper set the error cell, else `Ok` with the raw NanVal bits.
 /// Resets the JIT arena after each call (promoting the result if arena-tagged).
-pub fn call(func: &JitFunction, args: &[u64]) -> Result<u64, JitCallError> {
+pub fn call(
+    func: &JitFunction,
+    args: &[u64],
+    entry_name: Option<&str>,
+) -> Result<u64, JitCallError> {
     let _err_guard = JitRuntimeErrorGuard::new();
+
+    // Seed the per-thread JIT call stack with the entry function name so
+    // a surfaced `VmRuntimeError` carries `call_stack: ["<entry>"]` at
+    // minimum, matching what the VM produces via `make_runtime_error`.
+    // Nested OP_CALLs push/pop on top of this seed. The
+    // `JitRuntimeErrorGuard` cleared the stack on entry; on a clean
+    // return we drain it below so it doesn't leak into the next call.
+    if let Some(name) = entry_name {
+        crate::vm::JIT_CALL_STACK.with(|c| c.borrow_mut().push(name.to_owned()));
+    }
 
     let mut result = call_raw(func, args).ok_or(JitCallError::NotEligible)?;
 
@@ -4820,13 +4887,30 @@ pub fn call(func: &JitFunction, args: &[u64]) -> Result<u64, JitCallError> {
     }
     jit_arena_reset();
 
-    if let Some((err, span)) = jit_take_runtime_error() {
+    if let Some((err, span, call_stack)) = jit_take_runtime_error() {
+        // The call_stack was snapshotted at error-set time inside the
+        // JIT helper (see `jit_set_runtime_error_with_span`). That is
+        // the only place the deepest frame chain is observable: JIT
+        // helpers do not unwind on error — the post-call `pop_call_frame`
+        // emitted on each direct OP_CALL still fires on the native
+        // return path — so by the time we get here the live stack has
+        // already shrunk back to the entry seed. Tree/VM order frames
+        // outermost-to-innermost; `with_note` walks them in order, so
+        // `["main", "g"]` becomes `notes: ["called from 'main'",
+        // "called from 'g'"]`, bit-equal to VM/tree output.
         return Err(JitCallError::Runtime(VmRuntimeError {
             error: err,
             span,
-            call_stack: Vec::new(),
+            call_stack,
         }));
     }
+
+    // Clean return: drop the seeded entry name so a subsequent dispatch
+    // on the same thread starts from an empty stack. The guard's Drop
+    // would clear it on scope exit anyway, but draining here keeps the
+    // invariant tight against any future code added between this point
+    // and the guard's drop.
+    crate::vm::jit_clear_call_stack();
 
     Ok(result)
 }
@@ -4913,6 +4997,21 @@ pub fn compile_and_call(
     // inside `call` clears the runtime-error cell on drop, and the chunk +
     // program references are immutable. No shared mutable state survives an
     // unwind in a corrupted state.
+    // Identify the entry function's name so the surfaced call_stack
+    // matches what the VM and tree interpreters produce. Tree/VM include
+    // the entry frame in their walk (see `VM::make_runtime_error`), so
+    // the `Diagnostic` notes contain `"called from '<entry>'"`. We seed
+    // the JIT's per-thread call stack with the same entry name; the
+    // push/pop helpers maintain depth from there. Falls back to the
+    // empty entry-name on the (impossible-in-practice) case where the
+    // chunk pointer doesn't match any program slot — better to emit no
+    // entry note than to invent one.
+    let entry_name: Option<String> = program
+        .chunks
+        .iter()
+        .position(|c| std::ptr::eq(c, chunk))
+        .and_then(|idx| program.func_names.get(idx).cloned());
+
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         with_active_registry(program, || {
             #[cfg(debug_assertions)]
@@ -4924,7 +5023,7 @@ pub fn compile_and_call(
                 check_force_panic_env();
             }
             let func = compile(chunk, nan_consts, program).ok_or(JitCallError::NotEligible)?;
-            call(&func, args)
+            call(&func, args, entry_name.as_deref())
         })
     }));
 
@@ -5105,7 +5204,7 @@ mod tests {
         let nan_consts = &compiled.nan_constants[idx];
         if let Some(func) = compile(chunk, nan_consts, &compiled) {
             let args: Vec<u64> = (1..=9).map(|i| NanVal::number(i as f64).0).collect();
-            let result = call(&func, &args);
+            let result = call(&func, &args, None);
             assert!(matches!(result, Err(JitCallError::NotEligible)));
         }
     }
@@ -5794,7 +5893,7 @@ mod tests {
         let func = compile(chunk, nan_consts, &compiled);
         // If it compiled, try calling it (should call g() and return 42).
         if let Some(f) = func {
-            let result = call(&f, &[]);
+            let result = call(&f, &[], None);
             assert_eq!(result.ok(), Some(NanVal::number(42.0).0));
         }
     }
@@ -5924,7 +6023,7 @@ mod tests {
         crate::vm::with_active_registry(&compiled, || {
             if let Some(jit_func) = compile(chunk, nan_consts, &compiled) {
                 for i in 0..10_100u32 {
-                    let result = call(&jit_func, &nan_args).expect("JIT call failed");
+                    let result = call(&jit_func, &nan_args, None).expect("JIT call failed");
                     let val = crate::vm::NanVal(result).to_value();
                     assert_eq!(val, Value::Number(4950.0), "failed on iteration {}", i);
                 }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -5229,8 +5229,7 @@ pub(crate) fn jit_arena_reset() {
 // instant the helper recorded the error. Aliased so the TLS RefCell
 // type below stays inside clippy's type-complexity budget.
 #[cfg(feature = "cranelift")]
-pub(crate) type JitRuntimeErrorPayload =
-    (VmError, Option<crate::ast::Span>, Vec<String>);
+pub(crate) type JitRuntimeErrorPayload = (VmError, Option<crate::ast::Span>, Vec<String>);
 
 thread_local! {
     // JIT helpers raise errors but do not unwind native frames — the

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -5224,18 +5224,24 @@ pub(crate) fn jit_arena_reset() {
 // (`jit_lst`, `jit_listget`, `jit_index`, `jit_jpth`, `jit_slc`, ...) keep
 // the existing permissive-nil semantics; harmonising them is parked. Each
 // new erroring helper costs +1 u64 arg and +1 iconst at the call site.
+// Payload stored in the JIT_RUNTIME_ERROR cell: the error itself, the
+// optional source span, and the call-stack snapshot captured at the
+// instant the helper recorded the error. Aliased so the TLS RefCell
+// type below stays inside clippy's type-complexity budget.
+#[cfg(feature = "cranelift")]
+pub(crate) type JitRuntimeErrorPayload =
+    (VmError, Option<crate::ast::Span>, Vec<String>);
+
 thread_local! {
-    // The stack snapshot at error-set time is stored alongside the
-    // error itself: JIT helpers raise errors but do not unwind native
-    // frames, so the JIT continues executing post-call OP code (the
-    // pop_call_frame emitted by direct OP_CALL fires on what the
-    // native ABI sees as a normal return). By snapshotting here we
-    // capture the deepest stack — exactly the chain
-    // [entry, caller, ..., callee_that_errored] the VM/tree builds
-    // when it walks live frames at error time.
-    static JIT_RUNTIME_ERROR: std::cell::RefCell<
-        Option<(VmError, Option<crate::ast::Span>, Vec<String>)>,
-    > = const { std::cell::RefCell::new(None) };
+    // JIT helpers raise errors but do not unwind native frames — the
+    // pop_call_frame emitted after each direct OP_CALL still fires on
+    // the native return path. So by the time the entry returns, the
+    // live call stack has shrunk back to the seed. Capturing the chain
+    // here, at the instant the helper sets the error, is the only way
+    // to record [entry, caller, ..., callee_that_errored] — the same
+    // shape VM and tree build by walking live frames at error time.
+    static JIT_RUNTIME_ERROR: std::cell::RefCell<Option<JitRuntimeErrorPayload>> =
+        const { std::cell::RefCell::new(None) };
 }
 
 /// Decode the (start, end) span bits packed by the cranelift call site.
@@ -5283,7 +5289,7 @@ pub(crate) fn jit_set_runtime_error_with_span(err: VmError, span_bits: u64) {
 /// build a `VmRuntimeError` whose `notes` match what the VM and tree
 /// interpreters produce for the same repro.
 #[cfg(feature = "cranelift")]
-pub(crate) fn jit_take_runtime_error() -> Option<(VmError, Option<crate::ast::Span>, Vec<String>)> {
+pub(crate) fn jit_take_runtime_error() -> Option<JitRuntimeErrorPayload> {
     JIT_RUNTIME_ERROR.with(|cell| cell.borrow_mut().take())
 }
 

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -5225,8 +5225,17 @@ pub(crate) fn jit_arena_reset() {
 // the existing permissive-nil semantics; harmonising them is parked. Each
 // new erroring helper costs +1 u64 arg and +1 iconst at the call site.
 thread_local! {
-    static JIT_RUNTIME_ERROR: std::cell::RefCell<Option<(VmError, Option<crate::ast::Span>)>> =
-        const { std::cell::RefCell::new(None) };
+    // The stack snapshot at error-set time is stored alongside the
+    // error itself: JIT helpers raise errors but do not unwind native
+    // frames, so the JIT continues executing post-call OP code (the
+    // pop_call_frame emitted by direct OP_CALL fires on what the
+    // native ABI sees as a normal return). By snapshotting here we
+    // capture the deepest stack — exactly the chain
+    // [entry, caller, ..., callee_that_errored] the VM/tree builds
+    // when it walks live frames at error time.
+    static JIT_RUNTIME_ERROR: std::cell::RefCell<
+        Option<(VmError, Option<crate::ast::Span>, Vec<String>)>,
+    > = const { std::cell::RefCell::new(None) };
 }
 
 /// Decode the (start, end) span bits packed by the cranelift call site.
@@ -5258,17 +5267,23 @@ pub(crate) fn jit_set_runtime_error_with_span(err: VmError, span_bits: u64) {
         // cause.
         let mut slot = cell.borrow_mut();
         if slot.is_none() {
-            *slot = Some((err, span));
+            // Snapshot the call stack at this exact instant. The JIT
+            // does not unwind on helper errors — post-call pops still
+            // fire on the native return path — so capturing here is
+            // the only way to record the deepest live frame chain.
+            let stack = JIT_CALL_STACK.with(|c| c.borrow().clone());
+            *slot = Some((err, span, stack));
         }
     });
 }
 
 /// Pop any pending JIT runtime error. Called by the JIT entry point after
-/// the compiled function returns. Returns the `(VmError, Option<Span>)`
-/// pair so the entry point can attach the span to the surfaced
-/// `VmRuntimeError`.
+/// the compiled function returns. Returns the error, its span, and the
+/// call-stack snapshot captured at error-set time so the entry point can
+/// build a `VmRuntimeError` whose `notes` match what the VM and tree
+/// interpreters produce for the same repro.
 #[cfg(feature = "cranelift")]
-pub(crate) fn jit_take_runtime_error() -> Option<(VmError, Option<crate::ast::Span>)> {
+pub(crate) fn jit_take_runtime_error() -> Option<(VmError, Option<crate::ast::Span>, Vec<String>)> {
     JIT_RUNTIME_ERROR.with(|cell| cell.borrow_mut().take())
 }
 
@@ -5284,6 +5299,7 @@ impl JitRuntimeErrorGuard {
         JIT_RUNTIME_ERROR.with(|cell| {
             *cell.borrow_mut() = None;
         });
+        jit_clear_call_stack();
         JitRuntimeErrorGuard
     }
 }
@@ -5294,7 +5310,81 @@ impl Drop for JitRuntimeErrorGuard {
         JIT_RUNTIME_ERROR.with(|cell| {
             *cell.borrow_mut() = None;
         });
+        jit_clear_call_stack();
     }
+}
+
+// Per-thread call stack for the Cranelift JIT.
+//
+// Tree/VM build `VmRuntimeError.call_stack` by walking their frame stack
+// when an error fires (see `VM::make_runtime_error`). Cranelift compiles
+// every function to a real native function and dispatches through direct
+// native `call` instructions, so by the time `jit_take_runtime_error`
+// surfaces the error we have no software frame stack to walk — without
+// extra bookkeeping the surfaced `call_stack` is always empty.
+//
+// This TLS Vec is pushed by `jit_push_call_frame` immediately before a
+// direct OP_CALL in JIT IR and popped by `jit_pop_call_frame` immediately
+// after the call returns. If the callee surfaces an error, the pop is
+// still emitted on the success branch only via post-call check — the
+// stack snapshot fires before the unwind so we capture the deepest live
+// frame name. Inlined OP_CALLs (the `is_inlinable` fast path) skip the
+// push/pop entirely: their work is fused into the caller's IR, so they
+// belong to the caller's frame anyway and any error in their body reports
+// the caller's name, matching the VM/tree semantics for inlined helpers.
+//
+// Cost: two `extern "C"` calls per non-inlined OP_CALL. The hottest
+// dispatch path (inlinable numeric guards, see PR #340 / #346) is
+// unaffected. Non-inlined calls already pay direct call ABI cost; an
+// extra TLS append/pop is dominated by that.
+#[cfg(feature = "cranelift")]
+thread_local! {
+    pub(crate) static JIT_CALL_STACK: std::cell::RefCell<Vec<String>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// Push a function name onto the JIT call-stack. Emitted by Cranelift
+/// just before a direct `OP_CALL` to a known function. `name_ptr` and
+/// `name_len` describe a `&'static str` (the entry in
+/// `program.func_names`) — Cranelift owns the program for the duration
+/// of the JIT dispatch, so the slice is valid until the call returns.
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_push_call_frame(name_ptr: *const u8, name_len: u64) -> u64 {
+    if name_ptr.is_null() || name_len == 0 {
+        return 0;
+    }
+    // SAFETY: name_ptr / name_len come from a CompiledProgram.func_names
+    // String borrow that outlives the JIT dispatch (held by
+    // `with_active_registry`). UTF-8 validity is guaranteed because the
+    // source is a Rust `String`.
+    let name = unsafe {
+        let slice = std::slice::from_raw_parts(name_ptr, name_len as usize);
+        std::str::from_utf8_unchecked(slice).to_owned()
+    };
+    JIT_CALL_STACK.with(|cell| cell.borrow_mut().push(name));
+    0
+}
+
+/// Pop the most-recent JIT call-stack entry. Emitted after a successful
+/// return from `OP_CALL`. Skipped implicitly on the error path because
+/// JIT runtime errors short-circuit before reaching this opcode boundary.
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_pop_call_frame() -> u64 {
+    JIT_CALL_STACK.with(|cell| {
+        let mut s = cell.borrow_mut();
+        s.pop();
+    });
+    0
+}
+
+/// Clear the JIT call stack. Called from the `JitRuntimeErrorGuard`
+/// install path so a stale partial stack from a previous panic-recovered
+/// dispatch cannot leak into the next call. Idempotent.
+#[cfg(feature = "cranelift")]
+pub(crate) fn jit_clear_call_stack() {
+    JIT_CALL_STACK.with(|cell| cell.borrow_mut().clear());
 }
 
 // Why a separate tag for ListView
@@ -9843,8 +9933,10 @@ impl<'a> VM<'a> {
                         };
                         match char_at_signed(s, raw) {
                             CharAtResult::Found(c) => NanVal::heap_string(c.to_string()),
-                            CharAtResult::OutOfRange { .. } => {
-                                vm_err!(VmError::Type("at: index out of range"))
+                            CharAtResult::OutOfRange { len } => {
+                                vm_err!(VmError::Runtime(format!(
+                                    "at: index {raw} out of range for text of length {len}"
+                                )))
                             }
                         }
                     } else if v.is_heap() {
@@ -9854,7 +9946,9 @@ impl<'a> VM<'a> {
                                 let len = items.len() as i64;
                                 let adjusted = if raw < 0 { raw + len } else { raw };
                                 if adjusted < 0 || adjusted >= len {
-                                    vm_err!(VmError::Type("at: index out of range"));
+                                    vm_err!(VmError::Runtime(format!(
+                                        "at: index {raw} out of range for list of length {len}"
+                                    )));
                                 }
                                 let idx = adjusted as usize;
                                 items[idx].clone_rc();
@@ -10588,7 +10682,10 @@ impl<'a> VM<'a> {
                             h @ (HeapObj::List(_) | HeapObj::ListView { .. }) => {
                                 let items = slice_of(h);
                                 if idx >= items.len() {
-                                    vm_err!(VmError::Type("lst: index out of range"));
+                                    let len = items.len();
+                                    vm_err!(VmError::Runtime(format!(
+                                        "lst: index {idx} out of range for list of length {len}"
+                                    )));
                                 }
                                 let mut new_items: Vec<NanVal> = Vec::with_capacity(items.len());
                                 for (i, v) in items.iter().enumerate() {
@@ -12927,8 +13024,13 @@ pub(crate) extern "C" fn jit_at(a: u64, b: u64, span_bits: u64) -> u64 {
         };
         return match char_at_signed(s, raw) {
             CharAtResult::Found(c) => NanVal::heap_string(c.to_string()).0,
-            CharAtResult::OutOfRange { .. } => {
-                jit_set_runtime_error_with_span(VmError::Type("at: index out of range"), span_bits);
+            CharAtResult::OutOfRange { len } => {
+                jit_set_runtime_error_with_span(
+                    VmError::Runtime(format!(
+                        "at: index {raw} out of range for text of length {len}"
+                    )),
+                    span_bits,
+                );
                 TAG_NIL
             }
         };
@@ -12939,7 +13041,12 @@ pub(crate) extern "C" fn jit_at(a: u64, b: u64, span_bits: u64) -> u64 {
         let len = items.len() as i64;
         let adjusted = if raw < 0 { raw + len } else { raw };
         if adjusted < 0 || adjusted >= len {
-            jit_set_runtime_error_with_span(VmError::Type("at: index out of range"), span_bits);
+            jit_set_runtime_error_with_span(
+                VmError::Runtime(format!(
+                    "at: index {raw} out of range for list of length {len}"
+                )),
+                span_bits,
+            );
             return TAG_NIL;
         }
         let idx = adjusted as usize;
@@ -12973,7 +13080,13 @@ pub(crate) extern "C" fn jit_lst(list: u64, idx: u64, val: u64, span_bits: u64) 
         && let HeapObj::List(items) = unsafe { v.as_heap_ref() }
     {
         if pos >= items.len() {
-            jit_set_runtime_error_with_span(VmError::Type("lst: index out of range"), span_bits);
+            let len = items.len();
+            jit_set_runtime_error_with_span(
+                VmError::Runtime(format!(
+                    "lst: index {pos} out of range for list of length {len}"
+                )),
+                span_bits,
+            );
             return TAG_NIL;
         }
         let mut new_items: Vec<NanVal> = Vec::with_capacity(items.len());

--- a/tests/regression_cross_engine_error_parity.rs
+++ b/tests/regression_cross_engine_error_parity.rs
@@ -1,0 +1,181 @@
+// Regression: cross-engine error message + call-stack parity.
+//
+// db-analyst rerun8 on v0.11.7 reported three divergences in runtime error
+// shape between the tree walker, VM, and Cranelift JIT:
+//
+//   (a) Error codes diverged: tree emitted ILO-R009 for at-OOB while VM and
+//       Cranelift emitted ILO-R004 for the same condition.
+//   (b) VM and Cranelift dropped the rich values: tree said "index 99 out
+//       of range for list of length 3"; VM/Cranelift said "index out of
+//       range" with no values, forcing the agent to add `prnt` to discover
+//       what bad index actually fired.
+//   (c) Cranelift dropped the call-stack notes entirely: tree and VM
+//       produced `notes:["called from 'main'", "called from 'g'"]`,
+//       Cranelift produced `notes:[]`.
+//
+// These tests assert the first-pass fix:
+//   - (b) at/lst OOB sites in VM and Cranelift now produce the full
+//     `"<builtin>: index N out of range for list/text of length M"` message,
+//     matching tree's wording.
+//   - (a) Since the OOB sites switched from `VmError::Type` (R004) to
+//     `VmError::Runtime` (R009), the code is also reconciled with tree.
+//   - (c) Cranelift now seeds the JIT call stack with the entry function
+//     name and pushes/pops frames around each direct OP_CALL, so a runtime
+//     error surfaces with `notes` matching VM/tree.
+//
+// Parked (filed as follow-ups, not covered here):
+//   - mget-on-non-map code reconciliation (tree R009 vs VM/Cranelift R004).
+//   - jpth missing-key panic-unwrap code reconciliation (tree R026 vs
+//     VM/Cranelift R009).
+//   - num!! parse-fail code reconciliation (same shape).
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+#[cfg(feature = "cranelift")]
+const ENGINES_ALL: &[&str] = &["--run-tree", "--run-vm", "--run-cranelift"];
+#[cfg(not(feature = "cranelift"))]
+const ENGINES_ALL: &[&str] = &["--run-tree", "--run-vm"];
+
+/// Run `src` on every engine and return the JSON stderr line for each, so
+/// the caller can assert on shape parity directly (message, code, notes).
+fn run_on_all_engines(src_path: &str, entry: &str) -> Vec<(String, String)> {
+    ENGINES_ALL
+        .iter()
+        .map(|engine| {
+            let out = ilo()
+                .args(["run", "--json", engine, src_path, entry])
+                .output()
+                .expect("failed to spawn ilo");
+            assert!(
+                !out.status.success(),
+                "engine={engine}: expected non-zero exit on runtime error\nstdout={}\nstderr={}",
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr),
+            );
+            let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+            ((*engine).to_string(), stderr)
+        })
+        .collect()
+}
+
+fn write_src(src: &str, name: &str) -> String {
+    let dir = std::env::temp_dir().join("ilo-cross-engine-error-parity");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(name);
+    std::fs::write(&path, src).unwrap();
+    path.to_str().unwrap().to_owned()
+}
+
+// (a) + (b): `at` OOB on a list surfaces ILO-R009 with the full
+// "index N out of range for list of length M" message on every engine.
+#[test]
+fn at_list_oob_has_rich_message_and_r009_on_every_engine() {
+    let src = "g xs:L n>n;at xs 99\nmain>n;xs=[1,2,3];g xs\n";
+    let path = write_src(src, "at_list_oob.ilo");
+    for (engine, stderr) in run_on_all_engines(&path, "main") {
+        assert!(
+            stderr.contains("ILO-R009"),
+            "engine={engine}: expected ILO-R009 (matching tree), got:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("at: index 99 out of range for list of length 3"),
+            "engine={engine}: expected rich tree-style message, got:\n{stderr}"
+        );
+    }
+}
+
+// (b): `at` OOB on text surfaces with the same rich shape, mentioning text
+// length rather than list length.
+#[test]
+fn at_text_oob_has_rich_message_and_r009_on_every_engine() {
+    let src = "g s:t>t;at s 50\nmain>t;s=\"hi\";g s\n";
+    let path = write_src(src, "at_text_oob.ilo");
+    for (engine, stderr) in run_on_all_engines(&path, "main") {
+        assert!(
+            stderr.contains("ILO-R009"),
+            "engine={engine}: expected ILO-R009, got:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("at: index 50 out of range for text of length 2"),
+            "engine={engine}: expected rich text message, got:\n{stderr}"
+        );
+    }
+}
+
+// (a) + (b): `lst` OOB likewise reports the full "index N out of range for
+// list of length M" wording with R009 across engines.
+#[test]
+fn lst_oob_has_rich_message_and_r009_on_every_engine() {
+    let src = "g xs:L n>L n;lst xs 99 0\nmain>L n;xs=[1,2,3];g xs\n";
+    let path = write_src(src, "lst_oob.ilo");
+    for (engine, stderr) in run_on_all_engines(&path, "main") {
+        assert!(
+            stderr.contains("ILO-R009"),
+            "engine={engine}: expected ILO-R009, got:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("lst: index 99 out of range for list of length 3"),
+            "engine={engine}: expected rich lst message, got:\n{stderr}"
+        );
+    }
+}
+
+// (c): Cranelift's call_stack now matches tree/VM. The repro is the
+// db-analyst report's exact shape: main calls g, g raises OOB, every
+// engine reports notes=["called from 'main'", "called from 'g'"].
+#[test]
+fn call_stack_notes_match_across_engines_two_levels() {
+    let src = "g xs:L n>n;at xs 99\nmain>n;xs=[1,2,3];g xs\n";
+    let path = write_src(src, "callstack_two_levels.ilo");
+    for (engine, stderr) in run_on_all_engines(&path, "main") {
+        assert!(
+            stderr.contains("\"called from 'main'\""),
+            "engine={engine}: expected note for 'main', got:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("\"called from 'g'\""),
+            "engine={engine}: expected note for 'g', got:\n{stderr}"
+        );
+    }
+}
+
+// (c) stress: three-level call chain (main → h → g). Cranelift's
+// pre-fix behaviour was `notes:[]`; tree/VM produced all three. With the
+// per-thread JIT call-stack snapshot at error-set time, Cranelift now
+// reports all three names too.
+#[test]
+fn call_stack_notes_match_across_engines_three_levels() {
+    let src = "g xs:L n>n;at xs 99\nh xs:L n>n;a=g xs;+ a 1\nmain>n;xs=[1,2,3];h xs\n";
+    let path = write_src(src, "callstack_three_levels.ilo");
+    for (engine, stderr) in run_on_all_engines(&path, "main") {
+        for expected in [
+            "\"called from 'main'\"",
+            "\"called from 'h'\"",
+            "\"called from 'g'\"",
+        ] {
+            assert!(
+                stderr.contains(expected),
+                "engine={engine}: missing note {expected}, got:\n{stderr}"
+            );
+        }
+    }
+}
+
+// Sanity: when the JIT entry function itself raises (no nested call),
+// the notes still mention the entry. Previously Cranelift produced an
+// empty notes array because no call stack was tracked at all.
+#[test]
+fn call_stack_notes_present_when_entry_errors_directly() {
+    let src = "main>n;xs=[1,2,3];at xs 99\n";
+    let path = write_src(src, "callstack_entry_only.ilo");
+    for (engine, stderr) in run_on_all_engines(&path, "main") {
+        assert!(
+            stderr.contains("\"called from 'main'\""),
+            "engine={engine}: expected entry-frame note, got:\n{stderr}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

db-analyst rerun8 on v0.11.7 flagged three divergences in runtime error shape across the three engines, all in the same friction entry (`/Users/dan/code/ilo_assessment_feedback.md` line 8025, table at the at-OOB row):

| Probe | tree | VM | Cranelift |
|---|---|---|---|
| at OOB | R009 "at: index 99 out of range for list of length 3" | R004 "at: index out of range" | R004 same; notes: [] |

Three sub-issues:
- (a) Codes diverge: tree R009 vs VM/Cranelift R004 for the same root cause. An agent filtering by code sees inconsistent behaviour.
- (b) VM/Cranelift drop the rich values, forcing a `prnt`-and-retry cycle to learn the actual bad index.
- (c) Cranelift drops the call-stack `notes` entirely (`[]` vs tree/VM `["called from 'main'", "called from 'g'"]`).

This PR fixes all three for the `at` and `lst` builtins. Wider scope (mget-on-non-map, jpth panic-unwrap R026, num!! parse-fail) is parked as follow-ups noted in the assessment doc.

Manifesto framing: every cross-engine divergence is a re-run someone has to do to confirm the root cause. The (b) drop alone forced a `prnt`-and-retry cycle to learn what the bad index was; (c) forced a re-run on tree to see whether the error was top-level or three frames deep. With this fix the default-runner choice no longer changes the error you have to debug.

## Repro before / after

```
g xs:L n>n;at xs 99
main>n;xs=[1,2,3];g xs
```

Before:
```
$ ilo run --json --run-cranelift /tmp/oob.ilo
{"code":"ILO-R004","message":"at: index out of range","notes":[],...}
$ ilo run --json --run-vm /tmp/oob.ilo
{"code":"ILO-R004","message":"at: index out of range","notes":["called from 'main'","called from 'g'"],...}
$ ilo run --json --run-tree /tmp/oob.ilo
{"code":"ILO-R009","message":"at: index 99 out of range for list of length 3","notes":["called from 'main'","called from 'g'"],...}
```

After: all three engines produce the tree shape bit-equal.

## What's in the diff

Single commit:
- VM (OP_AT, OP_LST) and Cranelift helpers (jit_at, jit_lst): switch OOB sites from `VmError::Type("...: index out of range")` (R004) to `VmError::Runtime(format!("...: index {i} out of range for list of length {len}"))` (R009). The diagnostic layer already maps the Runtime variant to R009, so this one change fixes both (a) and (b).
- Cranelift call_stack: per-thread `JIT_CALL_STACK` Vec, `jit_push_call_frame` / `jit_pop_call_frame` helpers emitted around each direct OP_CALL, entry name seeded in `jit_cranelift::call`. The snapshot is captured at error-set time inside `jit_set_runtime_error_with_span` and stored alongside the error, because helper-set errors do not unwind native frames - the post-call pops still fire on the native return path, so the only correct moment to capture the chain is at the error site.
- Cost: two extra `extern "C"` calls per non-inlined OP_CALL. Inlinable callees (the hot path covered by PR #340 / #346) are unaffected because their work is fused into the caller's IR.

## Test plan

- [x] `tests/regression_cross_engine_error_parity.rs`: six tests covering at-list-OOB, at-text-OOB, lst-OOB (all checking ILO-R009 code + full rich message on every engine), two-level call-stack, three-level call-stack, and entry-frame-only.
- [x] `examples/cross-engine-error-parity.ilo`: documents the positive paths the harness can pin against `-- out:`, points at the regression file for the error-shape contract.
- [ ] Full `cargo test --release --features cranelift` green on CI.
- [ ] `cargo fmt` + clippy clean.

## Follow-ups

Parked in `## 📋 Parked / Follow-ups` of the assessment doc:
- mget-on-non-map code reconciliation (tree R009 vs VM/Cranelift R004).
- jpth missing-key panic-unwrap (tree R026 vs VM/Cranelift R009).
- num!! parse-fail (same shape).

Wider blast radius, separate PRs once a per-builtin error-code policy is agreed.