### PR TITLE
fix: .? on typed map gives mget hint instead of T018

### DIFF
--- a/src/diagnostic/registry.rs
+++ b/src/diagnostic/registry.rs
@@ -613,8 +613,12 @@ A field in a record literal was given a value of the wrong type.
         short: "field access on non-record type",
         long: r#"## ILO-T018: field access on non-record type
 
-A field access (`value.field`) was attempted on a value that is not
-a record type. Field access is only valid on named `type` instances.
+A field access (`value.field` or `value.?field`) was attempted on a
+value that is not a record type. Field access (including the safe
+`.?` form) is only valid on named `type` instances.
+
+**Fix:** if the receiver is a map (`M _ _`), use `mget m "key"`, which
+returns an Option you can match on or default with `??`.
 "#,
     },
     ErrorEntry {

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -3864,11 +3864,17 @@ impl VerifyContext {
                     }
                     Ty::Unknown => Ty::Unknown,
                     other => {
+                        let hint = match other {
+                            Ty::Map(_, _) => Some(format!(
+                                "use 'mget m \"{field}\"' which returns Option"
+                            )),
+                            _ => None,
+                        };
                         self.err(
                             "ILO-T018",
                             func,
                             format!("field access on non-record type {other}"),
-                            None,
+                            hint,
                             Some(span),
                         );
                         Ty::Unknown

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -3865,9 +3865,9 @@ impl VerifyContext {
                     Ty::Unknown => Ty::Unknown,
                     other => {
                         let hint = match other {
-                            Ty::Map(_, _) => Some(format!(
-                                "use 'mget m \"{field}\"' which returns Option"
-                            )),
+                            Ty::Map(_, _) => {
+                                Some(format!("use 'mget m \"{field}\"' which returns Option"))
+                            }
                             _ => None,
                         };
                         self.err(

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -213,6 +213,42 @@ fn t018_field_access_on_number() {
     assert_error("f x:n>n;x.field", "ILO-T018");
 }
 
+#[test]
+fn t018_safe_field_on_map_hints_mget() {
+    // `.?x` on a typed map errors with ILO-T018. The verifier should
+    // suggest `mget m "x"` (which returns Option) rather than leaving the
+    // agent stuck with a bare "field access on non-record type" message.
+    let code = "f>n;m=mset mmap \"x\" 1;mx=m.?x;mx??0";
+    let (ok, stderr) = run(code);
+    assert!(!ok, "expected failure for snippet {code:?}");
+    assert!(
+        stderr.contains("ILO-T018"),
+        "expected ILO-T018 in stderr, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("mget m \"x\""),
+        "expected mget hint in stderr, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn t018_strict_field_on_map_hints_mget() {
+    // Same hint should fire for the strict `.field` form on a map, since the
+    // shape mistake is identical — agents reaching for record-syntax on a
+    // map deserve the same nudge whether they wrote `.x` or `.?x`.
+    let code = "f>n;m=mset mmap \"x\" 1;mx=m.x;mx";
+    let (ok, stderr) = run(code);
+    assert!(!ok, "expected failure for snippet {code:?}");
+    assert!(
+        stderr.contains("ILO-T018"),
+        "expected ILO-T018 in stderr, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("mget m \"x\""),
+        "expected mget hint in stderr, got:\n{stderr}"
+    );
+}
+
 // ---- ILO-T019: no such field on record ----
 
 #[test]

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -225,8 +225,10 @@ fn t018_safe_field_on_map_hints_mget() {
         stderr.contains("ILO-T018"),
         "expected ILO-T018 in stderr, got:\n{stderr}"
     );
+    // Stderr is emitted as JSON, so embedded `"` in the suggestion are
+    // escaped to `\"`. Match the escaped form to assert the hint is present.
     assert!(
-        stderr.contains("mget m \"x\""),
+        stderr.contains("mget m \\\"x\\\""),
         "expected mget hint in stderr, got:\n{stderr}"
     );
 }
@@ -234,7 +236,7 @@ fn t018_safe_field_on_map_hints_mget() {
 #[test]
 fn t018_strict_field_on_map_hints_mget() {
     // Same hint should fire for the strict `.field` form on a map, since the
-    // shape mistake is identical — agents reaching for record-syntax on a
+    // shape mistake is identical, agents reaching for record-syntax on a
     // map deserve the same nudge whether they wrote `.x` or `.?x`.
     let code = "f>n;m=mset mmap \"x\" 1;mx=m.x;mx";
     let (ok, stderr) = run(code);
@@ -243,8 +245,10 @@ fn t018_strict_field_on_map_hints_mget() {
         stderr.contains("ILO-T018"),
         "expected ILO-T018 in stderr, got:\n{stderr}"
     );
+    // Stderr is emitted as JSON, so embedded `"` in the suggestion are
+    // escaped to `\"`. Match the escaped form to assert the hint is present.
     assert!(
-        stderr.contains("mget m \"x\""),
+        stderr.contains("mget m \\\"x\\\""),
         "expected mget hint in stderr, got:\n{stderr}"
     );
 }


### PR DESCRIPTION
Closes security-researcher rerun8 yellow finding.