### PR TITLE
chore: bump version to 0.11.8

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ilo",
       "source": "./",
       "description": "Write, run, debug, and explain programs in ilo — a token-optimised programming language for AI agents",
-      "version": "0.11.7",
+      "version": "0.11.8",
       "author": {
         "name": "Daniel Morris"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ilo",
   "description": "Write, run, debug, and explain programs in ilo — a token-optimised programming language for AI agents",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "author": {
     "name": "Daniel Morris"
   },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "ilo"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ilo"
-version = "0.11.7"
+version = "0.11.8"
 edition = "2024"
 rust-version = "1.85"
 description = "ilo — a programming language for AI agents"


### PR DESCRIPTION
v0.11.8: 23 PRs from rerun8 fix batch + coverage uplift. Local binary verified at 0.11.8.