### PR TITLE
fix: ILO-T035 for ~v:/^e: arms on Option subjects

### DIFF
--- a/examples/option-arm-diag.ilo
+++ b/examples/option-arm-diag.ilo
@@ -1,0 +1,41 @@
+-- `mget` returns Optional (`O T`) - the key may not exist.
+--
+-- The wrong shape (caught by ILO-T035):
+--
+--   ?(mget m "k"){~v:v;_:0}
+--
+-- `~v:` is a Result arm. Option values aren't Ok/Err-tagged at
+-- runtime, so the `~v:` arm never matches and the match silently
+-- falls through to the wildcard, returning 0 even when the key
+-- exists. The verifier flags this so the bug surfaces at check
+-- time instead of as a wrong answer.
+--
+-- The right shapes are below: `??x default` to unwrap the Option,
+-- or match a literal value with `_:` for the nil case.
+
+unwrap-with-default>n
+  m=mmap
+  m=mset m "k" 5
+  ??(mget m "k") 0
+
+unwrap-missing-key>n
+  m=mmap
+  ??(mget m "k") 99
+
+match-literal-or-nil>t
+  m=mmap
+  m=mset m "k" 5
+  ?(mget m "k"){5:"hit";_:"miss"}
+
+match-literal-or-nil-missing>t
+  m=mmap
+  ?(mget m "k"){5:"hit";_:"miss"}
+
+-- run: unwrap-with-default
+-- out: 5
+-- run: unwrap-missing-key
+-- out: 99
+-- run: match-literal-or-nil
+-- out: hit
+-- run: match-literal-or-nil-missing
+-- out: miss

--- a/src/diagnostic/registry.rs
+++ b/src/diagnostic/registry.rs
@@ -878,6 +878,39 @@ This error fires only when the bang is adjacent to the ident (`x!`,
 and is unaffected.
 "#,
     },
+    ErrorEntry {
+        code: "ILO-T035",
+        short: "Result arm (`~v:` / `^e:`) on Option subject",
+        long: r#"## ILO-T035: Result arm (`~v:` / `^e:`) on Option subject
+
+`~v:` and `^e:` are **Result** arms - they discriminate on the Ok/Err
+tag carried by a `R T E` value. Optional values (`O T`) are not tagged
+this way: an Option is either the inner value or `_` (nil). At runtime
+a `~v:` arm on an Option subject never matches and the match silently
+falls through to the wildcard or to no arm at all - usually returning
+the wrong answer with no error.
+
+The verifier now flags this shape so the bug surfaces at check time
+instead of being chased through wrong outputs.
+
+**Example (bug):**
+
+    main>n;m=mmap;m=mset m "k" 5;?(mget m "k"){~v:v;_:0}
+    -- mget returns O n; ~v: never matches; result is 0, not 5
+
+**Fix - unwrap with `??`:**
+
+    main>n;m=mmap;m=mset m "k" 5;??(mget m "k") 0
+    -- ??x default: inner value if non-nil, default otherwise
+
+**Fix - match a literal value and `_:` for nil:**
+
+    main>t;m=mmap;m=mset m "k" 5;?(mget m "k"){5:"hit";_:"miss"}
+
+`~v:` / `^e:` arms remain correct on Result (`R T E`) subjects and are
+unaffected.
+"#,
+    },
     // ── Warnings ─────────────────────────────────────────────────────────────
     ErrorEntry {
         code: "ILO-W001",

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -4183,6 +4183,36 @@ impl VerifyContext {
         arms: &[MatchArm],
         span: Span,
     ) {
+        // ILO-T035: `~v:` / `^e:` are Result arms and never match on an
+        // Optional subject at runtime - they silently fall through to the
+        // wildcard, hiding bugs. Catch this before the wildcard early
+        // return below so the diagnostic fires whether or not the user
+        // also wrote `_:`.
+        if let Ty::Optional(_) = subject_ty {
+            let bad_arm = arms
+                .iter()
+                .find(|a| matches!(a.pattern, Pattern::Ok(_) | Pattern::Err(_)));
+            if let Some(arm) = bad_arm {
+                let marker = match arm.pattern {
+                    Pattern::Ok(_) => "~",
+                    Pattern::Err(_) => "^",
+                    _ => unreachable!(),
+                };
+                self.err(
+                    "ILO-T035",
+                    func,
+                    format!(
+                        "`{marker}` arm on Option subject ({subject_ty}); Option values aren't Ok/Err-tagged so this arm never matches at runtime"
+                    ),
+                    Some(
+                        "use `??x default` to unwrap, or match a literal value and `_:` for nil; `~`/`^` only apply to Result (R T E)".to_string(),
+                    ),
+                    Some(span),
+                );
+                return;
+            }
+        }
+
         let has_wildcard = arms
             .iter()
             .any(|a| matches!(a.pattern, Pattern::Wildcard | Pattern::TypeIs { .. }));

--- a/tests/coverage_verify.rs
+++ b/tests/coverage_verify.rs
@@ -818,6 +818,49 @@ fn match_non_exhaustive_other_no_wildcard() {
     assert_err(src, "ILO-T024", "main");
 }
 
+// ---- ILO-T035: Result arm on Option subject ---------------------------------
+
+// `~v:` on an Option subject (mget returns O n) silently falls through to the
+// wildcard at runtime. The verifier now flags this.
+#[test]
+fn match_ok_arm_on_option_subject() {
+    let src = "main>n;m=mmap;m=mset m \"k\" 5;?(mget m \"k\"){~v:v;_:0}";
+    assert_err(src, "ILO-T035", "main");
+}
+
+#[test]
+fn match_err_arm_on_option_subject() {
+    let src = "main>n;m=mmap;m=mset m \"k\" 5;?(mget m \"k\"){^e:0;_:9}";
+    assert_err(src, "ILO-T035", "main");
+}
+
+#[test]
+fn match_both_ok_and_err_arm_on_option_subject() {
+    let src = "main>n;m=mmap;m=mset m \"k\" 5;?(mget m \"k\"){~v:v;^e:0;_:9}";
+    assert_err(src, "ILO-T035", "main");
+}
+
+// Negative: `~v:` / `^e:` on a Result subject still verify cleanly.
+#[test]
+fn match_ok_arm_on_result_subject_ok() {
+    let src = "main>n;r=num \"5\";?r{~v:v;^e:0}";
+    assert_ok(src, "main");
+}
+
+// Negative: Option subject with literal + wildcard arms is fine (no ~/^ arm).
+#[test]
+fn match_literal_and_wildcard_on_option_subject_ok() {
+    let src = "main>t;m=mmap;m=mset m \"k\" 5;?(mget m \"k\"){5:\"hit\";_:\"miss\"}";
+    assert_ok(src, "main");
+}
+
+// Negative: Option subject with only wildcard is fine.
+#[test]
+fn match_wildcard_only_on_option_subject_ok() {
+    let src = "main>n;m=mmap;m=mset m \"k\" 5;?(mget m \"k\"){_:0}";
+    assert_ok(src, "main");
+}
+
 // ---- bang / unwrap / Result --------------------------------------------------
 
 #[test]


### PR DESCRIPTION
Closes db-analyst rerun9. ~v:/^e: arms on Option subjects now emit ILO-T035 with mget-suggestion hint.