### PR TITLE
fix: ident-suggest scanner skips string literals + comments

### DIFF
--- a/examples/ident-suggest-skip-strings.ilo
+++ b/examples/ident-suggest-skip-strings.ilo
@@ -1,0 +1,14 @@
+-- The camelCase rename-cascade scanner (ILO-L003 "Also found in this file: ...")
+-- now skips string-literal content. Before this fix, format strings like
+-- "%Y-%m-%dT%H:%M:%S" surfaced fake offenders like `dT` from the strftime
+-- pattern, polluting the suggestion list with bytes that aren't identifiers.
+--
+-- This example is a regression smoke test: a function that returns a format
+-- string verbatim. If the scanner ever regresses and tries to lex inside the
+-- string, the source won't even compile, so the cross-engine harness will
+-- catch it on every backend.
+
+fmtstr>t;"%Y-%m-%dT%H:%M:%S"
+
+-- run: fmtstr
+-- out: %Y-%m-%dT%H:%M:%S

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -1171,6 +1171,36 @@ fn scan_camel_offenders(src: &str) -> Vec<CamelOffender> {
     let mut i = 0;
     while i < bytes.len() {
         let b = bytes[i];
+        // Skip string literal content so format strings like
+        // `"%Y-%m-%dT%H:%M"` don't surface `dT` as a fake camelCase
+        // offender. Mirrors the pre-pass at the top of this file: a `"`
+        // opens a string that runs to the next unescaped `"`.
+        if b == b'"' {
+            i += 1;
+            while i < bytes.len() {
+                let c = bytes[i];
+                if c == b'\\' {
+                    // Skip the escape byte too (handles `\"`, `\\`, etc.).
+                    i += 2;
+                    continue;
+                }
+                if c == b'"' {
+                    i += 1;
+                    break;
+                }
+                i += 1;
+            }
+            continue;
+        }
+        // Skip `--` line comments so identifiers explaining the bug in
+        // a comment don't double-report.
+        if b == b'-' && i + 1 < bytes.len() && bytes[i + 1] == b'-' {
+            i += 2;
+            while i < bytes.len() && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue;
+        }
         // Find start of a lowercase-led identifier.
         let prev = if i == 0 { 0 } else { bytes[i - 1] };
         let prev_prev = if i >= 2 { bytes[i - 2] } else { 0 };

--- a/tests/regression_friendly_errors.rs
+++ b/tests/regression_friendly_errors.rs
@@ -313,6 +313,48 @@ fn camel_cascade_truncates_long_lists() {
     );
 }
 
+// The cascade scanner walks raw bytes, so without skipping string literals it
+// would surface `dT` from a strftime format string like `"%Y-%m-%dT%H..."` as
+// a phantom camelCase offender. Skip strings (and `--` comments) so only real
+// identifiers show up in the "Also found in this file" list.
+
+#[test]
+fn camel_cascade_skips_string_literal_content() {
+    let err = run_err("main x:n>t;r=fmt \"%Y-%m-%dT%H:%M:%S\" x;badIdent=r");
+    assert!(err.contains("ILO-L003"), "stderr: {err}");
+    assert!(
+        err.contains("badIdent"),
+        "should still report the real offender: {err}"
+    );
+    assert!(
+        !err.contains("dT"),
+        "should not surface `dT` from inside the format string: {err}"
+    );
+}
+
+#[test]
+fn camel_cascade_skips_comment_content() {
+    let err = run_err("go>n;fooBar=1\n-- fixMe later\nfooBar");
+    assert!(err.contains("ILO-L003"), "stderr: {err}");
+    assert!(
+        !err.contains("fixMe"),
+        "should not surface `fixMe` from inside a comment: {err}"
+    );
+}
+
+#[test]
+fn camel_cascade_handles_escaped_quotes_in_strings() {
+    // `\"` inside a string must not close the literal early, otherwise
+    // `wowZa` in the trailing real-source position would be missed and
+    // `evilZ` (which only appears inside the escaped string) would leak.
+    let err = run_err("go>t;s=\"a\\\"evilZap\\\"b\";wowZa=1");
+    assert!(err.contains("ILO-L003"), "stderr: {err}");
+    assert!(
+        !err.contains("evilZap"),
+        "escaped quotes must not break out of the string skip: {err}"
+    );
+}
+
 // ---- `?cond{body}` bare-bool match-vs-conditional confusion ----
 
 #[test]


### PR DESCRIPTION
Closes devops-sre rerun9 false-positive on strftime format strings.