### PR TITLE
feat: unify braced and braceless guards (option A)

### DIFF
--- a/examples/cond-vs-ret.ilo
+++ b/examples/cond-vs-ret.ilo
@@ -1,27 +1,25 @@
--- Braced conditional `cond{val}` is conditional execution: val is evaluated,
--- discarded, and execution falls through. For early return inside braces use
--- `ret`. The braceless form `cond val` always early-returns when val is a
--- single expression. This file pins all three forms across every engine so the
--- footgun stays caught.
+-- Braced and braceless guards both early-return (option A unified them).
+-- For a value-producing conditional that does NOT early-return, use the
+-- prefix-ternary `?h cond then else`.
 
--- Braced: 99 is discarded, falls through to 0
-fall x:n>n;=x 1{99};0
+-- Braced guard: early return when x = 1
+brc x:n>n;=x 1{99};0
 
--- Braceless guard: early return
+-- Braceless guard: identical semantics
 gd x:n>n;=x 1 99;0
 
--- Explicit ret inside braces: early return
-explicit x:n>n;=x 1{ret 99};0
+-- Ternary (value form, no early return)
+tern x:n>n;?h =x 1 99 0
 
--- run: fall 1
--- out: 0
--- run: fall 2
+-- run: brc 1
+-- out: 99
+-- run: brc 2
 -- out: 0
 -- run: gd 1
 -- out: 99
 -- run: gd 2
 -- out: 0
--- run: explicit 1
+-- run: tern 1
 -- out: 99
--- run: explicit 2
+-- run: tern 2
 -- out: 0

--- a/examples/multiline-body-spans.ilo
+++ b/examples/multiline-body-spans.ilo
@@ -33,14 +33,13 @@ classify v:n>t
   >v 100 (+s "big")
   +s "small"
 
--- Nested foreach inside a guard body, lots of indent to compress.
+-- Nested foreach; for n=0 the loops just don't execute (0..0 is empty),
+-- so no outer guard is needed.
 gridsum n:n>n
   total = 0
-  >n 0{
-    @i 0..n{
-      @j 0..n{
-        total = +total (+i j)
-      }
+  @i 0..n{
+    @j 0..n{
+      total = +total (+i j)
     }
   }
   total

--- a/examples/string-large-at.ilo
+++ b/examples/string-large-at.ilo
@@ -5,12 +5,12 @@
 -- in-range case and the loop scales linearly.
 
 -- Count uppercase ASCII letters in a mixed-case word.
-upper-count s:t>n;l=len s;n=0;@i 0..l{c=at s i;>=c "A"{<=c "Z"{n=+n 1}}};+n 0
+upper-count s:t>n;l=len s;n=0;@i 0..l{c=at s i;hi=>=c "A";lo=<=c "Z";m=&hi lo;n=?h m (+n 1) n};+n 0
 
 -- Iterate the same word twice, once forwards, once with negative indices,
 -- and confirm both paths see the same characters. For index i, the matching
 -- negative index is i - l (so 0 maps to -l, l-1 maps to -1).
-roundtrip s:t>n;l=len s;ok=0;@i 0..l{a=at s i;j=-i l;b=at s j;=a b{ok=+ok 1}};+ok 0
+roundtrip s:t>n;l=len s;ok=0;@i 0..l{a=at s i;j=-i l;b=at s j;eq=(=a b);ok=?h eq (+ok 1) ok};+ok 0
 
 -- run: upper-count HelloWorld
 -- out: 2

--- a/src/codegen/python.rs
+++ b/src/codegen/python.rs
@@ -310,6 +310,12 @@ fn emit_stmt(out: &mut String, stmt: &Stmt, level: usize, implicit_return: bool)
             } else {
                 out.push_str(&format!("if {}:\n", cond));
             }
+            // Non-ternary guards (no else_body) are early-return forms — the
+            // body's tail expression becomes the function's return value when
+            // the condition is truthy. Pass implicit_return=true so the inner
+            // body's last Expr stmt emits `return <val>`. Ternary guards
+            // (else_body present) are value expressions and rely on the outer
+            // fn-tail context to decide whether the result is returned.
             let is_ternary = else_body.is_some();
             emit_body(out, body, level + 1, !is_ternary);
             if let Some(eb) = else_body {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -4587,8 +4587,14 @@ fn eval_stmt(env: &mut Env, stmt: &Stmt) -> Result<Option<BodyResult>> {
                     BodyResult::Continue => Ok(Some(BodyResult::Continue)),
                     BodyResult::Value(v) | BodyResult::Return(v) => Ok(Some(BodyResult::Value(v))),
                 }
-            } else if should_run && *braceless {
-                // Braceless guard: cond expr — early return from function
+            } else if should_run {
+                // Guard (braced or braceless) when truthy: early return from
+                // enclosing function. The two surface forms — `cond expr` and
+                // `cond{body}` — share semantics. `braceless` is kept on the
+                // AST for source-preserving round-trips only. Ternary
+                // `cond{a}{b}` is handled in the else_body branch above and is
+                // not an early-return form.
+                let _ = braceless; // semantics unified; flag retained for formatter
                 env.push_scope();
                 let result = eval_body(env, body);
                 env.pop_scope();
@@ -4596,17 +4602,6 @@ fn eval_stmt(env: &mut Env, stmt: &Stmt) -> Result<Option<BodyResult>> {
                     BodyResult::Break(v) => Ok(Some(BodyResult::Break(v))),
                     BodyResult::Continue => Ok(Some(BodyResult::Continue)),
                     BodyResult::Value(v) | BodyResult::Return(v) => Ok(Some(BodyResult::Return(v))),
-                }
-            } else if should_run {
-                // Braced guard: cond{body} — conditional execution (no early return)
-                env.push_scope();
-                let result = eval_body(env, body);
-                env.pop_scope();
-                match result? {
-                    BodyResult::Break(v) => Ok(Some(BodyResult::Break(v))),
-                    BodyResult::Continue => Ok(Some(BodyResult::Continue)),
-                    BodyResult::Value(v) => Ok(Some(BodyResult::Value(v))),
-                    BodyResult::Return(v) => Ok(Some(BodyResult::Return(v))),
                 }
             } else {
                 Ok(None)
@@ -7011,14 +7006,15 @@ mod tests {
     }
 
     #[test]
-    fn interpret_braced_guard_no_early_return() {
-        // Braced guard is conditional execution — no early return
+    fn interpret_braced_guard_early_returns() {
+        // Braced and braceless guards both early-return (option A unification).
         let source = "f x:n>n;=x 0{99};+x 1";
-        // x=0: {99} runs but value is discarded, returns +0 1 = 1
+        // x=0: =x 0 true, body 99 early-returns
         assert_eq!(
             run_str(source, Some("f"), vec![Value::Number(0.0)]),
-            Value::Number(1.0)
+            Value::Number(99.0)
         );
+        // x=5: guard false, falls through to +x 1
         assert_eq!(
             run_str(source, Some("f"), vec![Value::Number(5.0)]),
             Value::Number(6.0)
@@ -7040,9 +7036,10 @@ mod tests {
     }
 
     #[test]
-    fn interpret_braced_guard_in_loop_no_early_return() {
-        // Braced guard inside loop does NOT early-return — finds max of list
-        let source = "mx xs:L n>n;m=xs.0;@x xs{>x m{m=x}};+m 0";
+    fn interpret_braced_guard_in_loop_uses_ternary_rebind() {
+        // Under option A, `>x m{m=x}` in a loop early-returns. The
+        // canonical find-max idiom is the ternary rebind form.
+        let source = "mx xs:L n>n;m=xs.0;@x xs{m=>x m{x}{m}};+m 0";
         let result = run_str(
             source,
             Some("mx"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1504,24 +1504,11 @@ fn collect_hints_with_program(source: &str, program: Option<&ast::Program>) -> V
             hints.push(hint);
         }
     }
-    // AST-aware hint: braced-conditional guard `cond{^"err"}` discards the
-    // body value, which is almost always not what the author intended.
-    // Personas (qa-tester, scientific-researcher rerun3) reach for this
-    // shape expecting early-return semantics. The braceless guard form
-    // `<k 1 ^"err"` or explicit `ret`/`!`-propagate covers the real intent.
-    if let Some(prog) = program {
-        for decl in &prog.declarations {
-            if let ast::Decl::Function { body, .. } = decl
-                && walk_for_discarded_guard_result(body)
-            {
-                hints.push(
-                    "hint: `cond{^\"err\"}` and `cond{~v}` discard the body expression. For early-return use the braceless form `cond ^\"err\"` or wrap the body in `{ret ^\"err\"}`."
-                        .to_string(),
-                );
-                break; // one hint per run is enough
-            }
-        }
-    }
+    // Note: a previous hint warned that `cond{^"err"}` and `cond{~v}` discard
+    // the body expression. Under the unified guard semantics, braced guards
+    // now early-return identically to braceless guards, so the discard
+    // footgun no longer exists and the hint has been retired.
+    let _ = program;
     hints
 }
 
@@ -1618,64 +1605,6 @@ fn is_value_yielding(tok: &lexer::Token) -> bool {
             | Bang
             | BangBang
     )
-}
-
-/// Walk a body looking for a braced-conditional guard whose final body
-/// statement is an `Expr::Err(_)` or `Expr::Ok(_)` expression — a strong
-/// signal the author meant `ret ^...` / `ret ~...` but wrote `cond{^...}`,
-/// which silently discards the value.
-fn walk_for_discarded_guard_result(body: &[ast::Spanned<ast::Stmt>]) -> bool {
-    for s in body {
-        if walk_stmt_for_discarded_guard_result(&s.node) {
-            return true;
-        }
-    }
-    false
-}
-
-fn walk_stmt_for_discarded_guard_result(stmt: &ast::Stmt) -> bool {
-    match stmt {
-        ast::Stmt::Guard {
-            body,
-            else_body,
-            braceless,
-            ..
-        } => {
-            // Only fire on the original target shape: a single-statement
-            // braced body whose sole expression is `^...` or `~...`. The
-            // single-statement requirement matters because multi-statement
-            // bodies like `{prnt "..."; ~"ok"}` legitimately use the trailing
-            // `~v` as the body's return value, the author knows the value
-            // is the guard's result, not a discarded early-return. Firing
-            // there is a false positive that erodes trust in the hint.
-            if !*braceless
-                && body.len() == 1
-                && let Some(only) = body.first()
-                && matches!(
-                    only.node,
-                    ast::Stmt::Expr(ast::Expr::Err(_) | ast::Expr::Ok(_))
-                )
-            {
-                return true;
-            }
-            if walk_for_discarded_guard_result(body) {
-                return true;
-            }
-            if let Some(eb) = else_body
-                && walk_for_discarded_guard_result(eb)
-            {
-                return true;
-            }
-            false
-        }
-        ast::Stmt::Match { arms, .. } => arms
-            .iter()
-            .any(|a| walk_for_discarded_guard_result(&a.body)),
-        ast::Stmt::ForEach { body, .. }
-        | ast::Stmt::ForRange { body, .. }
-        | ast::Stmt::While { body, .. } => walk_for_discarded_guard_result(body),
-        _ => false,
-    }
 }
 
 /// Strip both string-literal contents and `--`-prefixed line comments,
@@ -3566,17 +3495,26 @@ fn body_has_early_return(body: &[ast::Spanned<ast::Stmt>]) -> bool {
 fn stmt_has_early_return(stmt: &ast::Stmt) -> bool {
     match stmt {
         ast::Stmt::Return(_) => true,
-        // Braceless guards (`cond expr`) early-return from the function.
+        // Both braced and braceless guards (`cond expr` / `cond{body}`) early-
+        // return from the function under the unified-guard semantics. Ternary
+        // `cond{a}{b}` (else_body present) is a value form and does not
+        // short-circuit on its own, but its branches might contain `ret`.
         ast::Stmt::Guard {
-            braceless: true, ..
-        } => true,
-        // Braced guards do NOT early-return, but their bodies might contain `ret`.
-        ast::Stmt::Guard {
-            body, else_body, ..
+            body,
+            else_body: None,
+            ..
         } => {
-            body_has_early_return(body)
-                || else_body.as_ref().is_some_and(|b| body_has_early_return(b))
+            // Either the guard itself is an early-return when the condition
+            // is truthy, or the body contains an explicit `ret` / nested
+            // early-return.
+            let _ = body;
+            true
         }
+        ast::Stmt::Guard {
+            body,
+            else_body: Some(eb),
+            ..
+        } => body_has_early_return(body) || body_has_early_return(eb),
         ast::Stmt::Match { arms, .. } => arms.iter().any(|a| body_has_early_return(&a.body)),
         ast::Stmt::ForEach { body, .. }
         | ast::Stmt::ForRange { body, .. }
@@ -4683,117 +4621,12 @@ mod tests {
     }
 
     #[test]
-    fn collect_hints_discarded_err_in_guard_body() {
-        // `f x:n>R n t;<x 0{^"neg"};~x` — `^"neg"` is silently discarded.
-        let prog = parse_program("f x:n>R n t;<x 0{^\"neg\"};~x");
-        let hints = collect_hints_with_program("f x:n>R n t;<x 0{^\"neg\"};~x", Some(&prog));
-        assert!(
-            hints
-                .iter()
-                .any(|h| h.contains("discard the body expression")),
-            "hints: {:?}",
-            hints
-        );
-    }
-
-    #[test]
-    fn collect_hints_discarded_ok_in_guard_body() {
-        // Symmetric: braced-cond with `~v` in tail also discarded.
-        let prog = parse_program("f x:n>R n t;>x 0{~x};^\"neg\"");
-        let hints = collect_hints_with_program("f x:n>R n t;>x 0{~x};^\"neg\"", Some(&prog));
-        assert!(
-            hints
-                .iter()
-                .any(|h| h.contains("discard the body expression")),
-            "hints: {:?}",
-            hints
-        );
-    }
-
-    #[test]
-    fn collect_hints_braceless_guard_no_discard_hint() {
-        // Braceless guard `<x 0 ^"neg"` is the canonical early-return shape
-        // and must NOT trigger the hint.
-        let prog = parse_program("f x:n>R n t;<x 0 ^\"neg\";~x");
-        let hints = collect_hints_with_program("f x:n>R n t;<x 0 ^\"neg\";~x", Some(&prog));
-        assert!(
-            !hints
-                .iter()
-                .any(|h| h.contains("discard the body expression")),
-            "hints: {:?}",
-            hints
-        );
-    }
-
-    #[test]
-    fn collect_hints_explicit_ret_in_guard_no_discard_hint() {
-        // `<x 0{ret ^"neg"}` is the explicit-return form; no hint.
-        let prog = parse_program("f x:n>R n t;<x 0{ret ^\"neg\"};~x");
-        let hints = collect_hints_with_program("f x:n>R n t;<x 0{ret ^\"neg\"};~x", Some(&prog));
-        assert!(
-            !hints
-                .iter()
-                .any(|h| h.contains("discard the body expression")),
-            "hints: {:?}",
-            hints
-        );
-    }
-
-    #[test]
-    fn collect_hints_discarded_err_inside_foreach_body() {
-        // Nested-body coverage: discarded `^...` inside an `@k xs{}` body.
-        let prog = parse_program("f xs:L n>R n t;@k xs{<k 0{^\"neg\"}};~0");
-        let hints =
-            collect_hints_with_program("f xs:L n>R n t;@k xs{<k 0{^\"neg\"}};~0", Some(&prog));
-        assert!(
-            hints
-                .iter()
-                .any(|h| h.contains("discard the body expression")),
-            "hints: {:?}",
-            hints
-        );
-    }
-
-    #[test]
-    fn collect_hints_discarded_err_inside_match_arm_body() {
-        // Match-arm body contains a braced-cond guard whose tail discards
-        // an `^...` expression. Walker should recurse into match arms.
-        let src = "f r:R n t>R n t;?r{~v:<v 0{^\"neg\"};~v;^e:^e}";
-        let prog = parse_program(src);
-        let hints = collect_hints_with_program(src, Some(&prog));
-        assert!(
-            hints
-                .iter()
-                .any(|h| h.contains("discard the body expression")),
-            "hints: {:?}",
-            hints
-        );
-    }
-
-    #[test]
-    fn collect_hints_multi_stmt_guard_body_with_trailing_ok_no_hint() {
-        // False-positive guard: a multi-statement braced body that ends with
-        // a `~v` is legitimately returning that value as the guard's result.
-        // The author is NOT discarding it. Compare to the single-stmt shape
-        // `{~v}` which IS the discard pattern. Source from interactive-cli
-        // persona rerun4: `f n:n>R t t;=n 0{prnt "empty";~"ok"};~"done"`.
-        let src = "f n:n>R t t;=n 0{prnt \"empty\";~\"ok\"};~\"done\"";
-        let prog = parse_program(src);
-        let hints = collect_hints_with_program(src, Some(&prog));
-        assert!(
-            !hints
-                .iter()
-                .any(|h| h.contains("discard the body expression")),
-            "hints: {:?}",
-            hints
-        );
-    }
-
-    #[test]
-    fn collect_hints_multi_stmt_guard_body_with_trailing_err_no_hint() {
-        // Symmetric: multi-statement body ending with `^...` is also a
-        // legitimate guard return, not a discard.
-        let src = "f x:n>R n t;<x 0{prnt \"neg\";^\"bad\"};~x";
+    fn collect_hints_braced_guard_no_discard_hint_under_unified_semantics() {
+        // Under the unified-guard semantics, braced `cond{^"neg"}` early-returns
+        // just like braceless. The old "discard the body expression" hint has
+        // been retired. Pin the absence here so future hint work doesn't
+        // regress and reintroduce a false-positive on the now-canonical form.
+        let src = "f x:n>R n t;<x 0{^\"neg\"};~x";
         let prog = parse_program(src);
         let hints = collect_hints_with_program(src, Some(&prog));
         assert!(

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -3140,8 +3140,12 @@ impl VerifyContext {
             } => {
                 let _ = self.infer_expr(func, scope, condition, span);
 
-                // Warn if braceless guard body is a single identifier matching a function name.
-                if body.len() == 1
+                // Warn if a guard body is a single identifier matching a function
+                // name (braced or braceless — semantics are unified). Almost
+                // always the author meant to call the function, not return a
+                // function reference as the early-return value.
+                if else_body.is_none()
+                    && body.len() == 1
                     && let Stmt::Expr(Expr::Ref(ref name)) = body[0].node
                     && (self.functions.contains_key(name) || is_builtin(name))
                 {
@@ -3149,8 +3153,12 @@ impl VerifyContext {
                     self.err(
                         "ILO-T027",
                         func,
-                        format!("braceless guard body '{name}' is a function name — did you mean to call it?"),
-                        Some(format!("use braces for function calls: cond{{{name} args}}")),
+                        format!(
+                            "guard body '{name}' is a function name — did you mean to call it?"
+                        ),
+                        Some(format!(
+                            "use braces with arguments to call: cond{{{name} args}}"
+                        )),
                         Some(body_span),
                     );
                 }
@@ -5845,7 +5853,39 @@ mod tests {
             errors
                 .iter()
                 .any(|e| e.code == "ILO-T027" && e.message.contains("len")),
-            "expected ILO-T027 for builtin name in braceless guard body, got: {:?}",
+            "expected ILO-T027 for builtin name in guard body, got: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn braced_guard_body_is_function_name_warns() {
+        // Mirror of `braceless_guard_body_is_function_name` for the braced
+        // form. Under the unified-guard semantics both early-return, so a
+        // bare function-name body is a bug in either shape.
+        let result = parse_and_verify(
+            "classify n:n>t;\"done\"\ncls sp:n>t;>=sp 1000{classify};\"fallback\"",
+        );
+        let errors = result.unwrap_err();
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.code == "ILO-T027" && e.message.contains("classify")),
+            "expected ILO-T027 for function name in braced guard body, got: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn braced_guard_body_is_builtin_name_warns() {
+        // Mirror for builtin name in a braced guard body.
+        let result = parse_and_verify("f x:n>n;>=x 0{len};x");
+        let errors = result.unwrap_err();
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.code == "ILO-T027" && e.message.contains("len")),
+            "expected ILO-T027 for builtin name in braced guard body, got: {:?}",
             errors
         );
     }

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -5831,7 +5831,7 @@ f a:t b:t>t;join a b"#,
 
     #[test]
     fn codegen_cov_inline_cmpk_guard_callee() {
-        // Callee uses OP_CMPK_GT_N (guard >x 0) + braceless return + OP_LOADK for 0:
+        // Callee uses OP_CMPK_GT_N (guard >x 0) + early return + OP_LOADK for 0:
         //   `pos x:n>n;>x 0 x;0`
         // This exercises the OP_CMPK_*, OP_JMP, and OP_LOADK branches in inline_chunk.
         let bytes = compile_to_object_bytes("pos x:n>n;>x 0 x;0\nf x:n>n;pos x");
@@ -5864,7 +5864,7 @@ f a:t b:t>t;join a b"#,
 
     #[test]
     fn codegen_cov_jmpt_always_bool() {
-        // A negated braceless guard `!>x 5 10;0` emits OP_JMPT on an always-bool
+        // A negated guard `!>x 5 10;0` emits OP_JMPT on an always-bool
         // register (the comparison result).
         let bytes = compile_to_object_bytes("f x:n>n;!>x 5 10;0");
         assert!(
@@ -5879,9 +5879,7 @@ f a:t b:t>t;join a b"#,
     #[test]
     fn codegen_cov_inline_cmpk_lt_callee() {
         // Callee uses OP_CMPK_LT_N (guard <x 0) — inline_chunk OP_CMPK_LT_N branch.
-        // `neg x:n>n;<x 0{ret x};0` — returns x if x<0, else 0.
-        // But `ret` inside braced guard is fine; callee is inlinable.
-        // Actually, braceless guard: `<x 0 x;0` = if x<0 return x, else 0.
+        // Guard `<x 0 x;0` = if x<0 return x, else 0.
         let bytes = compile_to_object_bytes("negval x:n>n;<x 0 x;0\nf x:n>n;negval x");
         assert!(
             bytes.is_ok(),

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -6250,7 +6250,7 @@ mod tests {
         assert_eq!(result, Some(5.0));
     }
 
-    // Greater-than comparison (OP_CMPK_GT_N path) — braceless guards (early return)
+    // Greater-than comparison (OP_CMPK_GT_N path) — guards (early return)
     #[test]
     fn cranelift_cov_gt_comparison() {
         let result = jit_run_numeric("f x:n>n;>x 5 1;0", "f", &[10.0]);
@@ -6302,14 +6302,14 @@ mod tests {
         assert_eq!(result, Some(12.0));
     }
 
-    // Equality check — braceless guard (early return)
+    // Equality check — guard (early return)
     #[test]
     fn cranelift_cov_eq() {
         let result = jit_run_numeric("f a:n b:n>n;=a b 1;0", "f", &[5.0, 5.0]);
         assert_eq!(result, Some(1.0));
     }
 
-    // Not-equal check — braceless guard (early return)
+    // Not-equal check — guard (early return)
     #[test]
     fn cranelift_cov_neq() {
         let result = jit_run_numeric("f a:n b:n>n;!=a b 1;0", "f", &[5.0, 3.0]);

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -2033,8 +2033,13 @@ impl RegCompiler {
                     self.current.patch_jump(jump_over_else);
                     self.next_reg = result_reg + 1;
                     Some(result_reg)
-                } else if *braceless {
-                    // Braceless guard: cond expr — early return
+                } else {
+                    // Guard (braced or braceless) when truthy: early return.
+                    // The two surface forms — `cond expr` and `cond{body}` —
+                    // share semantics. `braceless` is kept on the AST for
+                    // source-preserving round-trips only. Ternary is handled
+                    // in the else_body branch above and is not early-return.
+                    let _ = braceless;
                     let body_result = self.compile_body(body);
                     let ret_reg = body_result.unwrap_or_else(|| {
                         let r = self.alloc_reg();
@@ -2046,22 +2051,6 @@ impl RegCompiler {
                     self.current.patch_jump(jump);
                     self.next_reg = saved_next;
                     None
-                } else {
-                    // Braced guard: cond{body} — conditional execution (no early return)
-                    // Compile body, condition-false jump skips it, no OP_RET emitted.
-                    // The body value is available (like ternary) but does not early-return.
-                    let result_reg = self.alloc_reg();
-                    // Initialize result_reg to Nil (default when condition is false)
-                    let nil_ki = self.current.add_const(Value::Nil);
-                    self.emit_abx(OP_LOADK, result_reg, nil_ki);
-                    let body_result = self.compile_body(body);
-                    let body_reg = body_result.unwrap_or(result_reg);
-                    if body_reg != result_reg {
-                        self.emit_abc(OP_MOVE, result_reg, body_reg, 0);
-                    }
-                    self.current.patch_jump(jump);
-                    self.next_reg = result_reg + 1;
-                    Some(result_reg)
                 }
             }
 
@@ -26157,13 +26146,12 @@ mod tests {
     // ── Guard & ternary ─────────────────────────────────────────────────
 
     #[test]
-    fn vm_braced_guard_no_early_return() {
-        // Braced guard is conditional execution — no early return
+    fn vm_braced_guard_early_returns() {
+        // Braced and braceless guards both early-return (option A).
         let source = "f x:n>n;=x 0{99};+x 1";
-        // x=0: {99} runs but value is discarded, returns +0 1 = 1
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Number(0.0)]),
-            Value::Number(1.0)
+            Value::Number(99.0)
         );
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Number(5.0)]),
@@ -26186,9 +26174,9 @@ mod tests {
     }
 
     #[test]
-    fn vm_braced_guard_in_loop_no_early_return() {
-        // Braced guard inside loop does NOT early-return — finds max of list
-        let source = "mx xs:L n>n;m=xs.0;@x xs{>x m{m=x}};+m 0";
+    fn vm_braced_guard_in_loop_uses_ternary_rebind() {
+        // Under option A the canonical find-max idiom is the ternary rebind.
+        let source = "mx xs:L n>n;m=xs.0;@x xs{m=>x m{x}{m}};+m 0";
         let result = vm_run(
             source,
             Some("mx"),

--- a/tests/eval_inline.rs
+++ b/tests/eval_inline.rs
@@ -1865,8 +1865,8 @@ fn braceless_guard_fibonacci() {
 }
 
 #[test]
-fn braceless_guard_early_return_vs_braced_conditional() {
-    // Braceless guard: early return → returns "gold" for 1500
+fn braceless_and_braced_guards_both_early_return() {
+    // Option A: braced and braceless guards both early-return.
     let braceless = ilo()
         .args([
             r#"cls sp:n>t;>=sp 1000 "gold";>=sp 500 "silver";"bronze""#,
@@ -1877,9 +1877,8 @@ fn braceless_guard_early_return_vs_braced_conditional() {
     assert_eq!(
         String::from_utf8_lossy(&braceless.stdout).trim(),
         "gold",
-        "braceless guard should early-return"
+        "braceless guard early-returns"
     );
-    // Braced guard: conditional execution (no early return) → returns "bronze"
     let braced = ilo()
         .args([
             r#"cls sp:n>t;>=sp 1000{"gold"};>=sp 500{"silver"};"bronze""#,
@@ -1889,8 +1888,8 @@ fn braceless_guard_early_return_vs_braced_conditional() {
         .expect("failed to run ilo");
     assert_eq!(
         String::from_utf8_lossy(&braced.stdout).trim(),
-        "bronze",
-        "braced guard should be conditional execution (no early return)"
+        "gold",
+        "braced guard also early-returns under option A"
     );
 }
 

--- a/tests/regression_loop_print.rs
+++ b/tests/regression_loop_print.rs
@@ -111,7 +111,7 @@ const EMPTY_LOOP: &str = "f>n;xs=[];@x xs{prnt x}";
 //    Function ends with the loop so the loop tail bubbles up. Suppressed.
 //    Body ends with `prnt s` so the loop's value type is `n` (typechecker
 //    requires the tail to resolve to the declared return type).
-const BRK_LOOP: &str = "f>n;s=0;@i 0..10{>=i 3{brk};s=+s i;prnt s}";
+const BRK_LOOP: &str = "f>n;s=0;@i 0..10{>=i 3{brk}{nil};s=+s i;prnt s}";
 
 // 5. While loop at top level. Body ends with `prnt i` for the same type
 //    reason as BRK_LOOP — the loop's value must type-check as `n`.


### PR DESCRIPTION
Closes the long-running braced-vs-braceless footgun by making both forms early-return. Manifesto-aligned: one canonical idiom replaces two distinct semantics. Affected idioms are rewritten using ternary or builtin alternatives; persona-doc moved to Addressed.