### PR TITLE
feature: VM closure support (Phase 2 PR1)

### DIFF
--- a/examples/inline-lambda-capture.ilo
+++ b/examples/inline-lambda-capture.ilo
@@ -29,7 +29,7 @@ contains ws:L t needle:t>L t;flt (w:t>b;has w needle) ws
 -- Weighted sum: the per-item weight is captured.
 wsum xs:L n w:n>n;fld (a:n x:n>n;+a *x w) xs 0
 
--- engine-skip: vm jit cranelift
+-- engine-skip: jit cranelift
 -- run: above [1,5,3,8,2] 4
 -- out: [5, 8]
 -- run: near [1,5,10,20] 8

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -5674,6 +5674,21 @@ enum HeapObj {
     },
     OkVal(NanVal),
     ErrVal(NanVal),
+    /// Closure: a named (lifted) function plus by-value capture snapshots.
+    ///
+    /// Produced by `OP_MAKE_CLOSURE` when an inline lambda `(params>ret;body)`
+    /// closes over enclosing-scope variables. Stored under the `TAG_LIST` tag
+    /// (heap-pointer space) and discriminated at deref by HeapObj variant.
+    /// `slice_of`, `materialize_list_view`, and other list-shaped ops error on
+    /// this variant — closures are not list-like. `OP_CALL_DYN` checks for
+    /// `HeapObj::Closure` at callee deref and prepends `captures` onto the
+    /// call frame's arg slice before dispatching as a plain User/Builtin
+    /// call (mirroring the tree interpreter's Value::Closure handling).
+    Closure {
+        kind: FnRefKind,
+        id: u32,
+        captures: Vec<NanVal>,
+    },
 }
 
 impl Drop for HeapObj {
@@ -5704,6 +5719,11 @@ impl Drop for HeapObj {
             }
             HeapObj::OkVal(inner) | HeapObj::ErrVal(inner) => {
                 inner.drop_rc();
+            }
+            HeapObj::Closure { captures, .. } => {
+                for v in captures {
+                    v.drop_rc();
+                }
             }
         }
     }
@@ -5744,7 +5764,10 @@ fn materialize_list_view(v: NanVal) -> NanVal {
                 .collect();
             NanVal::heap_list(items)
         }
-        // Tag-checked above, so unreachable; explicit arms for audit.
+        // Tag-checked above, so unreachable for these variants. Closure
+        // shares TAG_LIST but is not list-shaped — materialize_list_view is
+        // a no-op for closures (they don't have a list-view sibling).
+        HeapObj::Closure { .. } => v,
         HeapObj::Str(_)
         | HeapObj::Map(_)
         | HeapObj::Record { .. }
@@ -5794,11 +5817,15 @@ fn slice_of(obj: &HeapObj) -> &[NanVal] {
         HeapObj::List(items) => items.as_slice(),
         // Non-list variants: slice_of is contractually list-only, but explicit
         // arms keep rustc audit-enforced if HeapObj grows new variants later.
+        // Closure shares TAG_LIST but is not list-like — list ops must error
+        // rather than silently return an empty slice or read closure bytes
+        // as if they were list elements.
         HeapObj::Str(_)
         | HeapObj::Map(_)
         | HeapObj::Record { .. }
         | HeapObj::OkVal(_)
-        | HeapObj::ErrVal(_) => {
+        | HeapObj::ErrVal(_)
+        | HeapObj::Closure { .. } => {
             debug_assert!(false, "slice_of called on non-list HeapObj variant");
             &[]
         }
@@ -5831,7 +5858,8 @@ fn slice_of(obj: &HeapObj) -> &[NanVal] {
                 | HeapObj::Map(_)
                 | HeapObj::Record { .. }
                 | HeapObj::OkVal(_)
-                | HeapObj::ErrVal(_) => {
+                | HeapObj::ErrVal(_)
+                | HeapObj::Closure { .. } => {
                     debug_assert!(false, "ListView::src does not reference HeapObj::List");
                     &[]
                 }
@@ -5948,6 +5976,18 @@ impl NanVal {
         let rc = Rc::new(HeapObj::Record { type_info, fields });
         let ptr = Rc::into_raw(rc) as u64;
         NanVal(TAG_RECORD | (ptr & PTR_MASK))
+    }
+
+    /// Construct a closure value wrapping a named (lifted) function and a
+    /// vector of by-value capture snapshots. Stored under `TAG_LIST` so the
+    /// caller can use the existing heap-pointer space without carving a new
+    /// NaN tag; discrimination from real lists happens at deref by HeapObj
+    /// variant. The caller transfers ownership of each capture's RC into
+    /// the closure (no clone_rc here); the closure's Drop releases them.
+    fn heap_closure(kind: FnRefKind, id: u32, captures: Vec<NanVal>) -> Self {
+        let rc = Rc::new(HeapObj::Closure { kind, id, captures });
+        let ptr = Rc::into_raw(rc) as u64;
+        NanVal(TAG_LIST | (ptr & PTR_MASK))
     }
 
     /// Create a NanVal pointing to an arena-allocated record.
@@ -6238,6 +6278,23 @@ impl NanVal {
                     NanVal::heap_string(name.clone())
                 }
             }
+            Value::Closure { fn_name, captures } => {
+                let (kind, id) = if let Some(idx) = func_names.iter().position(|n| n == fn_name) {
+                    (FnRefKind::User, idx as u32)
+                } else if let Some(b) = crate::builtins::Builtin::from_name(fn_name) {
+                    (FnRefKind::Builtin, b.tag() as u32)
+                } else {
+                    // Unresolved closure name — fall back to text so any
+                    // downstream call surfaces a clear diagnostic rather
+                    // than producing an opaque closure with a dangling id.
+                    return NanVal::heap_string(fn_name.clone());
+                };
+                let nv_captures: Vec<NanVal> = captures
+                    .iter()
+                    .map(|v| NanVal::from_value_with_program(v, func_names))
+                    .collect();
+                NanVal::heap_closure(kind, id, nv_captures)
+            }
             _ => NanVal::from_value(val),
         }
     }
@@ -6327,6 +6384,20 @@ impl NanVal {
                     },
                     HeapObj::OkVal(inner) => Value::Ok(Box::new(inner.to_value())),
                     HeapObj::ErrVal(inner) => Value::Err(Box::new(inner.to_value())),
+                    HeapObj::Closure { kind, id, captures } => {
+                        let fn_name = match kind {
+                            FnRefKind::Builtin => crate::builtins::Builtin::from_tag(*id as u8)
+                                .map(|b| b.name().to_string())
+                                .unwrap_or_else(|| format!("<unknown_builtin:{}>", id)),
+                            FnRefKind::User => {
+                                active_func_name(*id).unwrap_or_else(|| format!("<user_fn:{}>", id))
+                            }
+                        };
+                        Value::Closure {
+                            fn_name,
+                            captures: captures.iter().map(|v| v.to_value()).collect(),
+                        }
+                    }
                 }
             },
         }
@@ -6393,6 +6464,24 @@ impl NanVal {
                         }
                         HeapObj::ErrVal(inner) => {
                             Value::Err(Box::new(inner.to_value_with_program(func_names)))
+                        }
+                        HeapObj::Closure { kind, id, captures } => {
+                            let fn_name = match kind {
+                                FnRefKind::Builtin => crate::builtins::Builtin::from_tag(*id as u8)
+                                    .map(|b| b.name().to_string())
+                                    .unwrap_or_else(|| format!("<unknown_builtin:{}>", id)),
+                                FnRefKind::User => func_names
+                                    .get(*id as usize)
+                                    .cloned()
+                                    .unwrap_or_else(|| format!("<user_fn:{}>", id)),
+                            };
+                            Value::Closure {
+                                fn_name,
+                                captures: captures
+                                    .iter()
+                                    .map(|v| v.to_value_with_program(func_names))
+                                    .collect(),
+                            }
                         }
                     }
                 }
@@ -8006,7 +8095,8 @@ impl<'a> VM<'a> {
                             | HeapObj::Map(_)
                             | HeapObj::Record { .. }
                             | HeapObj::OkVal(_)
-                            | HeapObj::ErrVal(_) => {
+                            | HeapObj::ErrVal(_)
+                            | HeapObj::Closure { .. } => {
                                 vm_err!(VmError::Type("index access on non-list"))
                             }
                         }
@@ -8045,7 +8135,8 @@ impl<'a> VM<'a> {
                                 | HeapObj::Map(_)
                                 | HeapObj::Record { .. }
                                 | HeapObj::OkVal(_)
-                                | HeapObj::ErrVal(_) => {
+                                | HeapObj::ErrVal(_)
+                                | HeapObj::Closure { .. } => {
                                     vm_err!(VmError::Type("foreach requires a list"))
                                 }
                             }
@@ -8086,7 +8177,8 @@ impl<'a> VM<'a> {
                             | HeapObj::Map(_)
                             | HeapObj::Record { .. }
                             | HeapObj::OkVal(_)
-                            | HeapObj::ErrVal(_) => {
+                            | HeapObj::ErrVal(_)
+                            | HeapObj::Closure { .. } => {
                                 vm_err!(VmError::Type("foreach requires a list"))
                             }
                         }
@@ -8128,7 +8220,8 @@ impl<'a> VM<'a> {
                             | HeapObj::Map(_)
                             | HeapObj::Record { .. }
                             | HeapObj::OkVal(_)
-                            | HeapObj::ErrVal(_) => {
+                            | HeapObj::ErrVal(_)
+                            | HeapObj::Closure { .. } => {
                                 // Should never happen: list was validated by FOREACHPREP.
                                 vm_err!(VmError::Type("foreach requires a list"))
                             }
@@ -9070,7 +9163,8 @@ impl<'a> VM<'a> {
                             HeapObj::Str(_)
                             | HeapObj::Record { .. }
                             | HeapObj::OkVal(_)
-                            | HeapObj::ErrVal(_) => {
+                            | HeapObj::ErrVal(_)
+                            | HeapObj::Closure { .. } => {
                                 vm_err!(VmError::Type("len requires string, list, or map"))
                             }
                         }
@@ -10100,7 +10194,8 @@ impl<'a> VM<'a> {
                             | HeapObj::Map(_)
                             | HeapObj::Record { .. }
                             | HeapObj::OkVal(_)
-                            | HeapObj::ErrVal(_) => {
+                            | HeapObj::ErrVal(_)
+                            | HeapObj::Closure { .. } => {
                                 vm_err!(VmError::Type("has requires a list or text"))
                             }
                         }
@@ -10143,7 +10238,8 @@ impl<'a> VM<'a> {
                             | HeapObj::Map(_)
                             | HeapObj::Record { .. }
                             | HeapObj::OkVal(_)
-                            | HeapObj::ErrVal(_) => {
+                            | HeapObj::ErrVal(_)
+                            | HeapObj::Closure { .. } => {
                                 vm_err!(VmError::Type("hd requires a list or text"))
                             }
                         }
@@ -10218,7 +10314,8 @@ impl<'a> VM<'a> {
                             | HeapObj::Map(_)
                             | HeapObj::Record { .. }
                             | HeapObj::OkVal(_)
-                            | HeapObj::ErrVal(_) => {
+                            | HeapObj::ErrVal(_)
+                            | HeapObj::Closure { .. } => {
                                 vm_err!(VmError::Type("at requires a list or text"))
                             }
                         }
@@ -10615,7 +10712,8 @@ impl<'a> VM<'a> {
                             | HeapObj::Map(_)
                             | HeapObj::Record { .. }
                             | HeapObj::OkVal(_)
-                            | HeapObj::ErrVal(_) => {
+                            | HeapObj::ErrVal(_)
+                            | HeapObj::Closure { .. } => {
                                 vm_err!(VmError::Type("tl requires a list or text"))
                             }
                         }
@@ -10654,7 +10752,8 @@ impl<'a> VM<'a> {
                             | HeapObj::Map(_)
                             | HeapObj::Record { .. }
                             | HeapObj::OkVal(_)
-                            | HeapObj::ErrVal(_) => {
+                            | HeapObj::ErrVal(_)
+                            | HeapObj::Closure { .. } => {
                                 vm_err!(VmError::Type("rev requires a list or text"))
                             }
                         }
@@ -10722,7 +10821,8 @@ impl<'a> VM<'a> {
                             | HeapObj::Map(_)
                             | HeapObj::Record { .. }
                             | HeapObj::OkVal(_)
-                            | HeapObj::ErrVal(_) => {
+                            | HeapObj::ErrVal(_)
+                            | HeapObj::Closure { .. } => {
                                 vm_err!(VmError::Type("srt requires a list or text"))
                             }
                         }
@@ -10789,7 +10889,8 @@ impl<'a> VM<'a> {
                             | HeapObj::Map(_)
                             | HeapObj::Record { .. }
                             | HeapObj::OkVal(_)
-                            | HeapObj::ErrVal(_) => {
+                            | HeapObj::ErrVal(_)
+                            | HeapObj::Closure { .. } => {
                                 vm_err!(VmError::Type("rsrt requires a list or text"))
                             }
                         }
@@ -10980,7 +11081,8 @@ impl<'a> VM<'a> {
                             | HeapObj::Map(_)
                             | HeapObj::Record { .. }
                             | HeapObj::OkVal(_)
-                            | HeapObj::ErrVal(_) => {
+                            | HeapObj::ErrVal(_)
+                            | HeapObj::Closure { .. } => {
                                 vm_err!(VmError::Type("slc requires a list or text"))
                             }
                         }
@@ -11034,7 +11136,8 @@ impl<'a> VM<'a> {
                             | HeapObj::Map(_)
                             | HeapObj::Record { .. }
                             | HeapObj::OkVal(_)
-                            | HeapObj::ErrVal(_) => {
+                            | HeapObj::ErrVal(_)
+                            | HeapObj::Closure { .. } => {
                                 vm_err!(VmError::Type("lst requires a list"))
                             }
                         }
@@ -11187,7 +11290,8 @@ impl<'a> VM<'a> {
                             | HeapObj::Map(_)
                             | HeapObj::Record { .. }
                             | HeapObj::OkVal(_)
-                            | HeapObj::ErrVal(_) => {
+                            | HeapObj::ErrVal(_)
+                            | HeapObj::Closure { .. } => {
                                 vm_err!(VmError::Type("take requires a list or text"))
                             }
                         }
@@ -11237,7 +11341,8 @@ impl<'a> VM<'a> {
                             | HeapObj::Map(_)
                             | HeapObj::Record { .. }
                             | HeapObj::OkVal(_)
-                            | HeapObj::ErrVal(_) => {
+                            | HeapObj::ErrVal(_)
+                            | HeapObj::Closure { .. } => {
                                 vm_err!(VmError::Type("drop requires a list or text"))
                             }
                         }
@@ -11314,7 +11419,8 @@ impl<'a> VM<'a> {
                             | HeapObj::Map(_)
                             | HeapObj::Record { .. }
                             | HeapObj::OkVal(_)
-                            | HeapObj::ErrVal(_) => {
+                            | HeapObj::ErrVal(_)
+                            | HeapObj::Closure { .. } => {
                                 return Err(VmError::Type("+= requires a list"));
                             }
                         }
@@ -11339,7 +11445,8 @@ impl<'a> VM<'a> {
                             | HeapObj::Map(_)
                             | HeapObj::Record { .. }
                             | HeapObj::OkVal(_)
-                            | HeapObj::ErrVal(_) => {
+                            | HeapObj::ErrVal(_)
+                            | HeapObj::Closure { .. } => {
                                 vm_err!(VmError::Type("+= requires a list"))
                             }
                         }
@@ -11690,6 +11797,20 @@ fn nanval_to_json(v: NanVal) -> serde_json::Value {
                             .collect();
                         serde_json::Value::Object(obj)
                     }
+                    HeapObj::Closure { kind, id, .. } => {
+                        // Closures don't have a meaningful JSON representation —
+                        // serialise as a sentinel string so jdmp surfaces "got a
+                        // closure" rather than panicking or producing junk.
+                        let name = match kind {
+                            FnRefKind::Builtin => crate::builtins::Builtin::from_tag(*id as u8)
+                                .map(|b| b.name().to_string())
+                                .unwrap_or_else(|| format!("<unknown_builtin:{}>", id)),
+                            FnRefKind::User => {
+                                active_func_name(*id).unwrap_or_else(|| format!("<user_fn:{}>", id))
+                            }
+                        };
+                        serde_json::Value::String(format!("<closure:{}>", name))
+                    }
                 }
             }
         }
@@ -11832,7 +11953,8 @@ fn nanval_truthy(v: NanVal) -> bool {
                     HeapObj::Map(_)
                     | HeapObj::Record { .. }
                     | HeapObj::OkVal(_)
-                    | HeapObj::ErrVal(_) => true,
+                    | HeapObj::ErrVal(_)
+                    | HeapObj::Closure { .. } => true,
                 }
             },
         }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -372,6 +372,19 @@ pub(crate) const OP_CHARS: u8 = 158; // R[A] = chars(R[B])
 // heap allocation, so OP_LOADFN compiles to a single register write.
 pub(crate) const OP_LOADFN: u8 = 159;
 
+// ABC OP_MAKE_CLOSURE: build a HeapObj::Closure capturing N values.
+//   A = destination register (closure NanVal)
+//   B = source register holding a FnRef NanVal (kind + id come from there)
+//   C = capture count N, 0..=255
+// Followed by ceil(N / 4) inline data words holding the source register
+// indices to capture from, packed 4 per 32-bit word in little-endian
+// byte order: word[0] = idx0 | (idx1<<8) | (idx2<<16) | (idx3<<24).
+// Captures are snapshot by value at construction time (RC-bumped on
+// the way into the closure); subsequent rebinding of the source
+// registers leaves the closure unchanged. Mirrors the by-value
+// semantics of Value::Closure in the tree interpreter.
+pub(crate) const OP_MAKE_CLOSURE: u8 = 178;
+
 // Dynamic call by function reference. The callee is a FnRef NanVal sitting
 // in a register; we decode its (kind, id), then either push a VM frame
 // (user fn) or invoke the builtin dispatch path (builtin).
@@ -4993,19 +5006,72 @@ impl RegCompiler {
                     a
                 }
             }
-            Expr::MakeClosure { fn_name, .. } => {
-                // VM/Cranelift HOF dispatch is the parked FnRef NaN-tagging
-                // effort. Inline lambdas with captures only run on the tree
-                // interpreter. Surface a compile error via `first_error` so
-                // `vm::compile` returns `Err(UnsupportedClosureCapture)`; the
-                // default runner in main.rs treats a failed `vm::compile` as
-                // "skip JIT, run on the tree" — which is exactly what we want
-                // until the FnRef NaN-tagging follow-up lands.
-                self.first_error
-                    .get_or_insert(CompileError::UnsupportedClosureCapture {
-                        fn_name: fn_name.clone(),
-                    });
-                0
+            Expr::MakeClosure { fn_name, captures } => {
+                // PR1 Phase 2 closure capture: emit a fn-ref load + OP_MAKE_CLOSURE
+                // that snapshots N capture values into a HeapObj::Closure NanVal.
+                // OP_CALL_DYN at dispatch time detects the closure variant and
+                // prepends captures onto the call frame's arg slice before
+                // entering the lifted function. Cranelift JIT inherits this on
+                // PR2 via its existing jit_call_dyn re-entry into the VM.
+                if captures.len() > 255 {
+                    self.first_error
+                        .get_or_insert(CompileError::UnsupportedClosureCapture {
+                            fn_name: fn_name.clone(),
+                        });
+                    return 0;
+                }
+                // Resolve the lifted fn's chunk index (or builtin tag). The
+                // parser only emits MakeClosure with fn_name pointing at a
+                // synthetic `__lit_N` decl, so the User path is the common
+                // case; we keep the Builtin path symmetric for future use.
+                let (kind_bit, id_bits): (u16, u16) =
+                    if let Some(idx) = self.func_names.iter().position(|n| n == fn_name) {
+                        assert!(
+                            idx <= 0x7FFF,
+                            "OP_MAKE_CLOSURE: user-fn index {} exceeds 15-bit limit",
+                            idx
+                        );
+                        (0, idx as u16)
+                    } else if let Some(b) = crate::builtins::Builtin::from_name(fn_name) {
+                        (0x8000, b.tag() as u16)
+                    } else {
+                        self.first_error
+                            .get_or_insert(CompileError::UndefinedVariable {
+                                name: fn_name.clone(),
+                            });
+                        return 0;
+                    };
+
+                // Compile each capture expression into a register. Collect
+                // the source register indices for the trailing data words.
+                let cap_regs: Vec<u8> = captures
+                    .iter()
+                    .map(|c_expr| self.compile_expr(c_expr))
+                    .collect();
+
+                // Load the fn-ref into a fresh register so OP_MAKE_CLOSURE
+                // can read it as plain register B (mirrors OP_CALL_DYN's
+                // callee ABI for naming consistency).
+                let fn_reg = self.alloc_reg();
+                self.emit_abx(OP_LOADFN, fn_reg, kind_bit | id_bits);
+
+                let dest = self.alloc_reg();
+                self.emit_abc(OP_MAKE_CLOSURE, dest, fn_reg, cap_regs.len() as u8);
+                // Pack capture source register indices 4 per 32-bit data
+                // word, little-endian byte order.
+                let n = cap_regs.len();
+                let n_words = n.div_ceil(4);
+                for w in 0..n_words {
+                    let mut word: u32 = 0;
+                    for slot in 0..4 {
+                        let i = w * 4 + slot;
+                        if i < n {
+                            word |= (cap_regs[i] as u32) << (slot * 8);
+                        }
+                    }
+                    self.current.emit(word, self.current_span);
+                }
+                dest
             }
         }
     }
@@ -5030,7 +5096,7 @@ fn chunk_is_all_numeric(chunk: &Chunk) -> bool {
             | OP_TL | OP_FMT2 | OP_RGXSUB | OP_ZIP | OP_ENUMERATE | OP_WINDOW | OP_WINDOW_VIEW
             | OP_FFT | OP_IFFT | OP_RANGE | OP_CHUNKS | OP_CUMSUM | OP_SETUNION | OP_SETINTER
             | OP_SETDIFF | OP_TRANSPOSE | OP_MATMUL | OP_INV | OP_SOLVE | OP_DTFMT | OP_DTPARSE
-            | OP_FLAT | OP_CALL_BUILTIN_TREE | OP_LOADFN | OP_CALL_DYN => {
+            | OP_FLAT | OP_CALL_BUILTIN_TREE | OP_LOADFN | OP_CALL_DYN | OP_MAKE_CLOSURE => {
                 return false;
             }
             _ => {}
@@ -8314,6 +8380,45 @@ impl<'a> VM<'a> {
                     let id = (bx & 0x7FFF) as u32;
                     reg_set!(a, NanVal::fnref(kind, id));
                 }
+                OP_MAKE_CLOSURE => {
+                    // ABC: A = dest, B = fn-ref reg, C = capture count N.
+                    // Followed by ceil(N/4) data words of source register
+                    // indices packed 4 per word (little-endian byte order).
+                    let a = ((inst >> 16) & 0xFF) as u8;
+                    let b = ((inst >> 8) & 0xFF) as u8;
+                    let n = (inst & 0xFF) as usize;
+                    let fn_val = reg!(base + b as usize);
+                    if !fn_val.is_fnref() {
+                        vm_err!(VmError::Type(
+                            "make_closure: fn-ref operand is not a function reference"
+                        ));
+                    }
+                    let (kind, id) = fn_val.fnref_parts();
+                    let n_words = n.div_ceil(4);
+                    let mut captures: Vec<NanVal> = Vec::with_capacity(n);
+                    for w in 0..n_words {
+                        // SAFETY: emitter always writes n_words trailing data
+                        // words immediately after the opcode word, so ip..ip+n_words
+                        // is in range.
+                        let word = unsafe { *code.get_unchecked(ip + w) };
+                        for slot in 0..4 {
+                            let i = w * 4 + slot;
+                            if i >= n {
+                                break;
+                            }
+                            let src_reg = ((word >> (slot * 8)) & 0xFF) as usize;
+                            let v = reg!(base + src_reg);
+                            // By-value capture snapshot: bump RC so the
+                            // closure owns its own ref independent of any
+                            // future mutation in the source register.
+                            v.clone_rc();
+                            captures.push(v);
+                        }
+                    }
+                    ip += n_words;
+                    let closure = NanVal::heap_closure(kind, id, captures);
+                    reg_set!(base + a as usize, closure);
+                }
                 OP_JMP => {
                     let sbx = (inst & 0xFFFF) as i16;
                     ip = (ip as isize + sbx as isize) as usize;
@@ -8441,13 +8546,37 @@ impl<'a> VM<'a> {
                     base = new_base;
                 }
                 OP_CALL_DYN => {
-                    // Dynamic call by FnRef. Layout:
+                    // Dynamic call by FnRef or Closure. Layout:
                     //   A = result_reg, B = fnref_reg, C = argc
                     //   args live in R[A+1..=A+argc] (mirrors OP_CALL).
+                    //
+                    // Closure callees carry trailing capture values which we
+                    // append after the user-supplied args before dispatching
+                    // (matches the tree interpreter's `Value::Closure`
+                    // semantics: lifted-fn signature is
+                    // `[original_params..., capture_params...]`).
                     let a = ((inst >> 16) & 0xFF) as u8;
                     let b = ((inst >> 8) & 0xFF) as u8;
                     let n_args = (inst & 0xFF) as usize;
                     let mut callee = reg!(base + b as usize);
+
+                    // Closure path: deref the heap pointer and check the
+                    // HeapObj variant. If it's a closure, swap the callee
+                    // for a plain FnRef and remember the captures to append
+                    // after the user args.
+                    let mut closure_captures: Option<Vec<NanVal>> = None;
+                    if callee.is_heap() && (callee.0 & TAG_MASK) == TAG_LIST {
+                        // SAFETY: is_heap() + TAG_LIST tag means the pointer
+                        // was produced by heap_list / heap_list_view /
+                        // heap_closure, and we hold an owned RC on it (it's
+                        // sitting in register `b`).
+                        let heap = unsafe { callee.as_heap_ref() };
+                        if let HeapObj::Closure { kind, id, captures } = heap {
+                            callee = NanVal::fnref(*kind, *id);
+                            closure_captures = Some(captures.clone());
+                        }
+                    }
+
                     // Text callee — resolve the name to a user fn or builtin
                     // and re-shape into a FnRef NanVal. This mirrors the
                     // tree interpreter's `Value::Text(name)` callee path
@@ -8476,6 +8605,8 @@ impl<'a> VM<'a> {
                         ));
                     }
                     let (kind, id) = callee.fnref_parts();
+                    let n_caps = closure_captures.as_ref().map(|c| c.len()).unwrap_or(0);
+                    let total_args = n_args + n_caps;
                     match kind {
                         FnRefKind::User => {
                             let func_idx = id as u16;
@@ -8496,6 +8627,20 @@ impl<'a> VM<'a> {
                                     v.clone_rc();
                                 }
                                 self.stack.push(v);
+                            }
+                            // Append closure captures after the user args.
+                            // The captures vec already holds its own RCs on
+                            // each value (taken at OP_MAKE_CLOSURE time); we
+                            // clone_rc one more time here so each call to the
+                            // closure pushes an independent ref onto the
+                            // frame (consumed by OP_RET / register overwrite).
+                            if let Some(caps) = &closure_captures {
+                                for &v in caps.iter() {
+                                    if !callee_all_numeric && !v.is_number() {
+                                        v.clone_rc();
+                                    }
+                                    self.stack.push(v);
+                                }
                             }
 
                             let reg_count =
@@ -8540,10 +8685,16 @@ impl<'a> VM<'a> {
                                 Some(b) => b,
                                 None => vm_err!(VmError::Type("dynamic call: unknown builtin tag")),
                             };
-                            let mut value_args: Vec<Value> = Vec::with_capacity(n_args);
+                            let mut value_args: Vec<Value> = Vec::with_capacity(total_args);
                             for i in 0..n_args {
                                 let v = reg!(base + a as usize + 1 + i);
                                 value_args.push(v.to_value_with_program(&self.program.func_names));
+                            }
+                            if let Some(caps) = &closure_captures {
+                                for v in caps.iter() {
+                                    value_args
+                                        .push(v.to_value_with_program(&self.program.func_names));
+                                }
                             }
                             let result = match crate::interpreter::call_builtin_for_bridge(
                                 builtin.name(),
@@ -17272,6 +17423,15 @@ pub(crate) fn find_block_leaders(code: &[u32]) -> Vec<usize> {
                 // bogus leaders. The instruction after the data word is a normal leader
                 // candidate (and will be reached on the next loop iteration).
                 i += 2;
+                continue;
+            }
+            OP_MAKE_CLOSURE => {
+                // Variable-length: ceil(N/4) trailing data words holding
+                // packed capture source register indices. Skip them so
+                // their bytes aren't mis-decoded as opcodes.
+                let n = (inst & 0xFF) as usize;
+                let n_words = n.div_ceil(4);
+                i += 1 + n_words;
                 continue;
             }
             op if op == OP_CMPK_GE_N

--- a/tests/regression_phase2_closure_capture_vm.rs
+++ b/tests/regression_phase2_closure_capture_vm.rs
@@ -1,0 +1,181 @@
+// Cross-engine regression coverage for Phase 2 inline lambdas (closure
+// capture) on the VM. Phase 1 (PR #247) lifts `(params>ret;body)` to
+// synthetic `__lit_N` decls; Phase 2 (PR #265) adds by-value capture of
+// free variables and produces `Expr::MakeClosure` at the call site.
+//
+// Before this PR (#373 baseline) the VM compiler bailed at the
+// MakeClosure compile site with `CompileError::UnsupportedClosureCapture`
+// and the runtime silently fell back to the tree interpreter. With
+// `OP_MAKE_CLOSURE` + closure-aware `OP_CALL_DYN` dispatch in place,
+// every Phase 2 shape should run identically on tree and VM.
+//
+// Cranelift parity arrives in the next PR (PR2). For now the JIT path
+// bails on chunks that contain OP_MAKE_CLOSURE (unknown opcode → return
+// false in compile_function_body), which transparently falls back to
+// the VM. So we run tree + VM here; PR2 expands the matrix.
+
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn write_src(name: &str, src: &str) -> std::path::PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut path = std::env::temp_dir();
+    path.push(format!("ilo_p2cap_{name}_{}_{n}.ilo", std::process::id()));
+    std::fs::write(&path, src).expect("write src");
+    path
+}
+
+fn run_ok(engine: &str, src: &str, entry: &str, args: &[&str]) -> String {
+    let path = write_src(entry, src);
+    let mut cmd = ilo();
+    cmd.arg(&path).arg(engine).arg(entry);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Run a Phase 2 inline-lambda program on every engine that supports
+/// closure capture today (tree + VM). PR2 will widen this to include
+/// `--run-cranelift` once the jit_call_dyn helper is closure-aware.
+fn run_all(src: &str, entry: &str, args: &[&str], expected: &str) {
+    for engine in ["--run-tree", "--run-vm"] {
+        let actual = run_ok(engine, src, entry, args);
+        assert_eq!(
+            actual, expected,
+            "engine {engine} produced {actual:?}, expected {expected:?} for src `{src}`"
+        );
+    }
+}
+
+// ── single-value capture ────────────────────────────────────────────────
+
+#[test]
+fn closure_single_capture_filter() {
+    let src = "f xs:L n thr:n>L n;flt (x:n>b;>x thr) xs";
+    run_all(src, "f", &["[1,5,3,8,2]", "4"], "[5, 8]");
+}
+
+#[test]
+fn closure_single_capture_map() {
+    let src = "f xs:L n bump:n>L n;map (x:n>n;+x bump) xs";
+    run_all(src, "f", &["[1,2,3]", "10"], "[11, 12, 13]");
+}
+
+// ── multiple captures ───────────────────────────────────────────────────
+
+#[test]
+fn closure_two_captures_range_filter() {
+    // Two captures appended in order: lo first, hi second.
+    let src = "f xs:L n lo:n hi:n>L n;flt (x:n>b;&(>=x lo) <=x hi) xs";
+    run_all(src, "f", &["[1,3,5,7,9,11]", "3", "7"], "[3, 5, 7]");
+}
+
+#[test]
+fn closure_three_captures_in_map() {
+    // Three captures: each appears in the body. Order matters because
+    // the lifter places them as trailing params in source order.
+    let src = "f xs:L n a:n b:n c:n>L n;map (x:n>n;+*x a +*x b c) xs";
+    run_all(src, "f", &["[1,2,3]", "10", "100", "7"], "[117, 227, 337]");
+}
+
+// ── text capture ────────────────────────────────────────────────────────
+
+#[test]
+fn closure_capture_text_prefix() {
+    // Capture a heap-allocated text value. Exercises the RC bump path
+    // for non-numeric captures.
+    let src = "f ws:L t prefix:t>L t;flt (w:t>b;has w prefix) ws";
+    run_all(
+        src,
+        "f",
+        &["[\"apple\",\"banana\",\"apricot\"]", "ap"],
+        "[apple, apricot]",
+    );
+}
+
+// ── by-value snapshot semantics ─────────────────────────────────────────
+
+#[test]
+fn closure_capture_is_snapshot_not_live() {
+    // The closure must hold the capture's value at construction time,
+    // independent of any later rebinding of the source register. We
+    // emulate that by passing the bias straight through: srt has
+    // already drained the closure by the time the function returns,
+    // and the result must reflect the original bias.
+    let src = "f xs:L n bias:n>L n;ys=srt (x:n>n;+x bias) xs;ys";
+    run_all(src, "f", &["[3,1,2]", "0"], "[1, 2, 3]");
+}
+
+// ── capture in fold reducer ─────────────────────────────────────────────
+
+#[test]
+fn closure_capture_in_fld() {
+    // The reducer takes two ordinary params (acc, x) and one capture
+    // (weight) appended at the end.
+    let src = "f xs:L n weight:n>n;fld (a:n x:n>n;+a *x weight) xs 0";
+    run_all(src, "f", &["[1,2,3,4]", "5"], "50");
+}
+
+// ── capture order is preserved ──────────────────────────────────────────
+
+#[test]
+fn closure_capture_order_a_then_b() {
+    // Captures `a` and `b` in that order; the body subtracts to verify
+    // we didn't transpose them.
+    let src = "f xs:L n a:n b:n>L n;map (x:n>n;+x -a b) xs";
+    run_all(src, "f", &["[10,20]", "100", "30"], "[80, 90]");
+}
+
+#[test]
+fn closure_capture_order_b_then_a() {
+    // Same lambda body but the captures appear in the opposite order
+    // in the enclosing fn's signature; the lifter should pick them up
+    // in body-reference order, so the result is identical to the above.
+    let src = "f xs:L n b:n a:n>L n;map (x:n>n;+x -a b) xs";
+    run_all(src, "f", &["[10,20]", "30", "100"], "[80, 90]");
+}
+
+// ── ctx-bind 3-arg form alongside captures ──────────────────────────────
+
+#[test]
+fn closure_capture_with_explicit_ctx_arg_form() {
+    // Phase 1 ctx-bind form keeps working when the lambda has no
+    // captures — pins that the closure plumbing doesn't regress the
+    // existing tree-bridge path.
+    let src = "f xs:L n thr:n>L n;flt (x:n c:n>b;>x c) thr xs";
+    run_all(src, "f", &["[1,5,3,8,2]", "4"], "[5, 8]");
+}
+
+// ── nested HOF call: capture flows through outer + inner lambda ────────
+
+#[test]
+fn closure_capture_in_sort_key_distance() {
+    // srt with an inline key that closes over `target`. Two distinct
+    // call sites per element: srt drives many comparisons internally,
+    // so this exercises capture re-use across repeated invocations.
+    let src = "f xs:L n target:n>L n;srt (x:n>n;abs -x target) xs";
+    run_all(src, "f", &["[1,5,10,20]", "8"], "[10, 5, 1, 20]");
+}
+
+// ── capture with empty list edge case ───────────────────────────────────
+
+#[test]
+fn closure_capture_on_empty_list() {
+    // Empty input list: closure is constructed but never invoked. The
+    // capture's RC still needs to round-trip cleanly through OP_RET.
+    let src = "f xs:L n thr:n>L n;flt (x:n>b;>x thr) xs";
+    run_all(src, "f", &["[]", "4"], "[]");
+}


### PR DESCRIPTION
## Summary

First of a 5-PR rollout porting Phase 2 inline lambdas (closure capture) off the tree-only fallback and onto the VM + Cranelift, per [plan](https://github.com/ilo-lang/ilo/blob/main/docs/internal/phase2-closure-port.md). Today every persona that reaches for the natural `(params>ret;body)` form with free vars hits a silent tree-walker fallback (compile bails at `UnsupportedClosureCapture`, runtime quietly switches engines), so HOFs that look fast aren't, and the 3-arg ctx-bind workaround costs +5-12 tokens per call site multiplied across map/flt/fld/srt/grp.

This PR makes the VM closure-aware. After PR2 (Cranelift parity) and PR3 (HOF native dispatch), the workaround cost goes away entirely. Manifesto framing: a token-cost paper-cut that hits every HOF call site, removed for the whole agent population.

## What's in the diff

Four logical steps, one commit each:

1. `vm: add HeapObj::Closure variant` — new HeapObj arm under TAG_LIST, discriminated at deref by variant. Drop releases each capture's RC, mirroring HeapObj::List. slice_of, materialize_list_view, to_value, to_value_with_program, from_value_with_program, nanval_to_json all updated. 13 exhaustive matches in src/vm/mod.rs grow a Closure arm.
2. `vm: emit OP_MAKE_CLOSURE for inline lambdas with captures` — new opcode slot 178, ABC layout (A=dest, B=fn-ref reg, C=capture count) with ceil(N/4) trailing data words packing source register indices 4 per word. Replaces the UnsupportedClosureCapture early-return at the Expr::MakeClosure compile site. OP_CALL_DYN gains a closure-detection arm that derefs the heap pointer, swaps to a plain FnRef, and appends captures after the user args (matching tree interpreter semantics). chunk_is_all_numeric and find_block_leaders both pick up the new opcode so trailing data words aren't mis-decoded. inline_kind_for_opcode leaves OP_MAKE_CLOSURE on Reject so closures don't inline into HOF callbacks for now.
3. `test: cross-engine regression coverage` — 12 tree+VM tests in tests/regression_phase2_closure_capture_vm.rs covering single-value/multi/text capture, by-value snapshot semantics, capture order, fold reducer, sort key, ctx-bind alongside captures, empty-list edge.
4. `examples: drop vm from inline-lambda-capture engine skip` — examples_engines harness picks up three more end-to-end checks on the VM.

## What this PR does NOT do

Staged rollout per the plan. Out of scope for this PR:

- **Cranelift dispatch logic** stays put. PR2 updates the `jit_call_dyn` helper to recognise closure callees. Today, chunks containing OP_MAKE_CLOSURE bail out of JIT compile (unknown opcode → return false in compile_function_body) and fall back to the VM transparently.
- **HOF native dispatch migration** — PR3. Today HOFs route capturing callbacks through the tree-bridge for the shapes listed in is_tree_bridge_eligible. The bridge still works because to_value_with_program and from_value_with_program now round-trip HeapObj::Closure to Value::Closure.
- **Test infra migration** in tests/regression_inline_lambda.rs — PR4 expands those tree-only tests cross-engine. Until then this PR's standalone test file keeps the VM coverage isolated.
- **SPEC.md / ai.txt / SKILL.md doc flips** — PR5. SPEC at lines 115-133 still reads "Phase 2 is tree-only"; we don't flip that line yet because Cranelift parity isn't in place. The only doc-surface change here is the example's engine-skip annotation.

## Repro

Before:

```
$ ilo --run-vm 'f xs:L n thr:n>L n;flt (x:n>b;>x thr) xs' f '[1,5,3,8,2]' 4
[5, 8]            -- works, but only because the VM compiler bails and silently
                  -- routes the program to the tree interpreter
```

After:

```
$ ilo --run-vm 'f xs:L n thr:n>L n;flt (x:n>b;>x thr) xs' f '[1,5,3,8,2]' 4
[5, 8]            -- now runs end-to-end on the bytecode VM with OP_MAKE_CLOSURE
                  -- + closure-aware OP_CALL_DYN dispatch
```

Same surface behaviour, but the VM path is real now instead of a tree-fallback masquerade.

## Test plan

- [x] `cargo test --release --features cranelift` — 6791 passed, 0 failed
- [x] `cargo clippy --release --features cranelift --tests -- -D warnings` — clean
- [x] `cargo fmt` — clean
- [x] 12 new cross-engine tests in tests/regression_phase2_closure_capture_vm.rs all pass on tree + vm
- [x] examples_engines harness picks up the relaxed engine-skip and runs every annotated case on --run-vm
- [x] Existing closure-using tests in tests/regression_inline_lambda.rs (tree-only) untouched and still pass

## Follow-ups

- PR2: Cranelift closure parity via jit_call_dyn helper
- PR3: migrate HOFs off the tree-bridge for capturing callbacks
- PR4: parameterise tests/regression_inline_lambda.rs cross-engine
- PR5: SPEC.md / ai.txt / SKILL.md / site docs flip; narrow ILO-R012 wording