### PR TITLE
cranelift: route OP_WINDOW / OP_WINDOW_VIEW through extern helpers

### DIFF
--- a/examples/window-cranelift-jit.ilo
+++ b/examples/window-cranelift-jit.ilo
@@ -1,0 +1,22 @@
+-- Cranelift JIT used to bail out on any function containing
+-- `OP_WINDOW` / `OP_WINDOW_VIEW`, forcing the bio-canonical shape
+-- `flt p (window k xs)` onto the VM dispatcher. This example pins
+-- the shape that the fix unbails so all engines now run it through
+-- the same JIT-compiled outer loop.
+
+basic>L (L n);window 3 [1, 2, 3, 4, 5]
+
+-- Outer foreach over a window result — exercises FOREACHPREP /
+-- FOREACHNEXT on the list-of-lists produced by OP_WINDOW.
+sumheads>n;s=0;@w (window 2 [10, 20, 30, 40]){s=+s hd w};s
+
+-- Fused `flt p (window n xs)` shape — emitter uses OP_WINDOW_VIEW.
+hastwo w:L n>b;>(hd w) 1
+fused>n;len (flt hastwo (window 2 [1, 2, 3, 2, 4]))
+
+-- run: basic
+-- out: [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
+-- run: sumheads
+-- out: 60
+-- run: fused
+-- out: 3

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -2615,25 +2615,57 @@ fn compile_function_body(
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
-            OP_WINDOW | OP_WINDOW_VIEW => {
-                // PR-2 (window-listview-perf): the VM dispatcher's OP_WINDOW /
-                // OP_WINDOW_VIEW arms now emit `HeapObj::ListView` aliasing the
-                // source list (O(1) per stride instead of n clone_rc's). Views
-                // share the TAG_LIST tag with real Lists; Cranelift's inlined
-                // FOREACHPREP / FOREACHNEXT / LISTGET / LEN fast paths read Vec
-                // metadata at fixed offsets (see audit comments in OP_FOREACHPREP
-                // below) and would UB on a view's struct layout.
+            OP_WINDOW => {
+                // OP_WINDOW: R[A] = window(R[B] (n), R[C] (list)).
                 //
-                // Cleanest fix: bail out of JIT compilation for any function
-                // touching window opcodes; it runs on the VM dispatcher, which
-                // gets the perf win. This is the design-of-record from PR-1
-                // ("VM gets the new fast path, Cranelift falls back via
-                // unknown-opcode return None") and the path the predecessor's
-                // perf analysis approved.
+                // History: this arm previously bailed JIT compilation
+                // (`return None`) because the VM dispatcher's OP_WINDOW emits
+                // `HeapObj::ListView` strides and the inlined LISTGET /
+                // FOREACHPREP / FOREACHNEXT fast paths read Vec metadata at
+                // fixed offsets that would UB on a view's struct layout.
                 //
-                // A future PR can add a discriminant guard in the inlined Vec
-                // loads to let Cranelift emit views directly.
-                return None;
+                // Fix: call the existing `jit_window` extern helper. That
+                // helper always returns an owning `HeapObj::List` of owning
+                // `HeapObj::List`s (no views), so any subsequent inlined
+                // foreach reads operate on the expected Vec layout. The
+                // function compiles, the rest of the hot path (e.g. bio's
+                // `flt all-h (window k seqs)`) runs JIT-native, and we trade
+                // the VM dispatcher's per-stride ListView win for the much
+                // larger JIT-compiled outer loop.
+                let bv = builder.use_var(vars[b_idx]);
+                let cv = builder.use_var(vars[c_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
+                let fref = get_func_ref(&mut builder, module, helpers.window);
+                let call_inst = builder.ins().call(fref, &[bv, cv, span_arg]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            OP_WINDOW_VIEW => {
+                // OP_WINDOW_VIEW: stride-1 fused-loop materialiser used by
+                // the `flt fn (window n xs)` / `map fn (window n xs)` emitter.
+                //
+                //   word 0 (ABC): A = dest list reg, B = xs reg, C = idx reg
+                //   word 1 (data, A field): A = n reg
+                //
+                // Like OP_WINDOW above, this used to bail JIT compilation.
+                // Route to the `jit_window_view` extern helper which mirrors
+                // the VM dispatcher's in-place reuse path and always returns
+                // a `HeapObj::List` (never a view), keeping the inlined
+                // foreach fast paths sound.
+                let cur = builder.use_var(vars[a_idx]);
+                let bv = builder.use_var(vars[b_idx]);
+                let cv = builder.use_var(vars[c_idx]);
+                let data_inst = chunk.code[ip + 1];
+                skip_next = true;
+                let n_idx = ((data_inst >> 16) & 0xFF) as usize;
+                let nv = builder.use_var(vars[n_idx]);
+                let span_bits = pack_span_bits(chunk.spans[ip]);
+                let span_arg = builder.ins().iconst(I64, span_bits);
+                let fref = get_func_ref(&mut builder, module, helpers.window_view);
+                let call_inst = builder.ins().call(fref, &[cur, bv, cv, nv, span_arg]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
             }
             OP_CHUNKS => {
                 let bv = builder.use_var(vars[b_idx]);

--- a/tests/regression_window_cranelift.rs
+++ b/tests/regression_window_cranelift.rs
@@ -1,0 +1,109 @@
+// Regression: Cranelift JIT used to bail out (`JitCallError::NotEligible`)
+// on any function containing `OP_WINDOW` or `OP_WINDOW_VIEW` because the
+// VM dispatcher emits `HeapObj::ListView` strides and Cranelift's inlined
+// LISTGET / FOREACHPREP / FOREACHNEXT fast paths read Vec metadata at
+// fixed offsets that would UB on a view's struct layout.
+//
+// Fix: route OP_WINDOW / OP_WINDOW_VIEW through their existing extern
+// helpers (`jit_window` / `jit_window_view`) which always return owning
+// `HeapObj::List`s. The function compiles, the rest of the hot path
+// (e.g. bio's `flt all-h (window k seqs)`) runs JIT-native.
+//
+// These tests exercise the shapes that would previously have bailed, on
+// every engine, asserting parity.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn engines() -> &'static [&'static str] {
+    &["--run-tree", "--run-vm", "--run-cranelift"]
+}
+
+fn run_ok(engine: &str, src: &str, fn_name: &str, args: &[&str]) -> String {
+    let mut cmd = ilo();
+    cmd.arg(src).arg(engine).arg(fn_name);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+#[test]
+fn window_compiles_in_cranelift() {
+    // Plain OP_WINDOW: was the primary bail trigger.
+    let src = "f xs:L n>L (L n);window 3 xs";
+    for engine in engines() {
+        assert_eq!(
+            run_ok(engine, src, "f", &["1,2,3,4,5"]),
+            "[[1, 2, 3], [2, 3, 4], [3, 4, 5]]",
+            "engine={engine}"
+        );
+    }
+}
+
+#[test]
+fn window_then_foreach_in_cranelift() {
+    // Outer foreach over window result exercises the inlined FOREACHPREP
+    // / FOREACHNEXT path that previously bailed when window was present.
+    let src = "f xs:L n>n;s=0;@w (window 2 xs){s=+s hd w};s";
+    for engine in engines() {
+        assert_eq!(
+            run_ok(engine, src, "f", &["10,20,30,40"]),
+            // hd of each of [[10,20],[20,30],[30,40]] = 10+20+30 = 60
+            "60",
+            "engine={engine}"
+        );
+    }
+}
+
+#[test]
+fn fused_flt_window_in_cranelift() {
+    // Bio-canonical-shape: `flt p (window k xs)`. Emitter uses the fused
+    // OP_WINDOW_VIEW two-word encoding. Without the fix, cranelift bails
+    // on the whole function. With the fix, it compiles end-to-end.
+    //
+    // Predicate: window contains a 2 anywhere. We assert the count of
+    // matching windows so the test is robust to formatting.
+    let src = "headgt w:L n>b;>(hd w) 1\nf xs:L n>n;len (flt headgt (window 2 xs))";
+    for engine in engines() {
+        assert_eq!(
+            run_ok(engine, src, "f", &["1,2,3,2,4"]),
+            // pairs: [1,2] [2,3] [3,2] [2,4] — heads 1,2,3,2 — > 1 → 3 matches
+            "3",
+            "engine={engine}"
+        );
+    }
+}
+
+#[test]
+fn window_size_one_in_cranelift() {
+    let src = "f xs:L n>L (L n);window 1 xs";
+    for engine in engines() {
+        assert_eq!(
+            run_ok(engine, src, "f", &["7,8,9"]),
+            "[[7], [8], [9]]",
+            "engine={engine}"
+        );
+    }
+}
+
+#[test]
+fn window_n_greater_than_len_in_cranelift() {
+    let src = "f xs:L n>L (L n);window 5 xs";
+    for engine in engines() {
+        assert_eq!(
+            run_ok(engine, src, "f", &["1,2,3"]),
+            "[]",
+            "engine={engine}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Cranelift's JIT used to bail out (`JitCallError::NotEligible`) on any function containing `OP_WINDOW` or `OP_WINDOW_VIEW`, forcing entire hot paths back to the VM dispatcher. The reason: the VM dispatcher's OP_WINDOW emits `HeapObj::ListView` strides, and Cranelift's inlined LISTGET / FOREACHPREP / FOREACHNEXT fast paths read Vec metadata at fixed offsets that would UB on a view's struct layout.

Fix: emit calls to the existing `jit_window` / `jit_window_view` extern helpers in both arms. Both helpers always return owning `HeapObj::List`s (never views), so subsequent inlined foreach reads operate on the expected Vec layout and remain sound. We trade the VM dispatcher's per-stride ListView win for the much larger JIT-compiled outer loop, which is exactly the trade bio-canonical-shape `flt p (window k xs)` needs.

## Repro before / after

`f xs:L n>L (L n);window 3 xs` on `--run-cranelift`:

- before: silently fell back to VM dispatcher (no error, but the surrounding function never benefited from JIT).
- after: compiles in JIT, full hot path runs native.

## What's in the diff

- `cranelift: route OP_WINDOW / OP_WINDOW_VIEW through extern helpers` (`src/vm/jit_cranelift.rs`) — replaces the `return None` bail with calls to `helpers.window` (3 args) and `helpers.window_view` (5 args). OP_WINDOW_VIEW is a two-word op; `skip_next = true` consumes the data word holding the n register, mirroring OP_SLC / OP_LST / OP_MSET / OP_RGXSUB. Stale audit comments referencing the bail in OP_FOREACHPREP / OP_LISTGET remain accurate (no view reaches them under JIT because the helpers materialise to Lists).
- `test: cover OP_WINDOW / OP_WINDOW_VIEW on cranelift JIT` (`tests/regression_window_cranelift.rs`, `examples/window-cranelift-jit.ilo`) — 5 cross-engine regression tests across tree / VM / cranelift covering plain `window`, foreach-over-window, the fused `flt p (window n xs)` shape (OP_WINDOW_VIEW), size-1 windows, and n>len. Example file pins the same shapes for the engine harness.

## Test plan

- [x] `cargo test --release --features cranelift --test regression_window_cranelift` — 5/5 pass
- [x] `cargo test --release --features cranelift` — full suite green
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --release --features cranelift --all-targets -- -D warnings` clean
- [x] Smoke: `ilo --run-cranelift 'main xs:L n>L n;ws=window 3 xs;hd ws' 1,2,3,4,5` → `[1, 2, 3]`

## Follow-ups

- A future PR can teach the inlined LISTGET / FOREACHPREP / FOREACHNEXT paths to detect `HeapObj::ListView` via a `[ptr+0] == 1` discriminant guard, fall back to the `listget` helper on mismatch, and then let OP_WINDOW emit views directly. That recovers the per-stride ListView win that the VM dispatcher currently has exclusively, on top of JIT-compiled outer loops. Out of scope here; the helper-routing path is the smaller, safer first step.