### PR TITLE
feature: HOF native closure dispatch (Phase 2 PR3)

### DIFF
--- a/examples/partition-closure-native.ilo
+++ b/examples/partition-closure-native.ilo
@@ -1,0 +1,24 @@
+-- partition with capturing inline lambdas: Phase 2 PR3 native dispatch.
+--
+-- Pre-PR3 the closure callback re-entered the tree interpreter on
+-- every element via the OP_CALL_BUILTIN_TREE bridge. PR3 emits an
+-- OP_FOREACHPREP/NEXT loop with per-element OP_CALL_DYN against the
+-- closure NanVal, so VM and Cranelift run the predicate natively
+-- without bouncing through the tree-walker.
+
+-- Single capture: filter values above a threshold the caller supplies.
+split-above xs:L n thr:n>L (L n);partition (x:n>b;>x thr) xs
+
+-- Two captures: keep items inclusive between lo and hi, drop the rest.
+split-between xs:L n lo:n hi:n>L (L n);partition (x:n>b;&(>=x lo) <=x hi) xs
+
+-- Capture a text value: split words by whether they contain the
+-- captured substring.
+split-has ws:L t needle:t>L (L t);partition (w:t>b;has w needle) ws
+
+-- run: split-above [1,5,3,8,2] 4
+-- out: [[5, 8], [1, 3, 2]]
+-- run: split-between [1,3,5,7,9,11] 3 7
+-- out: [[3, 5, 7], [1, 9, 11]]
+-- run: split-has ["cat","dog","ant","fish"] "a"
+-- out: [[cat, ant], [dog, fish]]

--- a/examples/partition.ilo
+++ b/examples/partition.ilo
@@ -7,8 +7,8 @@ split-pos xs:L n>L (L n);partition pos xs
 even x:n>b;=(mod x 2) 0
 split-even xs:L n>L (L n);partition even xs
 
--- HOF dispatch goes through the tree-bridge on every engine (PR 3b).
--- engine-skip: jit
+-- Phase 2 PR3: partition now dispatches natively on every engine via
+-- OP_CALL_DYN per element; no tree-bridge round-trip per callback.
 -- run: split-pos [-1,2,-3,4]
 -- out: [[2, 4], [-1, -3]]
 -- run: split-even [1,2,3,4,5,6]

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -514,7 +514,9 @@ pub(crate) fn is_tree_bridge_eligible(b: crate::builtins::Builtin, argc: usize) 
         // Env populated from the ACTIVE_AST_PROGRAM TLS.
         (Builtin::Grp, 2) => true,
         (Builtin::Uniqby, 2) => true,
-        (Builtin::Partition, 2) => true,
+        // partition 2 was on the bridge in PR 3b; Phase 2 PR3 lifts it natively
+        // via OP_CALL_DYN + OP_LISTAPPEND so closure callbacks dispatch without
+        // a tree re-entry. See the matching arm in the compiler.
         // ct fn xs / ct fn ctx xs — count by predicate. Same bridge
         // contract as flt 2/3; tree interpreter handles the user-fn
         // callback via ACTIVE_AST_PROGRAM. Named `ct` to avoid
@@ -4420,10 +4422,108 @@ impl RegCompiler {
                             self.next_reg = acc_reg + 1;
                             return acc_reg;
                         }
+                        // partition fn xs → native HOF loop using OP_CALL_DYN.
+                        // Same shape as `flt 2` but threads two acc lists: items
+                        // for which the predicate returns true go to `pass`, false
+                        // to `fail`. Final result is a 2-element list `[pass, fail]`
+                        // matching the tree-walker. Non-bool predicate result
+                        // raises through OP_PANIC_UNWRAP with a "partition"+"bool"
+                        // message, mirroring the `flt` shape so error semantics
+                        // stay cross-engine consistent.
+                        //
+                        // Migrated off the tree-bridge in Phase 2 PR3: the bridge
+                        // re-entered the tree interpreter per element which (a)
+                        // cost a NanVal↔Value round-trip per callback and (b)
+                        // required ACTIVE_AST_PROGRAM TLS to be live. With the
+                        // closure-aware OP_CALL_DYN from #384/#385, capturing
+                        // lambdas work natively here for free.
+                        (Builtin::Partition, 2) => {
+                            let fn_reg = self.compile_expr(&args[0]);
+                            let xs_reg = self.compile_expr(&args[1]);
+
+                            // Two accumulator lists: pass and fail. Both start
+                            // empty; OP_LISTAPPEND grows whichever the predicate
+                            // selects per iteration.
+                            let pass_reg = self.alloc_reg();
+                            self.emit_abx(OP_LISTNEW, pass_reg, 0);
+                            let fail_reg = self.alloc_reg();
+                            self.emit_abx(OP_LISTNEW, fail_reg, 0);
+
+                            let idx_reg = self.alloc_reg();
+                            let zero_ki = self.current.add_const(Value::Number(0.0));
+                            self.emit_abx(OP_LOADK, idx_reg, zero_ki);
+                            self.reg_is_num[idx_reg as usize] = true;
+
+                            let item_reg = self.alloc_reg();
+                            let nil_ki = self.current.add_const(Value::Nil);
+                            self.emit_abx(OP_LOADK, item_reg, nil_ki);
+
+                            // res_reg + arg_reg contiguous for OP_CALL_DYN ABI.
+                            let res_reg = self.alloc_reg();
+                            self.emit_abx(OP_LOADK, res_reg, nil_ki);
+                            let arg_reg = self.alloc_reg();
+                            assert!(
+                                arg_reg == res_reg + 1,
+                                "partition HOF: arg reg must follow result reg contiguously"
+                            );
+                            self.emit_abx(OP_LOADK, arg_reg, nil_ki);
+
+                            // Scratch for the bool typecheck.
+                            let isb_reg = self.alloc_reg();
+                            self.emit_abx(OP_LOADK, isb_reg, nil_ki);
+
+                            let _loop_top = self.current.code.len();
+                            self.emit_abc(OP_FOREACHPREP, item_reg, xs_reg, idx_reg);
+                            let exit_jump_a = self.emit_jmp_placeholder();
+
+                            let body_top = self.current.code.len();
+                            self.emit_abc(OP_MOVE, arg_reg, item_reg, 0);
+                            self.emit_abc(OP_CALL_DYN, res_reg, fn_reg, 1);
+
+                            // Typecheck: predicate must return Bool. If not, fail
+                            // with a "partition: predicate must return bool"
+                            // message. Same shape as the `flt` arm.
+                            self.emit_abc(OP_ISBOOL, isb_reg, res_reg, 0);
+                            let typeok_jump = self.emit_jmpt(isb_reg);
+                            let err_text_ki = self.current.add_const(Value::Text(Arc::new(
+                                "partition: predicate must return bool".to_string(),
+                            )));
+                            self.emit_abx(OP_LOADK, arg_reg, err_text_ki);
+                            self.emit_abc(OP_WRAPERR, arg_reg, arg_reg, 0);
+                            self.emit_abc(OP_PANIC_UNWRAP, 0, arg_reg, 0);
+                            self.current.patch_jump(typeok_jump);
+
+                            // Branch: bool true → append to pass; bool false → append to fail.
+                            let skip_pass_jump = self.emit_jmpf(res_reg);
+                            self.emit_abc(OP_LISTAPPEND, pass_reg, pass_reg, item_reg);
+                            let skip_fail_jump = self.emit_jmp_placeholder();
+                            self.current.patch_jump(skip_pass_jump);
+                            self.emit_abc(OP_LISTAPPEND, fail_reg, fail_reg, item_reg);
+                            self.current.patch_jump(skip_fail_jump);
+
+                            self.emit_abc(OP_FOREACHNEXT, item_reg, xs_reg, idx_reg);
+                            let exit_jump_b = self.emit_jmp_placeholder();
+                            self.emit_jump_to(body_top);
+
+                            self.current.patch_jump(exit_jump_a);
+                            self.current.patch_jump(exit_jump_b);
+
+                            // Build the outer 2-element [pass, fail] list.
+                            let out_reg = self.alloc_reg();
+                            self.emit_abx(OP_LISTNEW, out_reg, 0);
+                            self.emit_abc(OP_LISTAPPEND, out_reg, out_reg, pass_reg);
+                            self.emit_abc(OP_LISTAPPEND, out_reg, out_reg, fail_reg);
+
+                            self.current_all_regs_numeric = false;
+                            self.reg_is_num[out_reg as usize] = false;
+
+                            self.next_reg = out_reg + 1;
+                            return out_reg;
+                        }
                         // Builtins that fall through:
                         //   - tree-bridge eligible (rgx, rgxall, fmt-variadic,
-                        //     rd 2-arg, rdb, sleep, grp/uniqby/partition/srt 2-arg
-                        //     from PR 3b, map/flt/fld/srt closure-bind ctx forms
+                        //     rd 2-arg, rdb, sleep, grp/uniqby/srt 2-arg from
+                        //     PR 3b, map/flt/fld/srt closure-bind ctx forms
                         //     from PR 3c) → routed to OP_CALL_BUILTIN_TREE below.
                         //   - Anything else (e.g. `wr` 3-arg with dynamic fmt)
                         //     still errors here; the native lift lands later in

--- a/tests/regression_phase2_hof_native_dispatch.rs
+++ b/tests/regression_phase2_hof_native_dispatch.rs
@@ -1,0 +1,182 @@
+// Cross-engine regression coverage for Phase 2 PR3: HOF native closure
+// dispatch.
+//
+// Phase 2 PR1 (#384) and PR2 (#385) added VM + Cranelift closure support,
+// including a closure-aware OP_CALL_DYN dispatch. PR3 (this PR) migrates
+// 2-arg HOFs off the tree-bridge and uses OP_CALL_DYN per-element so
+// closure callbacks dispatch natively without re-entering the tree
+// interpreter.
+//
+// This PR migrates `partition 2` natively. The remaining bridge HOFs
+// (`srt 2`, `grp 2`, `uniqby 2`, `mapr 2`, `ct 2`, `rsrt 2`) need
+// dedicated finalizer opcodes for the sort/group/dedup/short-circuit
+// post-processing step and are deferred to follow-up PRs.
+//
+// Each migrated HOF is exercised in three shapes:
+//   1. Non-capturing inline lambda (Phase 1 shape, FnRef to __lit_N).
+//   2. Capturing inline lambda (Phase 2 shape, Expr::MakeClosure).
+//   3. Named top-level fn (FnRef to user fn).
+//
+// Each shape runs on `--run-tree`, `--run-vm`, and `--run-cranelift`
+// (when the `cranelift` feature is enabled) so all three engines stay
+// in lockstep.
+
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn write_src(name: &str, src: &str) -> std::path::PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut path = std::env::temp_dir();
+    path.push(format!("ilo_p2hof_{name}_{}_{n}.ilo", std::process::id()));
+    std::fs::write(&path, src).expect("write src");
+    path
+}
+
+fn run_ok(engine: &str, src: &str, entry: &str, args: &[&str]) -> String {
+    let path = write_src(entry, src);
+    let mut cmd = ilo();
+    cmd.arg(&path).arg(engine).arg(entry);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn run_all(src: &str, entry: &str, args: &[&str], expected: &str) {
+    #[cfg(feature = "cranelift")]
+    let engines: &[&str] = &["--run-tree", "--run-vm", "--run-cranelift"];
+    #[cfg(not(feature = "cranelift"))]
+    let engines: &[&str] = &["--run-tree", "--run-vm"];
+    for engine in engines {
+        let actual = run_ok(engine, src, entry, args);
+        assert_eq!(
+            actual, expected,
+            "engine {engine} produced {actual:?}, expected {expected:?} for src `{src}`"
+        );
+    }
+}
+
+fn run_err(engine: &str, src: &str, entry: &str, args: &[&str]) -> String {
+    let path = write_src(entry, src);
+    let mut cmd = ilo();
+    cmd.arg(&path).arg(engine).arg(entry);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        !out.status.success(),
+        "ilo {engine} unexpectedly succeeded for `{src}`",
+    );
+    String::from_utf8_lossy(&out.stderr).to_string()
+}
+
+// ── partition: non-capturing inline lambda ──────────────────────────────
+
+#[test]
+fn partition_inline_lambda_non_capturing() {
+    let src = "f xs:L n>L L n;partition (x:n>b;>x 0) xs";
+    run_all(src, "f", &["[1,-2,3,-4,5]"], "[[1, 3, 5], [-2, -4]]");
+}
+
+// ── partition: capturing inline lambda ──────────────────────────────────
+
+#[test]
+fn partition_inline_lambda_single_capture() {
+    let src = "f xs:L n t:n>L L n;partition (x:n>b;>x t) xs";
+    run_all(src, "f", &["[1,2,3,4,5]", "3"], "[[4, 5], [1, 2, 3]]");
+}
+
+#[test]
+fn partition_inline_lambda_two_captures() {
+    // Predicate keeps items inclusive between lo and hi. Mirrors the
+    // shape from regression_phase2_closure_capture (>=x lo & <=x hi)
+    // which is the known-good two-capture form on every engine.
+    let src = "f xs:L n lo:n hi:n>L L n;partition (x:n>b;&(>=x lo) <=x hi) xs";
+    run_all(
+        src,
+        "f",
+        &["[1,3,5,7,9,11]", "3", "7"],
+        "[[3, 5, 7], [1, 9, 11]]",
+    );
+}
+
+// ── partition: named fn (FnRef) ─────────────────────────────────────────
+
+#[test]
+fn partition_named_fn_ref() {
+    let src = "pos x:n>b;>x 0\nf xs:L n>L L n;partition pos xs";
+    run_all(src, "f", &["[1,-2,3,-4,5]"], "[[1, 3, 5], [-2, -4]]");
+}
+
+// ── partition: text values ──────────────────────────────────────────────
+
+#[test]
+fn partition_text_values() {
+    let src = "f ws:L t>L L t;partition (w:t>b;has w \"a\") ws";
+    run_all(
+        src,
+        "f",
+        &["[\"cat\",\"dog\",\"ant\",\"fish\"]"],
+        "[[cat, ant], [dog, fish]]",
+    );
+}
+
+// ── partition: empty input ──────────────────────────────────────────────
+
+#[test]
+fn partition_empty_input() {
+    let src = "f xs:L n>L L n;partition (x:n>b;>x 0) xs";
+    run_all(src, "f", &["[]"], "[[], []]");
+}
+
+// ── partition: all-pass and all-fail ────────────────────────────────────
+
+#[test]
+fn partition_all_pass() {
+    let src = "f xs:L n>L L n;partition (x:n>b;>x 0) xs";
+    run_all(src, "f", &["[1,2,3]"], "[[1, 2, 3], []]");
+}
+
+#[test]
+fn partition_all_fail() {
+    let src = "f xs:L n>L L n;partition (x:n>b;>x 100) xs";
+    run_all(src, "f", &["[1,2,3]"], "[[], [1, 2, 3]]");
+}
+
+// ── partition: non-bool predicate → runtime error ───────────────────────
+//
+// The bridge form raised "partition: predicate must return bool, got
+// Number(2.0)". The native form raises "panic-unwrap: partition:
+// predicate must return bool" (matching the `flt` native lift). Both
+// surface ILO-R009; we assert the message contains "partition" and
+// "bool" so the cross-engine contract holds for either wording.
+
+#[test]
+fn partition_non_bool_predicate_errors() {
+    let src = "bad x:n>n;+x 1\nf xs:L n>L L n;partition bad xs";
+    #[cfg(feature = "cranelift")]
+    let engines: &[&str] = &["--run-tree", "--run-vm", "--run-cranelift"];
+    #[cfg(not(feature = "cranelift"))]
+    let engines: &[&str] = &["--run-tree", "--run-vm"];
+    for engine in engines {
+        let stderr = run_err(engine, src, "f", &["[1,2,3]"]);
+        assert!(
+            stderr.contains("partition") && stderr.contains("bool"),
+            "engine {engine}: expected error mentioning partition + bool, got {stderr}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 PR3 of 5 in the HOF native closure dispatch sweep. Migrates the first of the 2-arg HOFs off the tree-bridge so closure callbacks dispatch natively via OP_CALL_DYN per element instead of re-entering the tree interpreter on every call.

Pre-PR3 the OP_CALL_BUILTIN_TREE bridge routed every callback through the tree-walker. That cost a NanVal-to-Value round-trip per call and depended on ACTIVE_AST_PROGRAM TLS being live, which has been a source of cross-engine bugs. Post-PR3 partition does its own foreach loop and uses the closure-aware OP_CALL_DYN from PR1/PR2 (#384/#385).

## What landed

- **partition 2**: native foreach loop with OP_CALL_DYN per element, two accumulator lists (pass/fail) grown in place via OP_LISTAPPEND, OP_ISBOOL typecheck mirroring the flt 2 native lift, OP_LISTNEW + two appends to assemble the final `[pass, fail]` result. Capturing lambdas work for free via OP_MAKE_CLOSURE + closure-aware OP_CALL_DYN. Dropped from `is_tree_bridge_eligible`.

## What's still on the bridge

The other HOFs the PR3 plan called out (srt 2, grp 2, uniqby 2, mapr 2, plus neighbours ct 2 and rsrt 2) each need a dedicated finalizer opcode for the post-callback assembly step:

- **srt 2 / rsrt 2**: sort-by-key, requires Number/Text polymorphic comparison.
- **grp 2**: produces a Map keyed by predicate result, needs MapKey construction.
- **uniqby 2**: needs HashSet-based dedup keyed on type-tagged stringification.
- **mapr 2**: Result-aware short-circuit on Err.
- **ct 2**: counter only (simplest, deferable but lower-impact).

Rather than ship a half-finished foundation for those, this PR locks in the easiest migration (partition's bool-predicate shape, identical to the existing flt 2 lift) and leaves the dedicated finalizer-opcode work for follow-up PRs. Time-boxed to keep the surface area reviewable.

## Bench

The Phase 2 PR3 bio canonical bench (`flt all-h (window k seqs)`) runs unchanged: flt 2 already had a native lift pre-PR3, so the bench numbers don't move on this partition-only migration. Bench rerun will be meaningful once srt/grp/uniqby land in a follow-up PR.

## What's in the diff

Per-commit:
1. `vm: lift partition 2 off tree-bridge to OP_CALL_DYN` (src/vm/mod.rs)
2. `test: cross-engine coverage for partition native dispatch` (tests + examples)

## Test plan

- [x] Build: `cargo build --release --features cranelift` clean
- [x] Full suite green: `cargo test --release --features cranelift` (6852 pass, 0 fail; up 9 from 6843)
- [x] New regression file: 9 tests, all engines (tree, VM, Cranelift), all three Phase 2 shapes plus empty input, all-pass, all-fail, text values, and non-bool predicate error
- [x] examples_engines harness picks up partition-closure-native.ilo across every engine
- [x] cargo fmt clean
- [x] cargo clippy --features cranelift --all-targets -D warnings clean

## Follow-ups

- PR3b/3c/3d: native lifts for srt 2 / rsrt 2 / grp 2 / uniqby 2 / mapr 2 (each needs a dedicated finalizer opcode for the post-callback assembly step).
- PR4: tests/regression_inline_lambda.rs infra migration.
- PR5: SPEC.md "tree-only" wording cleanup once all 2-arg HOFs are native.