### PR TITLE
chore: Phase 0 hygiene (0.12.0)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,43 @@ Thanks for your interest in contributing to ilo!
 
 ```bash
 git clone https://github.com/ilo-lang/ilo
-cd ilo-lang
+cd ilo
 cargo test
 ```
+
+## Shared build cache (recommended)
+
+ilo development typically involves many worktrees (one per fix / feature
+branch). By default each worktree gets its own `target/` directory and these
+add up fast, historically into the tens of GB on a single developer machine.
+Set a shared cache once in your shell config:
+
+```bash
+# ~/.zshrc or ~/.bashrc
+export CARGO_TARGET_DIR="$HOME/.cargo-shared"
+mkdir -p "$CARGO_TARGET_DIR"
+```
+
+All worktrees then share one build cache. Cargo namespaces artefacts per
+package + feature combination internally, so this is safe across branches.
+
+## Empirical discipline
+
+Claims about ilo's performance, token count, or runtime behaviour need
+benchmarks or tests, not assertions. "Measured, not asserted" is the rule.
+If you're tightening a hot path, add a criterion bench or a deterministic
+timing harness. If you're claiming a token win in docs, the number comes
+from the benchmark, not from rounding what feels right.
+
+The binary-size tripwire (`tests/binary_size.rs`) is one expression of this:
+AOT output for a trivial program is checked against a ceiling on every CI
+run, so dep upgrades that inflate the runtime fail loudly instead of
+drifting silently.
+
+## Strategic context
+
+Longer-form plans for upcoming phases live in `zero-gap-specs/` (separate
+repo). Briefs there set the why; PRs here implement the how.
 
 ## Development
 

--- a/research/deps-snapshot.txt
+++ b/research/deps-snapshot.txt
@@ -1,0 +1,525 @@
+# ilo dependency snapshot (0.12.0 hygiene)
+#
+# Generated as part of Phase 0 (zero-gap-specs/briefs/phase-0-hygiene-brief.md).
+#
+# Totals (default features = cranelift + http):
+#   cargo tree --edges normal             →  158 unique transitive crates
+#   cargo tree --edges normal --no-dedupe →  462 dep-edges total
+#   cargo tree --edges normal --no-default-features →  67 (lean baseline)
+#
+# Direct deps ranked by transitive subtree size:
+#
+#   50  cranelift-jit          (feature: cranelift, default)
+#   42  cranelift-object       (feature: cranelift, default)
+#   31  cranelift-frontend     (feature: cranelift, default)
+#   30  cranelift-module       (feature: cranelift, default)
+#   29  cranelift-native       (feature: cranelift, default)
+#   27  cranelift-codegen      (feature: cranelift, default)
+#   22  clap                   (always on, CLI)
+#   17  minreq                 (feature: http, default; pulls https-rustls)
+#   17  logos                  (always on, lexer derive)
+#   10  serde
+#    9  thiserror
+#    8  regex
+#    4  serde_json
+#    3  chrono
+#    0  target-lexicon         (feature: cranelift)
+#    0  libc
+#    0  fastrand
+#
+# Findings / disposition:
+#
+# 1. Cranelift family (6 crates → ~200 transitive edges) is by far the largest
+#    contributor. Already feature-gated behind `cranelift`. `--no-default-features`
+#    drops the entire tree to 67 unique crates. This is load-bearing for the JIT
+#    and AOT paths; keep.
+#
+# 2. clap is the heaviest non-cranelift dep (22 transitive). Replacing with `lexopt`
+#    or hand-rolled argv parsing would save ~20 crates but cost the `--help` /
+#    derive ergonomics and require rewriting CLI surface. Deferred — flagged as
+#    a follow-up issue.
+#
+# 3. minreq (HTTPS) is already the lightweight choice (vs reqwest/tokio which
+#    are gated behind the `tools` feature, off by default). 17 transitive,
+#    mostly rustls + webpki. Unavoidable given HTTPS requirement. Documented.
+#
+# 4. logos brings 17 transitive via its derive crate (regex-automata + syn).
+#    Load-bearing for the lexer. Keep.
+#
+# 5. Duplicate versions detected by `cargo tree -d`:
+#       hashbrown v0.14.5, 0.15.5, 0.16.1  (three majors live in the tree)
+#       regex-automata v0.4.14             (via logos-codegen and regex; same ver, no dup waste)
+#       target-lexicon v0.12.16            (single version, no dup)
+#    The hashbrown spread is driven by cranelift (0.14), object/regalloc2 (0.15),
+#    and indexmap-2 (0.16). All upstream; not actionable from ilo.
+#
+# 6. Headline number from the brief (249 transitive) has already drifted down
+#    to 158 unique / 462 with dupes due to prior cleanup work. Stretch goal of
+#    ≤150 is within touching distance — would need either clap replacement (-20)
+#    or a smaller HTTP client (-10). Both are user-visible-surface changes and
+#    out of scope for pure hygiene.
+#
+# ── Full tree below ───────────────────────────────────────────────────────────
+
+ilo v0.11.8 (/Users/dan/code/ilo-lang/ilo-feature-phase0-hygiene)
+├── chrono v0.4.44
+│   ├── iana-time-zone v0.1.65
+│   │   └── core-foundation-sys v0.8.7
+│   └── num-traits v0.2.19
+├── clap v4.5.60
+│   ├── clap_builder v4.5.60
+│   │   ├── anstream v0.6.21
+│   │   │   ├── anstyle v1.0.13
+│   │   │   ├── anstyle-parse v0.2.7
+│   │   │   │   └── utf8parse v0.2.2
+│   │   │   ├── anstyle-query v1.1.5
+│   │   │   ├── colorchoice v1.0.4
+│   │   │   ├── is_terminal_polyfill v1.70.2
+│   │   │   └── utf8parse v0.2.2
+│   │   ├── anstyle v1.0.13
+│   │   ├── clap_lex v1.1.0
+│   │   └── strsim v0.11.1
+│   └── clap_derive v4.5.55 (proc-macro)
+│       ├── heck v0.5.0
+│       ├── proc-macro2 v1.0.106
+│       │   └── unicode-ident v1.0.24
+│       ├── quote v1.0.44
+│       │   └── proc-macro2 v1.0.106
+│       │       └── unicode-ident v1.0.24
+│       └── syn v2.0.117
+│           ├── proc-macro2 v1.0.106
+│           │   └── unicode-ident v1.0.24
+│           ├── quote v1.0.44
+│           │   └── proc-macro2 v1.0.106
+│           │       └── unicode-ident v1.0.24
+│           └── unicode-ident v1.0.24
+├── cranelift-codegen v0.116.1
+│   ├── bumpalo v3.20.2
+│   │   └── allocator-api2 v0.2.21
+│   ├── cranelift-bforest v0.116.1
+│   │   └── cranelift-entity v0.116.1
+│   │       └── cranelift-bitset v0.116.1
+│   ├── cranelift-bitset v0.116.1
+│   ├── cranelift-codegen-shared v0.116.1
+│   ├── cranelift-control v0.116.1
+│   │   └── arbitrary v1.4.2
+│   ├── cranelift-entity v0.116.1
+│   │   └── cranelift-bitset v0.116.1
+│   ├── gimli v0.31.1
+│   │   └── indexmap v2.13.0
+│   │       ├── equivalent v1.0.2
+│   │       └── hashbrown v0.16.1
+│   ├── hashbrown v0.14.5
+│   ├── log v0.4.29
+│   ├── regalloc2 v0.11.2
+│   │   ├── allocator-api2 v0.2.21
+│   │   ├── bumpalo v3.20.2
+│   │   │   └── allocator-api2 v0.2.21
+│   │   ├── hashbrown v0.15.5
+│   │   │   └── foldhash v0.1.5
+│   │   ├── log v0.4.29
+│   │   ├── rustc-hash v2.1.1
+│   │   └── smallvec v1.15.1
+│   ├── rustc-hash v2.1.1
+│   ├── smallvec v1.15.1
+│   └── target-lexicon v0.13.5
+├── cranelift-frontend v0.116.1
+│   ├── cranelift-codegen v0.116.1
+│   │   ├── bumpalo v3.20.2
+│   │   │   └── allocator-api2 v0.2.21
+│   │   ├── cranelift-bforest v0.116.1
+│   │   │   └── cranelift-entity v0.116.1
+│   │   │       └── cranelift-bitset v0.116.1
+│   │   ├── cranelift-bitset v0.116.1
+│   │   ├── cranelift-codegen-shared v0.116.1
+│   │   ├── cranelift-control v0.116.1
+│   │   │   └── arbitrary v1.4.2
+│   │   ├── cranelift-entity v0.116.1
+│   │   │   └── cranelift-bitset v0.116.1
+│   │   ├── gimli v0.31.1
+│   │   │   └── indexmap v2.13.0
+│   │   │       ├── equivalent v1.0.2
+│   │   │       └── hashbrown v0.16.1
+│   │   ├── hashbrown v0.14.5
+│   │   ├── log v0.4.29
+│   │   ├── regalloc2 v0.11.2
+│   │   │   ├── allocator-api2 v0.2.21
+│   │   │   ├── bumpalo v3.20.2
+│   │   │   │   └── allocator-api2 v0.2.21
+│   │   │   ├── hashbrown v0.15.5
+│   │   │   │   └── foldhash v0.1.5
+│   │   │   ├── log v0.4.29
+│   │   │   ├── rustc-hash v2.1.1
+│   │   │   └── smallvec v1.15.1
+│   │   ├── rustc-hash v2.1.1
+│   │   ├── smallvec v1.15.1
+│   │   └── target-lexicon v0.13.5
+│   ├── log v0.4.29
+│   ├── smallvec v1.15.1
+│   └── target-lexicon v0.13.5
+├── cranelift-jit v0.116.1
+│   ├── anyhow v1.0.102
+│   ├── cranelift-codegen v0.116.1
+│   │   ├── bumpalo v3.20.2
+│   │   │   └── allocator-api2 v0.2.21
+│   │   ├── cranelift-bforest v0.116.1
+│   │   │   └── cranelift-entity v0.116.1
+│   │   │       └── cranelift-bitset v0.116.1
+│   │   ├── cranelift-bitset v0.116.1
+│   │   ├── cranelift-codegen-shared v0.116.1
+│   │   ├── cranelift-control v0.116.1
+│   │   │   └── arbitrary v1.4.2
+│   │   ├── cranelift-entity v0.116.1
+│   │   │   └── cranelift-bitset v0.116.1
+│   │   ├── gimli v0.31.1
+│   │   │   └── indexmap v2.13.0
+│   │   │       ├── equivalent v1.0.2
+│   │   │       └── hashbrown v0.16.1
+│   │   ├── hashbrown v0.14.5
+│   │   ├── log v0.4.29
+│   │   ├── regalloc2 v0.11.2
+│   │   │   ├── allocator-api2 v0.2.21
+│   │   │   ├── bumpalo v3.20.2
+│   │   │   │   └── allocator-api2 v0.2.21
+│   │   │   ├── hashbrown v0.15.5
+│   │   │   │   └── foldhash v0.1.5
+│   │   │   ├── log v0.4.29
+│   │   │   ├── rustc-hash v2.1.1
+│   │   │   └── smallvec v1.15.1
+│   │   ├── rustc-hash v2.1.1
+│   │   ├── smallvec v1.15.1
+│   │   └── target-lexicon v0.13.5
+│   ├── cranelift-control v0.116.1
+│   │   └── arbitrary v1.4.2
+│   ├── cranelift-entity v0.116.1
+│   │   └── cranelift-bitset v0.116.1
+│   ├── cranelift-module v0.116.1
+│   │   ├── anyhow v1.0.102
+│   │   ├── cranelift-codegen v0.116.1
+│   │   │   ├── bumpalo v3.20.2
+│   │   │   │   └── allocator-api2 v0.2.21
+│   │   │   ├── cranelift-bforest v0.116.1
+│   │   │   │   └── cranelift-entity v0.116.1
+│   │   │   │       └── cranelift-bitset v0.116.1
+│   │   │   ├── cranelift-bitset v0.116.1
+│   │   │   ├── cranelift-codegen-shared v0.116.1
+│   │   │   ├── cranelift-control v0.116.1
+│   │   │   │   └── arbitrary v1.4.2
+│   │   │   ├── cranelift-entity v0.116.1
+│   │   │   │   └── cranelift-bitset v0.116.1
+│   │   │   ├── gimli v0.31.1
+│   │   │   │   └── indexmap v2.13.0
+│   │   │   │       ├── equivalent v1.0.2
+│   │   │   │       └── hashbrown v0.16.1
+│   │   │   ├── hashbrown v0.14.5
+│   │   │   ├── log v0.4.29
+│   │   │   ├── regalloc2 v0.11.2
+│   │   │   │   ├── allocator-api2 v0.2.21
+│   │   │   │   ├── bumpalo v3.20.2
+│   │   │   │   │   └── allocator-api2 v0.2.21
+│   │   │   │   ├── hashbrown v0.15.5
+│   │   │   │   │   └── foldhash v0.1.5
+│   │   │   │   ├── log v0.4.29
+│   │   │   │   ├── rustc-hash v2.1.1
+│   │   │   │   └── smallvec v1.15.1
+│   │   │   ├── rustc-hash v2.1.1
+│   │   │   ├── smallvec v1.15.1
+│   │   │   └── target-lexicon v0.13.5
+│   │   └── cranelift-control v0.116.1
+│   │       └── arbitrary v1.4.2
+│   ├── cranelift-native v0.116.1
+│   │   ├── cranelift-codegen v0.116.1
+│   │   │   ├── bumpalo v3.20.2
+│   │   │   │   └── allocator-api2 v0.2.21
+│   │   │   ├── cranelift-bforest v0.116.1
+│   │   │   │   └── cranelift-entity v0.116.1
+│   │   │   │       └── cranelift-bitset v0.116.1
+│   │   │   ├── cranelift-bitset v0.116.1
+│   │   │   ├── cranelift-codegen-shared v0.116.1
+│   │   │   ├── cranelift-control v0.116.1
+│   │   │   │   └── arbitrary v1.4.2
+│   │   │   ├── cranelift-entity v0.116.1
+│   │   │   │   └── cranelift-bitset v0.116.1
+│   │   │   ├── gimli v0.31.1
+│   │   │   │   └── indexmap v2.13.0
+│   │   │   │       ├── equivalent v1.0.2
+│   │   │   │       └── hashbrown v0.16.1
+│   │   │   ├── hashbrown v0.14.5
+│   │   │   ├── log v0.4.29
+│   │   │   ├── regalloc2 v0.11.2
+│   │   │   │   ├── allocator-api2 v0.2.21
+│   │   │   │   ├── bumpalo v3.20.2
+│   │   │   │   │   └── allocator-api2 v0.2.21
+│   │   │   │   ├── hashbrown v0.15.5
+│   │   │   │   │   └── foldhash v0.1.5
+│   │   │   │   ├── log v0.4.29
+│   │   │   │   ├── rustc-hash v2.1.1
+│   │   │   │   └── smallvec v1.15.1
+│   │   │   ├── rustc-hash v2.1.1
+│   │   │   ├── smallvec v1.15.1
+│   │   │   └── target-lexicon v0.13.5
+│   │   └── target-lexicon v0.13.5
+│   ├── libc v0.2.182
+│   ├── log v0.4.29
+│   ├── region v3.0.2
+│   │   ├── bitflags v1.3.2
+│   │   ├── libc v0.2.182
+│   │   └── mach2 v0.4.3
+│   │       └── libc v0.2.182
+│   ├── target-lexicon v0.13.5
+│   └── wasmtime-jit-icache-coherence v29.0.1
+│       ├── anyhow v1.0.102
+│       ├── cfg-if v1.0.4
+│       └── libc v0.2.182
+├── cranelift-module v0.116.1
+│   ├── anyhow v1.0.102
+│   ├── cranelift-codegen v0.116.1
+│   │   ├── bumpalo v3.20.2
+│   │   │   └── allocator-api2 v0.2.21
+│   │   ├── cranelift-bforest v0.116.1
+│   │   │   └── cranelift-entity v0.116.1
+│   │   │       └── cranelift-bitset v0.116.1
+│   │   ├── cranelift-bitset v0.116.1
+│   │   ├── cranelift-codegen-shared v0.116.1
+│   │   ├── cranelift-control v0.116.1
+│   │   │   └── arbitrary v1.4.2
+│   │   ├── cranelift-entity v0.116.1
+│   │   │   └── cranelift-bitset v0.116.1
+│   │   ├── gimli v0.31.1
+│   │   │   └── indexmap v2.13.0
+│   │   │       ├── equivalent v1.0.2
+│   │   │       └── hashbrown v0.16.1
+│   │   ├── hashbrown v0.14.5
+│   │   ├── log v0.4.29
+│   │   ├── regalloc2 v0.11.2
+│   │   │   ├── allocator-api2 v0.2.21
+│   │   │   ├── bumpalo v3.20.2
+│   │   │   │   └── allocator-api2 v0.2.21
+│   │   │   ├── hashbrown v0.15.5
+│   │   │   │   └── foldhash v0.1.5
+│   │   │   ├── log v0.4.29
+│   │   │   ├── rustc-hash v2.1.1
+│   │   │   └── smallvec v1.15.1
+│   │   ├── rustc-hash v2.1.1
+│   │   ├── smallvec v1.15.1
+│   │   └── target-lexicon v0.13.5
+│   └── cranelift-control v0.116.1
+│       └── arbitrary v1.4.2
+├── cranelift-native v0.116.1
+│   ├── cranelift-codegen v0.116.1
+│   │   ├── bumpalo v3.20.2
+│   │   │   └── allocator-api2 v0.2.21
+│   │   ├── cranelift-bforest v0.116.1
+│   │   │   └── cranelift-entity v0.116.1
+│   │   │       └── cranelift-bitset v0.116.1
+│   │   ├── cranelift-bitset v0.116.1
+│   │   ├── cranelift-codegen-shared v0.116.1
+│   │   ├── cranelift-control v0.116.1
+│   │   │   └── arbitrary v1.4.2
+│   │   ├── cranelift-entity v0.116.1
+│   │   │   └── cranelift-bitset v0.116.1
+│   │   ├── gimli v0.31.1
+│   │   │   └── indexmap v2.13.0
+│   │   │       ├── equivalent v1.0.2
+│   │   │       └── hashbrown v0.16.1
+│   │   ├── hashbrown v0.14.5
+│   │   ├── log v0.4.29
+│   │   ├── regalloc2 v0.11.2
+│   │   │   ├── allocator-api2 v0.2.21
+│   │   │   ├── bumpalo v3.20.2
+│   │   │   │   └── allocator-api2 v0.2.21
+│   │   │   ├── hashbrown v0.15.5
+│   │   │   │   └── foldhash v0.1.5
+│   │   │   ├── log v0.4.29
+│   │   │   ├── rustc-hash v2.1.1
+│   │   │   └── smallvec v1.15.1
+│   │   ├── rustc-hash v2.1.1
+│   │   ├── smallvec v1.15.1
+│   │   └── target-lexicon v0.13.5
+│   └── target-lexicon v0.13.5
+├── cranelift-object v0.116.1
+│   ├── anyhow v1.0.102
+│   ├── cranelift-codegen v0.116.1
+│   │   ├── bumpalo v3.20.2
+│   │   │   └── allocator-api2 v0.2.21
+│   │   ├── cranelift-bforest v0.116.1
+│   │   │   └── cranelift-entity v0.116.1
+│   │   │       └── cranelift-bitset v0.116.1
+│   │   ├── cranelift-bitset v0.116.1
+│   │   ├── cranelift-codegen-shared v0.116.1
+│   │   ├── cranelift-control v0.116.1
+│   │   │   └── arbitrary v1.4.2
+│   │   ├── cranelift-entity v0.116.1
+│   │   │   └── cranelift-bitset v0.116.1
+│   │   ├── gimli v0.31.1
+│   │   │   └── indexmap v2.13.0
+│   │   │       ├── equivalent v1.0.2
+│   │   │       └── hashbrown v0.16.1
+│   │   ├── hashbrown v0.14.5
+│   │   ├── log v0.4.29
+│   │   ├── regalloc2 v0.11.2
+│   │   │   ├── allocator-api2 v0.2.21
+│   │   │   ├── bumpalo v3.20.2
+│   │   │   │   └── allocator-api2 v0.2.21
+│   │   │   ├── hashbrown v0.15.5
+│   │   │   │   └── foldhash v0.1.5
+│   │   │   ├── log v0.4.29
+│   │   │   ├── rustc-hash v2.1.1
+│   │   │   └── smallvec v1.15.1
+│   │   ├── rustc-hash v2.1.1
+│   │   ├── smallvec v1.15.1
+│   │   └── target-lexicon v0.13.5
+│   ├── cranelift-control v0.116.1
+│   │   └── arbitrary v1.4.2
+│   ├── cranelift-module v0.116.1
+│   │   ├── anyhow v1.0.102
+│   │   ├── cranelift-codegen v0.116.1
+│   │   │   ├── bumpalo v3.20.2
+│   │   │   │   └── allocator-api2 v0.2.21
+│   │   │   ├── cranelift-bforest v0.116.1
+│   │   │   │   └── cranelift-entity v0.116.1
+│   │   │   │       └── cranelift-bitset v0.116.1
+│   │   │   ├── cranelift-bitset v0.116.1
+│   │   │   ├── cranelift-codegen-shared v0.116.1
+│   │   │   ├── cranelift-control v0.116.1
+│   │   │   │   └── arbitrary v1.4.2
+│   │   │   ├── cranelift-entity v0.116.1
+│   │   │   │   └── cranelift-bitset v0.116.1
+│   │   │   ├── gimli v0.31.1
+│   │   │   │   └── indexmap v2.13.0
+│   │   │   │       ├── equivalent v1.0.2
+│   │   │   │       └── hashbrown v0.16.1
+│   │   │   ├── hashbrown v0.14.5
+│   │   │   ├── log v0.4.29
+│   │   │   ├── regalloc2 v0.11.2
+│   │   │   │   ├── allocator-api2 v0.2.21
+│   │   │   │   ├── bumpalo v3.20.2
+│   │   │   │   │   └── allocator-api2 v0.2.21
+│   │   │   │   ├── hashbrown v0.15.5
+│   │   │   │   │   └── foldhash v0.1.5
+│   │   │   │   ├── log v0.4.29
+│   │   │   │   ├── rustc-hash v2.1.1
+│   │   │   │   └── smallvec v1.15.1
+│   │   │   ├── rustc-hash v2.1.1
+│   │   │   ├── smallvec v1.15.1
+│   │   │   └── target-lexicon v0.13.5
+│   │   └── cranelift-control v0.116.1
+│   │       └── arbitrary v1.4.2
+│   ├── log v0.4.29
+│   ├── object v0.36.7
+│   │   ├── crc32fast v1.5.0
+│   │   │   └── cfg-if v1.0.4
+│   │   ├── hashbrown v0.15.5
+│   │   │   └── foldhash v0.1.5
+│   │   ├── indexmap v2.13.0
+│   │   │   ├── equivalent v1.0.2
+│   │   │   └── hashbrown v0.16.1
+│   │   └── memchr v2.8.0
+│   └── target-lexicon v0.13.5
+├── fastrand v2.3.0
+├── libc v0.2.182
+├── logos v0.16.1
+│   └── logos-derive v0.16.1 (proc-macro)
+│       └── logos-codegen v0.16.1
+│           ├── fnv v1.0.7
+│           ├── proc-macro2 v1.0.106
+│           │   └── unicode-ident v1.0.24
+│           ├── quote v1.0.44
+│           │   └── proc-macro2 v1.0.106
+│           │       └── unicode-ident v1.0.24
+│           ├── regex-automata v0.4.14
+│           │   ├── aho-corasick v1.1.4
+│           │   │   └── memchr v2.8.0
+│           │   ├── memchr v2.8.0
+│           │   └── regex-syntax v0.8.10
+│           ├── regex-syntax v0.8.10
+│           └── syn v2.0.117
+│               ├── proc-macro2 v1.0.106
+│               │   └── unicode-ident v1.0.24
+│               ├── quote v1.0.44
+│               │   └── proc-macro2 v1.0.106
+│               │       └── unicode-ident v1.0.24
+│               └── unicode-ident v1.0.24
+├── minreq v2.14.1
+│   ├── rustls v0.21.12
+│   │   ├── log v0.4.29
+│   │   ├── ring v0.17.14
+│   │   │   ├── cfg-if v1.0.4
+│   │   │   ├── getrandom v0.2.17
+│   │   │   │   ├── cfg-if v1.0.4
+│   │   │   │   └── libc v0.2.182
+│   │   │   ├── libc v0.2.182
+│   │   │   └── untrusted v0.9.0
+│   │   ├── rustls-webpki v0.101.7
+│   │   │   ├── ring v0.17.14
+│   │   │   │   ├── cfg-if v1.0.4
+│   │   │   │   ├── getrandom v0.2.17
+│   │   │   │   │   ├── cfg-if v1.0.4
+│   │   │   │   │   └── libc v0.2.182
+│   │   │   │   ├── libc v0.2.182
+│   │   │   │   └── untrusted v0.9.0
+│   │   │   └── untrusted v0.9.0
+│   │   └── sct v0.7.1
+│   │       ├── ring v0.17.14
+│   │       │   ├── cfg-if v1.0.4
+│   │       │   ├── getrandom v0.2.17
+│   │       │   │   ├── cfg-if v1.0.4
+│   │       │   │   └── libc v0.2.182
+│   │       │   ├── libc v0.2.182
+│   │       │   └── untrusted v0.9.0
+│   │       └── untrusted v0.9.0
+│   ├── rustls-webpki v0.101.7
+│   │   ├── ring v0.17.14
+│   │   │   ├── cfg-if v1.0.4
+│   │   │   ├── getrandom v0.2.17
+│   │   │   │   ├── cfg-if v1.0.4
+│   │   │   │   └── libc v0.2.182
+│   │   │   ├── libc v0.2.182
+│   │   │   └── untrusted v0.9.0
+│   │   └── untrusted v0.9.0
+│   └── webpki-roots v0.25.4
+├── regex v1.12.3
+│   ├── aho-corasick v1.1.4
+│   │   └── memchr v2.8.0
+│   ├── memchr v2.8.0
+│   ├── regex-automata v0.4.14
+│   │   ├── aho-corasick v1.1.4
+│   │   │   └── memchr v2.8.0
+│   │   ├── memchr v2.8.0
+│   │   └── regex-syntax v0.8.10
+│   └── regex-syntax v0.8.10
+├── serde v1.0.228
+│   ├── serde_core v1.0.228
+│   └── serde_derive v1.0.228 (proc-macro)
+│       ├── proc-macro2 v1.0.106
+│       │   └── unicode-ident v1.0.24
+│       ├── quote v1.0.44
+│       │   └── proc-macro2 v1.0.106
+│       │       └── unicode-ident v1.0.24
+│       └── syn v2.0.117
+│           ├── proc-macro2 v1.0.106
+│           │   └── unicode-ident v1.0.24
+│           ├── quote v1.0.44
+│           │   └── proc-macro2 v1.0.106
+│           │       └── unicode-ident v1.0.24
+│           └── unicode-ident v1.0.24
+├── serde_json v1.0.149
+│   ├── itoa v1.0.17
+│   ├── memchr v2.8.0
+│   ├── serde_core v1.0.228
+│   └── zmij v1.0.21
+├── target-lexicon v0.12.16
+└── thiserror v2.0.18
+    └── thiserror-impl v2.0.18 (proc-macro)
+        ├── proc-macro2 v1.0.106
+        │   └── unicode-ident v1.0.24
+        ├── quote v1.0.44
+        │   └── proc-macro2 v1.0.106
+        │       └── unicode-ident v1.0.24
+        └── syn v2.0.117
+            ├── proc-macro2 v1.0.106
+            │   └── unicode-ident v1.0.24
+            ├── quote v1.0.44
+            │   └── proc-macro2 v1.0.106
+            │       └── unicode-ident v1.0.24
+            └── unicode-ident v1.0.24

--- a/tests/binary_size.rs
+++ b/tests/binary_size.rs
@@ -1,0 +1,79 @@
+// Binary-size tripwire.
+//
+// Compiles a minimal ilo program (`m>n;42`) via the AOT path and asserts the
+// resulting native binary stays under a generous ceiling. The point isn't to
+// drive size down — it's to catch silent regressions where a dep upgrade or a
+// new transitive crate quietly inflates the AOT runtime.
+//
+// Threshold rationale: under `cargo test` the AOT-linked binary is built
+// against the *debug* libilo.a (debuginfo + un-stripped HTTPS / cranelift
+// object code), which on macOS arm64 measures ~34 MB for `m>n;42`. Release
+// + strip + LTO shrinks the same program to ~9 MB but isn't what CI links
+// against in the test harness. The 50 MB ceiling gives ~50% headroom on
+// the debug baseline while still failing loudly if a new dep silently
+// inflates the AOT runtime.
+//
+// Gated on the `cranelift` feature because AOT compile requires it.
+
+#![cfg(feature = "cranelift")]
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// Maximum AOT binary size in bytes. Current debug baseline is ~34 MB;
+/// ceiling is 50 MB. Bump deliberately only with a PR note explaining the
+/// new floor — never silently.
+const MAX_AOT_BINARY_BYTES: u64 = 50 * 1024 * 1024;
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn tmp_paths(tag: &str) -> (PathBuf, PathBuf) {
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let src = std::env::temp_dir().join(format!("ilo-binsize-{tag}-{pid}-{n}.ilo"));
+    let bin = std::env::temp_dir().join(format!("ilo-binsize-{tag}-{pid}-{n}.bin"));
+    (src, bin)
+}
+
+#[test]
+fn aot_binary_size_under_threshold() {
+    let (src_path, bin_path) = tmp_paths("min");
+    std::fs::write(&src_path, "m>n;42").expect("write ilo source");
+
+    let compile = ilo()
+        .arg("compile")
+        .arg(&src_path)
+        .arg("-o")
+        .arg(&bin_path)
+        .output()
+        .expect("failed to invoke ilo compile");
+    assert!(
+        compile.status.success(),
+        "ilo compile failed: stdout={:?} stderr={:?}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr),
+    );
+
+    let size = std::fs::metadata(&bin_path)
+        .expect("AOT binary should exist after compile")
+        .len();
+
+    // Best-effort cleanup; ignore failures.
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+
+    assert!(
+        size <= MAX_AOT_BINARY_BYTES,
+        "AOT binary for `m>n;42` is {size} bytes, exceeds tripwire ceiling of \
+         {MAX_AOT_BINARY_BYTES} bytes ({:.2} MB > {:.2} MB). Either a dep \
+         upgrade has bloated the runtime, or the threshold should be revisited \
+         with an explicit PR note.",
+        size as f64 / (1024.0 * 1024.0),
+        MAX_AOT_BINARY_BYTES as f64 / (1024.0 * 1024.0),
+    );
+}

--- a/tests/binary_size.rs
+++ b/tests/binary_size.rs
@@ -7,11 +7,11 @@
 //
 // Threshold rationale: under `cargo test` the AOT-linked binary is built
 // against the *debug* libilo.a (debuginfo + un-stripped HTTPS / cranelift
-// object code), which on macOS arm64 measures ~34 MB for `m>n;42`. Release
-// + strip + LTO shrinks the same program to ~9 MB but isn't what CI links
-// against in the test harness. The 50 MB ceiling gives ~50% headroom on
-// the debug baseline while still failing loudly if a new dep silently
-// inflates the AOT runtime.
+// object code). The debug baseline differs across platforms: ~34 MB on
+// macOS arm64, ~94 MB on Linux x86_64 (CI). Release + strip + LTO shrinks
+// the same program to ~9 MB but isn't what `cargo test` links against in
+// CI. The 150 MB ceiling sits ~50% above the Linux debug baseline while
+// still failing loudly if a new dep silently inflates the AOT runtime.
 //
 // Gated on the `cranelift` feature because AOT compile requires it.
 
@@ -21,10 +21,10 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::sync::atomic::{AtomicU32, Ordering};
 
-/// Maximum AOT binary size in bytes. Current debug baseline is ~34 MB;
-/// ceiling is 50 MB. Bump deliberately only with a PR note explaining the
-/// new floor — never silently.
-const MAX_AOT_BINARY_BYTES: u64 = 50 * 1024 * 1024;
+/// Maximum AOT binary size in bytes. Debug baseline is ~34 MB (macOS arm64)
+/// / ~94 MB (Linux x86_64); ceiling is 150 MB. Bump deliberately only with
+/// a PR note explaining the new floor — never silently.
+const MAX_AOT_BINARY_BYTES: u64 = 150 * 1024 * 1024;
 
 static COUNTER: AtomicU32 = AtomicU32::new(0);
 

--- a/tests/regression_inline_lambda.rs
+++ b/tests/regression_inline_lambda.rs
@@ -60,7 +60,7 @@ fn run_engine(engine: &str, src: &str, entry: &str, args: &[&str]) -> String {
 /// Use this by default — closure capture works natively on tree, VM,
 /// and Cranelift after #384 + #385 + #387.
 fn run_all(src: &str, entry: &str, args: &[&str], expected: &str) {
-    for engine in ["--run-tree", "--run-vm", "--run-cranelift"] {
+    for engine in ["--run-tree", "--run-vm", "--jit"] {
         let actual = run_engine(engine, src, entry, args);
         assert_eq!(
             actual, expected,


### PR DESCRIPTION
## Summary

Phase 0 hygiene work ahead of 0.12.0 per `zero-gap-specs/briefs/phase-0-hygiene-brief.md`. Pure plumbing, no user-visible behaviour changes:

- **Binary-size tripwire** in `tests/binary_size.rs` so future PRs that bloat the AOT runtime fail in CI instead of drifting silently.
- **Dependency snapshot** at `research/deps-snapshot.txt` categorising direct deps by transitive subtree size, with a header explaining which are load-bearing vs replaceable.
- **CONTRIBUTING.md** documents the `CARGO_TARGET_DIR=$HOME/.cargo-shared` convention (one shared build cache across worktrees instead of per-branch multi-GB target/ dirs) and the "measured, not asserted" empirical discipline note.
- **CI-unblock fix** in `tests/regression_inline_lambda.rs`: rename `--run-cranelift` to `--jit` (the flag was removed in #392 but this test wasn't updated, leaving main red).

## Numbers

| | Before brief was written | Now |
|---|---|---|
| Unique transitive crates (default features) | 249 | **158** |
| Dep edges with dupes | (unmeasured) | 462 |
| Unique transitive crates (`--no-default-features`) | (unmeasured) | 67 |
| AOT binary for `m>n;42` (debug, macOS arm64) | (unmeasured) | ~34 MB |
| AOT binary for `m>n;42` (debug, Linux x86_64) | (unmeasured) | ~94 MB |
| AOT binary for `m>n;42` (release+strip+LTO) | ~9 MB | ~9 MB |

The 249 → 158 drop happened in prior cleanup before this PR landed; the snapshot now versions that floor. Tripwire ceiling is 150 MB, ~50% above the Linux debug baseline that CI links against.

## What's in the diff

1. **`docs(contrib): shared cargo target dir + empirical discipline note`** — adds the shared-cache convention, the empirical discipline section, and a pointer to `zero-gap-specs/`.
2. **`test: add AOT binary-size tripwire`** — `tests/binary_size.rs` compiles a minimal program via `ilo compile` and asserts the output stays under the ceiling. Runs under the existing `cargo nextest run --profile ci` step, no workflow change needed (brief: "No CI restructure").
3. **`chore(deps): snapshot transitive dependency tree`** — `research/deps-snapshot.txt` (force-added past the `research/` ignore, since this snapshot is versioned reference data).
4. **`test: raise binary-size tripwire ceiling to 150 MB`** — initial 50 MB ceiling failed on Linux x86_64 in CI; bumped with both-platform rationale.
5. **`test: rename --run-cranelift to --jit in regression_inline_lambda`** — picks up the one stale flag reference from #392 that was blocking CI on main.

## Deferred from the brief

- **Deleting per-worktree `target-*` dirs** (~17–18 GB reclaim) needs explicit user confirmation per the brief's "destructive operations" rule. Listed under follow-ups; not done here.
- **Mutating `~/.zshrc`** to set `CARGO_TARGET_DIR` is user-machine config, not in-repo. CONTRIBUTING.md documents the convention for contributors to apply locally.
- **Dropping transitive count to ≤150 (stretch)** would require either replacing `clap` (-22 transitive) or further trimming the HTTPS path. Both are user-visible-surface changes and out of scope for pure hygiene. Logged in the snapshot header.

## Doc sync

No user-visible surface changed, so the four-doc sync (SPEC.md / ai.txt / SKILL.md / site) is not applicable. CONTRIBUTING.md is the only doc touched and is contributor-facing.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --test binary_size` passes (debug, default features)
- [x] `cargo test --test regression_inline_lambda` passes (was failing on main)
- [x] CI: all four jobs green (lint, skill-validate, build, coverage)

## Follow-ups

- Get explicit user approval to mass-delete stale `target-*` dirs across `/Users/dan/code/ilo-lang/ilo-*/` for ~17 GB reclaim.
- Consider replacing `clap` with `lexopt` if the transitive count ever needs to dip under 150.