### PR TITLE
fix: rename stale --run-cranelift to --jit in inline_lambda tests

### DIFF
--- a/tests/regression_inline_lambda.rs
+++ b/tests/regression_inline_lambda.rs
@@ -60,7 +60,7 @@ fn run_engine(engine: &str, src: &str, entry: &str, args: &[&str]) -> String {
 /// Use this by default — closure capture works natively on tree, VM,
 /// and Cranelift after #384 + #385 + #387.
 fn run_all(src: &str, entry: &str, args: &[&str], expected: &str) {
-    for engine in ["--run-tree", "--run-vm", "--run-cranelift"] {
+    for engine in ["--run-tree", "--run-vm", "--jit"] {
         let actual = run_engine(engine, src, entry, args);
         assert_eq!(
             actual, expected,


### PR DESCRIPTION
PR4 #393 brought in cross-engine tests with --run-cranelift before #392 renamed the flag. Main is currently broken on these tests; this fixes.