### PR TITLE
feature: RC fast paths for sole-owned values (Memory 1)

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1800,13 +1800,26 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         };
     }
     if builtin == Some(Builtin::Rev) && args.len() == 1 {
-        return match &args[0] {
-            Value::List(items) => {
-                let mut reversed: Vec<Value> = (**items).clone();
-                reversed.reverse();
-                Ok(Value::List(Arc::new(reversed)))
+        // RC=1 fast path: consume args by value so we own the Arc; Arc::make_mut
+        // mutates the underlying Vec/String in place when the Arc is the sole
+        // reference, else clones once. Mirrors the mset/mdel pattern landed in
+        // PR #249. The clone-on-shared branch keeps the same observable
+        // behaviour (callers still see a fresh List/Text), while the sole-owner
+        // branch skips the buffer allocation entirely.
+        let mut it = args.into_iter();
+        let v = it.next().unwrap();
+        return match v {
+            Value::List(mut items) => {
+                let inner = Arc::make_mut(&mut items);
+                inner.reverse();
+                Ok(Value::List(items))
             }
-            Value::Text(s) => Ok(Value::Text(Arc::new(s.chars().rev().collect()))),
+            Value::Text(mut s) => {
+                let inner = Arc::make_mut(&mut s);
+                let reversed: String = inner.chars().rev().collect();
+                *inner = reversed;
+                Ok(Value::Text(s))
+            }
             other => Err(RuntimeError::new(
                 "ILO-R009",
                 format!("rev requires a list or text, got {:?}", other),
@@ -1814,33 +1827,39 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         };
     }
     if builtin == Some(Builtin::Srt) && args.len() == 1 {
-        return match &args[0] {
-            Value::List(items) => {
+        // RC=1 fast path: see Rev for rationale. When the input Arc is uniquely
+        // owned, Arc::make_mut hands back &mut Vec<Value> and we sort in place;
+        // when shared, it clones once and we sort the clone. Same observable
+        // behaviour either way.
+        let mut it = args.into_iter();
+        let v = it.next().unwrap();
+        return match v {
+            Value::List(mut items) => {
                 if items.is_empty() {
-                    return Ok(Value::List(Arc::new(vec![])));
+                    return Ok(Value::List(items));
                 }
                 let all_numbers = items.iter().all(|v| matches!(v, Value::Number(_)));
                 let all_text = items.iter().all(|v| matches!(v, Value::Text(_)));
                 if all_numbers {
-                    let mut sorted: Vec<Value> = (**items).clone();
-                    sorted.sort_by(|a, b| {
+                    let inner = Arc::make_mut(&mut items);
+                    inner.sort_by(|a, b| {
                         if let (Value::Number(x), Value::Number(y)) = (a, b) {
                             x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal)
                         } else {
                             unreachable!()
                         }
                     });
-                    Ok(Value::List(Arc::new(sorted)))
+                    Ok(Value::List(items))
                 } else if all_text {
-                    let mut sorted: Vec<Value> = (**items).clone();
-                    sorted.sort_by(|a, b| {
+                    let inner = Arc::make_mut(&mut items);
+                    inner.sort_by(|a, b| {
                         if let (Value::Text(x), Value::Text(y)) = (a, b) {
                             x.cmp(y)
                         } else {
                             unreachable!()
                         }
                     });
-                    Ok(Value::List(Arc::new(sorted)))
+                    Ok(Value::List(items))
                 } else {
                     Err(RuntimeError::new(
                         "ILO-R009",
@@ -1848,10 +1867,12 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                     ))
                 }
             }
-            Value::Text(s) => {
-                let mut chars: Vec<char> = s.chars().collect();
+            Value::Text(mut s) => {
+                let inner = Arc::make_mut(&mut s);
+                let mut chars: Vec<char> = inner.chars().collect();
                 chars.sort();
-                Ok(Value::Text(Arc::new(chars.into_iter().collect())))
+                *inner = chars.into_iter().collect();
+                Ok(Value::Text(s))
             }
             other => Err(RuntimeError::new(
                 "ILO-R009",
@@ -2982,13 +3003,23 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             )
         })?;
         let captures = closure_captures(&args[0]);
-        let (ctx, list_arg) = if args.len() == 3 {
-            (Some(args[1].clone()), &args[2])
+        // Consume args so we can move the input List Arc and try Arc::make_mut
+        // for the RC=1 in-place compact fast path. When the input is sole-owned
+        // we mutate the underlying Vec via Vec::retain — N kept items skip the
+        // per-item Value::clone() the cold path pays. When shared we fall
+        // through to a fresh allocation.
+        let mut args_iter = args.into_iter();
+        let fn_arg = args_iter.next().unwrap();
+        let _ = fn_arg;
+        let (ctx, list_arg) = if args_iter.len() == 2 {
+            let c = args_iter.next().unwrap();
+            let l = args_iter.next().unwrap();
+            (Some(c), l)
         } else {
-            (None, &args[1])
+            (None, args_iter.next().unwrap())
         };
-        let items = match list_arg {
-            Value::List(l) => l.clone(),
+        let mut items = match list_arg {
+            Value::List(l) => l,
             other => {
                 return Err(RuntimeError::new(
                     "ILO-R009",
@@ -2996,7 +3027,10 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 ));
             }
         };
-        let mut result = Vec::new();
+        // First pass: evaluate the predicate once per item, recording a bitmap
+        // of keeps so we never call the predicate twice. The predicate may
+        // panic — we don't reorder side effects relative to the cold path.
+        let mut keep: Vec<bool> = Vec::with_capacity(items.len());
         for item in items.iter() {
             let mut call_args = match &ctx {
                 Some(c) => vec![item.clone(), c.clone()],
@@ -3004,8 +3038,8 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
             };
             call_args.extend(captures.iter().cloned());
             match call_function(env, &fn_name, call_args)? {
-                Value::Bool(true) => result.push(item.clone()),
-                Value::Bool(false) => {}
+                Value::Bool(true) => keep.push(true),
+                Value::Bool(false) => keep.push(false),
                 other => {
                     return Err(RuntimeError::new(
                         "ILO-R009",
@@ -3014,7 +3048,27 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 }
             }
         }
-        return Ok(Value::List(Arc::new(result)));
+        // Second pass: branch on RC. Sole-owned -> retain in place (zero
+        // per-item Value::clone()s). Shared -> clone-collect kept items only
+        // (cheaper than cloning the full Vec when many items are dropped).
+        return if Arc::strong_count(&items) == 1 {
+            let inner = Arc::make_mut(&mut items);
+            let mut idx = 0usize;
+            inner.retain(|_| {
+                let k = keep[idx];
+                idx += 1;
+                k
+            });
+            Ok(Value::List(items))
+        } else {
+            let mut result = Vec::with_capacity(keep.iter().filter(|k| **k).count());
+            for (item, &k) in items.iter().zip(keep.iter()) {
+                if k {
+                    result.push(item.clone());
+                }
+            }
+            Ok(Value::List(Arc::new(result)))
+        };
     }
     if builtin == Some(Builtin::Ct) && (args.len() == 2 || args.len() == 3) {
         // ct fn xs / ct fn ctx xs  → number of elements where fn returns true.

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -11159,7 +11159,39 @@ impl<'a> VM<'a> {
                     let a = ((inst >> 16) & 0xFF) as usize + base;
                     let b = ((inst >> 8) & 0xFF) as usize + base;
                     let v = reg!(b);
+                    // RC=1 fast path applies when (1) destination matches
+                    // source (rebind shape `xs = rev xs`), (2) operand is a
+                    // plain HeapObj::List (NOT ListView — a view shares its
+                    // backing buffer with another list), (3) Rc strong count
+                    // is exactly 1. In that case we reverse the inner Vec in
+                    // place without cloning any items or allocating a fresh
+                    // list. Same observable behaviour as the cold path:
+                    // contents of the Vec at `a` after the op are the
+                    // reversal of the contents at `b` on entry. Mirror of the
+                    // OP_ADD string fast path (line ~7253).
                     let result = if v.is_string() {
+                        let ptr = (v.0 & PTR_MASK) as *const HeapObj;
+                        // SAFETY: is_string() ⇒ ptr is a live Rc-managed Str.
+                        let rc_count = {
+                            let rc_peek = unsafe { Rc::from_raw(ptr) };
+                            let count = Rc::strong_count(&rc_peek);
+                            std::mem::forget(rc_peek);
+                            count
+                        };
+                        if a == b && rc_count == 1 {
+                            // SAFETY: sole owner, same dest slot. No other
+                            // live ref can observe the in-place mutation.
+                            let heap_mut = unsafe { &mut *(ptr as *mut HeapObj) };
+                            match heap_mut {
+                                HeapObj::Str(s) => {
+                                    let reversed: String = s.chars().rev().collect();
+                                    *s = reversed;
+                                }
+                                _ => unreachable!(),
+                            }
+                            // a == b: bv already in slot a, nothing to write.
+                            continue;
+                        }
                         let s = unsafe {
                             match v.as_heap_ref() {
                                 HeapObj::Str(s) => s,
@@ -11169,7 +11201,41 @@ impl<'a> VM<'a> {
                         NanVal::heap_string(s.chars().rev().collect::<String>())
                     } else if v.is_heap() {
                         match unsafe { v.as_heap_ref() } {
-                            h @ (HeapObj::List(_) | HeapObj::ListView { .. }) => {
+                            HeapObj::List(_) => {
+                                let ptr = (v.0 & PTR_MASK) as *const HeapObj;
+                                // SAFETY: tag is TAG_LIST and variant matched
+                                // List ⇒ ptr is a live Rc-managed List.
+                                let rc_count = {
+                                    let rc_peek = unsafe { Rc::from_raw(ptr) };
+                                    let count = Rc::strong_count(&rc_peek);
+                                    std::mem::forget(rc_peek);
+                                    count
+                                };
+                                if a == b && rc_count == 1 {
+                                    // SAFETY: sole owner, same dest slot. Vec
+                                    // reversal touches no item NanVals' RCs.
+                                    let heap_mut = unsafe { &mut *(ptr as *mut HeapObj) };
+                                    match heap_mut {
+                                        HeapObj::List(items) => items.reverse(),
+                                        _ => unreachable!(),
+                                    }
+                                    continue;
+                                }
+                                let items = slice_of(unsafe { v.as_heap_ref() });
+                                let mut reversed: Vec<NanVal> = items
+                                    .iter()
+                                    .map(|item| {
+                                        item.clone_rc();
+                                        *item
+                                    })
+                                    .collect();
+                                reversed.reverse();
+                                NanVal::heap_list(reversed)
+                            }
+                            h @ HeapObj::ListView { .. } => {
+                                // ListView shares its backing buffer with
+                                // another List — no in-place reversal is
+                                // sound. Fall through to clone-and-reverse.
                                 let items = slice_of(h);
                                 let mut reversed: Vec<NanVal> = items
                                     .iter()
@@ -11199,6 +11265,51 @@ impl<'a> VM<'a> {
                     let a = ((inst >> 16) & 0xFF) as usize + base;
                     let b = ((inst >> 8) & 0xFF) as usize + base;
                     let v = reg!(b);
+                    // RC=1 fast path (list only, not ListView; rebind shape
+                    // `xs = srt xs`): sort the inner Vec in place. Same
+                    // contract / mirror as OP_REV's fast path above. Sorting
+                    // doesn't change item RCs.
+                    if a == b
+                        && v.is_heap()
+                        && matches!(unsafe { v.as_heap_ref() }, HeapObj::List(_))
+                    {
+                        let ptr = (v.0 & PTR_MASK) as *const HeapObj;
+                        let rc_count = {
+                            // SAFETY: live Rc<HeapObj::List>.
+                            let rc_peek = unsafe { Rc::from_raw(ptr) };
+                            let count = Rc::strong_count(&rc_peek);
+                            std::mem::forget(rc_peek);
+                            count
+                        };
+                        if rc_count == 1 {
+                            // SAFETY: sole owner, same dest slot.
+                            let heap_mut = unsafe { &mut *(ptr as *mut HeapObj) };
+                            let items = match heap_mut {
+                                HeapObj::List(v) => v,
+                                _ => unreachable!(),
+                            };
+                            if items.is_empty() {
+                                continue;
+                            }
+                            let all_numbers = items.iter().all(|v| v.is_number());
+                            let all_strings = items.iter().all(|v| v.is_string());
+                            if all_numbers {
+                                items.sort_by(|a, b| {
+                                    a.as_number()
+                                        .partial_cmp(&b.as_number())
+                                        .unwrap_or(std::cmp::Ordering::Equal)
+                                });
+                                continue;
+                            } else if all_strings {
+                                items.sort_by(|a, b| unsafe { nanval_str_cmp(*a, *b) });
+                                continue;
+                            } else {
+                                vm_err!(VmError::Type(
+                                    "srt: list must contain all numbers or all text"
+                                ));
+                            }
+                        }
+                    }
                     if v.is_string() {
                         let s = unsafe {
                             match v.as_heap_ref() {
@@ -14486,6 +14597,11 @@ pub(crate) extern "C" fn jit_tl(a: u64, span_bits: u64) -> u64 {
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn jit_rev(a: u64, span_bits: u64) -> u64 {
+    // NOTE: no RC=1 fast path here yet. The JIT calling convention for
+    // single-input helpers keeps the source slot's RC alive across the call
+    // (the compiler emits no drop_rc before invoking us), so we can't tell
+    // from inside this helper whether we're the sole owner. The bytecode
+    // OP_REV fast path covers the same shape; JIT-emitted code is a follow-up.
     let v = NanVal(a);
     if v.is_string() {
         let s = unsafe {


### PR DESCRIPTION
Per /Users/dan/code/ilo-lang/zero-gap-specs/briefs/memory/1-rc-fast-paths-brief.md. Adds 2-3 in-place mutation fast paths in interpreter+VM where refcount=1. Agent rate-limited mid-PR; pushing what landed for review.