### PR TITLE
vscode: ship language extension with syntax + snippets + cursor install

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ ilo build program.ilo -o ./bin            # AOT compile
 
 **[Tutorial: Write your first program →](https://ilo-lang.ai/docs/first-program/)**
 
+## Editor support
+
+Syntax highlighting, snippets, and `--` comment handling for `.ilo` files ships in [`extensions/vscode/`](./extensions/vscode/). Install into Cursor with `cd extensions/vscode && npm run install:cursor`. VS Code marketplace publish is tracked separately.
+
 ## What it looks like
 
 **Guards** - flat, no nesting:

--- a/extensions/vscode/.vscodeignore
+++ b/extensions/vscode/.vscodeignore
@@ -1,0 +1,5 @@
+tests/**
+scripts/**
+.vscodeignore
+.gitignore
+**/*.map

--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.12.0 - 2026-05-18
+
+- Initial release. Ships `ilo.tmLanguage.json` (moved from the site repo), `--` line comment config, kebab-case word pattern, bracket auto-close, eight snippets (`fn`, `tool`, `match`, `let`, `loop`, `guard`, `type`, `tern`), and a Cursor install script.
+- Version tracks ilo language version 0.12.x.

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -1,0 +1,43 @@
+# ilo Language Extension
+
+Syntax highlighting, snippets, and editor configuration for [ilo](https://ilo-lang.ai) `.ilo` files in VS Code and Cursor.
+
+ilo is a token-optimised programming language for AI agents. This extension covers:
+
+- Syntax highlighting (comments, strings, numbers, type sigils, builtins, operators)
+- `--` line comments with auto-toggle
+- Bracket pairs, auto-close, and surrounding for `{} [] () "" ''`
+- Word pattern that includes hyphens (ilo identifiers are kebab-case)
+- Snippets for the highest-friction patterns: `fn`, `tool`, `match`, `let`, `loop`, `guard`, `type`, `tern`
+
+## Install
+
+**VS Code marketplace** (once published):
+
+```sh
+code --install-extension ilo-lang.ilo-lang
+```
+
+**Cursor** (until Open VSX is live):
+
+```sh
+cd extensions/vscode
+npm run install:cursor
+```
+
+Reload the Cursor window after install.
+
+## Develop
+
+```sh
+npm test                 # runs the manifest + grammar smoke tests
+npm run install:cursor   # install into ~/.cursor/extensions for local testing
+```
+
+To package a `.vsix` for the marketplace, install `vsce` then run `vsce package` in this directory.
+
+## Links
+
+- Language site: <https://ilo-lang.ai>
+- Source: <https://github.com/ilo-lang/ilo>
+- Spec: <https://github.com/ilo-lang/ilo/blob/main/SPEC.md>

--- a/extensions/vscode/language-configuration/ilo.json
+++ b/extensions/vscode/language-configuration/ilo.json
@@ -1,0 +1,31 @@
+{
+  "comments": {
+    "lineComment": "--"
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"", "notIn": ["string", "comment"] },
+    { "open": "'", "close": "'", "notIn": ["string", "comment"] }
+  ],
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""],
+    ["'", "'"]
+  ],
+  "wordPattern": "(-?\\d+(?:\\.\\d+)?)|([A-Za-z][A-Za-z0-9-]*)",
+  "folding": {
+    "markers": {
+      "start": "^\\s*--\\s*#region\\b",
+      "end": "^\\s*--\\s*#endregion\\b"
+    }
+  }
+}

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "ilo-lang",
+  "displayName": "ilo Language",
+  "description": "Syntax highlighting and editor support for ilo, the token-optimised programming language for AI agents.",
+  "publisher": "ilo-lang",
+  "version": "0.12.0",
+  "license": "MIT",
+  "private": false,
+  "type": "module",
+  "homepage": "https://ilo-lang.ai",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ilo-lang/ilo.git",
+    "directory": "extensions/vscode"
+  },
+  "bugs": {
+    "url": "https://github.com/ilo-lang/ilo/issues"
+  },
+  "keywords": [
+    "ilo",
+    "ilo-lang",
+    "agents",
+    "ai",
+    "tokens"
+  ],
+  "categories": [
+    "Programming Languages",
+    "Snippets"
+  ],
+  "scripts": {
+    "install:cursor": "node scripts/install-cursor-extension.mjs",
+    "test": "node --test tests/*.test.mjs"
+  },
+  "engines": {
+    "node": ">=22",
+    "vscode": "^1.85.0"
+  },
+  "contributes": {
+    "languages": [
+      {
+        "id": "ilo",
+        "aliases": [
+          "ilo",
+          "ilo-lang"
+        ],
+        "extensions": [
+          ".ilo"
+        ],
+        "configuration": "./language-configuration/ilo.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "ilo",
+        "scopeName": "source.ilo",
+        "path": "./syntaxes/ilo.tmLanguage.json"
+      }
+    ],
+    "snippets": [
+      {
+        "language": "ilo",
+        "path": "./snippets/ilo.code-snippets"
+      }
+    ]
+  }
+}

--- a/extensions/vscode/scripts/install-cursor-extension.mjs
+++ b/extensions/vscode/scripts/install-cursor-extension.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// Install the ilo VS Code extension into Cursor's local extensions directory.
+// Cursor uses VS Code's extension model, so a plain file copy works until
+// the extension is published to Open VSX.
+import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const extensionRoot = dirname(here);
+
+const manifest = JSON.parse(await readFile(join(extensionRoot, "package.json"), "utf8"));
+const extensionId = `${manifest.publisher}.${manifest.name}-${manifest.version}`;
+const extensionDir = join(homedir(), ".cursor", "extensions", extensionId);
+
+await rm(extensionDir, { force: true, recursive: true });
+await mkdir(join(extensionDir, "language-configuration"), { recursive: true });
+await mkdir(join(extensionDir, "syntaxes"), { recursive: true });
+await mkdir(join(extensionDir, "snippets"), { recursive: true });
+
+await cp(join(extensionRoot, "package.json"), join(extensionDir, "package.json"));
+await cp(join(extensionRoot, "README.md"), join(extensionDir, "README.md"));
+await cp(
+  join(extensionRoot, "language-configuration/ilo.json"),
+  join(extensionDir, "language-configuration", "ilo.json"),
+);
+await cp(
+  join(extensionRoot, "syntaxes/ilo.tmLanguage.json"),
+  join(extensionDir, "syntaxes", "ilo.tmLanguage.json"),
+);
+await cp(
+  join(extensionRoot, "snippets/ilo.code-snippets"),
+  join(extensionDir, "snippets", "ilo.code-snippets"),
+);
+await writeFile(join(extensionDir, ".installed-by-ilo"), new Date().toISOString());
+
+console.log(`Installed ${manifest.publisher}.${manifest.name} to ${extensionDir}`);
+console.log("Reload the Cursor window for syntax highlighting to activate.");

--- a/extensions/vscode/snippets/ilo.code-snippets
+++ b/extensions/vscode/snippets/ilo.code-snippets
@@ -1,0 +1,58 @@
+{
+  "function": {
+    "prefix": "fn",
+    "body": [
+      "${1:name} ${2:x}:${3:n}>${4:n};${5:body}"
+    ],
+    "description": "ilo function declaration: name args:type>return;body"
+  },
+  "tool": {
+    "prefix": "tool",
+    "body": [
+      "tool ${1:name} \"${2:description}\" (${3:args}) > R ${4:t} ${5:t}"
+    ],
+    "description": "ilo tool declaration"
+  },
+  "match": {
+    "prefix": "match",
+    "body": [
+      "?{~${1:v}:${2:ok};^${3:e}:${4:err}}"
+    ],
+    "description": "ilo match expression on Result"
+  },
+  "let": {
+    "prefix": "let",
+    "body": [
+      "${1:name}=${2:value}"
+    ],
+    "description": "ilo variable binding"
+  },
+  "loop": {
+    "prefix": "loop",
+    "body": [
+      "@${1:x} ${2:xs}{${3:body}}"
+    ],
+    "description": "ilo loop over a list"
+  },
+  "guard": {
+    "prefix": "guard",
+    "body": [
+      ">=${1:x} ${2:0} ${3:result}"
+    ],
+    "description": "ilo prefix guard"
+  },
+  "type": {
+    "prefix": "type",
+    "body": [
+      "type ${1:Name} ${2:field}:${3:n}"
+    ],
+    "description": "ilo type declaration"
+  },
+  "ternary": {
+    "prefix": "tern",
+    "body": [
+      "?${1:cond} ${2:then} ${3:else}"
+    ],
+    "description": "ilo prefix ternary"
+  }
+}

--- a/extensions/vscode/syntaxes/ilo.tmLanguage.json
+++ b/extensions/vscode/syntaxes/ilo.tmLanguage.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "ilo",
+  "scopeName": "source.ilo",
+  "patterns": [
+    { "include": "#comment" },
+    { "include": "#string" },
+    { "include": "#number" },
+    { "include": "#boolean" },
+    { "include": "#type-sigil" },
+    { "include": "#operator" },
+    { "include": "#keyword" },
+    { "include": "#builtin" },
+    { "include": "#function-def" },
+    { "include": "#punctuation" }
+  ],
+  "repository": {
+    "comment": {
+      "match": "--.*$",
+      "name": "comment.line.double-dash.ilo"
+    },
+    "string": {
+      "match": "\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*\"",
+      "name": "string.quoted.double.ilo"
+    },
+    "number": {
+      "match": "\\b-?[0-9]+(\\.[0-9]+)?\\b",
+      "name": "constant.numeric.ilo"
+    },
+    "boolean": {
+      "match": "\\b(true|false)\\b",
+      "name": "constant.language.boolean.ilo"
+    },
+    "type-sigil": {
+      "patterns": [
+        {
+          "match": ":[ntb?LRMFOS]\\b",
+          "name": "support.type.ilo"
+        },
+        {
+          "match": ":(number|text|bool|List|Map|Result)\\b",
+          "name": "support.type.ilo"
+        },
+        {
+          "match": "(?<=\\s)>\\s*[ntb?LRMFOS]\\b",
+          "name": "support.type.ilo"
+        },
+        {
+          "match": "(?<=\\s)>\\s*(number|text|bool|List|Map|Result)\\b",
+          "name": "support.type.ilo"
+        }
+      ]
+    },
+    "operator": {
+      "match": ">>|>=|<=|!=|==|\\+=|\\?\\?|\\.\\?|\\+|-|\\*|/|%|>|<|=(?!=)|&|\\||!|\\^|~|\\$",
+      "name": "keyword.operator.ilo"
+    },
+    "keyword": {
+      "match": "\\b(type|tool|use|with|timeout|retry|return)\\b",
+      "name": "keyword.control.ilo"
+    },
+    "builtin": {
+      "match": "\\b(cat|len|trm|spl|has|rgx|fmt|hd|tl|rev|srt|slc|flat|unq|map|flt|fld|grp|sum|avg|mmap|mget|mset|mhas|mkeys|mvals|mdel|str|num|abs|flr|cel|rnd|get|post|rd|wr|rdb|jpth|jdmp|jpar|prnt|now|env|fac)\\b",
+      "name": "support.function.ilo"
+    },
+    "function-def": {
+      "match": "^([a-z][a-z0-9]*)(?=\\s+[a-z])",
+      "captures": {
+        "1": { "name": "entity.name.function.ilo" }
+      }
+    },
+    "punctuation": {
+      "patterns": [
+        { "match": "[;]", "name": "punctuation.separator.ilo" },
+        { "match": "[:\\.]", "name": "punctuation.accessor.ilo" },
+        { "match": "[{}()\\[\\]]", "name": "punctuation.bracket.ilo" },
+        { "match": ",", "name": "punctuation.comma.ilo" },
+        { "match": "→", "name": "punctuation.arrow.ilo" }
+      ]
+    }
+  }
+}

--- a/extensions/vscode/tests/vscode-extension.test.mjs
+++ b/extensions/vscode/tests/vscode-extension.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = dirname(here);
+
+describe("VS Code extension manifest", () => {
+  it("contributes ilo language support for .ilo files", async () => {
+    const manifest = JSON.parse(await readFile(join(root, "package.json"), "utf8"));
+    const language = manifest.contributes?.languages?.find((entry) => entry.id === "ilo");
+    const grammar = manifest.contributes?.grammars?.find((entry) => entry.language === "ilo");
+    const snippets = manifest.contributes?.snippets?.find((entry) => entry.language === "ilo");
+
+    assert.ok(language, "language contribution missing");
+    assert.deepEqual(language.extensions, [".ilo"]);
+    assert.equal(language.configuration, "./language-configuration/ilo.json");
+
+    assert.ok(grammar, "grammar contribution missing");
+    assert.equal(grammar.scopeName, "source.ilo");
+    assert.equal(grammar.path, "./syntaxes/ilo.tmLanguage.json");
+
+    assert.ok(snippets, "snippets contribution missing");
+    assert.equal(snippets.path, "./snippets/ilo.code-snippets");
+  });
+
+  it("is not marked private (we publish to the marketplace)", async () => {
+    const manifest = JSON.parse(await readFile(join(root, "package.json"), "utf8"));
+    assert.notEqual(manifest.private, true);
+    assert.equal(manifest.publisher, "ilo-lang");
+    assert.equal(manifest.name, "ilo-lang");
+  });
+
+  it("ships snippets for the highest-friction patterns", async () => {
+    const snippets = JSON.parse(await readFile(join(root, "snippets/ilo.code-snippets"), "utf8"));
+    for (const key of ["function", "tool", "match", "let", "loop", "guard"]) {
+      assert.ok(snippets[key], `missing snippet: ${key}`);
+      assert.ok(snippets[key].prefix, `snippet ${key} missing prefix`);
+      assert.ok(snippets[key].body, `snippet ${key} missing body`);
+    }
+  });
+
+  it("language config uses ilo's -- line comment and kebab-case word pattern", async () => {
+    const config = JSON.parse(await readFile(join(root, "language-configuration/ilo.json"), "utf8"));
+    assert.equal(config.comments.lineComment, "--");
+    assert.ok(!config.comments.blockComment, "ilo has no block comments");
+    // Word pattern must include hyphens so kebab-case identifiers select cleanly.
+    assert.match(config.wordPattern, /A-Za-z0-9-/);
+  });
+
+  it("grammar parses as JSON and declares the source.ilo scope", async () => {
+    const grammar = JSON.parse(await readFile(join(root, "syntaxes/ilo.tmLanguage.json"), "utf8"));
+    assert.equal(grammar.scopeName, "source.ilo");
+    assert.ok(Array.isArray(grammar.patterns));
+    assert.ok(grammar.repository);
+  });
+
+  it("highlights ilo comments, strings, numbers, and builtins", async () => {
+    const grammar = JSON.parse(await readFile(join(root, "syntaxes/ilo.tmLanguage.json"), "utf8"));
+    assert.equal(grammar.repository.comment.name, "comment.line.double-dash.ilo");
+    assert.equal(grammar.repository.string.name, "string.quoted.double.ilo");
+    assert.equal(grammar.repository.number.name, "constant.numeric.ilo");
+    // The builtin rule should at least mention some core HOFs.
+    const builtinMatch = grammar.repository.builtin.match;
+    for (const name of ["map", "flt", "fld", "len", "fmt"]) {
+      assert.match(builtinMatch, new RegExp(`\\b${name}\\b`));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Wraps the existing `ilo.tmLanguage.json` (which has been living quietly in the site repo, used only to render docs code blocks) into a proper VS Code extension at `extensions/vscode/`. Mirrors `zero/extensions/vscode/` so anyone who's seen Zero's layout finds ilo's the same shape.

Why now: Zero ships a VS Code extension but explicitly marks it `"private": true` and never publishes. ilo can leapfrog by being marketplace-installable, which is a much stronger adoption signal than parity. This PR is the local-install + tests + scaffolding side of that work. Publishing to the marketplace is a separate step that needs the `vsce` publisher token, so I've left it out of this PR per Dan's protocol on destructive external actions.

## What's in the diff

Five commits, one coherent change per commit:

1. **vscode: scaffold extension with grammar and language config** - copy the canonical grammar from `ilo-site/`, write `package.json` (publisher `ilo-lang`, name `ilo-lang`, version 0.12.0, NOT private) and `language-configuration/ilo.json` with ilo's `--` line comments, kebab-case word pattern, and bracket auto-close.
2. **vscode: add snippets for common ilo patterns** - eight tab-trigger snippets (`fn`, `tool`, `match`, `let`, `loop`, `guard`, `type`, `tern`) covering the highest-friction patterns. Kept minimal; prefix notation should stay short.
3. **vscode: add cursor install script** - `scripts/install-cursor-extension.mjs` mirrors Zero's, copies the extension into `~/.cursor/extensions/` so Cursor users can run it before Open VSX is live. Uses `import.meta.url` so it works from any cwd.
4. **vscode: add manifest and grammar smoke tests** - six `node --test` cases asserting the manifest is correct, we're not marked private, the six brief-required snippets exist, the language config uses `--` and kebab-case, and the grammar parses + names `source.ilo`. No external deps.
5. **vscode: add README, changelog, vscodeignore, and link from main README** - extension README points at `ilo-lang.ai`, main README gets an "Editor support" section.

## Test plan

- [x] `cd extensions/vscode && npm test` - 6/6 pass
- [x] `package.json` valid JSON, no `"private": true`
- [x] Manifest validates: language id `ilo`, extensions `[".ilo"]`, scope `source.ilo`, snippets at `./snippets/ilo.code-snippets`
- [x] Grammar parses, declares `source.ilo`, covers comments / strings / numbers / type sigils / builtins / keywords / operators
- [x] Snippets cover all six brief-required patterns
- [ ] Manual: install into Cursor with `npm run install:cursor`, open an `examples/*.ilo` file, verify highlighting + snippet expansion + bracket auto-close (asking Dan to run this since I don't have Cursor on the build machine)

## Follow-ups (not in this PR)

- **Marketplace publish.** Needs the `vsce` publisher account for `ilo-lang` and a personal access token. Once that's set up: `cd extensions/vscode && vsce package && vsce publish`. Same for Open VSX (`ovsx publish`) for Cursor / VSCodium / openvscode-server.
- **Site repo grammar dedupe.** The site at `ilo-lang/ilo-site` still reads `ilo.tmLanguage.json` from its own repo root for Astro / Expressive Code at build time. To avoid two grammar copies long-term, the site should either pull the grammar from this PR's path via a small build script (curl or a git submodule), or we publish the grammar to npm and the site depends on that. Out of scope for this PR; will open a follow-up issue on the site repo. The site's copy is byte-identical to the one in this PR today.
- **Marketplace screenshot.** Listing wants at least one syntax-highlighting screenshot. Easiest to grab from an `examples/*.ilo` open in VS Code after install.
- **Grammar polish.** Brief flagged the existing grammar might be stale (Risk 1). Quick spot-check is fine - I tested against `examples/01-simple-function.ilo`. Anything missing surfaces as a quick follow-up commit, not a blocker.

No em dashes in this PR; no AI signatures.