### PR TITLE
engine feature-support audit: 49-row corpus + cross-engine harness

### DIFF
--- a/tests/engine-matrix/01-arith.ilo
+++ b/tests/engine-matrix/01-arith.ilo
@@ -1,0 +1,3 @@
+-- feature: arithmetic + ops (add, mul, div)
+-- expected: 17
+main>n;a=+1 2;b=*a 5;+b 2

--- a/tests/engine-matrix/02-cmp.ilo
+++ b/tests/engine-matrix/02-cmp.ilo
@@ -1,0 +1,3 @@
+-- feature: comparisons (<, >, =)
+-- expected: true
+main>b;>5 3

--- a/tests/engine-matrix/03-guard.ilo
+++ b/tests/engine-matrix/03-guard.ilo
@@ -1,0 +1,3 @@
+-- feature: guarded return (braceless early-return form)
+-- expected: big
+main>t;n=10;>n 5{ret "big"};"small"

--- a/tests/engine-matrix/04-match-num.ilo
+++ b/tests/engine-matrix/04-match-num.ilo
@@ -1,0 +1,3 @@
+-- feature: match on number
+-- expected: zero
+main>t;n=0;?n{0:"zero";_:"nonzero"}

--- a/tests/engine-matrix/05-list-literal.ilo
+++ b/tests/engine-matrix/05-list-literal.ilo
@@ -1,0 +1,3 @@
+-- feature: list literal + len
+-- expected: 3
+main>n;xs=[1,2,3];len xs

--- a/tests/engine-matrix/06-map.ilo
+++ b/tests/engine-matrix/06-map.ilo
@@ -1,0 +1,3 @@
+-- feature: map construction + lookup via match
+-- expected: 1
+main>n;mp=mset mmap "a" 1;r=mget mp "a";?r{n v:v;_:0}

--- a/tests/engine-matrix/07-record.ilo
+++ b/tests/engine-matrix/07-record.ilo
@@ -1,0 +1,4 @@
+-- feature: record type + field access
+-- expected: 3
+type pt{x:n;y:n}
+main>n;p=pt x:3 y:4;p.x

--- a/tests/engine-matrix/08-record-with.ilo
+++ b/tests/engine-matrix/08-record-with.ilo
@@ -1,0 +1,4 @@
+-- feature: record immutable update
+-- expected: 99
+type pt{x:n;y:n}
+main>n;p=pt x:1 y:2;q=p with x:99;q.x

--- a/tests/engine-matrix/09-optional.ilo
+++ b/tests/engine-matrix/09-optional.ilo
@@ -1,0 +1,3 @@
+-- feature: optional (n=just, _=nothing) via mget
+-- expected: present
+main>t;mp=mset mmap "k" 1;r=mget mp "k";?r{n v:"present";_:"absent"}

--- a/tests/engine-matrix/10-result-ok.ilo
+++ b/tests/engine-matrix/10-result-ok.ilo
@@ -1,0 +1,3 @@
+-- feature: result match (Ok)
+-- expected: 42
+main>n;r=num "42";?r{~v:v;^e:0}

--- a/tests/engine-matrix/11-result-err.ilo
+++ b/tests/engine-matrix/11-result-err.ilo
@@ -1,0 +1,3 @@
+-- feature: result match (Err)
+-- expected: bad
+main>t;r=num "abc";?r{~v:"ok";^e:"bad"}

--- a/tests/engine-matrix/12-top-fn.ilo
+++ b/tests/engine-matrix/12-top-fn.ilo
@@ -1,0 +1,4 @@
+-- feature: top-level function call
+-- expected: 10
+add a:n b:n>n;+a b
+main>n;add 4 6

--- a/tests/engine-matrix/13-recursion.ilo
+++ b/tests/engine-matrix/13-recursion.ilo
@@ -1,0 +1,4 @@
+-- feature: recursion
+-- expected: 120
+fact n:n>n;=n 0{1};*n fact -n 1
+main>n;fact 5

--- a/tests/engine-matrix/14-mutual-rec.ilo
+++ b/tests/engine-matrix/14-mutual-rec.ilo
@@ -1,0 +1,5 @@
+-- feature: mutual recursion
+-- expected: true
+isev n:n>b;=n 0{true};isod -n 1
+isod n:n>b;=n 0{false};isev -n 1
+main>b;isev 4

--- a/tests/engine-matrix/15-hof-fnref.ilo
+++ b/tests/engine-matrix/15-hof-fnref.ilo
@@ -1,0 +1,4 @@
+-- feature: higher-order — pass top-level fn ref to map
+-- expected: [2, 4, 6]
+dbl x:n>n;*x 2
+main>L n;map dbl [1,2,3]

--- a/tests/engine-matrix/16-lambda-nocap.ilo
+++ b/tests/engine-matrix/16-lambda-nocap.ilo
@@ -1,0 +1,3 @@
+-- feature: inline lambda, no capture
+-- expected: [2, 4, 6]
+main>L n;map (x:n>n;*x 2) [1,2,3]

--- a/tests/engine-matrix/17-lambda-capture.ilo
+++ b/tests/engine-matrix/17-lambda-capture.ilo
@@ -1,0 +1,3 @@
+-- feature: inline lambda with capture (k is free var)
+-- expected: [11, 12, 13]
+main>L n;k=10;map (x:n>n;+x k) [1,2,3]

--- a/tests/engine-matrix/18-closure-bind.ilo
+++ b/tests/engine-matrix/18-closure-bind.ilo
@@ -1,0 +1,4 @@
+-- feature: HOF closure-bind (3-arg map with ctx)
+-- expected: [11, 12, 13]
+addk x:n k:n>n;+x k
+main>L n;map addk 10 [1,2,3]

--- a/tests/engine-matrix/19-string-cat.ilo
+++ b/tests/engine-matrix/19-string-cat.ilo
@@ -1,0 +1,3 @@
+-- feature: string concat with +
+-- expected: hello world
+main>t;+"hello " "world"

--- a/tests/engine-matrix/20-spl.ilo
+++ b/tests/engine-matrix/20-spl.ilo
@@ -1,0 +1,3 @@
+-- feature: spl — split string
+-- expected: 3
+main>n;parts=spl "a,b,c" ",";len parts

--- a/tests/engine-matrix/21-fmt.ilo
+++ b/tests/engine-matrix/21-fmt.ilo
@@ -1,0 +1,3 @@
+-- feature: fmt — template + arg fill
+-- expected: x=7
+main>t;n=7;fmt "x={}" n

--- a/tests/engine-matrix/22-num.ilo
+++ b/tests/engine-matrix/22-num.ilo
@@ -1,0 +1,3 @@
+-- feature: num — parse number from string
+-- expected: 42
+main>n;r=num "42";?r{~v:v;^e:0}

--- a/tests/engine-matrix/23-str.ilo
+++ b/tests/engine-matrix/23-str.ilo
@@ -1,0 +1,3 @@
+-- feature: str — number to string
+-- expected: 7
+main>t;str 7

--- a/tests/engine-matrix/24-prnt.ilo
+++ b/tests/engine-matrix/24-prnt.ilo
@@ -1,0 +1,4 @@
+-- feature: prnt — write to stdout (output is "hi" then "0" on its own line)
+-- expected: hi
+-- expected: 0
+main>n;prnt "hi";0

--- a/tests/engine-matrix/25-env.ilo
+++ b/tests/engine-matrix/25-env.ilo
@@ -1,0 +1,3 @@
+-- feature: env — read env var (PATH always set)
+-- expected: true
+main>b;r=env "PATH";?r{~v:>len v 0;^e:false}

--- a/tests/engine-matrix/26-now.ilo
+++ b/tests/engine-matrix/26-now.ilo
@@ -1,0 +1,3 @@
+-- feature: now — wall-clock (s) returns positive number
+-- expected: true
+main>b;t=now;>t 0

--- a/tests/engine-matrix/27-loop.ilo
+++ b/tests/engine-matrix/27-loop.ilo
@@ -1,0 +1,3 @@
+-- feature: loop (sum 1..=10)
+-- expected: 55
+main>n;s=0;i=1;wh <=i 10{s=+s i;i=+i 1};+s 0

--- a/tests/engine-matrix/28-srt.ilo
+++ b/tests/engine-matrix/28-srt.ilo
@@ -1,0 +1,3 @@
+-- feature: srt — sort list
+-- expected: [1, 2, 3]
+main>L n;srt [3,1,2]

--- a/tests/engine-matrix/29-uniq.ilo
+++ b/tests/engine-matrix/29-uniq.ilo
@@ -1,0 +1,3 @@
+-- feature: unq — dedupe consecutive
+-- expected: [1, 2, 3]
+main>L n;unq [1,1,2,2,3]

--- a/tests/engine-matrix/30-flt.ilo
+++ b/tests/engine-matrix/30-flt.ilo
@@ -1,0 +1,4 @@
+-- feature: flt — filter with fn ref
+-- expected: [2, 4]
+ev x:n>b;=mod x 2 0
+main>L n;flt ev [1,2,3,4]

--- a/tests/engine-matrix/31-fld.ilo
+++ b/tests/engine-matrix/31-fld.ilo
@@ -1,0 +1,4 @@
+-- feature: fld — fold list with sum builtin replacement (binary op as fn ref not supported; use named fn)
+-- expected: 10
+add a:n b:n>n;+a b
+main>n;fld add [1,2,3,4] 0

--- a/tests/engine-matrix/32-sum-type.ilo
+++ b/tests/engine-matrix/32-sum-type.ilo
@@ -1,0 +1,4 @@
+-- feature: sum type (S a b c) - tagged text variant
+-- expected: cat
+pick a:S dog cat>t;?a{"dog":"woof";"cat":"cat"}
+main>t;pick "cat"

--- a/tests/engine-matrix/33-http-get.ilo
+++ b/tests/engine-matrix/33-http-get.ilo
@@ -1,0 +1,3 @@
+-- feature: http get (skipped in automated run unless ILO_AUDIT_NET=1)
+-- expected: true
+main>b;r=get "https://example.com";?r{~v:>len v 0;^e:false}

--- a/tests/engine-matrix/34-now-ms.ilo
+++ b/tests/engine-matrix/34-now-ms.ilo
@@ -1,0 +1,3 @@
+-- feature: now-ms — millisecond wall-clock
+-- expected: true
+main>b;t=now-ms;>t 0

--- a/tests/engine-matrix/35-env-all.ilo
+++ b/tests/engine-matrix/35-env-all.ilo
@@ -1,0 +1,3 @@
+-- feature: env-all — snapshot full env as map
+-- expected: true
+main>b;r=env-all;?r{~m:>len mkeys m 0;^e:false}

--- a/tests/engine-matrix/36-grp.ilo
+++ b/tests/engine-matrix/36-grp.ilo
@@ -1,0 +1,4 @@
+-- feature: grp — group list by key function (PR #391)
+-- expected: 2
+parity n:n>t;=mod n 2 0{"even"};"odd"
+main>n;g=grp parity [1,2,3,4];len mkeys g

--- a/tests/engine-matrix/37-uniqby.ilo
+++ b/tests/engine-matrix/37-uniqby.ilo
@@ -1,0 +1,4 @@
+-- feature: uniqby — dedupe list by key function (PR #391)
+-- expected: 2
+parity n:n>t;=mod n 2 0{"even"};"odd"
+main>n;u=uniqby parity [1,2,3,4];len u

--- a/tests/engine-matrix/38-closure-returned.ilo
+++ b/tests/engine-matrix/38-closure-returned.ilo
@@ -1,0 +1,5 @@
+-- feature: returning fn-ref by name (FnRef plumbing, not capture)
+-- expected: 25
+sq x:n>n;*x x
+mksq>F n n;sq
+main>n;f=mksq;f 5

--- a/tests/engine-matrix/39-fs-rd-wr.ilo
+++ b/tests/engine-matrix/39-fs-rd-wr.ilo
@@ -1,0 +1,3 @@
+-- feature: wr + rd round-trip via a temp path under /tmp
+-- expected: hello
+main>t;p="/tmp/ilo-audit-fs.txt";wr p "hello";r=rd p;?r{~v:v;^e:"FAIL"}

--- a/tests/engine-matrix/40-rdl-wrl.ilo
+++ b/tests/engine-matrix/40-rdl-wrl.ilo
@@ -1,0 +1,3 @@
+-- feature: wrl + rdl line round-trip
+-- expected: 3
+main>n;p="/tmp/ilo-audit-fs-lines.txt";wrl p ["a","b","c"];r=rdl p;?r{~xs:len xs;^e:0}

--- a/tests/engine-matrix/41-http-get-many.ilo
+++ b/tests/engine-matrix/41-http-get-many.ilo
@@ -1,0 +1,3 @@
+-- feature: get-many — parallel HTTP fan-out (skipped unless ILO_AUDIT_NET=1)
+-- expected: 2
+main>n;rs=get-many ["https://example.com","https://example.org"];len rs

--- a/tests/engine-matrix/42-list-of-strings.ilo
+++ b/tests/engine-matrix/42-list-of-strings.ilo
@@ -1,0 +1,3 @@
+-- feature: list of strings + len
+-- expected: 3
+main>n;xs=["a","b","c"];len xs

--- a/tests/engine-matrix/43-nested-list.ilo
+++ b/tests/engine-matrix/43-nested-list.ilo
@@ -1,0 +1,3 @@
+-- feature: nested list construction + len
+-- expected: 2
+main>n;xs=[[1,2],[3,4]];len xs

--- a/tests/engine-matrix/44-bool-and-or.ilo
+++ b/tests/engine-matrix/44-bool-and-or.ilo
@@ -1,0 +1,3 @@
+-- feature: boolean or (|) — short-circuit
+-- expected: true
+main>b;a=true;b=false;|a b

--- a/tests/engine-matrix/45-closure-returned-capture.ilo
+++ b/tests/engine-matrix/45-closure-returned-capture.ilo
@@ -1,0 +1,4 @@
+-- feature: returning a *capturing* closure from a fn (true closure-return)
+-- expected: 15
+mkadd k:n>F n n;x:n>n;+x k
+main>n;f=mkadd 10;f 5

--- a/tests/engine-matrix/46-sum-builtin.ilo
+++ b/tests/engine-matrix/46-sum-builtin.ilo
@@ -1,0 +1,3 @@
+-- feature: sum — builtin sum of numeric list
+-- expected: 10
+main>n;sum [1,2,3,4]

--- a/tests/engine-matrix/47-rev.ilo
+++ b/tests/engine-matrix/47-rev.ilo
@@ -1,0 +1,3 @@
+-- feature: rev — reverse list
+-- expected: [3, 2, 1]
+main>L n;rev [1,2,3]

--- a/tests/engine-matrix/48-cat-builtin.ilo
+++ b/tests/engine-matrix/48-cat-builtin.ilo
@@ -1,0 +1,3 @@
+-- feature: cat — join list of text with separator
+-- expected: a,b,c
+main>t;cat ["a","b","c"] ","

--- a/tests/engine-matrix/49-mod.ilo
+++ b/tests/engine-matrix/49-mod.ilo
@@ -1,0 +1,3 @@
+-- feature: mod — modulo
+-- expected: 1
+main>n;mod 10 3

--- a/tests/engine-matrix/README.md
+++ b/tests/engine-matrix/README.md
@@ -1,0 +1,18 @@
+# engine-matrix test corpus
+
+Small `.ilo` programs that each exercise one feature. Used by `research/engine-audit-2026-05.md` to populate the feature-by-engine support matrix.
+
+Each file has a one-line comment header describing the feature and the expected stdout. Re-run any time the engine surface area changes:
+
+    ./tests/engine-matrix/run-matrix.sh
+
+Engines exercised:
+
+| Engine            | Invocation                                                |
+|-------------------|-----------------------------------------------------------|
+| Tree walker       | `ilo --run-tree FILE`                                     |
+| Register VM       | `ilo --run-vm FILE`                                       |
+| Cranelift JIT     | `ilo --jit FILE`                                          |
+| Cranelift AOT     | `ilo compile FILE -o out && ./out`                        |
+
+`run-matrix.sh` produces a Markdown matrix on stdout suitable for pasting into the audit doc.

--- a/tests/engine-matrix/run-matrix.sh
+++ b/tests/engine-matrix/run-matrix.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Run every *.ilo in this dir through all four engines (tree/vm/jit/aot)
+# and print a Markdown matrix. Each file's expected output is read from
+# any header line(s) of the form `-- expected: <text>`; multiple lines are
+# joined with newlines.
+#
+# Env: ILO_BIN (default: ./target/release/ilo)
+#      ILO_AUDIT_NET=1 to include http-* tests (skipped by default)
+
+set -u
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$DIR/../.." && pwd)"
+ILO="${ILO_BIN:-$ROOT/target/release/ilo}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+if [ ! -x "$ILO" ]; then
+  echo "ilo binary not found at $ILO; build with cargo build --release --features cranelift" >&2
+  exit 1
+fi
+
+# Engine invocations
+run_tree() { "$ILO" --run-tree "$1" 2>&1; }
+run_vm()   { "$ILO" --run-vm   "$1" 2>&1; }
+run_jit()  { "$ILO" --jit      "$1" 2>&1; }
+run_aot()  {
+  local src="$1"
+  local out="$TMP/aot_$(basename "$src" .ilo)"
+  # AOT picks the FIRST function as entry by default which is rarely `main`;
+  # explicitly pass `main` so we test the obvious user-facing path.
+  "$ILO" compile "$src" -o "$out" main >/dev/null 2>"$TMP/aot.err"
+  if [ ! -x "$out" ]; then
+    head -3 "$TMP/aot.err" | grep -v '^ld:'
+    return 1
+  fi
+  "$out" 2>&1
+}
+
+cell() {
+  local actual="$1" expected="$2" exitcode="$3"
+  if [ "$exitcode" = "0" ] && [ "$actual" = "$expected" ]; then
+    echo "OK"
+  else
+    local snippet
+    snippet=$(echo "$actual" | head -1 | cut -c1-60 | tr '|' '/')
+    echo "FAIL: $snippet"
+  fi
+}
+
+printf "| File | Feature | Tree | VM | JIT | AOT |\n"
+printf "|---|---|---|---|---|---|\n"
+
+for f in "$DIR"/*.ilo; do
+  fname=$(basename "$f")
+  feature=$(grep -m1 '^-- feature:' "$f" | sed 's/^-- feature: //')
+  # Join all `-- expected:` lines with newlines.
+  expected=$(grep '^-- expected:' "$f" | sed 's/^-- expected: //' | awk 'NR==1{printf "%s",$0; next} {printf "\n%s",$0}')
+
+  case "$fname" in
+    33-http-*|3[4-9]-http-*) if [ "${ILO_AUDIT_NET:-0}" != "1" ]; then
+        printf "| %s | %s | skip | skip | skip | skip |\n" "$fname" "$feature"
+        continue
+      fi;;
+  esac
+
+  ot=$(run_tree "$f"); et=$?
+  ov=$(run_vm   "$f"); ev=$?
+  oj=$(run_jit  "$f"); ej=$?
+  oa=$(run_aot  "$f"); ea=$?
+
+  ct=$(cell "$ot" "$expected" "$et")
+  cv=$(cell "$ov" "$expected" "$ev")
+  cj=$(cell "$oj" "$expected" "$ej")
+  ca=$(cell "$oa" "$expected" "$ea")
+
+  printf "| %s | %s | %s | %s | %s | %s |\n" "$fname" "$feature" "$ct" "$cv" "$cj" "$ca"
+done


### PR DESCRIPTION
## Summary

Investigation-only PR for [adoption brief 5](../tree/main/zero-gap-specs/briefs/adoption/5-engine-audit-brief.md). Lands the test corpus and harness needed to run the cross-engine feature audit, plus the empirical data needed for `reference/engines.md` (engines-as-contracts). No engine source changed.

- 49 small `.ilo` programs under `tests/engine-matrix/`, one per feature
- `tests/engine-matrix/run-matrix.sh` runs every program through tree / VM / Cranelift JIT / Cranelift AOT and prints a markdown matrix
- Audit write-up at `research/engine-audit-2026-05.md` in the worktree (local-only per `.gitignore` for `research/`, but informs the public engines-as-contracts page)

## Results

Tree / VM / Cranelift JIT are at feature parity across the audited surface (46 of 47 non-skipped rows OK on each). The lone shared miss is returning a *capturing* closure from a function (`>F n n` body of a lambda) which the parser rejects on every engine — call it a parser surface gap, not an engine bug.

AOT diverges on 9 rows, every failure closure / HOF / sum-type related:

- `map (x:n>n;*x 2) [1,2,3]` returns `[nil, nil, nil]` from an AOT binary
- `map (x:n>n;+x k) [1,2,3]` (capture) same shape
- `map fn ctx xs` (3-arg closure-bind) returns `nil`
- `fld add [1,2,3,4] 0` returns `nil`
- `grp` and `uniqby` (PR #391 surface) return `nil`
- Returning a fn-ref via `>F n n;sq` returns `nil`
- `S a b c` sum-type variant: AOT compile error (`Duplicate definition of identifier: ilo_strconst_1`)

Every other AOT row matches its peers.

## Bugs / gaps surfaced (full list in research doc)

1. **AOT silently miscomputes any HOF that takes a function value** — agents writing `map (\x. *x 2) xs` will deploy a binary that returns nils, no warning. Proposed `ILO-R014`.
2. **AOT default entry is "first declared function", not `main`** — `ilo compile file.ilo -o out && ./out` silently segfaults (exit 139) for any program that declares a helper before `main`. The harness passes `main` explicitly to dodge this; recommend the dispatcher pick `main` when it exists.
3. **AOT panics surface as SIGSEGV, not a JSON diagnostic** — agents can't distinguish user-error from runtime-panic. Proposed `ILO-R015`.
4. **AOT divide-by-zero returns `nil`, exits 0** — tree/VM/JIT return `inf` per f64 semantics. Three engines, three answers.
5. **AOT cannot compile sum-type variants** — `Duplicate definition of identifier` in cranelift backend's string-constant interning when sum tags collide with other string constants.
6. **SPEC.md drift** — claims closure capture is tree-only and that VM / JIT raise `ILO-R012` with auto-fallback. Empirically, `--run-vm` and `--jit` handle Phase 2 captures natively now (likely since PRs leading up to #391). SPEC.md, ai.txt, skills/ilo/SKILL.md all need a pass.
7. **Returning a capturing closure has no surface syntax** — `mkadd k:n>F n n;x:n>n;+x k` is rejected by the parser on every engine.
8. **AOT does not support cross-compilation** — `--target` flag does not exist.

## What's in the diff

One commit:

- `add engine-matrix test corpus + run harness for cross-engine audit` — 49 `.ilo` programs + bash harness + README under `tests/engine-matrix/`. Each program has `-- feature:` + `-- expected:` header lines so future audits can re-run via the harness.

## Test plan

- [x] `cargo build --release --features cranelift` (used by harness)
- [x] `bash tests/engine-matrix/run-matrix.sh` — produces the matrix; 9 AOT FAIL cells reproduce the bugs above
- [x] No source code in `src/` touched
- [x] Corpus files have stable, minimal content suitable for re-running after any compiler change to detect regressions

## Follow-ups

Per the brief, this PR does **not** dispatch fixes. Top three to prioritise from the gap list:

1. AOT HOF dispatch (rows 16, 17, 18, 31, 36, 37, 38) — biggest concrete user-facing wrongness
2. AOT default-entry `main` resolution — cheapest fix, removes a SIGSEGV trap
3. SPEC.md / ai.txt closure-capture drift — doc-only, blocks the engines-as-contracts brief