### PR TITLE
fix: AOT sum-type compile failure (data-section name collision)

### DIFF
--- a/examples/aot-strconst-interning.ilo
+++ b/examples/aot-strconst-interning.ilo
@@ -1,0 +1,25 @@
+-- AOT-compiled binaries handle programs where multiple functions
+-- each emit string constants. Before the fix in this PR, the AOT
+-- compiler reset its data-section counter per function but declared
+-- the data sections at module scope, so two functions each emitting
+-- a Text constant collided on `ilo_strconst_1` and the compile
+-- aborted with `Duplicate definition of identifier`.
+--
+-- Sum-type variants like `S dog cat` were the most visible trigger:
+-- the tag names always emit string constants, so any sum-type
+-- program with more than one function failed to AOT compile.
+-- Tree / VM / Cranelift JIT all handled this fine (the JIT compiles
+-- one chunk per module, so its per-function counter was also the
+-- module counter).
+--
+-- The example harness only drives the in-process runners. The full
+-- AOT contract (compile to a real binary, run it, compare against
+-- tree / VM / JIT byte-for-byte) lives in
+-- tests/regression_aot_strconst_interning.rs.
+
+pick a:S dog cat>t;?a{"dog":"woof";"cat":"cat"}
+
+m>t;pick "cat"
+
+-- run: m
+-- out: cat

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -889,7 +889,7 @@ fn compile_function_body(
     module: &mut ObjectModule,
     chunk: &Chunk,
     nan_consts: &[NanVal],
-    _name: &str,
+    name: &str,
     func_id: FuncId,
     helpers: &HelperFuncs,
     all_func_ids: Option<&[FuncId]>,
@@ -1911,7 +1911,12 @@ fn compile_function_body(
                         _ => b"\0".to_vec(),
                     };
                     data_section_counter += 1;
-                    let ds_name = format!("ilo_strconst_{}", data_section_counter);
+                    // Prefix with the cranelift function name so data sections
+                    // are unique across the module. The per-function counter
+                    // alone collides between functions because every
+                    // `compile_function_body` call resets it to 0 while
+                    // `module.declare_data` lives at module scope.
+                    let ds_name = format!("{}_strconst_{}", name, data_section_counter);
                     let str_ptr =
                         create_data_section(module, &mut builder, &ds_name, &string_bytes)?;
                     let fref = get_func_ref(&mut builder, module, helpers.string_const);
@@ -2909,7 +2914,7 @@ fn compile_function_body(
                 };
                 name_bytes.push(0); // null-terminate
                 data_section_counter += 1;
-                let ds_name = format!("ilo_fldname_{}", data_section_counter);
+                let ds_name = format!("{}_fldname_{}", name, data_section_counter);
                 let name_ptr = create_data_section(module, &mut builder, &ds_name, &name_bytes)?;
                 // Get registry pointer at runtime
                 let fref_reg = get_func_ref(&mut builder, module, helpers.get_registry_ptr);
@@ -2950,7 +2955,7 @@ fn compile_function_body(
                 };
                 name_bytes.push(0);
                 data_section_counter += 1;
-                let ds_name = format!("ilo_fldname_safe_{}", data_section_counter);
+                let ds_name = format!("{}_fldname_safe_{}", name, data_section_counter);
                 let name_ptr = create_data_section(module, &mut builder, &ds_name, &name_bytes)?;
                 let fref_reg = get_func_ref(&mut builder, module, helpers.get_registry_ptr);
                 let reg_call = builder.ins().call(fref_reg, &[]);
@@ -3102,7 +3107,7 @@ fn compile_function_body(
                 };
 
                 // Use a data section instead of leaking a Box
-                let ds_name = format!("ilo_recwith_indices_{}", data_section_counter);
+                let ds_name = format!("{}_recwith_indices_{}", name, data_section_counter);
                 data_section_counter += 1;
                 let indices_gv =
                     create_data_section(module, &mut builder, &ds_name, &update_indices)?;

--- a/tests/regression_aot_strconst_interning.rs
+++ b/tests/regression_aot_strconst_interning.rs
@@ -1,0 +1,149 @@
+// Regression: AOT compile must not collide on data-section names when
+// more than one function emits string constants (`OP_LOADK` of a Text
+// constant, `OP_RECFLD_NAME`, `OP_RECFLD_NAME_SAFE`, or `OP_RECWITH`).
+//
+// Background:
+//
+// `compile_function_body` (src/vm/compile_cranelift.rs) is called once
+// per ilo chunk and keeps a function-local `data_section_counter`
+// reset to 0 every call. The data-section names it derives from that
+// counter (`ilo_strconst_N`, `ilo_fldname_N`, `ilo_fldname_safe_N`,
+// `ilo_recwith_indices_N`) are declared at module scope via
+// `module.declare_data`, so the moment two functions in the same
+// AOT program each emit any string constant, both try to declare
+// `ilo_strconst_1` and cranelift's ObjectModule errors with
+// `Duplicate definition of identifier: ilo_strconst_1`.
+//
+// JIT does not hit this: each JIT compile is its own one-function
+// module so the per-function counter is also the module counter.
+//
+// Fix: prefix data-section names with the cranelift function name
+// (already module-unique from the first declaration pass), so
+// `pick`'s first string constant becomes `ilo_pick_strconst_1` and
+// `main`'s first becomes `ilo_main_strconst_1`. No collision.
+//
+// Gated on `cranelift` because the AOT compile path requires it.
+
+#![cfg(feature = "cranelift")]
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn tmp_paths(tag: &str) -> (PathBuf, PathBuf) {
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let src = std::env::temp_dir().join(format!("ilo-strconst-{tag}-{pid}-{n}.ilo"));
+    let bin = std::env::temp_dir().join(format!("ilo-strconst-{tag}-{pid}-{n}.bin"));
+    (src, bin)
+}
+
+/// Compile, run, and assert the AOT binary matches expected stdout. Also
+/// compares against tree / VM / JIT byte-for-byte so any future engine
+/// drift surfaces here.
+fn assert_aot_cross_engine(tag: &str, src: &str, entry: Option<&str>, expected_stdout: &[u8]) {
+    let (src_path, bin_path) = tmp_paths(tag);
+    std::fs::write(&src_path, src).expect("write ilo source");
+
+    // AOT compile + run.
+    let mut compile = ilo();
+    compile
+        .args(["compile"])
+        .arg(&src_path)
+        .arg("-o")
+        .arg(&bin_path);
+    if let Some(e) = entry {
+        compile.arg(e);
+    }
+    let c = compile.output().expect("invoke ilo compile");
+    assert!(
+        c.status.success(),
+        "{tag}: ilo compile failed: stdout={:?} stderr={:?}",
+        String::from_utf8_lossy(&c.stdout),
+        String::from_utf8_lossy(&c.stderr),
+    );
+    let aot = Command::new(&bin_path).output().expect("run AOT binary");
+    assert_eq!(
+        aot.stdout,
+        expected_stdout,
+        "{tag}: AOT stdout mismatch. got={:?} expected={:?}",
+        String::from_utf8_lossy(&aot.stdout),
+        String::from_utf8_lossy(expected_stdout),
+    );
+
+    // Cross-engine parity. Run the same source through tree, VM, JIT and
+    // require byte-identical stdout.
+    for engine in ["--run-tree", "--run-vm", "--jit"] {
+        let mut cmd = ilo();
+        cmd.arg(&src_path).arg(engine);
+        if let Some(e) = entry {
+            cmd.arg(e);
+        }
+        let out = cmd.output().expect("run ilo in-process");
+        assert_eq!(
+            out.stdout,
+            expected_stdout,
+            "{tag}/{engine}: stdout diverges. got={:?} expected={:?}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(expected_stdout),
+        );
+    }
+
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+}
+
+// ── Two functions, two string constants ──────────────────────────────
+//
+// The minimal trigger: any program where two AOT chunks each emit at
+// least one Text constant. Before the fix this errored with
+// `Duplicate definition of identifier: ilo_strconst_1`.
+
+#[test]
+fn aot_two_functions_each_with_string_constant() {
+    assert_aot_cross_engine(
+        "two-fn-two-strconst",
+        "g>t;\"hello\"\nm>t;\"world\"",
+        Some("m"),
+        b"world\n",
+    );
+}
+
+// ── Sum-type variant via `pick` (the original repro from #413) ───────
+//
+// `S dog cat` is a sum type with tag strings `dog` and `cat`. The
+// `pick` helper emits string constants for both arms. With `main`
+// calling `pick`, the AOT module has two chunks both emitting
+// strconsts.
+
+#[test]
+fn aot_sum_type_pick_compiles_and_runs() {
+    assert_aot_cross_engine(
+        "sum-type-pick",
+        "pick a:S dog cat>t;?a{\"dog\":\"woof\";\"cat\":\"cat\"}\nmain>t;pick \"cat\"\n",
+        Some("main"),
+        b"cat\n",
+    );
+}
+
+// ── Many functions, many string constants ────────────────────────────
+//
+// Stresses the counter past 1, ensuring `*_strconst_2`,
+// `*_strconst_3`, etc. also stay unique across functions. Three
+// functions, two string constants each.
+
+#[test]
+fn aot_many_functions_many_strconsts() {
+    let src = "\
+a>t;cat [\"a-\", \"1\"] \"\"\n\
+b>t;cat [\"b-\", \"2\"] \"\"\n\
+m>t;cat [(a), (b), \"!\"] \"\"\n\
+";
+    assert_aot_cross_engine("many-fn-many-strconst", src, Some("m"), b"a-1b-2!\n");
+}


### PR DESCRIPTION
## Summary

AOT compile failed with `Duplicate definition of identifier: ilo_strconst_1` on any program with two-or-more functions each emitting a string constant. Sum-type variants (`S a b c`) were the most visible trigger because the tag names always emit string constants, so audit row 32 in #413 (and the assessment-doc entry from 2026-05-14 around `cat` calls) both reproduced the same root cause.

Manifesto framing: AOT was silently rejecting a documented language feature. Agents that wrote a sum-type program and tried to compile it got an opaque cranelift identifier error with no obvious mapping back to source — burning retry budget for no learning gain. This restores parity so the contract "any program that runs on tree/VM/JIT can be AOT-compiled" holds again.

## Root cause

`compile_function_body` in `src/vm/compile_cranelift.rs` keeps a function-local `data_section_counter` reset to 0 every call. The four data-section name families it generates (`ilo_strconst_N`, `ilo_fldname_N`, `ilo_fldname_safe_N`, `ilo_recwith_indices_N`) are declared at module scope via `module.declare_data`. The moment two AOT chunks each emit any string constant, both try to declare `ilo_strconst_1` and `ObjectModule` errors.

JIT does not hit this because each JIT compile is its own one-function module, so the per-function counter is also the module counter. AOT emits every chunk into one shared module.

## Repro

Before:

```
$ cat >/tmp/sumrepro.ilo <<'ILO'
pick a:S dog cat>t;?a{"dog":"woof";"cat":"cat"}
main>t;pick "cat"
ILO
$ ilo compile /tmp/sumrepro.ilo -o /tmp/sumrepro-bin main
AOT compile error: Duplicate definition of identifier: ilo_strconst_1
```

After:

```
$ ilo compile /tmp/sumrepro.ilo -o /tmp/sumrepro-bin main
Compiled: /tmp/sumrepro-bin
$ /tmp/sumrepro-bin
cat
```

Matches tree/VM/JIT byte-for-byte.

## What's in the diff

Two commits.

1. `fix: prefix AOT data sections with function name to avoid module-scope collisions` — `src/vm/compile_cranelift.rs`. Renames `_name` to `name` in `compile_function_body` and changes the four data-section format strings to prefix the cranelift function name (already declared module-unique on the first pass at line 519). Names become `ilo_<funcname>_strconst_<n>`, etc. Five-line behaviour change, plus a five-line comment explaining the collision for the next person who reads this hot spot.

2. `tests: cross-engine regression coverage for AOT data-section interning` — new `tests/regression_aot_strconst_interning.rs` with three tests:
   - two top-level functions each emitting one string constant (minimal trigger)
   - sum-type variant via `pick a:S dog cat>t;?a{...}` (the row-32 repro)
   - three functions each emitting two string constants (counter past 1)

   Each test compiles to a real AOT binary and asserts stdout byte-identical to `--run-tree`, `--run-vm`, and `--jit`, mirroring the `regression_aot_wrapper_strip.rs` pattern from #281. Also adds `examples/aot-strconst-interning.ilo` as the in-context learning artefact, exercised through the cross-engine examples harness on every backend.

## Test plan

- [x] Repro reproduces on `main`, passes on this branch
- [x] `cargo test --release --features cranelift --test regression_aot_strconst_interning` — 3/3 pass
- [x] `cargo test --release --features cranelift --test examples_engines` — passes including the new sum-type example
- [x] `cargo test --release --features cranelift` — full suite green
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --release --features cranelift --tests -- -D warnings` clean

## Doc sync

None required. The fix is an internal data-section mangling change and restores previously-broken AOT capability that wasn't promised-broken anywhere. SPEC.md / ai.txt / skills already describe sum types generically with no AOT carve-out.

## Follow-ups

Audit PR #413 lists eight AOT gaps in total. This PR closes #5 (sum-type compile). Remaining (still in flight or open): #1 AOT HOF nil-return (closures/HOFs returning nil), #2 default-entry resolves to `main`, #3 SIGSEGV-to-JSON via signal handler, #4 div-by-zero divergence, #6 SPEC closure-capture drift, #7 missing surface syntax for returning capturing closure, #8 `--target` cross-compile.