### PR TITLE
cli: --bench --json envelope with top-level engine field

### DIFF
--- a/skills/ilo/ilo-engines.md
+++ b/skills/ilo/ilo-engines.md
@@ -39,13 +39,12 @@ Only the tree-walker runs **capturing** lambdas directly; VM, JIT, AOT detect ca
 ## Benchmarking
 
 ```
-ilo file.ilo --bench main args...      VM (default), reports ns/op
-ilo file.ilo --jit --bench main args   JIT
-ilo file.ilo --run-tree --bench main   Tree
-ilo compile file.ilo -o ./prog && ./prog args   AOT
+ilo file.ilo --bench main args         All engines, text
+ilo file.ilo --bench main args --json  All engines, JSON (one line per engine)
+ilo compile file.ilo -o ./prog && ./prog args   AOT (build then time)
 ```
 
-JIT cold-start includes Cranelift compilation; for short programs that swamps the run time. Use `--bench` which loops the hot path.
+`--bench` runs tree, vm, jit on the same input; JIT cold-start washes out in the hot loop. JSON envelope: `{"schemaVersion":1,"engine":"tree|vm|jit","variant":?,"result":...,"iterations":...,"totalMs":...,"perCallNs":...}`. VM emits two records (`variant: "fresh"` and `"reusable"`).
 
 ## AOT specifics
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2949,7 +2949,8 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
             &[][..]
         };
         let run_args = parse_cli_args_typed(&program, func_name, raw);
-        run_bench(&program, func_name, &run_args);
+        let json = matches!(mode, OutputMode::Json);
+        run_bench(&program, func_name, &run_args, json);
         0
     } else if r.explain {
         let filename = if is_file {
@@ -3865,7 +3866,54 @@ fn program_exit_code(val: &interpreter::Value) -> i32 {
 }
 
 #[allow(unused_variables, unused_mut)]
-fn run_bench(program: &ast::Program, func_name: Option<&str>, args: &[interpreter::Value]) {
+/// Emit one machine-readable JSON envelope for a single bench measurement.
+///
+/// One line per engine. Top-level `engine` field names which engine produced
+/// the timing — `tree` (Rust interpreter), `vm` (register VM, with `variant`
+/// distinguishing the fresh-compile vs reusable-VmState measurements), or
+/// `jit` (Cranelift). `llvm` and `python` are emitted for completeness but
+/// fall outside the four-engine `tree|vm|jit|aot` contract from adoption
+/// brief 4; AOT isn't measured by `--bench` today (use `ilo build` then time
+/// the binary). Text mode is unchanged — this only fires under `--json`.
+fn emit_bench_json(
+    engine: &str,
+    variant: Option<&str>,
+    result: &str,
+    iterations: u32,
+    total_ms: f64,
+    per_call_ns: u128,
+) {
+    // Escape the result string for JSON. Bench results are values rendered by
+    // `Display` so they can contain `"` and `\` (rare but possible — `Text`
+    // values pass through verbatim). Roll a minimal escaper here to avoid
+    // pulling serde just for one line.
+    let mut esc = String::with_capacity(result.len() + 2);
+    for c in result.chars() {
+        match c {
+            '"' => esc.push_str("\\\""),
+            '\\' => esc.push_str("\\\\"),
+            '\n' => esc.push_str("\\n"),
+            '\r' => esc.push_str("\\r"),
+            '\t' => esc.push_str("\\t"),
+            c if (c as u32) < 0x20 => esc.push_str(&format!("\\u{:04x}", c as u32)),
+            c => esc.push(c),
+        }
+    }
+    let variant_field = match variant {
+        Some(v) => format!(",\"variant\":\"{}\"", v),
+        None => String::new(),
+    };
+    println!(
+        "{{\"schemaVersion\":1,\"engine\":\"{engine}\"{variant_field},\"result\":\"{esc}\",\"iterations\":{iterations},\"totalMs\":{total_ms:.4},\"perCallNs\":{per_call_ns}}}"
+    );
+}
+
+fn run_bench(
+    program: &ast::Program,
+    func_name: Option<&str>,
+    args: &[interpreter::Value],
+    json: bool,
+) {
     use std::io::Write;
     use std::process::Command;
     use std::time::Instant;
@@ -3887,12 +3935,23 @@ fn run_bench(program: &ast::Program, func_name: Option<&str>, args: &[interprete
     let interp_dur = start.elapsed();
     let interp_ns = interp_dur.as_nanos() / iterations as u128;
 
-    println!("Rust interpreter");
-    println!("  result:     {}", result);
-    println!("  iterations: {}", iterations);
-    println!("  total:      {:.2}ms", interp_dur.as_nanos() as f64 / 1e6);
-    println!("  per call:   {}ns", interp_ns);
-    println!();
+    if json {
+        emit_bench_json(
+            "tree",
+            None,
+            &result.to_string(),
+            iterations,
+            interp_dur.as_nanos() as f64 / 1e6,
+            interp_ns,
+        );
+    } else {
+        println!("Rust interpreter");
+        println!("  result:     {}", result);
+        println!("  iterations: {}", iterations);
+        println!("  total:      {:.2}ms", interp_dur.as_nanos() as f64 / 1e6);
+        println!("  per call:   {}ns", interp_ns);
+        println!();
+    }
 
     // -- Register VM benchmark --
     let compiled = vm::compile(program).expect("compile error in benchmark");
@@ -3910,12 +3969,23 @@ fn run_bench(program: &ast::Program, func_name: Option<&str>, args: &[interprete
     let vm_dur = start.elapsed();
     let vm_ns = vm_dur.as_nanos() / iterations as u128;
 
-    println!("Register VM");
-    println!("  result:     {}", vm_result);
-    println!("  iterations: {}", iterations);
-    println!("  total:      {:.2}ms", vm_dur.as_nanos() as f64 / 1e6);
-    println!("  per call:   {}ns", vm_ns);
-    println!();
+    if json {
+        emit_bench_json(
+            "vm",
+            Some("fresh"),
+            &vm_result.to_string(),
+            iterations,
+            vm_dur.as_nanos() as f64 / 1e6,
+            vm_ns,
+        );
+    } else {
+        println!("Register VM");
+        println!("  result:     {}", vm_result);
+        println!("  iterations: {}", iterations);
+        println!("  total:      {:.2}ms", vm_dur.as_nanos() as f64 / 1e6);
+        println!("  per call:   {}ns", vm_ns);
+        println!();
+    }
 
     // -- Register VM (reusable) benchmark --
     let call_name = func_name.unwrap_or(
@@ -3939,15 +4009,26 @@ fn run_bench(program: &ast::Program, func_name: Option<&str>, args: &[interprete
     let vm_reuse_dur = start.elapsed();
     let vm_reuse_ns = vm_reuse_dur.as_nanos() / iterations as u128;
 
-    println!("Register VM (reusable)");
-    println!("  result:     {}", vm_result);
-    println!("  iterations: {}", iterations);
-    println!(
-        "  total:      {:.2}ms",
-        vm_reuse_dur.as_nanos() as f64 / 1e6
-    );
-    println!("  per call:   {}ns", vm_reuse_ns);
-    println!();
+    if json {
+        emit_bench_json(
+            "vm",
+            Some("reusable"),
+            &vm_result.to_string(),
+            iterations,
+            vm_reuse_dur.as_nanos() as f64 / 1e6,
+            vm_reuse_ns,
+        );
+    } else {
+        println!("Register VM (reusable)");
+        println!("  result:     {}", vm_result);
+        println!("  iterations: {}", iterations);
+        println!(
+            "  total:      {:.2}ms",
+            vm_reuse_dur.as_nanos() as f64 / 1e6
+        );
+        println!("  per call:   {}ns", vm_reuse_ns);
+        println!();
+    }
 
     // -- JIT benchmarks --
     // Extract function info for JIT
@@ -3997,12 +4078,23 @@ fn run_bench(program: &ast::Program, func_name: Option<&str>, args: &[interprete
                 // synthetic `<user_fn:N>` placeholder.
                 let jit_result =
                     vm::NanVal(jit_result_bits).to_value_with_program(&compiled.func_names);
-                println!("Cranelift JIT");
-                println!("  result:     {}", jit_result);
-                println!("  iterations: {}", iterations);
-                println!("  total:      {:.2}ms", jit_dur.as_nanos() as f64 / 1e6);
-                println!("  per call:   {}ns", ns);
-                println!();
+                if json {
+                    emit_bench_json(
+                        "jit",
+                        None,
+                        &jit_result.to_string(),
+                        iterations,
+                        jit_dur.as_nanos() as f64 / 1e6,
+                        ns,
+                    );
+                } else {
+                    println!("Cranelift JIT");
+                    println!("  result:     {}", jit_result);
+                    println!("  iterations: {}", iterations);
+                    println!("  total:      {:.2}ms", jit_dur.as_nanos() as f64 / 1e6);
+                    println!("  per call:   {}ns", ns);
+                    println!();
+                }
             }
         });
     }
@@ -4029,21 +4121,39 @@ fn run_bench(program: &ast::Program, func_name: Option<&str>, args: &[interprete
                 let ns = jit_dur.as_nanos() / iterations as u128;
                 jit_llvm_ns = Some(ns);
 
-                println!("LLVM JIT");
-                if jit_result == (jit_result as i64) as f64 {
-                    println!("  result:     {}", jit_result as i64);
+                let result_str = if jit_result == (jit_result as i64) as f64 {
+                    format!("{}", jit_result as i64)
                 } else {
-                    println!("  result:     {}", jit_result);
+                    format!("{}", jit_result)
+                };
+                if json {
+                    emit_bench_json(
+                        "llvm",
+                        None,
+                        &result_str,
+                        iterations,
+                        jit_dur.as_nanos() as f64 / 1e6,
+                        ns,
+                    );
+                } else {
+                    println!("LLVM JIT");
+                    println!("  result:     {}", result_str);
+                    println!("  iterations: {}", iterations);
+                    println!("  total:      {:.2}ms", jit_dur.as_nanos() as f64 / 1e6);
+                    println!("  per call:   {}ns", ns);
+                    println!();
                 }
-                println!("  iterations: {}", iterations);
-                println!("  total:      {:.2}ms", jit_dur.as_nanos() as f64 / 1e6);
-                println!("  per call:   {}ns", ns);
-                println!();
             }
         }
     }
 
     // -- Python transpiler benchmark (single invocation) --
+    // JSON mode skips Python entirely — it isn't one of the four engines
+    // (tree/vm/jit/aot) and the human-readable comparator only makes sense
+    // alongside the text-mode summary block below.
+    if json {
+        return;
+    }
     let py_code = codegen::python::emit(program);
     let call_func = func_name.unwrap_or("main").replace('-', "_");
     let call_args: Vec<String> = args

--- a/tests/eval_inline.rs
+++ b/tests/eval_inline.rs
@@ -1395,7 +1395,7 @@ fn run_default_interpreter_error() {
 fn bench_simple_function() {
     // `f>n;42` with --bench covers run_bench (L448+), L230 (vec![]), all benchmark paths
     let out = ilo()
-        .args(["f>n;42", "--bench", "f"])
+        .args(["f>n;42", "--bench", "f", "--text"])
         .output()
         .expect("failed to run ilo");
     assert!(
@@ -1417,7 +1417,7 @@ fn bench_with_text_arg() {
     // bench mode with a text arg → filter_map hits `_ => None` (L525), all_numeric=false,
     // and the Python call_args builder hits the Text(s) branch (L638)
     let out = ilo()
-        .args(["f x:t>t;x", "--bench", "f", "hello"])
+        .args(["f x:t>t;x", "--bench", "f", "hello", "--text"])
         .output()
         .expect("failed to run ilo");
     assert!(
@@ -1437,7 +1437,7 @@ fn bench_with_text_arg() {
 fn bench_with_bool_arg() {
     // bench mode with a bool arg → Python call_args builder hits Bool(b) branch (L639)
     let out = ilo()
-        .args(["f x:b>b;x", "--bench", "f", "true"])
+        .args(["f x:b>b;x", "--bench", "f", "true", "--text"])
         .output()
         .expect("failed to run ilo");
     assert!(
@@ -1457,7 +1457,7 @@ fn bench_with_bool_arg() {
 fn bench_with_list_arg() {
     // bench mode with a list arg → Python call_args builder hits _ => "None" branch (L640)
     let out = ilo()
-        .args(["f xs:L n>n;+xs.0 1", "--bench", "f", "[1,2,3]"])
+        .args(["f xs:L n>n;+xs.0 1", "--bench", "f", "[1,2,3]", "--text"])
         .output()
         .expect("failed to run ilo");
     assert!(
@@ -1478,7 +1478,7 @@ fn bench_with_list_arg() {
 fn bench_jit_float_result() {
     // f x:n>n;/x 2 with arg 1 → JIT result = 0.5 (non-integer) → covers else branch
     let out = ilo()
-        .args(["f x:n>n;/x 2", "--bench", "f", "1"])
+        .args(["f x:n>n;/x 2", "--bench", "f", "1", "--text"])
         .output()
         .expect("failed to run ilo");
     assert!(
@@ -1507,7 +1507,7 @@ fn bench_jit_float_result() {
 fn bench_jit_non_numeric_const() {
     // f x:n>n;y="hi";x — NanVal JIT now handles text constants
     let out = ilo()
-        .args(["f x:n>n;y=\"hi\";x", "--bench", "f", "5"])
+        .args(["f x:n>n;y=\"hi\";x", "--bench", "f", "5", "--text"])
         .output()
         .expect("failed to run ilo");
     assert!(
@@ -1537,7 +1537,7 @@ fn bench_jit_move_different_regs() {
     // compile_match_arms: result_reg = reg1, body compiles +x 1 to reg2
     // → OP_MOVE 1,2 (a=1 != b=2) → arm64 L207-209 + Cranelift L167-170
     let out = ilo()
-        .args(["f x:n>n;?x{_:+x 1}", "--bench", "f", "7"])
+        .args(["f x:n>n;?x{_:+x 1}", "--bench", "f", "7", "--text"])
         .output()
         .expect("failed to run ilo");
     assert!(

--- a/tests/regression_bench_engine_field.rs
+++ b/tests/regression_bench_engine_field.rs
@@ -1,0 +1,179 @@
+// Regression: `ilo --bench <fn> --json` emits one JSON envelope per engine
+// with a top-level `engine` field naming which engine produced the timing.
+//
+// Background: adoption brief 4 (engines as contracts) asked for an `engine`
+// field in `--json` bench output so agents reading bench results can tell
+// which engine generated the numbers. Before this fix, `--bench` ignored
+// `--json` entirely and dumped human-readable text only.
+//
+// Contract:
+//   - Each engine measurement emits one line of JSON to stdout.
+//   - Top-level `"engine"` value is one of `"tree"`, `"vm"`, `"jit"`, `"llvm"`.
+//     (`"aot"` is reserved but `--bench` doesn't measure AOT today — use
+//     `ilo build` then time the produced binary.)
+//   - Top-level `"schemaVersion": 1`.
+//   - The two VM runs (fresh-compile vs reusable VmState) both emit
+//     `"engine":"vm"` and distinguish via a `"variant"` field.
+//   - Text mode (default / explicit `--text`) is unchanged.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+/// Run `ilo --bench --json` on a small program and return stdout.
+fn bench_json(source: &str, func: &str, args: &[&str]) -> String {
+    let mut cmd = ilo();
+    cmd.arg(source).arg("--bench").arg(func);
+    for a in args {
+        cmd.arg(a);
+    }
+    cmd.arg("--json");
+    let out = cmd.output().expect("spawn ilo");
+    assert!(
+        out.status.success(),
+        "ilo --bench --json exited non-zero: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+#[test]
+fn bench_json_emits_engine_field_per_engine() {
+    // Tiny program: add two numbers. Every engine handles this.
+    let stdout = bench_json("add a:n b:n>n;+a b", "add", &["1", "2"]);
+
+    // Each JSON line must include schemaVersion and the right engine name.
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    assert!(
+        !lines.is_empty(),
+        "expected JSON envelopes on stdout, got nothing. full stdout: {stdout}"
+    );
+
+    for line in &lines {
+        assert!(
+            line.contains("\"schemaVersion\":1"),
+            "missing schemaVersion in bench JSON line: {line}"
+        );
+        assert!(
+            line.starts_with('{') && line.ends_with('}'),
+            "bench JSON line not a single-line object: {line}"
+        );
+        assert!(
+            line.contains("\"engine\":\""),
+            "bench JSON line missing top-level engine field: {line}"
+        );
+    }
+}
+
+#[test]
+fn bench_json_covers_tree_vm_jit() {
+    let stdout = bench_json("add a:n b:n>n;+a b", "add", &["1", "2"]);
+
+    // Pull the engine name from each line. Test relies only on these being
+    // present — not on order — so the bench can re-order engines without
+    // breaking the contract.
+    let engines: Vec<String> = stdout
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|line| {
+            // Find the `"engine":"X"` substring and pull out X.
+            let key = "\"engine\":\"";
+            let start = line.find(key).expect("engine field present") + key.len();
+            let rest = &line[start..];
+            let end = rest.find('"').expect("engine field terminator");
+            rest[..end].to_string()
+        })
+        .collect();
+
+    // tree, vm, jit are mandatory under the default feature set. llvm only
+    // shows up under `--features llvm` and isn't asserted here.
+    assert!(
+        engines.iter().any(|e| e == "tree"),
+        "expected an `engine: tree` record in bench JSON output. saw: {engines:?}"
+    );
+    assert!(
+        engines.iter().any(|e| e == "vm"),
+        "expected an `engine: vm` record in bench JSON output. saw: {engines:?}"
+    );
+    // jit only available under `--features cranelift`. When the build does
+    // include cranelift (the default for our CI matrix), assert it.
+    if cfg!(feature = "cranelift") {
+        assert!(
+            engines.iter().any(|e| e == "jit"),
+            "expected an `engine: jit` record (cranelift feature on). saw: {engines:?}"
+        );
+    }
+
+    // VM should appear twice (fresh + reusable variants) — both labeled vm,
+    // distinguished by the `variant` field.
+    let vm_count = engines.iter().filter(|e| e.as_str() == "vm").count();
+    assert_eq!(
+        vm_count, 2,
+        "expected exactly two `engine: vm` records (fresh + reusable). saw: {engines:?}"
+    );
+    let stdout_lower = stdout.to_lowercase();
+    assert!(
+        stdout_lower.contains("\"variant\":\"fresh\""),
+        "expected `variant: fresh` on one of the vm records. stdout: {stdout}"
+    );
+    assert!(
+        stdout_lower.contains("\"variant\":\"reusable\""),
+        "expected `variant: reusable` on one of the vm records. stdout: {stdout}"
+    );
+}
+
+#[test]
+fn bench_json_records_carry_timing_fields() {
+    let stdout = bench_json("add a:n b:n>n;+a b", "add", &["1", "2"]);
+
+    for line in stdout.lines().filter(|l| !l.is_empty()) {
+        assert!(
+            line.contains("\"iterations\":"),
+            "bench JSON line missing iterations: {line}"
+        );
+        assert!(
+            line.contains("\"totalMs\":"),
+            "bench JSON line missing totalMs: {line}"
+        );
+        assert!(
+            line.contains("\"perCallNs\":"),
+            "bench JSON line missing perCallNs: {line}"
+        );
+        assert!(
+            line.contains("\"result\":\"3\""),
+            "bench JSON line missing/wrong result: {line}"
+        );
+    }
+}
+
+#[test]
+fn bench_text_mode_unchanged() {
+    // Explicit --text bypasses auto-detect. Output must contain the legacy
+    // human-readable headings and NOT contain JSON envelopes.
+    let out = ilo()
+        .arg("add a:n b:n>n;+a b")
+        .arg("--bench")
+        .arg("add")
+        .arg("1")
+        .arg("2")
+        .arg("--text")
+        .output()
+        .expect("spawn ilo");
+    assert!(out.status.success(), "ilo --bench --text failed");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        stdout.contains("Rust interpreter"),
+        "text mode missing Rust interpreter heading: {stdout}"
+    );
+    assert!(
+        stdout.contains("Register VM"),
+        "text mode missing Register VM heading: {stdout}"
+    );
+    assert!(
+        !stdout.contains("\"schemaVersion\""),
+        "text mode unexpectedly emitted JSON envelope: {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

Slim slice of [adoption brief 4](../zero-gap-specs/briefs/adoption/4-engines-as-contracts-brief.md). `--bench` previously ignored output mode and dumped text only. With `--json` it now emits one JSON object per engine measurement, top-level `engine` field naming which engine produced the numbers — so agents can filter bench results without parsing prose.

```
$ ilo 'add a:n b:n>n;+a b' --bench add 1 2 --json
{"schemaVersion":1,"engine":"tree","result":"3","iterations":10000,"totalMs":6.83,"perCallNs":683}
{"schemaVersion":1,"engine":"vm","variant":"fresh","result":"3","iterations":10000,"totalMs":1.55,"perCallNs":155}
{"schemaVersion":1,"engine":"vm","variant":"reusable","result":"3","iterations":10000,"totalMs":0.66,"perCallNs":66}
{"schemaVersion":1,"engine":"jit","result":"3","iterations":10000,"totalMs":0.43,"perCallNs":43}
```

The other deliverables in the brief either already exist (engine docs at `skills/ilo/ilo-engines.md`) or were deliberately reversed (the `--engine` CLI flag, removed in 0e30891). This PR is just the JSON envelope.

## What's in the diff

- **cli: --bench honors --json with per-engine envelope** — `run_bench` takes a `json` flag from the resolved `OutputMode`. Each engine block emits either text or one JSON line. Python comparator + Summary skipped in JSON mode (Python isn't one of the four engines; Summary is prose).
- **tests: cover bench --json engine field; pin eval_inline bench to --text** — new `regression_bench_engine_field.rs` (4 tests) covers the JSON contract; the 7 pre-existing `bench_*` tests in `eval_inline.rs` need `--text` because subprocess mode now auto-resolves to JSON (matching every other subcommand).
- **docs: ilo-engines.md notes the bench --json schema** — replaces the misleading per-engine bench table (every `--bench` invocation already exercises all engines) with the actual invocations and the JSON envelope shape.

## Notes

- `aot` is reserved in the JSON contract but `--bench` doesn't measure AOT today (use `ilo build` then time the produced binary). When a future change adds an AOT bench it gets `"engine":"aot"` for free.
- VM emits two records distinguished by `variant: "fresh"|"reusable"`. Keeping both is useful — the reusable VmState measurement is closer to the steady-state cost agents care about, while the fresh-compile path matches what `ilo file.ilo` does today.

## Test plan

- [x] `cargo test --release --features cranelift` (all green)
- [x] `cargo fmt --check`
- [x] `cargo clippy --release --features cranelift --tests -- -D warnings`
- [x] New regression test covers tree / vm (fresh + reusable) / jit
- [x] `--text` mode unchanged

## Follow-ups

- Add a bench measurement for the AOT engine so `"engine":"aot"` is actually produced (separate brief — needs design on whether bench builds + spawns a binary, or compiles in-process).
- Engine-can't-handle-program diagnostic, mentioned in the brief — separate PR, needs the design decision on what to do under the auto-fallback regime.