### PR TITLE
fix: field access on `_`-typed objects uses name lookup, not stale type offsets

### DIFF
--- a/examples/field-access-underscore-typed.ilo
+++ b/examples/field-access-underscore-typed.ilo
@@ -1,0 +1,24 @@
+-- Field access on a `_`-typed param now resolves by NAME (not by positional
+-- offset of a same-named user `type`). Before this fix, declaring
+--   type row{sku:t;qty:n;rev:n}
+-- and then writing `(it:_>t;it.sku)` over a `jpar`'d record silently returned
+-- the value at row-offset 0 inside the live record. `jpar` records are
+-- sorted alphabetically (qty, rev, sku), so `it.sku` quietly returned qty's
+-- value with no diagnostic. Silent-wrong output is the worst class of bug
+-- for an AI agent reading the program at face value. Fix is in the bytecode
+-- compiler: when the object's static record type is unknown, emit
+-- OP_RECFLD_NAME (name-based) instead of the positional OP_RECFLD.
+type row{sku:t;qty:n;rev:n}
+
+sku-of>R t t;all=jpar! "[{\"sku\":\"x\",\"qty\":2,\"rev\":99}]";~jdmp (map (it:_>t;it.sku) all)
+qty-of>R t t;all=jpar! "[{\"sku\":\"x\",\"qty\":2,\"rev\":99}]";~jdmp (map (it:_>n;it.qty) all)
+rev-of>R t t;all=jpar! "[{\"sku\":\"x\",\"qty\":2,\"rev\":99}]";~jdmp (map (it:_>n;it.rev) all)
+
+-- run: sku-of
+-- out: ["x"]
+
+-- run: qty-of
+-- out: [2]
+
+-- run: rev-of
+-- out: [99]

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -1829,23 +1829,6 @@ impl RegCompiler {
         }
     }
 
-    /// Search all types for a field name and return its slot index.
-    /// Returns `Some(index)` if the field exists at the same index in all types that have it.
-    /// Returns `None` if different types place this field at different indices (ambiguous).
-    fn search_field_index(&self, field: &str) -> Option<usize> {
-        let mut found_idx = None;
-        for info in self.type_registry.types.iter() {
-            if let Some(idx) = info.fields.iter().position(|f| f == field) {
-                match found_idx {
-                    None => found_idx = Some(idx),
-                    Some(prev) if prev == idx => {} // same index across types, ok
-                    Some(_) => return None, // ambiguous — different index in different types
-                }
-            }
-        }
-        found_idx
-    }
-
     fn compile_program(mut self, program: &Program) -> Result<CompiledProgram, CompileError> {
         // Build type registry from TypeDefs
         for decl in &program.declarations {
@@ -2150,10 +2133,17 @@ impl RegCompiler {
                 let record_reg = self.compile_expr(value);
                 let rec_type = self.reg_record_type[record_reg as usize];
                 for binding in bindings {
+                    // Only resolve to a positional index when the object's
+                    // record type is known statically. For `_`-typed values
+                    // the runtime layout (e.g. `jpar`-alphabetised keys) need
+                    // not match any declared `type`'s field order, so we fall
+                    // through to the name-based dynamic path. See the
+                    // matching comment on `Expr::Field` and json-shaper
+                    // rerun10.
                     let field_idx = if rec_type != u16::MAX {
                         self.type_registry.field_index(rec_type, binding)
                     } else {
-                        self.search_field_index(binding)
+                        None
                     };
                     match field_idx {
                         Some(idx) => {
@@ -3199,12 +3189,26 @@ impl RegCompiler {
                 safe,
             } => {
                 let obj_reg = self.compile_expr(object);
-                // Resolve field to an index using compile-time type info
                 let obj_type = self.reg_record_type[obj_reg as usize];
+                // Resolve field to an index using compile-time type info.
+                //
+                // We only use the positional `OP_RECFLD` fast path when the
+                // object's static record type is known at compile time. If the
+                // object is `_`-typed (e.g. a generic param, or anything coming
+                // out of `jpar`), the runtime record's field order is not
+                // knowable from a declared `type` — declared types are sorted
+                // by source order, while `jpar` records are sorted
+                // alphabetically. Using `search_field_index` here previously
+                // produced silent-wrong output: `it.sku` on a `_`-typed value
+                // would resolve to the offset of `sku` in a same-name `type`
+                // declaration even though the live record had a different
+                // layout. Falling through to the name-based path
+                // (`OP_RECFLD_NAME`) costs one map lookup but is always
+                // correct. See json-shaper rerun10.
                 let field_idx = if obj_type != u16::MAX {
                     self.type_registry.field_index(obj_type, field)
                 } else {
-                    self.search_field_index(field)
+                    None
                 };
                 match field_idx {
                     Some(idx) => {
@@ -5359,14 +5363,19 @@ impl RegCompiler {
                 let obj_reg = self.compile_expr(object);
                 let obj_type = self.reg_record_type[obj_reg as usize];
 
-                // Resolve update field names to indices
+                // Resolve update field names to indices. Same `_`-typed
+                // caveat as `Expr::Field` and `Stmt::Destructure`: for an
+                // object of unknown static record type, the runtime layout
+                // may not match any declared `type`, so we don't trust
+                // `search_field_index` here. Unresolved entries fall through
+                // to the name-keyed fallback emitted by the With codegen.
                 let update_indices: Vec<Option<u8>> = updates
                     .iter()
                     .map(|(name, _)| {
                         let idx = if obj_type != u16::MAX {
                             self.type_registry.field_index(obj_type, name)
                         } else {
-                            self.search_field_index(name)
+                            None
                         };
                         idx.map(|i| i as u8)
                     })

--- a/tests/regression_field_access_underscore_typed.rs
+++ b/tests/regression_field_access_underscore_typed.rs
@@ -1,0 +1,163 @@
+// Regression tests for the json-shaper rerun10 silent-correctness bug:
+// field access on `_`-typed params was resolved via the offsets of a
+// same-named declared `type`, not the runtime record's actual layout.
+//
+// Pre-fix behaviour (tree-walk correct, VM + JIT + AOT silently wrong):
+//
+//     type row{sku:t;qty:n;rev:n}
+//     main>R t t;all=jpar! "[{\"sku\":\"x\",\"qty\":2,\"rev\":99}]";~jdmp (map (it:_>t;it.sku) all)
+//
+//   Expected `["x"]`. Tree-walker returned `["x"]`; VM, Cranelift JIT, and
+//   AOT all returned `[2]` because `jpar` records are sorted alphabetically
+//   (qty, rev, sku) and the bytecode compiler reached for the row-type's
+//   field offset (sku=0) via `search_field_index`. That offset happened to
+//   point at `qty` in the live record, so the agent silently got the wrong
+//   value with no diagnostic.
+//
+// Post-fix behaviour: when the object's static record type is unknown
+// (e.g. a `_`-typed param), the VM emits the name-based `OP_RECFLD_NAME`
+// instead of the positional `OP_RECFLD`. The runtime cost is one map
+// lookup; the correctness win is "agents can trust `it.sku`."
+//
+// The fix touches three call sites in `src/vm/mod.rs` that used
+// `search_field_index` as a fallback when `reg_record_type == u16::MAX`:
+// `Expr::Field`, `Stmt::Destructure`, and `Expr::With`. All three now
+// fall through to the name-keyed dynamic path instead.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str) -> String {
+    let mut cmd = ilo();
+    cmd.arg(src).arg(engine).arg(entry);
+    let out = cmd.output().expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+// ── The persona's exact repro (json-shaper rerun10) ───────────────────────
+//
+// `type row{sku:t;qty:n;rev:n}` is declared; the lambda parameter is `_`;
+// the runtime record comes out of `jpar` with alphabetical keys
+// (`qty, rev, sku`). `it.sku` must return `"x"`, not `2`.
+
+const REPRO: &str = r#"type row{sku:t;qty:n;rev:n}
+main>R t t
+  all=jpar! "[{\"sku\":\"x\",\"qty\":2,\"rev\":99}]"
+  ~jdmp (map (it:_>t;it.sku) all)"#;
+
+fn check_repro(engine: &str) {
+    assert_eq!(
+        run(engine, REPRO, "main"),
+        r#"["x"]"#,
+        "engine={engine}: `it.sku` on a `_`-typed jpar'd record must \
+         return \"x\", not the value at row-type offset 0"
+    );
+}
+
+#[test]
+fn field_access_underscore_typed_tree() {
+    check_repro("--run-tree");
+}
+
+#[test]
+fn field_access_underscore_typed_vm() {
+    check_repro("--run-vm");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn field_access_underscore_typed_jit() {
+    check_repro("--jit");
+}
+
+// ── Also exercise the other two fields to be sure the mapping is correct
+// across the layout difference, not just luckily-aligned. The user-type
+// puts sku at 0, qty at 1, rev at 2; the jpar record (alphabetical) puts
+// qty at 0, rev at 1, sku at 2.
+
+const REPRO_QTY: &str = r#"type row{sku:t;qty:n;rev:n}
+main>R t t
+  all=jpar! "[{\"sku\":\"x\",\"qty\":2,\"rev\":99}]"
+  ~jdmp (map (it:_>n;it.qty) all)"#;
+
+const REPRO_REV: &str = r#"type row{sku:t;qty:n;rev:n}
+main>R t t
+  all=jpar! "[{\"sku\":\"x\",\"qty\":2,\"rev\":99}]"
+  ~jdmp (map (it:_>n;it.rev) all)"#;
+
+fn check_qty(engine: &str) {
+    assert_eq!(run(engine, REPRO_QTY, "main"), "[2]", "engine={engine}");
+}
+
+fn check_rev(engine: &str) {
+    assert_eq!(run(engine, REPRO_REV, "main"), "[99]", "engine={engine}");
+}
+
+#[test]
+fn field_access_qty_tree() {
+    check_qty("--run-tree");
+}
+#[test]
+fn field_access_qty_vm() {
+    check_qty("--run-vm");
+}
+#[test]
+#[cfg(feature = "cranelift")]
+fn field_access_qty_jit() {
+    check_qty("--jit");
+}
+
+#[test]
+fn field_access_rev_tree() {
+    check_rev("--run-tree");
+}
+#[test]
+fn field_access_rev_vm() {
+    check_rev("--run-vm");
+}
+#[test]
+#[cfg(feature = "cranelift")]
+fn field_access_rev_jit() {
+    check_rev("--jit");
+}
+
+// ── Typed-object fast path is unaffected ──────────────────────────────────
+//
+// When the object's static type IS a declared record (no `_` indirection),
+// the compiler still uses the positional `OP_RECFLD` fast path, and the
+// answer remains correct.
+
+const TYPED_FAST_PATH: &str = r#"type pt{x:n;y:n}
+main>R n t
+  p=pt x:10 y:20
+  ~p.x"#;
+
+fn check_typed_fast(engine: &str) {
+    assert_eq!(
+        run(engine, TYPED_FAST_PATH, "main"),
+        "10",
+        "engine={engine}"
+    );
+}
+
+#[test]
+fn typed_record_fast_path_tree() {
+    check_typed_fast("--run-tree");
+}
+#[test]
+fn typed_record_fast_path_vm() {
+    check_typed_fast("--run-vm");
+}
+#[test]
+#[cfg(feature = "cranelift")]
+fn typed_record_fast_path_jit() {
+    check_typed_fast("--jit");
+}


### PR DESCRIPTION
## Summary

Field access on a `_`-typed object (generic param, anything out of `jpar`) was silently resolving to a positional offset borrowed from a same-name declared `type`. When the runtime record's actual layout differed - and `jpar`-produced records always alphabetise their keys, so they almost always do - `it.sku` returned the wrong field's value with no diagnostic. The tree-walker was correct (name-based lookup); VM, Cranelift JIT, and AOT were all silently wrong.

This is the worst class of bug for AI tooling: the program looks right, type-checks, runs, and emits a plausible value that is just not the one the agent asked for. Surfaced by the json-shaper rerun10 persona.

## Repro

```
type row{sku:t;qty:n;rev:n}
main>R t t
  all=jpar! "[{\"sku\":\"x\",\"qty\":2,\"rev\":99}]"
  ~jdmp (map (it:_>t;it.sku) all)
```

| Engine | Before | After |
|---|---|---|
| `--run-tree` | `["x"]` | `["x"]` |
| `--run-vm` | `[2]` | `["x"]` |
| `--jit` | `[2]` | `["x"]` |
| AOT | `[2]` | `["x"]` |

`jpar` records are alphabetical (`qty, rev, sku`); the declared `row` type is source-order (`sku, qty, rev`). The bytecode compiler was reaching for the `row` offset (sku=0) and indexing into the live record at slot 0, which was `qty`.

## What's in the diff

Three commits:

1. **vm: use name-based field access for `_`-typed objects** - the fix. Three call sites in `src/vm/mod.rs` previously fell back to `search_field_index` when `reg_record_type == u16::MAX`: `Expr::Field`, `Stmt::Destructure`, `Expr::With`. All three now return `None` in that branch, which routes to the existing name-based dynamic path (`OP_RECFLD_NAME` / `OP_RECFLD_NAME_SAFE` / the with-fallback that keys updates by name). `search_field_index` itself is no longer reachable and is removed.

2. **tests: cross-engine regression for `_`-typed field access** - 12 tests in `tests/regression_field_access_underscore_typed.rs` covering tree / VM / JIT for: the persona's exact repro on `sku`, the same shape on `qty` and `rev` so the passing case isn't a coincidence, and a typed-record fast-path control.

3. **examples: field access on `_`-typed param resolves by name** - `examples/field-access-underscore-typed.ilo` with three `-- run:` cases, picked up by `tests/examples_engines.rs`.

The typed fast path (object whose static record type IS known) is untouched - `OP_RECFLD` with a positional offset still fires there, so this is a correctness fix on the dynamic path only, with no perf impact on typed code.

Targeting **0.12.1** (bug fix release).

## Test plan

- [x] `cargo test --release --features cranelift` - 3554 passed, 0 failed (two parallel-only flakes in `tests::graph_cmd_dot_output_exits_zero` and `tests::load_env_file_line_without_equals_skipped` are pre-existing - both touch global env / cwd and pass cleanly under `--test-threads=1`; unrelated to this fix)
- [x] `cargo test --release --features cranelift --test regression_field_access_underscore_typed` - 12 pass
- [x] `cargo test --release --features cranelift --test examples_engines` - 1 pass
- [x] `cargo test --release --features cranelift --bin ilo -- --test-threads=1` - 361 pass
- [x] `cargo fmt`, `cargo clippy --release --features cranelift --all-targets` - clean

## Follow-ups

None. No doc-sync needed: this is a behaviour-restoration fix, no surface or signature change.