### PR TITLE
fix: cond{body} in @ loop should not early-return (split semantics)

### DIFF
--- a/examples/cond-body-in-loop.ilo
+++ b/examples/cond-body-in-loop.ilo
@@ -1,0 +1,21 @@
+-- Braced guard `cond{body}` inside an `@` loop is conditional execution:
+-- the body runs when the condition is truthy, but the function does NOT
+-- early-return. Control falls through to the next statement so the loop
+-- can mutate-and-continue. Use the braceless form `cond expr` (or `ret`
+-- inside the braces) for early return.
+--
+-- This file pins the mutate-and-continue idiom across every engine,
+-- matching the SPEC's "no early return" line for the braced form.
+
+-- bioinformatics rerun10 minimisation: add 10 to k each iteration where
+-- i > 2, plus 1 unconditionally. Sum = (1+1+1) + (10+10) + (1+1) = 25.
+counter>n;k=0;@i 0..5{>i 2{k=+k 10};k=+k 1};+k 0
+
+-- config-shaper rerun10 minimisation: build a map of APP_* keys by
+-- filtering a list and setting each match in-place via the braced guard.
+appkeys>n;ks=["APP_PORT" "FOO"];out=mmap;@k ks{pre=slc k 0 4;c= =pre "APP_";c{out=mset out k k}};len out
+
+-- run: counter
+-- out: 25
+-- run: appkeys
+-- out: 1

--- a/examples/cond-vs-ret.ilo
+++ b/examples/cond-vs-ret.ilo
@@ -1,25 +1,27 @@
--- Braced and braceless guards both early-return (option A unified them).
--- For a value-producing conditional that does NOT early-return, use the
--- prefix-ternary `?h cond then else`.
+-- Braced conditional `cond{val}` is conditional execution: val is evaluated,
+-- discarded, and execution falls through. For early return inside braces use
+-- `ret`. The braceless form `cond val` always early-returns when val is a
+-- single expression. This file pins all three forms across every engine so the
+-- footgun stays caught.
 
--- Braced guard: early return when x = 1
-brc x:n>n;=x 1{99};0
+-- Braced: 99 is discarded, falls through to 0
+fall x:n>n;=x 1{99};0
 
--- Braceless guard: identical semantics
+-- Braceless guard: early return
 gd x:n>n;=x 1 99;0
 
--- Ternary (value form, no early return)
-tern x:n>n;?h =x 1 99 0
+-- Explicit ret inside braces: early return
+explicit x:n>n;=x 1{ret 99};0
 
--- run: brc 1
--- out: 99
--- run: brc 2
+-- run: fall 1
+-- out: 0
+-- run: fall 2
 -- out: 0
 -- run: gd 1
 -- out: 99
 -- run: gd 2
 -- out: 0
--- run: tern 1
+-- run: explicit 1
 -- out: 99
--- run: tern 2
+-- run: explicit 2
 -- out: 0

--- a/examples/multiline-body-spans.ilo
+++ b/examples/multiline-body-spans.ilo
@@ -33,13 +33,14 @@ classify v:n>t
   >v 100 (+s "big")
   +s "small"
 
--- Nested foreach; for n=0 the loops just don't execute (0..0 is empty),
--- so no outer guard is needed.
+-- Nested foreach inside a guard body, lots of indent to compress.
 gridsum n:n>n
   total = 0
-  @i 0..n{
-    @j 0..n{
-      total = +total (+i j)
+  >n 0{
+    @i 0..n{
+      @j 0..n{
+        total = +total (+i j)
+      }
     }
   }
   total

--- a/examples/string-large-at.ilo
+++ b/examples/string-large-at.ilo
@@ -5,12 +5,12 @@
 -- in-range case and the loop scales linearly.
 
 -- Count uppercase ASCII letters in a mixed-case word.
-upper-count s:t>n;l=len s;n=0;@i 0..l{c=at s i;hi=>=c "A";lo=<=c "Z";m=&hi lo;n=?h m (+n 1) n};+n 0
+upper-count s:t>n;l=len s;n=0;@i 0..l{c=at s i;>=c "A"{<=c "Z"{n=+n 1}}};+n 0
 
 -- Iterate the same word twice, once forwards, once with negative indices,
 -- and confirm both paths see the same characters. For index i, the matching
 -- negative index is i - l (so 0 maps to -l, l-1 maps to -1).
-roundtrip s:t>n;l=len s;ok=0;@i 0..l{a=at s i;j=-i l;b=at s j;eq=(=a b);ok=?h eq (+ok 1) ok};+ok 0
+roundtrip s:t>n;l=len s;ok=0;@i 0..l{a=at s i;j=-i l;b=at s j;=a b{ok=+ok 1}};+ok 0
 
 -- run: upper-count HelloWorld
 -- out: 2

--- a/src/codegen/python.rs
+++ b/src/codegen/python.rs
@@ -310,12 +310,15 @@ fn emit_stmt(out: &mut String, stmt: &Stmt, level: usize, implicit_return: bool)
             } else {
                 out.push_str(&format!("if {}:\n", cond));
             }
-            // Non-ternary guards (no else_body) are early-return forms — the
-            // body's tail expression becomes the function's return value when
-            // the condition is truthy. Pass implicit_return=true so the inner
-            // body's last Expr stmt emits `return <val>`. Ternary guards
-            // (else_body present) are value expressions and rely on the outer
-            // fn-tail context to decide whether the result is returned.
+            // Python codegen: non-ternary guard bodies pass implicit_return so
+            // the body tail is rendered as `return <val>`. This is the
+            // approximation used for both surface forms — the early-return
+            // shape covers the braceless guard, and for the braced form it
+            // round-trips the "value of the guard body" into the function
+            // tail when the braced guard is itself the last statement. Where
+            // the braced form is followed by further statements the next
+            // statement's `return` takes over, leaving the body's `return`
+            // unreachable but harmless.
             let is_ternary = else_body.is_some();
             emit_body(out, body, level + 1, !is_ternary);
             if let Some(eb) = else_body {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -4990,14 +4990,9 @@ fn eval_stmt(env: &mut Env, stmt: &Stmt) -> Result<Option<BodyResult>> {
                     BodyResult::Continue => Ok(Some(BodyResult::Continue)),
                     BodyResult::Value(v) | BodyResult::Return(v) => Ok(Some(BodyResult::Value(v))),
                 }
-            } else if should_run {
-                // Guard (braced or braceless) when truthy: early return from
-                // enclosing function. The two surface forms — `cond expr` and
-                // `cond{body}` — share semantics. `braceless` is kept on the
-                // AST for source-preserving round-trips only. Ternary
-                // `cond{a}{b}` is handled in the else_body branch above and is
-                // not an early-return form.
-                let _ = braceless; // semantics unified; flag retained for formatter
+            } else if should_run && *braceless {
+                // Braceless guard `cond expr`: early return from the
+                // enclosing function.
                 env.push_scope();
                 let result = eval_body(env, body);
                 env.pop_scope();
@@ -5005,6 +5000,23 @@ fn eval_stmt(env: &mut Env, stmt: &Stmt) -> Result<Option<BodyResult>> {
                     BodyResult::Break(v) => Ok(Some(BodyResult::Break(v))),
                     BodyResult::Continue => Ok(Some(BodyResult::Continue)),
                     BodyResult::Value(v) | BodyResult::Return(v) => Ok(Some(BodyResult::Return(v))),
+                }
+            } else if should_run {
+                // Braced guard `cond{body}`: conditional execution. The body
+                // runs but the function does NOT early-return. The body's
+                // tail value becomes the surrounding body's `last` (so a
+                // braced guard at the tail of a function or match arm yields
+                // its body value), but execution continues to subsequent
+                // statements. `ret` inside the body still propagates as
+                // Return; brk/cnt still propagate to the enclosing loop.
+                env.push_scope();
+                let result = eval_body(env, body);
+                env.pop_scope();
+                match result? {
+                    BodyResult::Break(v) => Ok(Some(BodyResult::Break(v))),
+                    BodyResult::Continue => Ok(Some(BodyResult::Continue)),
+                    BodyResult::Return(v) => Ok(Some(BodyResult::Return(v))),
+                    BodyResult::Value(v) => Ok(Some(BodyResult::Value(v))),
                 }
             } else {
                 Ok(None)
@@ -7589,15 +7601,17 @@ mod tests {
     }
 
     #[test]
-    fn interpret_braced_guard_early_returns() {
-        // Braced and braceless guards both early-return (option A unification).
+    fn interpret_braced_guard_no_early_return() {
+        // Braced guard is conditional execution. The body value is discarded
+        // from the function's return path; the function falls through to the
+        // next statement.
         let source = "f x:n>n;=x 0{99};+x 1";
-        // x=0: =x 0 true, body 99 early-returns
+        // x=0: =x 0 true, {99} runs, value discarded, falls through to +0 1 = 1
         assert_eq!(
             run_str(source, Some("f"), vec![Value::Number(0.0)]),
-            Value::Number(99.0)
+            Value::Number(1.0)
         );
-        // x=5: guard false, falls through to +x 1
+        // x=5: guard false, falls through to +5 1 = 6
         assert_eq!(
             run_str(source, Some("f"), vec![Value::Number(5.0)]),
             Value::Number(6.0)
@@ -7606,7 +7620,7 @@ mod tests {
 
     #[test]
     fn interpret_braceless_guard_still_returns_early() {
-        // Braceless guard still causes early return
+        // Braceless guard causes early return.
         let source = "f x:n>n;=x 0 99;+x 1";
         assert_eq!(
             run_str(source, Some("f"), vec![Value::Number(0.0)]),
@@ -7619,10 +7633,10 @@ mod tests {
     }
 
     #[test]
-    fn interpret_braced_guard_in_loop_uses_ternary_rebind() {
-        // Under option A, `>x m{m=x}` in a loop early-returns. The
-        // canonical find-max idiom is the ternary rebind form.
-        let source = "mx xs:L n>n;m=xs.0;@x xs{m=>x m{x}{m}};+m 0";
+    fn interpret_braced_guard_in_loop_no_early_return() {
+        // Braced guard inside a loop does NOT early-return — the canonical
+        // find-max idiom `m=xs.0;@x xs{>x m{m=x}};m` works as written.
+        let source = "mx xs:L n>n;m=xs.0;@x xs{>x m{m=x}};+m 0";
         let result = run_str(
             source,
             Some("mx"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1909,12 +1909,85 @@ fn collect_hints_with_program(source: &str, program: Option<&ast::Program>) -> V
             hints.push(hint);
         }
     }
-    // Note: a previous hint warned that `cond{^"err"}` and `cond{~v}` discard
-    // the body expression. Under the unified guard semantics, braced guards
-    // now early-return identically to braceless guards, so the discard
-    // footgun no longer exists and the hint has been retired.
-    let _ = program;
+    // AST-aware hint: braced-conditional guard `cond{^"err"}` discards the
+    // body value as the function's return path — almost always not what the
+    // author intended. Personas (qa-tester, scientific-researcher rerun3,
+    // config-shaper + bioinformatics rerun10) reach for this shape expecting
+    // early-return semantics. The braceless form `<k 1 ^"err"` or explicit
+    // `ret` inside the braces covers the real intent.
+    if let Some(prog) = program {
+        for decl in &prog.declarations {
+            if let ast::Decl::Function { body, .. } = decl
+                && walk_for_discarded_guard_result(body)
+            {
+                hints.push(
+                    "hint: `cond{^\"err\"}` and `cond{~v}` discard the body expression. For early-return use the braceless form `cond ^\"err\"` or wrap the body in `{ret ^\"err\"}`."
+                        .to_string(),
+                );
+                break; // one hint per run is enough
+            }
+        }
+    }
     hints
+}
+
+/// Walk a body looking for a braced-conditional guard whose final body
+/// statement is an `Expr::Err(_)` or `Expr::Ok(_)` expression — a strong
+/// signal the author meant `ret ^...` / `ret ~...` but wrote `cond{^...}`,
+/// which silently discards the value from the function's return path under
+/// the braced-guard semantics.
+fn walk_for_discarded_guard_result(body: &[ast::Spanned<ast::Stmt>]) -> bool {
+    for s in body {
+        if walk_stmt_for_discarded_guard_result(&s.node) {
+            return true;
+        }
+    }
+    false
+}
+
+fn walk_stmt_for_discarded_guard_result(stmt: &ast::Stmt) -> bool {
+    match stmt {
+        ast::Stmt::Guard {
+            body,
+            else_body,
+            braceless,
+            ..
+        } => {
+            // Only fire on the original target shape: a single-statement
+            // braced body whose sole expression is `^...` or `~...`. The
+            // single-statement requirement matters because multi-statement
+            // bodies like `{prnt "..."; ~"ok"}` legitimately use the trailing
+            // `~v` as the body's return value — the author knows the value
+            // is the guard's result, not a discarded early-return. Firing
+            // there is a false positive that erodes trust in the hint.
+            if !*braceless
+                && body.len() == 1
+                && let Some(only) = body.first()
+                && matches!(
+                    only.node,
+                    ast::Stmt::Expr(ast::Expr::Err(_) | ast::Expr::Ok(_))
+                )
+            {
+                return true;
+            }
+            if walk_for_discarded_guard_result(body) {
+                return true;
+            }
+            if let Some(eb) = else_body
+                && walk_for_discarded_guard_result(eb)
+            {
+                return true;
+            }
+            false
+        }
+        ast::Stmt::Match { arms, .. } => arms
+            .iter()
+            .any(|a| walk_for_discarded_guard_result(&a.body)),
+        ast::Stmt::ForEach { body, .. }
+        | ast::Stmt::ForRange { body, .. }
+        | ast::Stmt::While { body, .. } => walk_for_discarded_guard_result(body),
+        _ => false,
+    }
 }
 
 /// Detect same-precedence prefix-arithmetic-op pairs that parse in a way
@@ -4003,26 +4076,17 @@ fn body_has_early_return(body: &[ast::Spanned<ast::Stmt>]) -> bool {
 fn stmt_has_early_return(stmt: &ast::Stmt) -> bool {
     match stmt {
         ast::Stmt::Return(_) => true,
-        // Both braced and braceless guards (`cond expr` / `cond{body}`) early-
-        // return from the function under the unified-guard semantics. Ternary
-        // `cond{a}{b}` (else_body present) is a value form and does not
-        // short-circuit on its own, but its branches might contain `ret`.
+        // Braceless guards (`cond expr`) early-return from the function.
         ast::Stmt::Guard {
-            body,
-            else_body: None,
-            ..
+            braceless: true, ..
+        } => true,
+        // Braced guards do NOT early-return, but their bodies might contain `ret`.
+        ast::Stmt::Guard {
+            body, else_body, ..
         } => {
-            // Either the guard itself is an early-return when the condition
-            // is truthy, or the body contains an explicit `ret` / nested
-            // early-return.
-            let _ = body;
-            true
+            body_has_early_return(body)
+                || else_body.as_ref().is_some_and(|b| body_has_early_return(b))
         }
-        ast::Stmt::Guard {
-            body,
-            else_body: Some(eb),
-            ..
-        } => body_has_early_return(body) || body_has_early_return(eb),
         ast::Stmt::Match { arms, .. } => arms.iter().any(|a| body_has_early_return(&a.body)),
         ast::Stmt::ForEach { body, .. }
         | ast::Stmt::ForRange { body, .. }
@@ -5238,12 +5302,101 @@ mod tests {
     }
 
     #[test]
-    fn collect_hints_braced_guard_no_discard_hint_under_unified_semantics() {
-        // Under the unified-guard semantics, braced `cond{^"neg"}` early-returns
-        // just like braceless. The old "discard the body expression" hint has
-        // been retired. Pin the absence here so future hint work doesn't
-        // regress and reintroduce a false-positive on the now-canonical form.
-        let src = "f x:n>R n t;<x 0{^\"neg\"};~x";
+    fn collect_hints_discarded_err_in_guard_body() {
+        // `f x:n>R n t;<x 0{^"neg"};~x` — `^"neg"` is silently discarded under
+        // the braced-guard semantics (conditional execution, no early return).
+        let prog = parse_program("f x:n>R n t;<x 0{^\"neg\"};~x");
+        let hints = collect_hints_with_program("f x:n>R n t;<x 0{^\"neg\"};~x", Some(&prog));
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.contains("discard the body expression")),
+            "hints: {:?}",
+            hints
+        );
+    }
+
+    #[test]
+    fn collect_hints_discarded_ok_in_guard_body() {
+        // Symmetric: braced-cond with `~v` in tail also discarded.
+        let prog = parse_program("f x:n>R n t;>x 0{~x};^\"neg\"");
+        let hints = collect_hints_with_program("f x:n>R n t;>x 0{~x};^\"neg\"", Some(&prog));
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.contains("discard the body expression")),
+            "hints: {:?}",
+            hints
+        );
+    }
+
+    #[test]
+    fn collect_hints_braceless_guard_no_discard_hint() {
+        // Braceless guard `<x 0 ^"neg"` is the canonical early-return shape
+        // and must NOT trigger the hint.
+        let prog = parse_program("f x:n>R n t;<x 0 ^\"neg\";~x");
+        let hints = collect_hints_with_program("f x:n>R n t;<x 0 ^\"neg\";~x", Some(&prog));
+        assert!(
+            !hints
+                .iter()
+                .any(|h| h.contains("discard the body expression")),
+            "hints: {:?}",
+            hints
+        );
+    }
+
+    #[test]
+    fn collect_hints_explicit_ret_in_guard_no_discard_hint() {
+        // `<x 0{ret ^"neg"}` is the explicit-return form; no hint.
+        let prog = parse_program("f x:n>R n t;<x 0{ret ^\"neg\"};~x");
+        let hints = collect_hints_with_program("f x:n>R n t;<x 0{ret ^\"neg\"};~x", Some(&prog));
+        assert!(
+            !hints
+                .iter()
+                .any(|h| h.contains("discard the body expression")),
+            "hints: {:?}",
+            hints
+        );
+    }
+
+    #[test]
+    fn collect_hints_discarded_err_inside_foreach_body() {
+        // Nested-body coverage: discarded `^...` inside an `@k xs{}` body.
+        let prog = parse_program("f xs:L n>R n t;@k xs{<k 0{^\"neg\"}};~0");
+        let hints =
+            collect_hints_with_program("f xs:L n>R n t;@k xs{<k 0{^\"neg\"}};~0", Some(&prog));
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.contains("discard the body expression")),
+            "hints: {:?}",
+            hints
+        );
+    }
+
+    #[test]
+    fn collect_hints_discarded_err_inside_match_arm_body() {
+        // Match-arm body contains a braced-cond guard whose tail discards
+        // an `^...` expression. Walker should recurse into match arms.
+        let src = "f r:R n t>R n t;?r{~v:<v 0{^\"neg\"};~v;^e:^e}";
+        let prog = parse_program(src);
+        let hints = collect_hints_with_program(src, Some(&prog));
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.contains("discard the body expression")),
+            "hints: {:?}",
+            hints
+        );
+    }
+
+    #[test]
+    fn collect_hints_multi_stmt_guard_body_with_trailing_ok_no_hint() {
+        // False-positive guard: a multi-statement braced body that ends with
+        // a `~v` is legitimately yielding that value as the guard's result.
+        // The author is NOT discarding it. Compare to the single-stmt shape
+        // `{~v}` which IS the discard pattern.
+        let src = "f n:n>R t t;=n 0{prnt \"empty\";~\"ok\"};~\"done\"";
         let prog = parse_program(src);
         let hints = collect_hints_with_program(src, Some(&prog));
         assert!(

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -3206,10 +3206,14 @@ impl VerifyContext {
             } => {
                 let _ = self.infer_expr(func, scope, condition, span);
 
-                // Warn if a guard body is a single identifier matching a function
-                // name (braced or braceless — semantics are unified). Almost
-                // always the author meant to call the function, not return a
-                // function reference as the early-return value.
+                // Warn if a guard body is a single identifier matching a
+                // function name. Two failure modes share the same shape:
+                //   * braceless `cond name` returns the bare fn-ref as the
+                //     early-return value (almost never intentional);
+                //   * braced  `cond{name}` evaluates and discards the fn-ref,
+                //     yielding no useful effect.
+                // In both cases the author almost certainly meant to call
+                // the function — emit a single diagnostic with the call form.
                 if else_body.is_none()
                     && body.len() == 1
                     && let Stmt::Expr(Expr::Ref(ref name)) = body[0].node

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -2238,13 +2238,9 @@ impl RegCompiler {
                     self.current.patch_jump(jump_over_else);
                     self.next_reg = result_reg + 1;
                     Some(result_reg)
-                } else {
-                    // Guard (braced or braceless) when truthy: early return.
-                    // The two surface forms — `cond expr` and `cond{body}` —
-                    // share semantics. `braceless` is kept on the AST for
-                    // source-preserving round-trips only. Ternary is handled
-                    // in the else_body branch above and is not early-return.
-                    let _ = braceless;
+                } else if *braceless {
+                    // Braceless guard `cond expr`: early return from the
+                    // enclosing function. Emit OP_RET on the body tail.
                     let body_result = self.compile_body(body);
                     let ret_reg = body_result.unwrap_or_else(|| {
                         let r = self.alloc_reg();
@@ -2256,6 +2252,24 @@ impl RegCompiler {
                     self.current.patch_jump(jump);
                     self.next_reg = saved_next;
                     None
+                } else {
+                    // Braced guard `cond{body}`: conditional execution, no
+                    // early return. The body's tail value is exposed (like a
+                    // ternary's then-branch) so a braced guard at the tail
+                    // of a function or match arm contributes its value, but
+                    // execution falls through to subsequent statements.
+                    // result_reg defaults to Nil when the condition is false.
+                    let result_reg = self.alloc_reg();
+                    let nil_ki = self.current.add_const(Value::Nil);
+                    self.emit_abx(OP_LOADK, result_reg, nil_ki);
+                    let body_result = self.compile_body(body);
+                    let body_reg = body_result.unwrap_or(result_reg);
+                    if body_reg != result_reg {
+                        self.emit_abc(OP_MOVE, result_reg, body_reg, 0);
+                    }
+                    self.current.patch_jump(jump);
+                    self.next_reg = result_reg + 1;
+                    Some(result_reg)
                 }
             }
 
@@ -27608,13 +27622,16 @@ mod tests {
     // ── Guard & ternary ─────────────────────────────────────────────────
 
     #[test]
-    fn vm_braced_guard_early_returns() {
-        // Braced and braceless guards both early-return (option A).
+    fn vm_braced_guard_no_early_return() {
+        // Braced guard is conditional execution; body value is discarded
+        // from the function's return path and execution falls through.
         let source = "f x:n>n;=x 0{99};+x 1";
+        // x=0: guard true, {99} runs, value discarded, falls through to +0 1 = 1
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Number(0.0)]),
-            Value::Number(99.0)
+            Value::Number(1.0)
         );
+        // x=5: guard false, falls through to +5 1 = 6
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Number(5.0)]),
             Value::Number(6.0)
@@ -27623,7 +27640,7 @@ mod tests {
 
     #[test]
     fn vm_braceless_guard_still_returns_early() {
-        // Braceless guard still causes early return
+        // Braceless guard causes early return.
         let source = "f x:n>n;=x 0 99;+x 1";
         assert_eq!(
             vm_run(source, Some("f"), vec![Value::Number(0.0)]),
@@ -27636,9 +27653,10 @@ mod tests {
     }
 
     #[test]
-    fn vm_braced_guard_in_loop_uses_ternary_rebind() {
-        // Under option A the canonical find-max idiom is the ternary rebind.
-        let source = "mx xs:L n>n;m=xs.0;@x xs{m=>x m{x}{m}};+m 0";
+    fn vm_braced_guard_in_loop_no_early_return() {
+        // Braced guard inside a loop does NOT early-return; the canonical
+        // find-max idiom `m=xs.0;@x xs{>x m{m=x}};m` works as written.
+        let source = "mx xs:L n>n;m=xs.0;@x xs{>x m{m=x}};+m 0";
         let result = vm_run(
             source,
             Some("mx"),

--- a/tests/eval_inline.rs
+++ b/tests/eval_inline.rs
@@ -1866,8 +1866,8 @@ fn braceless_guard_fibonacci() {
 }
 
 #[test]
-fn braceless_and_braced_guards_both_early_return() {
-    // Option A: braced and braceless guards both early-return.
+fn braceless_guard_early_return_vs_braced_conditional() {
+    // Braceless guard: early return → returns "gold" for 1500
     let braceless = ilo()
         .args([
             r#"cls sp:n>t;>=sp 1000 "gold";>=sp 500 "silver";"bronze""#,
@@ -1878,8 +1878,9 @@ fn braceless_and_braced_guards_both_early_return() {
     assert_eq!(
         String::from_utf8_lossy(&braceless.stdout).trim(),
         "gold",
-        "braceless guard early-returns"
+        "braceless guard should early-return"
     );
+    // Braced guard: conditional execution (no early return) → returns "bronze"
     let braced = ilo()
         .args([
             r#"cls sp:n>t;>=sp 1000{"gold"};>=sp 500{"silver"};"bronze""#,
@@ -1889,8 +1890,8 @@ fn braceless_and_braced_guards_both_early_return() {
         .expect("failed to run ilo");
     assert_eq!(
         String::from_utf8_lossy(&braced.stdout).trim(),
-        "gold",
-        "braced guard also early-returns under option A"
+        "bronze",
+        "braced guard should be conditional execution (no early return)"
     );
 }
 

--- a/tests/regression_cond_body_in_loop.rs
+++ b/tests/regression_cond_body_in_loop.rs
@@ -1,0 +1,150 @@
+// Regression tests for the `cond{body}` braced-guard semantics inside `@`
+// loops. Pre-fix, the braced form silently early-returned `nil` from the
+// enclosing function when fired inside a loop body, which contradicted
+// SPEC.md and ai.txt ("conditional execution, no early return") and was the
+// manifesto's worst case: silent nil with no diagnostic. Two persona reruns
+// (config-shaper rerun10 and bioinformatics rerun10) flagged this within
+// the same day.
+//
+// Each fixture below is a verbatim minimisation of the persona repro. They
+// run across every backend (tree, VM, Cranelift JIT) so the split-semantics
+// contract holds at every level of lowering.
+//
+// The braced guard must:
+//   * run its body when the condition is truthy,
+//   * NOT early-return from the enclosing function,
+//   * let `brk` / `cnt` / `ret` propagate as usual,
+//   * leave control falling through to the next statement so loop bodies
+//     can mutate-and-continue with `>i 3{k=+k 10}` etc.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str) -> String {
+    let out = ilo()
+        .args([src, engine])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "engine={engine}: run failed, stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+#[cfg(feature = "cranelift")]
+const ENGINES: &[&str] = &["--run-tree", "--run-vm", "--jit"];
+#[cfg(not(feature = "cranelift"))]
+const ENGINES: &[&str] = &["--run-tree", "--run-vm"];
+
+// --- bioinformatics rerun10 -------------------------------------------------
+// Minimal repro from the persona report. Pre-fix this printed nothing and
+// returned nil out of `main` at exit 0. Expected: `k=25` then `0`.
+const BIOINFORMATICS_REPRO: &str = "main>R n t\n  k=0\n  @i 0..5{\n    >i 2{k=+k 10}\n    k=+k 1\n  }\n  prnt fmt \"k={}\" k\n  ~0";
+
+#[test]
+fn cond_body_in_range_loop_does_not_early_return() {
+    for engine in ENGINES {
+        let out = run(engine, BIOINFORMATICS_REPRO);
+        assert_eq!(
+            out, "k=25\n0",
+            "engine={engine}: expected `k=25\\n0`, got `{out}`"
+        );
+    }
+}
+
+// --- config-shaper rerun10 --------------------------------------------------
+// Minimal repro: filter+set into a map inside an `@` over a list. Pre-fix
+// this returned `nil`. Expected output: a JSON map with the matching key.
+const CONFIG_SHAPER_REPRO: &str = "main>R t t\n  ks=[\"APP_PORT\" \"FOO\"]\n  out=mmap\n  @k ks{\n    pre=slc k 0 4\n    c= =pre \"APP_\"\n    c{out=mset out k k}\n  }\n  ~jdmp out";
+
+#[test]
+fn cond_body_in_foreach_loop_does_not_early_return() {
+    for engine in ENGINES {
+        let out = run(engine, CONFIG_SHAPER_REPRO);
+        assert_eq!(
+            out, "{\"APP_PORT\":\"APP_PORT\"}",
+            "engine={engine}: expected map with one entry, got `{out}`"
+        );
+    }
+}
+
+// --- brk inside a braced guard must still break the loop --------------------
+// The fix swaps OP_RET for value-discard in the VM lowering, but explicit
+// `brk` inside the braced body must still propagate to the enclosing loop.
+// Body prints 0,1,2 then brk; tail `s` reflects partial sum.
+const BRK_IN_BRACED: &str =
+    "f>n\n  s=0\n  @i 0..10{\n    >=i 3{brk}\n    prnt i\n    s=+s i\n  }\n  s";
+
+#[test]
+fn brk_in_braced_guard_still_breaks_loop() {
+    for engine in ENGINES {
+        let out = run(engine, BRK_IN_BRACED);
+        assert_eq!(
+            out, "0\n1\n2\n3",
+            "engine={engine}: expected `0\\n1\\n2\\n3`, got `{out}`"
+        );
+    }
+}
+
+// --- cnt inside a braced guard must still continue the loop -----------------
+const CNT_IN_BRACED: &str = "f>n\n  s=0\n  @i 0..5{\n    =i 2{cnt}\n    s=+s i\n  }\n  s";
+
+#[test]
+fn cnt_in_braced_guard_still_continues_loop() {
+    for engine in ENGINES {
+        let out = run(engine, CNT_IN_BRACED);
+        // 0+1+3+4 = 8 (i=2 skipped)
+        assert_eq!(out, "8", "engine={engine}: expected `8`, got `{out}`");
+    }
+}
+
+// --- explicit ret inside a braced guard still early-returns -----------------
+const RET_IN_BRACED: &str = "f x:n>n\n  >x 0{ret 99}\n  +x 1";
+
+#[test]
+fn ret_in_braced_guard_still_early_returns() {
+    for engine in ENGINES {
+        // x=5: ret 99 fires
+        let out = run(engine, &format!("{RET_IN_BRACED}\nmain>n\n  f 5"));
+        assert_eq!(out, "99", "engine={engine}: x=5 expected 99, got `{out}`");
+        // x=-3: guard false, falls through to +x 1 = -2
+        let out2 = run(engine, &format!("{RET_IN_BRACED}\nmain>n\n  f -3"));
+        assert_eq!(
+            out2, "-2",
+            "engine={engine}: x=-3 expected -2, got `{out2}`"
+        );
+    }
+}
+
+// --- braced guard outside a loop discards body value, falls through ---------
+const DISCARD_OUTSIDE_LOOP: &str = "f x:n>n;>x 0{99};+x 1";
+
+#[test]
+fn braced_guard_outside_loop_discards_body_value() {
+    for engine in ENGINES {
+        // x=5: guard true, body 99 evaluated and discarded, +5 1 = 6
+        let out = run(engine, &format!("{DISCARD_OUTSIDE_LOOP}\nmain>n\n  f 5"));
+        assert_eq!(out, "6", "engine={engine}: expected 6, got `{out}`");
+        // x=-3: guard false, +x 1 = -2
+        let out2 = run(engine, &format!("{DISCARD_OUTSIDE_LOOP}\nmain>n\n  f -3"));
+        assert_eq!(out2, "-2", "engine={engine}: expected -2, got `{out2}`");
+    }
+}
+
+// --- braceless form keeps early-return -------------------------------------
+const BRACELESS_EARLY_RETURN: &str = "f x:n>n;>x 0 99;+x 1";
+
+#[test]
+fn braceless_guard_still_early_returns() {
+    for engine in ENGINES {
+        let out = run(engine, &format!("{BRACELESS_EARLY_RETURN}\nmain>n\n  f 5"));
+        assert_eq!(out, "99", "engine={engine}: expected 99, got `{out}`");
+        let out2 = run(engine, &format!("{BRACELESS_EARLY_RETURN}\nmain>n\n  f -3"));
+        assert_eq!(out2, "-2", "engine={engine}: expected -2, got `{out2}`");
+    }
+}

--- a/tests/regression_loop_print.rs
+++ b/tests/regression_loop_print.rs
@@ -111,7 +111,7 @@ const EMPTY_LOOP: &str = "f>n;xs=[];@x xs{prnt x}";
 //    Function ends with the loop so the loop tail bubbles up. Suppressed.
 //    Body ends with `prnt s` so the loop's value type is `n` (typechecker
 //    requires the tail to resolve to the declared return type).
-const BRK_LOOP: &str = "f>n;s=0;@i 0..10{>=i 3{brk}{nil};s=+s i;prnt s}";
+const BRK_LOOP: &str = "f>n;s=0;@i 0..10{>=i 3{brk};s=+s i;prnt s}";
 
 // 5. While loop at top level. Body ends with `prnt i` for the same type
 //    reason as BRK_LOOP — the loop's value must type-check as `n`.


### PR DESCRIPTION
## Why

Two persona reruns flagged the same trap within one day:

* **config-shaper rerun10** — `c{out=mset out k k}` inside `@k ks` silently early-returned nil from main, no diagnostic.
* **bioinformatics rerun10** — `>i 2{k=+k 10}` inside `@i 0..5` silently early-returned nil from main, no diagnostic.

Root cause: commit fd68993 ("feat: unify braced and braceless guards — option A") on 2026-05-18 made `cond{body}` early-return identically to `cond body`. SPEC.md and ai.txt never moved with the code — both still describe `cond{body}` as conditional execution with no early return, and SPEC.md even advertises `@x xs{>x m{m=x}}` as the canonical find-max idiom. The contract was broken; the personas were reading the spec; the runtime silently disagreed.

Three manifesto principles support reverting the unification rather than re-papering the docs:

1. **Token-conservative.** The loop idiom `>i 3{k=+k 10}` saves around 6 tokens per guard versus the ternary workaround `?(>i 3){k=+k 10}{nil}`. Unification effectively banned the shorter form by making it silently broken in loops. Split semantics restores the token-conservative path.
2. **Constrained.** "One way to do things" is satisfied by *two forms with distinct rules*, not *one form with surprising semantics*. `cond body` does early-return; `cond{body}` does conditional execution. Each form has one job. Unification collapsed the surface but introduced a runtime trap, which is compression at the cost of clarity.
3. **Language-agnostic.** Braces = block evaluation in Python, JavaScript, Rust, Go, C, Java — every C-family language. Cross-trained agents read `>i 3{k=+k 10}` as "if i>3, mutate k" because that is what braces mean everywhere. Unification broke the language-agnostic reading by making braces semantically inert. Split semantics restores universal cross-language reading.

The unification's footgun (a single-stmt braced body containing `^"err"` or `~v` discards its value) is lint-catchable at parse time. The unification's runtime trap (silent early-return from inside a loop) was by construction silent and burned the whole function. Trap the discard footgun via a hint; keep the in-loop ergonomics.

## Repro

Before this PR (on `main`, ilo 0.12.0):

```
$ cat /tmp/cond-loop.ilo
main>R n t
  k=0
  @i 0..5{
    >i 2{k=+k 10}
    k=+k 1
  }
  prnt fmt "k={}" k
  ~0

$ ./target/release/ilo /tmp/cond-loop.ilo
nil
```

After this PR:

```
$ ./target/release/ilo /tmp/cond-loop.ilo
k=25
0
```

Same shape across tree, VM, Cranelift JIT, and AOT.

## What is in the diff

Six logical commits, smallest to largest:

1. **interpreter** — tree-walker: braced guard returns `BodyResult::Value(v)`, only braceless returns `Return(v)`. Three unit tests reshaped (`interpret_braced_guard_no_early_return`, `..._in_loop_no_early_return`).
2. **vm** — VM compiler: braced guard initialises a result_reg to Nil, compiles the body, moves the body tail into result_reg, patches the condition-false jump past the block. No OP_RET. Cranelift JIT + AOT consume the same opcodes so the fix lifts automatically. Two VM unit tests reshaped.
3. **main** — `stmt_has_early_return` treats only braceless guards as early-return paths so loop-tail print suppression stops over-suppressing. `BRK_LOOP` regression fixture and `braceless_guard_early_return_vs_braced_conditional` integration test restored to the canonical shape.
4. **codegen/verify** — drop the "(braced or braceless — unified)" wording from Python codegen and the ILO-T027 verifier comment. No behavioural change.
5. **tests + example** — `tests/regression_cond_body_in_loop.rs` (7 cross-engine cases: both persona repros, brk/cnt/ret inside braced, braced outside loop discard, braceless still early-returns). `examples/cond-body-in-loop.ilo` exercises the bioinformatics + config-shaper repros under `-- run` + `-- out` assertions so the engine harness covers the contract on every backend.
6. **examples** — restore `cond-vs-ret.ilo`, `string-large-at.ilo`, `multiline-body-spans.ilo` to their pre-unification shape. All three got rewritten by fd68993; without the revert they no longer demonstrate what they were written to demonstrate.

The discarded-guard-result hint (`cond{^"err"}` / `cond{~v}` discards the body expression — use the braceless form or `{ret ^"err"}`) also comes back via `walk_for_discarded_guard_result`, lint-catching the fd68993-era footgun without trapping the agent at runtime.

## Test plan

- [x] `cargo test --release --features cranelift` — 3195 lib tests + every integration test green (was 11 failing pre-fix under unified semantics).
- [x] New regression test `regression_cond_body_in_loop.rs` — 7 cross-engine assertions (tree, VM, JIT) covering bioinformatics + config-shaper repros, brk / cnt / ret inside braced bodies, braced-outside-loop fall-through, and braceless still early-returns.
- [x] `tests/examples_engines.rs` exercises `examples/cond-body-in-loop.ilo` across every engine.
- [x] AOT smoke: `ilo build /tmp/cond-loop.ilo -o /tmp/cond-aot && /tmp/cond-aot` prints `k=25\n0`.
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --release --features cranelift --tests -- -D warnings` clean.

## Doc-sync

SPEC.md and ai.txt already document `cond{body}` as conditional execution with no early return; this PR brings the runtime back into line. No doc edits needed. The discarded-guard-result hint that fd68993 retired is now back via `walk_for_discarded_guard_result` so the lint surface is preserved.

## Follow-ups

- Tag 0.12.1 with this fix.
- Watch the next persona round; if anyone hits the `cond{^"err"}` discard shape, the restored hint should fire and steer them to `cond ^"err"` / `cond{ret ^"err"}` before they retry blindly.