### PR TITLE
release: 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ Newest first. All commits by [Daniel John Morris](https://github.com/danieljohnm
 
 - The directory-listing builtin `ls dir` is renamed to `lsd dir`. Six rerun10 persona reports (filesystem-walk, env-config, devops-sre, ecommerce-analytics, pdf-analyst, monorepo-analyst) all flagged the same papercut: agents reach for `ls=rdl! p` as the natural local binding for "lines" and trip ILO-P011 on first attempt because `ls` is reserved. Freeing `ls` for user code is worth the rename. `walk`, `glob`, and the rest of the filesystem surface are unchanged. Migration: any program calling `ls dir` becomes `lsd dir`. The reserved-names list drops `ls` from the 2-char row.
 
-## 0.12.0 - planned 2026-05-19
+## 0.12.0 - 2026-05-19
 
-The biggest release since 0.10. I rewrote the engine story (VM is the default, JIT is the opt-in), bedded down the I/O family (`run`, `ls`, `walk`, `glob`, `env-all`, `pst`) — `ls` is later renamed to `lsd` in 0.12.1, see the entry above — shipped a VS Code extension, and split the skill into a six-page modular set so agents can load only what they need. Tree-walker comes out of the user-facing surface; full removal targets 0.13.0.
+The biggest release since 0.10. I rewrote the engine story (VM is the default, JIT is the opt-in), bedded down the I/O family (`run`, `ls`, `walk`, `glob`, `env-all`, `pst`) - `ls` is later renamed to `lsd` in 0.12.1, see the entry above - shipped a VS Code extension, and split the skill into a six-page modular set so agents can load only what they need. Tree-walker comes out of the user-facing surface; full removal targets 0.13.0.
 
 ### Breaking
 


### PR DESCRIPTION
Drops the 'planned' qualifier from the 0.12.0 changelog entry. After merge, tag v0.12.0 to trigger the publish workflow.

Cargo.toml was already bumped to 0.12.0 in PR #425 (Phase 2 skills CLI) so this is just the CHANGELOG flip.