### PR TITLE
fix: release workflow needs skills/ in sparse-checkout + WASM cfg gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
             SPEC.md
             Cargo.toml
             Cargo.lock
+            skills
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -81,6 +82,7 @@ jobs:
             SPEC.md
             Cargo.toml
             Cargo.lock
+            skills
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -6037,6 +6037,7 @@ pub(crate) fn jit_arena_reset() {
 #[cfg(feature = "cranelift")]
 pub(crate) type JitRuntimeErrorPayload = (VmError, Option<crate::ast::Span>, Vec<String>);
 
+#[cfg(feature = "cranelift")]
 thread_local! {
     // JIT helpers raise errors but do not unwind native frames — the
     // pop_call_frame emitted after each direct OP_CALL still fires on


### PR DESCRIPTION
v0.12.0 publish workflow (#37) failed with two issues:

1. **Linux/macOS/Windows builds** fail at compile because PR #425 (Phase 2 skills CLI) added `include_str!("../skills/ilo/ilo-*.md")` but the release workflow uses sparse-checkout that excludes `skills/`. Fix: add `skills` to the sparse-checkout list in both build jobs.

2. **WASM build** fails with `cannot find type JitRuntimeErrorPayload`. The type alias is cfg-gated to `feature="cranelift"` but the `JIT_RUNTIME_ERROR` thread_local that uses it is unconditional. Fix: cfg-gate the thread_local block too.

After merge, retag v0.12.0 (delete the existing broken tag, re-tag the fixed commit) to re-trigger the publish workflow.

## Test plan
- [ ] CI green on this PR
- [ ] After merge + retag, release workflow #38 succeeds and publishes 0.12.0 to crates.io + npm