### PR TITLE
ILO-T006 on lst: suggest at xs -1 for last-element misreads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 - `rand` alias for `rnd` (universal short-form for random; matches C/Python/Rust/Go/JS naming). Resolves to canonical `rnd` after parsing; rejected as binding or user-fn name via ILO-P011 to prevent silent shadow mis-dispatch. `random` continues to resolve to `rnd` as before.
 
+### Diagnostics
+
+- ILO-T006 on `lst` (and its `lset` alias) now carries a suggestion clarifying that `lst xs i v` is "list set at index" (3 args, returns a new list with index `i` replaced by `v`), not "last element". The 1-arg case (`lst xs`) points at the canonical `at xs -1` for last-element intent; other arities point at the 3-arg signature without misreading the call as a last-element attempt. Surfaced by git-workflow rerun11 - agents reached for `lst xs` and hit an empty-suggestion arity error.
+
 ### Fixed
 
 - `walk dir` and `glob dir pat` now skip unreadable subdirectories (most commonly `chmod 000` or sandbox roots) instead of aborting the entire traversal. Previously the first permission-denied subdir would poison the whole walk and lose every readable path that had already been collected, breaking realistic uses like `walk /` or `walk ~/`. An unreadable root still returns Err so the agent can distinguish "starting point unreadable" from "descendant unreadable". Surfaced by filesystem-walk rerun11.

--- a/examples/lst-vs-at.ilo
+++ b/examples/lst-vs-at.ilo
@@ -1,0 +1,17 @@
+-- `lst xs i v` is "list set at index" (3 args, returns updated list).
+-- It is NOT "last element". Agents often misread the name and reach for
+-- `lst xs`, hitting an arity error. The canonical "last element" is
+-- `at xs -1`, which mirrors Python-style negative indexing.
+
+-- Wrong: `lst xs` would error with ILO-T006 + suggestion pointing here.
+-- Right (last element):
+last xs:L n>n;at xs -1
+
+-- Right (set index i to v): replace index 1 with 99.
+setone xs:L n>L n;lst xs 1 99
+
+-- run: last [10,20,30]
+-- out: 30
+
+-- run: setone [10,20,30]
+-- out: [10, 99, 30]

--- a/skills/ilo/ilo-builtins.md
+++ b/skills/ilo/ilo-builtins.md
@@ -17,7 +17,7 @@ Prefix-call syntax: `name arg1 arg2 ...`. All builtins work cross-engine unless 
 
 ## List
 
-`len hd tl at lst take drop slc`; `rev srt rsrt unq uniqby flat grp zip enumerate range`; `chunks window flatmap partition`; `setunion setinter setdiff`. `at xs i` floors floats; negative indexes from end (same for `slc take drop`). Bounds clamp.
+`len hd tl at lst take drop slc`; `rev srt rsrt unq uniqby flat grp zip enumerate range`; `chunks window flatmap partition`; `setunion setinter setdiff`. `at xs i` floors floats; negative indexes from end (same for `slc take drop`). Bounds clamp. `lst xs i v` is **list set at index** (3 args: returns a new list with index `i` replaced by `v`; alias `lset`) - it is NOT "last element". For the last element use `at xs -1`.
 
 ## HOFs
 

--- a/skills/ilo/ilo-builtins.md
+++ b/skills/ilo/ilo-builtins.md
@@ -17,11 +17,11 @@ Prefix-call syntax: `name arg1 arg2 ...`. All builtins work cross-engine unless 
 
 ## List
 
-`len hd tl at lst take drop slc`; `rev srt rsrt unq uniqby flat grp zip enumerate range`; `chunks window flatmap partition`; `setunion setinter setdiff`. `at xs i` floors floats; negative indexes from end (same for `slc take drop`). Bounds clamp. `lst xs i v` is **list set at index** (3 args: returns a new list with index `i` replaced by `v`; alias `lset`) - it is NOT "last element". For the last element use `at xs -1`.
+`len hd tl at lst take drop slc`; `rev srt rsrt unq uniqby flat grp zip enumerate range`; `chunks window flatmap partition`; `setunion setinter setdiff`. `at xs i` floors floats; negative indexes from end (same for `slc take drop`). Bounds clamp. `lst xs i v` = set index (alias `lset`); last element = `at xs -1`.
 
 ## HOFs
 
-`map f xs`, `flt f xs` (filter), `ct f xs` (count), `fld f xs init` (reduce). Inline lambdas: `map (x:n>n;+x 1) xs`.
+`map f xs`, `flt f xs`, `ct f xs`, `fld f xs init`. Inline lambdas: `map (x:n>n;+x 1) xs`.
 
 ## Map
 
@@ -52,5 +52,4 @@ mmap mset mget mhas mdel mkeys mvals
 ```
 xs >> flt pos >> map sq >> sum
 r=get! url; name=jpth! r "name"
-ls=rdl! "input.txt"
 ```

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -3547,6 +3547,29 @@ impl VerifyContext {
                         } else {
                             expected_arity.to_string()
                         };
+                        // Callee-specific hint: `lst`/`lset` is "list set at
+                        // index" (3 args). Agents reaching for it with a single
+                        // arg usually misread the name as "last element" — the
+                        // canonical form for that is `at xs -1`. For other
+                        // wrong arities, point at the correct 3-arg signature
+                        // without the "last element" misread.
+                        let hint = if callee == "lst" {
+                            if args.len() == 1 {
+                                Some(
+                                    "`lst xs i v` updates index i; \
+                                     for \"last element\" use `at xs -1`"
+                                        .to_string(),
+                                )
+                            } else {
+                                Some(
+                                    "`lst xs i v` returns a new list with \
+                                     index i replaced by v"
+                                        .to_string(),
+                                )
+                            }
+                        } else {
+                            None
+                        };
                         self.err(
                             "ILO-T006",
                             func,
@@ -3554,7 +3577,7 @@ impl VerifyContext {
                                 "arity mismatch: '{callee}' expects {arity_desc} args, got {}",
                                 args.len()
                             ),
-                            None,
+                            hint,
                             Some(span),
                         );
                         return Ty::Unknown;

--- a/tests/regression_ilo_t006_lst_suggestion.rs
+++ b/tests/regression_ilo_t006_lst_suggestion.rs
@@ -1,0 +1,114 @@
+// Regression: ILO-T006 on `lst` carries a suggestion clarifying that
+// `lst xs i v` is "list set at index" (3 args), not "last element". Agents
+// frequently misread the name and reach for `lst xs` — the diagnostic now
+// points them at the canonical `at xs -1` for "last element" and at the
+// 3-arg signature for any other arity mismatch.
+//
+// git-workflow rerun11 surfaced this: the empty-suggestion ILO-T006 cost
+// agents extra retries because there was no name-aware hint.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_err_json(src: &str) -> String {
+    let out = ilo()
+        .args([src, "--json"])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "expected failure for {src:?}, stdout: {}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+    // JSON diagnostics go to stderr; merge both for robust assertions.
+    let mut combined = String::from_utf8_lossy(&out.stderr).into_owned();
+    combined.push('\n');
+    combined.push_str(&String::from_utf8_lossy(&out.stdout));
+    combined
+}
+
+#[test]
+fn lst_one_arg_suggests_at_for_last_element() {
+    let out = run_err_json("foo xs:L n>L n;lst xs");
+    assert!(out.contains("ILO-T006"), "missing ILO-T006: {out}");
+    assert!(
+        out.contains("arity mismatch: 'lst' expects 3 args, got 1"),
+        "missing arity message: {out}"
+    );
+    assert!(
+        out.contains("for \\\"last element\\\" use `at xs -1`")
+            || out.contains("for \"last element\" use `at xs -1`"),
+        "missing last-element suggestion: {out}"
+    );
+    assert!(
+        out.contains("`lst xs i v` updates index i"),
+        "missing canonical 3-arg form in suggestion: {out}"
+    );
+}
+
+#[test]
+fn lst_two_args_suggests_canonical_form_without_last_misread() {
+    let out = run_err_json("foo xs:L n>L n;lst xs 0");
+    assert!(out.contains("ILO-T006"), "missing ILO-T006: {out}");
+    assert!(
+        out.contains("arity mismatch: 'lst' expects 3 args, got 2"),
+        "missing arity message: {out}"
+    );
+    assert!(
+        out.contains("`lst xs i v` returns a new list with index i replaced by v"),
+        "missing 3-arg signature suggestion: {out}"
+    );
+    // Critical: do NOT misread `lst xs i` as "last element" intent.
+    assert!(
+        !out.contains("last element"),
+        "2-arg form should not mention last element: {out}"
+    );
+}
+
+#[test]
+fn lst_four_args_suggests_canonical_form_without_last_misread() {
+    let out = run_err_json("foo xs:L n>L n;lst xs 0 1 2");
+    assert!(out.contains("ILO-T006"), "missing ILO-T006: {out}");
+    assert!(
+        out.contains("arity mismatch: 'lst' expects 3 args, got 4"),
+        "missing arity message: {out}"
+    );
+    assert!(
+        out.contains("`lst xs i v` returns a new list with index i replaced by v"),
+        "missing 3-arg signature suggestion: {out}"
+    );
+    assert!(
+        !out.contains("last element"),
+        "4-arg form should not mention last element: {out}"
+    );
+}
+
+#[test]
+fn other_builtin_arity_errors_do_not_get_lst_hint() {
+    // Sanity: arity errors on a different builtin must not pick up the
+    // lst-specific suggestion.
+    let out = run_err_json("foo xs:L n>n;hd xs 1 2");
+    assert!(out.contains("ILO-T006"), "missing ILO-T006: {out}");
+    assert!(
+        !out.contains("`lst xs i v`") && !out.contains("last element"),
+        "lst hint leaked to other builtin: {out}"
+    );
+}
+
+#[test]
+fn lst_suggestion_is_exposed_as_json_suggestion_field() {
+    // Pin the diagnostic JSON shape: the suggestion lives under the
+    // top-level "suggestion" key, alongside code/message/severity.
+    let out = run_err_json("foo xs:L n>L n;lst xs");
+    assert!(
+        out.contains("\"suggestion\":\""),
+        "suggestion field missing from JSON: {out}"
+    );
+    assert!(
+        out.contains("\"code\":\"ILO-T006\""),
+        "expected ILO-T006 code: {out}"
+    );
+}


### PR DESCRIPTION
## Summary

git-workflow rerun11 caught an agent reaching for `lst xs` expecting "last element of `xs`", hitting `ILO-T006 arity mismatch: 'lst' expects 3 args, got 1` with an empty suggestion field. The canonical "last element" in ilo is `at xs -1`; `lst xs i v` is "list set at index" (alias `lset`). Without a name-aware hint the agent has to round-trip through docs to find the right shape, costing tokens and retries on the manifesto's bread-and-butter list ops.

This PR attaches a callee-specific suggestion on `ILO-T006` when the offending builtin is `lst`:

- 1 arg (`lst xs`): suggestion points at `at xs -1` for last-element intent, plus the 3-arg `lst xs i v` form.
- Other arities (2, 4, ...): suggestion points at the 3-arg signature without misreading the call as last-element. Agents in those positions usually know they want "set at index" and just had the wrong arity.

Manifesto framing: a name-aware suggestion turns a multi-turn "what does `lst` mean?" doc-dive into a single retry. The arity-error path already had a `hint` slot; this PR just fills it for the one builtin where the name shape is non-obvious.

## Repro

```
$ ilo 'foo xs:L n>L n;lst xs' --json
```

Before:
```json
{"code":"ILO-T006","message":"arity mismatch: 'lst' expects 3 args, got 1","severity":"error"}
```

After:
```json
{"code":"ILO-T006","message":"arity mismatch: 'lst' expects 3 args, got 1","severity":"error","suggestion":"`lst xs i v` updates index i; for \"last element\" use `at xs -1`"}
```

## What's in the diff

1. **`verify: name-aware suggestion on ILO-T006 for lst`** - `src/verify.rs` builds a `hint` for `lst` arity errors at the existing arity-check site (~L3550). 1-arg case carries the `at xs -1` pointer; other arities carry the 3-arg signature with no last-element mention. `lset` is resolved to `lst` before verify runs, so the single `callee == "lst"` branch covers both.
2. **`tests: cross-arity regression coverage for the lst suggestion`** - Five cases in `tests/regression_ilo_t006_lst_suggestion.rs`: 1-arg attaches the `at xs -1` pointer, 2-arg and 4-arg attach the canonical 3-arg signature without mentioning "last element", a sanity case confirms other-builtin arity errors don't pick up the `lst` hint, and a JSON-shape case pins the suggestion under the top-level `suggestion` key. `examples/lst-vs-at.ilo` doubles as an in-context learning example exercised by the `examples_engines` harness on every engine.
3. **`docs: clarify lst is list-set-at-index, log in CHANGELOG`** - `skills/ilo/ilo-builtins.md` spells out that `lst xs i v` is list set at index (not last element) and points at `at xs -1`. CHANGELOG gets a 0.12.1 Diagnostics entry.

## Test plan

- [x] `cargo test --release --features cranelift` - full suite green (518 passed, 0 failed across 40 test binaries).
- [x] New `regression_ilo_t006_lst_suggestion` - 5 / 5 pass.
- [x] `examples/lst-vs-at.ilo` runs on `--run-vm` for both entry fns.
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --release --features cranelift --tests -- -D warnings` clean.

## Follow-ups

- Proposed new persona: **list-builtin-discovery** - a corpus that exercises every list builtin where the name shape is non-obvious (`lst` / `lset`, `slc` vs `take`/`drop`, `at` vs `hd`, `flat` vs `flatmap`, `ct` vs `len (flt ...)`). git-workflow rerun11 caught `lst` once; the broader question is which other list builtins lose the same lookup race against agent priors. Worth a dedicated rerun so any remaining same-shape gaps surface before 0.12.1 ships.
- The arity-check `else` branch in `src/verify.rs` is still callee-by-callee `if`-cascades for the multi-arity builtins. Tidying those into a small per-builtin metadata struct would let future "callee X needs a hint" entries become data-driven. Not load-bearing for this fix; flagging for a future refactor pass.