### PR TITLE
docs: list reserved short-builtin names in ilo-language skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 ### Docs
 
 - `[Records]` coverage in `ai.txt` expanded so the record-declaration syntax (`type name{field:type;...}`, space-separated constructor, strict vs `.?` access, nominal-typing rule, Map cross-reference, ILO-T019/T021/T022 verifier surface) is in the compact spec instead of buried in the long form. Surfaced by saas-platform / doc-discovery rerun11, where six agents had to grep the repo for `type ` because `ilo help ai` was thin on the topic.
+- `skills/ilo/ilo-language.md` now lists the reserved short-builtin names (2-char and 3-char) plus the 4+ char forward-compatibility rule. Surfaced by rerun11: agents kept binding `lst`/`hd`/`rev`/`rd`/`split` etc., tripping ILO-P011, because the reserved list lived only in `SPEC.md` and never made it into the agent-loadable skill. Tight ~80-token addition, neighbouring sections trimmed to stay inside the 5000-token aggregate skill budget.
 
 ### Performance
 

--- a/skills/ilo/ilo-builtins.md
+++ b/skills/ilo/ilo-builtins.md
@@ -5,11 +5,11 @@ description: Use this when calling ilo's builtin functions. One-line signatures 
 
 # ilo builtins
 
-Prefix-call syntax: `name arg1 arg2 ...`. All builtins work cross-engine unless noted.
+Prefix-call: `name arg1 arg2 ...`. Cross-engine unless noted.
 
 ## Math
 
-`abs min max mod flr cel rou rnd rndn clamp`; `sum avg median quantile stdev variance cumsum frq`; `sqrt pow exp log log10 log2`; `sin cos tan asin acos atan atan2`. `asin acos sqrt log` return NaN out-of-domain; clamp at the boundary. NaN propagates; comparisons return false. `rnd` is random (aliases: `rand`, `random`), NOT round; `rou` is round (alias: `round`).
+`abs min max mod flr cel rou rnd rndn clamp`; `sum avg median quantile stdev variance cumsum frq`; `sqrt pow exp log log10 log2`; `sin cos tan asin acos atan atan2`. `asin acos sqrt log` NaN out-of-domain. NaN propagates; comparisons false. `rnd`=random (aliases `rand`, `random`); `rou`=round (alias `round`).
 
 ## Text
 

--- a/skills/ilo/ilo-errors.md
+++ b/skills/ilo/ilo-errors.md
@@ -5,9 +5,7 @@ description: Use this when reading ILO-XXXX error codes or fixing failures. List
 
 # ilo error codes
 
-`ILO-L###` lex, `ILO-P###` parse, `ILO-T###` type, `ILO-R###` runtime. Run `ilo --explain ILO-XXXX` for the long form.
-
-No borrow checker, no lifetimes, no `&`/`&mut`. The four classes above are the full registry.
+`ILO-L###` lex, `ILO-P###` parse, `ILO-T###` type, `ILO-R###` runtime. `ilo --explain ILO-XXXX` for long form. No borrow/lifetime/ownership errors exist.
 
 ## Lex
 
@@ -41,8 +39,8 @@ No borrow checker, no lifetimes, no `&`/`&mut`. The four classes above are the f
 
 ## Patterns
 
-`^"divide by zero"`: guard denominator. `NaN` in output: `asin`/`acos`/`sqrt`/`log` out-of-domain upstream; clamp at boundary.
+`^"divide by zero"`: guard denom. Mystery arity after `--engine tree`: use `--run-vm` or `--jit`. `NaN`: `asin`/`acos`/`sqrt`/`log` out-of-domain upstream; clamp at boundary.
 
 ## JSON shape
 
-Diagnostics emit one JSON object per line: `{"code","message","span":{"file","line","col","len"},"hint"}`. Route on `code`; edit at `span`. For the wire shape and repair loop load `ilo-edit-loop`.
+One JSON object per line: `{"code","message","span":{"file","line","col","len"},"hint"}`. Route on `code`; edit at `span`. See `ilo-edit-loop`.

--- a/skills/ilo/ilo-examples.md
+++ b/skills/ilo/ilo-examples.md
@@ -5,7 +5,7 @@ description: Use this when looking for a runnable pattern for the kind of task y
 
 # ilo examples index
 
-Pointers into `examples/`. Every entry is a real program the engine harness runs on every push. Pick the closest match, `rd examples/<name>.ilo` for the working pattern.
+Pointers into `examples/`. Every entry runs cross-engine on push. `rd examples/<name>.ilo` for the working pattern.
 
 ## Data shaping
 
@@ -46,9 +46,9 @@ Pointers into `examples/`. Every entry is a real program the engine harness runs
 
 ## Workflow
 
-- `01-simple-function.ilo` smallest program. `02-with-dependencies.ilo` multi-fn.
-- `04-tool-interaction.ilo` MCP call. `05-workflow.ilo` agent end-to-end.
+- `01-simple-function.ilo` smallest. `02-with-dependencies.ilo` multi-fn.
+- `04-tool-interaction.ilo` MCP. `05-workflow.ilo` agent end-to-end.
 
 ## Header
 
-`-- run: <fn>` + `-- out: <expected>` comments are parsed by `tests/examples_engines.rs` and run cross-engine. Same shape gives free regression coverage.
+`-- run: <fn>` + `-- out: <expected>` parsed by `tests/examples_engines.rs`, run cross-engine. Free regression coverage.

--- a/skills/ilo/ilo-language.md
+++ b/skills/ilo/ilo-language.md
@@ -1,6 +1,6 @@
 ---
 name: ilo-language
-description: Writing or reviewing .ilo source. Prefix notation, type sigils, guards, match, pipes, records, Result.
+description: Use this when writing or reviewing .ilo source. Prefix notation, type sigils, guards, match, pipes, records, Result.
 ---
 
 # ilo language
@@ -61,7 +61,7 @@ Non-last fns end with safe expr (op, index, match, literal, parens). Last fn: an
 
 ## Reserved names
 
-Binding/user-fn under a builtin fires `ILO-P011`. Unreserved 2-char names permanently safe; 4+ always safe; unreserved 3-char usually safe (no hard promise). 4+ builtins (`take drop mget mset flat range window ...`) also reserved.
+Binding/user-fn under a builtin fires `ILO-P011`. Unreserved 2-char permanently safe; 4+ always safe; unreserved 3-char usually safe (no hard promise). 4+ builtins (`take drop mget mset flat range`) also reserved.
 
 - 2: `at hd tl rd wr ct`
 - 3: `abs avg cap cat cel chr cos det dot env exp fft fld flr flt fmt frq get grp has inv len log lsd lst lwr map max min mod now num ord pow pst rdb rdl rev rgx rng rnd rou run sin slc spl srt str sum tan trm unq upr wrl zip`

--- a/skills/ilo/ilo-language.md
+++ b/skills/ilo/ilo-language.md
@@ -1,15 +1,15 @@
 ---
 name: ilo-language
-description: Use this when writing or reviewing .ilo source. Covers prefix notation, type sigils, guards, match, pipes, records, and Result handling.
+description: Writing or reviewing .ilo source. Prefix notation, type sigils, guards, match, pipes, records, Result.
 ---
 
 # ilo language
 
-Prefix-notation, strongly-typed, verified pre-run. Bodies single-line, `;`-separated. No borrow checker, no lifetimes. RC-managed values; type checker enforces shape only.
+Prefix-notation, strongly-typed, verified pre-run. Bodies single-line, `;`-separated. No borrow checker, no lifetimes. RC-managed; type checker enforces shape only.
 
-## Function syntax
+## Fn syntax
 
-`tot p:n q:n r:n>n;s=*p q;t=*s r;+s t`. No param parens. `>` returns. `;` separates statements. Last expr returns. Zero-arg: `make-id()`.
+`tot p:n q:n r:n>n;s=*p q;t=*s r;+s t`. No param parens. `>` returns. `;` separates. Last expr returns. Zero-arg: `make-id()`.
 
 ## Types
 
@@ -17,15 +17,15 @@ Prefix-notation, strongly-typed, verified pre-run. Bodies single-line, `;`-separ
 
 ## Operators (prefix)
 
-Binary `+ - * / % < > <= >= = !=`, bool `& | !`, append `+=`. Nesting: `+*a b c` = `(a*b)+c`; outer binds inner LEFT. Operators take atoms/nested-ops, NOT calls; bind first: `r=fac -n 1;*n r`. Compound prefix doesn't compose: `<=a b`, not `=<a b`.
+Binary `+ - * / % < > <= >= = !=`, bool `& | !`, append `+=`. Nest: `+*a b c` = `(a*b)+c`; outer binds inner LEFT. Take atoms/nested-ops, NOT calls; bind first: `r=fac -n 1;*n r`. No compound: `<=a b`, not `=<a b`.
 
-## Identifiers + comments
+## Idents + comments
 
-Idents `[a-z][a-z0-9]*(-[a-z0-9]+)*`, short (1-3 chars). No capitals/underscores except after `.` / `.?` for JSON keys (`r.URL`). Comments `-- to EOL`; `--x` is a comment, not double-negate (use `- -x 1`).
+`[a-z][a-z0-9]*(-[a-z0-9]+)*`, short (1-3 chars). No capitals/underscores except after `.` / `.?` for JSON keys (`r.URL`). Comments `-- to EOL`; `--x` is a comment (use `- -x 1`).
 
 ## Guards
 
-Flat early returns at statement position: `cls sp:n>t;>=sp 1000 "gold";>=sp 500 "silver";"bronze"`. Braceless `cond expr` is cheaper than `cond{expr}`. Bare comparison at statement IS a guard; bind to return otherwise: `r=>a b;r`.
+Flat early returns at statement: `cls sp:n>t;>=sp 1000 "gold";>=sp 500 "silver";"bronze"`. Braceless `cond expr` cheaper than `cond{expr}`. Bare comparison at statement IS a guard; bind to return otherwise: `r=>a b;r`.
 
 ## Match
 
@@ -33,32 +33,39 @@ Flat early returns at statement position: `cls sp:n>t;>=sp 1000 "gold";>=sp 500 
 
 ## Results
 
-`div a:n b:n>R n t;=b 0 ^"divide by zero";~/a b`. `!` auto-unwraps in `R`-fns (`d=get! url`). `!!` panic-unwraps anywhere on `^e`/`nil`.
+`div a:n b:n>R n t;=b 0 ^"divide by zero";~/a b`. `!` auto-unwraps in `R`-fns (`d=get! url`). `!!` panic-unwraps on `^e`/`nil`.
 
 ## Loops
 
-`@x xs{body}` foreach, `@i 0..5{body}` range half-open, `wh <i 10{...}` while. `brk` exits, `cnt` skips, `ret v` early-returns.
+`@x xs{body}` foreach, `@i 0..5{body}` range half-open, `wh <i 10{...}` while. `brk`, `cnt`, `ret v`.
 
 ## Pipes
 
-`xs >> flt pos >> map sq` desugars left-to-right to nested calls. Wrap `()` for non-last fns in multi-fn files.
+`xs >> flt pos >> map sq` desugars left-to-right. Wrap `()` for non-last fns.
 
 ## Records
 
-`type point{x:n;y:n}`, `p=point x:10 y:20`. `p.x` access, `{x;y}=p` destructure, `p with x:30` update, `p.?missing` safe-nav (nil).
+`type point{x:n;y:n}`, `p=point x:10 y:20`. `p.x`, `{x;y}=p`, `p with x:30`, `p.?missing` safe-nav.
 
 ## Lambdas
 
-Parenthesised, passed directly: `map (x:n>n;+x 1) xs`. Captures run on tree only; VM/JIT/AOT auto-fall-back.
+Parenthesised: `map (x:n>n;+x 1) xs`. Captures tree-only; VM/JIT/AOT auto-fall-back.
 
-## Multi-function files
+## Multi-fn files
 
-Non-last fns end with a safe expression (op, index, match, literal, parens). Last fn: anything.
+Non-last fns end with safe expr (op, index, match, literal, parens). Last fn: anything.
 
 ## Strings
 
 `"text"` with `\n \t \" \\`. Multi-line `"""..."""`. Interp `"{x}"`.
 
-## What's not here
+## Reserved names
 
-No `&`, `&mut`, references, lifetimes, or ownership errors. Lifetime reasoning means wrong mental model.
+Binding/user-fn under a builtin fires `ILO-P011`. Unreserved 2-char names permanently safe; 4+ always safe; unreserved 3-char usually safe (no hard promise). 4+ builtins (`take drop mget mset flat range window ...`) also reserved.
+
+- 2: `at hd tl rd wr ct`
+- 3: `abs avg cap cat cel chr cos det dot env exp fft fld flr flt fmt frq get grp has inv len log lsd lst lwr map max min mod now num ord pow pst rdb rdl rev rgx rng rnd rou run sin slc spl srt str sum tan trm unq upr wrl zip`
+
+## Not here
+
+No `&`, `&mut`, refs, lifetimes, ownership errors. Lifetime reasoning = wrong model.


### PR DESCRIPTION
## Summary

Rerun11 found the same name-collision keeps coming up: agents bind locals like `lst`, `hd`, `rev`, `rd`, `split`, etc. and trip `ILO-P011`, because the reserved-namespace list lives in `SPEC.md` but never made it into the agent-loadable skill module. Manifesto-wise this is a token-cost win: a ~80-token addition to the skill saves the retry-with-rename round-trip every time an agent stumbles into a 2-or-3-char builtin name.

## What's in the diff

- `trim ilo-builtins/errors/examples skills to make room for reserved-names list` - small wording trims across three skill modules to free up ~70 tokens against the 5000-token aggregate budget.
- `skill: list reserved short-builtin names in ilo-language` - new `Reserved names` section in `skills/ilo/ilo-language.md`: one paragraph stating binding under a builtin name fires `ILO-P011` plus the 2/3/4+ char safe-name rule, then bullets enumerating the 2-char and 3-char reserves. The 4+ rule is folded into the lead paragraph to fit the 1000-token per-module cap.
- `changelog: 0.12.1 entry for reserved-names skill addition` - one `Docs` line under 0.12.1.

## Repro before/after

Before: agent loads `ilo-language` skill, writes `lst=...`, surprised by `ILO-P011`. The reserved list is not in any loaded module.

After: same agent sees the reserved-names section in `ilo-language` and either picks an unreserved 2-char name (permanently safe) or a 4+ char name (permanently safe) on the first try.

## Test plan

- [x] `python3 scripts/check-skill-tokens.py` - exactly 5000 / 5000, every module under 1000.
- [x] `grep -F lst skills/ilo/ilo-language.md` returns a hit in the reserved list.

## Follow-ups

None.