### PR TITLE
verify: ILO-T013 suggests fmt/+ for string concat (cat is list-concat)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Diagnostics
 
 - ILO-T006 on `lst` (and its `lset` alias) now carries a suggestion clarifying that `lst xs i v` is "list set at index" (3 args, returns a new list with index `i` replaced by `v`), not "last element". The 1-arg case (`lst xs`) points at the canonical `at xs -1` for last-element intent; other arities point at the 3-arg signature without misreading the call as a last-element attempt. Surfaced by git-workflow rerun11 - agents reached for `lst xs` and hit an empty-suggestion arity error.
+- ILO-T013 on `cat "a" "b"` (the string-concat instinct from Python/JS) now suggests `fmt "{}{}" a b` or `+a b` as the canonical text-concat shapes. `cat` is list-concat; the verifier used to flag the type error but leave the user to guess the fix, costing one round-trip on every new-write. Surfaced by scaffold rerun11.
 
 ### Fixed
 

--- a/examples/cat-vs-fmt.ilo
+++ b/examples/cat-vs-fmt.ilo
@@ -1,0 +1,23 @@
+-- `cat` is list-concat, not string-concat. Coming from Python/JS the
+-- instinct is to write `cat "a" "b"` for "ab" - but `cat` expects a
+-- list of strings as its first arg and a separator as its second.
+--
+-- The verifier flags `cat "a" "b"` as ILO-T013 with a suggestion
+-- pointing at the two canonical text-concat shapes: `fmt` for
+-- arbitrary interpolation, and `+` when both operands are text.
+
+-- Idiom 1: `fmt` builds a string from a template and values
+join-fmt>t;fmt "{}{}" "foo" "bar"
+
+-- Idiom 2: `+` on two text values concatenates them
+join-plus>t;+"foo" "bar"
+
+-- Idiom 3: actual list-concat - what `cat` is for
+join-cat>t;cat ["a" "b" "c"] ","
+
+-- run: join-fmt
+-- out: foobar
+-- run: join-plus
+-- out: foobar
+-- run: join-cat
+-- out: a,b,c

--- a/skills/ilo/ilo-errors.md
+++ b/skills/ilo/ilo-errors.md
@@ -28,6 +28,7 @@ No borrow checker, no lifetimes, no `&`/`&mut`. The four classes above are the f
 - **T006 arity mismatch** - add/remove args to match signature.
 - **T007 not a function** - calling a value. Rename or rebind.
 - **T010 non-result error-propagate** - `!` in a non-`R` fn. Declare `>R t t` or use `??` / match.
+- **T013 builtin arg type** - `cat` is list-concat; text uses `fmt`/`+`.
 - **T038 non-bool ternary cond** - `?h c a b` cond must be `b`. Bind first.
 
 ## Runtime

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -707,11 +707,23 @@ fn builtin_check_args(
             if let Some(arg) = arg_types.first()
                 && !compatible(arg, &Ty::List(Box::new(Ty::Text)))
             {
+                // String-concat instinct: user wrote `cat "a" "b"` expecting
+                // string concatenation. `cat` is list-concat; point them at
+                // the canonical text-concat shapes.
+                let hint = if matches!(arg, Ty::Text)
+                    && arg_types.get(1).is_some_and(|a| matches!(a, Ty::Text))
+                {
+                    Some(
+                        "`cat` is list-concat. For text use `fmt \"{}{}\" a b`, or `+a b` if both are text".to_string(),
+                    )
+                } else {
+                    None
+                };
                 errors.push(VerifyError {
                     code: "ILO-T013",
                     function: func_ctx.to_string(),
                     message: format!("'cat' arg 1 expects L t, got {arg}"),
-                    hint: None,
+                    hint,
                     span,
                     is_warning: false,
                 });
@@ -6164,6 +6176,42 @@ mod tests {
             errors
                 .iter()
                 .any(|e| e.message.contains("cat") && e.message.contains("2"))
+        );
+    }
+
+    #[test]
+    fn cat_two_strings_suggests_fmt_or_plus() {
+        // `cat "a" "b"` is the string-concat instinct from Python/JS/etc.
+        // `cat` is list-concat; we should point users at `fmt` or `+`.
+        let result = parse_and_verify(r#"main>t;cat "a" "b""#);
+        let errors = result.unwrap_err();
+        let e = errors
+            .iter()
+            .find(|e| e.code == "ILO-T013" && e.message.contains("cat"))
+            .expect("expected ILO-T013 for cat");
+        let hint = e.hint.as_ref().expect("expected hint suggesting fmt/+");
+        assert!(hint.contains("fmt"), "hint should mention fmt: {hint}");
+        assert!(hint.contains("+"), "hint should mention +: {hint}");
+        assert!(
+            hint.contains("list-concat") || hint.contains("list concat"),
+            "hint should explain cat is list-concat: {hint}"
+        );
+    }
+
+    #[test]
+    fn cat_text_then_list_no_string_concat_hint() {
+        // Only the string-concat instinct (both args text) gets the hint.
+        // Other arg-1 mismatches (e.g. number) should not show fmt/+ hint.
+        let result = parse_and_verify("f x:n>t;cat x \",\"");
+        let errors = result.unwrap_err();
+        let e = errors
+            .iter()
+            .find(|e| e.code == "ILO-T013" && e.message.contains("cat"))
+            .unwrap();
+        assert!(
+            e.hint.is_none(),
+            "non-text arg should not get string-concat hint, got: {:?}",
+            e.hint
         );
     }
 


### PR DESCRIPTION
## Summary

Coming from Python/JS the instinct is to write `cat "a" "b"` for `"ab"`. In ilo, `cat` is list-concat, not string-concat. The first arg must be `L t` and the second a separator.

When the user writes `cat <text> <text>`, ILO-T013 now suggests the two canonical text-concat shapes: `fmt "{}{}" a b` for templates, and `+a b` when both operands are text. That saves a verifier round-trip when an agent is reaching for string-concat by reflex.

## Repro

Before:
```
$ echo 'main>t;cat "a" "b"' | ilo verify -
ILO-T013: 'cat' arg 1 expects L t, got t
```

After:
```
$ echo 'main>t;cat "a" "b"' | ilo verify -
ILO-T013: 'cat' arg 1 expects L t, got t
  hint: `cat` is list-concat. For text use `fmt "{}{}" a b`, or `+a b` if both are text
```

## What's in the diff

- `src/verify.rs` - hint when arg-1 and arg-2 are both `Ty::Text`
- `examples/cat-vs-fmt.ilo` - shows the three canonical shapes (`fmt`, `+`, `cat`) with run/out assertions
- `skills/ilo/ilo-errors.md` - updates ILO-T013 entry
- `CHANGELOG.md`

## Test plan

- [x] `cat_two_strings_suggests_fmt_or_plus` - hint present
- [x] `cat_text_then_list_no_string_concat_hint` - non-text arg gets no hint
- [x] `cargo check --release --features cranelift`
- [x] `cargo fmt --check`
- [x] Token budget under 5000

## Follow-ups

None.