### PR TITLE
parser: ILO-P003 surfaces source chars instead of token-enum names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@
 
 - `mset` accumulator via helper fn no longer pays a ~1000x perf cliff. The canonical DRY refactor `addto m k v > mset m k v` followed by `m = addto m k v` in a loop now runs at the same speed as the inline form. New OP_MOVE_OWN / OP_CALL_OWN1 opcodes thread the first arg into the helper at the caller's RC, and a tail-position rewrite lets the helper's `mset m k v` fire the existing in-place fast path. 40k rows: 25.8s to 0.01s on VM; JIT and AOT linear at 1M rows.
 
+### Diagnostics
+
+- Parser diagnostics (ILO-P001/P003/P004/P005/P007/P009/P011/P013/P016) now render tokens using their source characters (`` `>` ``, `` `{` ``, `` `>>` ``, `` identifier `foo` ``, `` number `42` ``) instead of parser-internal `TokenKind` variant names (`Greater`, `LBrace`, `PipeOp`, `Ident("foo")`, `Number(42.0)`). The old wording `expected Greater, got PipeOp` told an agent nothing about what character it had typed; the new `` expected `>`, got `>>` `` shows the offending bytes directly. Surfaced by agent-repair-loop rerun11.
+
 ## 0.12.0 - 2026-05-19
 
 ### Breaking

--- a/examples/ilo-p003-missing-return-arrow.ilo
+++ b/examples/ilo-p003-missing-return-arrow.ilo
@@ -1,0 +1,37 @@
+-- Shows the canonical fix-up for ILO-P003 "missing return-type marker".
+--
+-- A common slip is to put `>>` (pipe operator), `|` (or), or `:>`
+-- between the parameter list and the return type, where ilo expects a
+-- single `>`. The 0.12.1 diagnostic surfaces the offending character
+-- literally so the next attempt sees what to change:
+--
+--   f x:n>>n;x    ==>   ERROR ILO-P003: expected `>`, got `>>`
+--   f x:n|n;x     ==>   ERROR ILO-P003: expected `>`, got `|`
+--   main:>n;x     ==>   ERROR ILO-P003: unexpected `:>` after `main`
+--
+-- Old wording was `expected Greater, got PipeOp` — the parser's
+-- internal token-kind names leaked into user diagnostics and gave
+-- agents no source-level information to act on.
+--
+-- The functions below are the correct shape after fixing each slip.
+
+-- No-param fn — `name>return;body`, no colon, no extra arrow.
+main>n;42
+
+-- Single-param fn — `name p:t>r;body`, single `>`.
+inc x:n>n;+x 1
+
+-- Multi-param fn — params space-separated.
+add x:n y:n>n;+x y
+
+-- Param of list type — `L n` is "list of n", still `>` for return.
+total xs:L n>n;sum xs
+
+-- run: main
+-- out: 42
+
+-- run: inc 4
+-- out: 5
+
+-- run: add 2 3
+-- out: 5

--- a/src/diagnostic/mod.rs
+++ b/src/diagnostic/mod.rs
@@ -286,7 +286,7 @@ mod tests {
             code: "ILO-P001",
             position: 0,
             span: Span { start: 0, end: 8 },
-            message: "expected declaration, got Ident(\"function\")".to_string(),
+            message: "expected declaration, got identifier `function`".to_string(),
             hint: Some("ilo function syntax: name param:type > return-type; body".to_string()),
         };
         let d = Diagnostic::from(&e);

--- a/src/diagnostic/registry.rs
+++ b/src/diagnostic/registry.rs
@@ -220,7 +220,19 @@ An incomplete function definition is a common cause.
         long: r#"## ILO-P003: unexpected token
 
 A token was found where a different token was expected. The error
-message names the expected and actual tokens.
+message names the expected and actual tokens using their source
+characters (e.g. ``expected `>`, got `|` ``), not the parser's
+internal token-kind names.
+
+**Example:**
+
+    f x:n|n;x
+
+    ERROR ILO-P003: expected `>`, got `|`
+
+The fix is to use `>` between the parameter list and the return type:
+
+    f x:n>n;x
 "#,
     },
     ErrorEntry {

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -181,6 +181,110 @@ pub enum Token {
     Newline,
 }
 
+impl Token {
+    /// Return a user-facing rendering of this token suitable for inclusion
+    /// in diagnostics. Operators and punctuation render as their source
+    /// character(s) wrapped in backticks (e.g. `` `>` `` for `Token::Greater`),
+    /// content-carrying tokens render with their literal payload
+    /// (`` identifier `foo` ``, `` number `42` ``, `` text `"hi"` ``), and
+    /// keyword/type tokens render as the keyword in backticks (`` `if` ``,
+    /// `` `L` ``). The intent is that an agent reading a diagnostic sees the
+    /// same characters they would have typed, not the parser's internal
+    /// `TokenKind` variant name (`Greater`, `PipeOp`, `LBrace` ...).
+    pub fn user_facing_name(&self) -> String {
+        match self {
+            // Keywords
+            Token::Type => "`type`".into(),
+            Token::Tool => "`tool`".into(),
+            Token::Use => "`use`".into(),
+            Token::With => "`with`".into(),
+            Token::Timeout => "`timeout`".into(),
+            Token::Retry => "`retry`".into(),
+
+            // Type constructors
+            Token::ListType => "`L`".into(),
+            Token::ResultType => "`R`".into(),
+            Token::FnType => "`F`".into(),
+            Token::OptType => "`O`".into(),
+            Token::MapType => "`M`".into(),
+            Token::SumType => "`S`".into(),
+
+            // Reserved cross-language keywords
+            Token::KwIf => "`if`".into(),
+            Token::KwReturn => "`return`".into(),
+            Token::KwLet => "`let`".into(),
+            Token::KwFn => "`fn`".into(),
+            Token::KwDef => "`def`".into(),
+            Token::KwVar => "`var`".into(),
+            Token::KwConst => "`const`".into(),
+
+            // Boolean / nil
+            Token::True => "`true`".into(),
+            Token::False => "`false`".into(),
+            Token::Nil => "`nil`".into(),
+
+            // Multi-char operators
+            Token::GreaterEq => "`>=`".into(),
+            Token::LessEq => "`<=`".into(),
+            Token::NotEq => "`!=`".into(),
+            Token::PlusEq => "`+=`".into(),
+            Token::PipeOp => "`>>`".into(),
+            Token::NilCoalesce => "`??`".into(),
+            Token::BangBang => "`!!`".into(),
+
+            // Single-char operators
+            Token::Plus => "`+`".into(),
+            Token::Minus => "`-`".into(),
+            Token::Star => "`*`".into(),
+            Token::Slash => "`/`".into(),
+            Token::Greater => "`>`".into(),
+            Token::Less => "`<`".into(),
+            Token::Eq => "`=`".into(),
+            Token::Amp => "`&`".into(),
+            Token::Pipe => "`|`".into(),
+
+            // Special
+            Token::Question => "`?`".into(),
+            Token::At => "`@`".into(),
+            Token::Bang => "`!`".into(),
+            Token::Caret => "`^`".into(),
+            Token::Tilde => "`~`".into(),
+            Token::Dollar => "`$`".into(),
+
+            // Punctuation
+            Token::Colon => "`:`".into(),
+            Token::Semi => "`;`".into(),
+            Token::DotDot => "`..`".into(),
+            Token::DotQuestion => "`.?`".into(),
+            Token::Dot => "`.`".into(),
+            Token::Comma => "`,`".into(),
+            Token::LBrace => "`{`".into(),
+            Token::RBrace => "`}`".into(),
+            Token::LParen => "`(`".into(),
+            Token::RParen => "`)`".into(),
+            Token::LBracket => "`[`".into(),
+            Token::RBracket => "`]`".into(),
+            Token::Underscore => "`_`".into(),
+
+            // Literals — include the payload so the diagnostic mentions
+            // the actual offending value (`number 42`, `text "hi"`).
+            Token::Number(n) => {
+                if n.fract() == 0.0 && n.is_finite() && n.abs() < 1e16 {
+                    format!("number `{}`", *n as i64)
+                } else {
+                    format!("number `{n}`")
+                }
+            }
+            Token::Text(s) => format!("text `\"{s}\"`"),
+            Token::Ident(name) => format!("identifier `{name}`"),
+
+            // Newline isn't usually surfaced (the normaliser eats them),
+            // but render conservatively if one slips through.
+            Token::Newline => "newline".into(),
+        }
+    }
+}
+
 /// Convert indented newlines to semicolons so multi-line file format works.
 ///
 /// Rules:

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -214,12 +214,19 @@ impl Parser {
                 };
                 let mut err = self.error(
                     "ILO-P003",
-                    format!("expected {:?}, got {:?}", expected, tok),
+                    format!(
+                        "expected {}, got {}",
+                        expected.user_facing_name(),
+                        tok.user_facing_name()
+                    ),
                 );
                 err.hint = hint;
                 Err(err)
             }
-            None => Err(self.error("ILO-P004", format!("expected {:?}, got EOF", expected))),
+            None => Err(self.error(
+                "ILO-P004",
+                format!("expected {}, got end of input", expected.user_facing_name()),
+            )),
         }
     }
 
@@ -233,7 +240,10 @@ impl Parser {
                 if let Some((msg, hint)) = reserved_keyword_message(&tok) {
                     Err(self.error_hint("ILO-P011", msg, hint))
                 } else {
-                    Err(self.error("ILO-P005", format!("expected identifier, got {:?}", tok)))
+                    Err(self.error(
+                        "ILO-P005",
+                        format!("expected identifier, got {}", tok.user_facing_name()),
+                    ))
                 }
             }
             None => Err(self.error("ILO-P006", "expected identifier, got EOF".into())),
@@ -564,7 +574,7 @@ impl Parser {
                 if let Some(hint_msg) = hint {
                     let mut err = self.error(
                         "ILO-P001",
-                        format!("expected declaration, got Ident({ident_str:?})"),
+                        format!("expected declaration, got identifier `{ident_str}`"),
                     );
                     err.hint = Some(hint_msg);
                     return Err(err);
@@ -572,7 +582,7 @@ impl Parser {
                 self.parse_fn_decl()
             }
             Some(tok) => {
-                let msg = format!("expected declaration, got {:?}", tok);
+                let msg = format!("expected declaration, got {}", tok.user_facing_name());
                 let hint = match tok {
                     Token::Plus | Token::Minus | Token::Star | Token::Slash
                     | Token::Greater | Token::Less | Token::GreaterEq | Token::LessEq
@@ -609,7 +619,10 @@ impl Parser {
             Some(tok) => {
                 return Err(self.error(
                     "ILO-P016",
-                    format!("expected a string path after `use`, got {:?}", tok),
+                    format!(
+                        "expected a string path after `use`, got {}",
+                        tok.user_facing_name()
+                    ),
                 ));
             }
             None => {
@@ -1012,7 +1025,10 @@ impl Parser {
                 self.advance();
                 Ok(Type::Named(name))
             }
-            Some(tok) => Err(self.error("ILO-P007", format!("expected type, got {:?}", tok))),
+            Some(tok) => Err(self.error(
+                "ILO-P007",
+                format!("expected type, got {}", tok.user_facing_name()),
+            )),
             None => Err(self.error("ILO-P008", "expected type, got EOF".into())),
         }
     }
@@ -1765,7 +1781,10 @@ impl Parser {
                 };
                 Ok(Pattern::TypeIs { ty, binding })
             }
-            Some(tok) => Err(self.error("ILO-P011", format!("expected pattern, got {:?}", tok))),
+            Some(tok) => Err(self.error(
+                "ILO-P011",
+                format!("expected pattern, got {}", tok.user_facing_name()),
+            )),
             None => Err(self.error("ILO-P012", "expected pattern, got EOF".into())),
         }
     }
@@ -3531,7 +3550,10 @@ results first: `r={first_op}a b;…r` keeps each step explicit."
                 if let Some((msg, hint)) = lambda_keyword_message(&tok) {
                     return Err(self.error_hint("ILO-P009", msg, hint));
                 }
-                Err(self.error("ILO-P009", format!("expected expression, got {:?}", tok)))
+                Err(self.error(
+                    "ILO-P009",
+                    format!("expected expression, got {}", tok.user_facing_name()),
+                ))
             }
             None => Err(ParseError {
                 code: "ILO-P010",
@@ -3700,8 +3722,8 @@ For variable-position list indexing bind the head first: \
             return Err(self.error_hint(
                 "ILO-P003",
                 format!(
-                    "expected `)` to close inline lambda body, got {:?}",
-                    self.peek().unwrap()
+                    "expected `)` to close inline lambda body, got {}",
+                    self.peek().unwrap().user_facing_name()
                 ),
                 "chained calls inside an inline-lambda body need explicit parens: `(a:n x:t>n;+a (kc (body x)))`. The body parses a single prefix call greedily and the trailing idents look like a malformed lambda close.".into(),
             ));
@@ -3996,7 +4018,10 @@ For variable-position list indexing bind the head first: \
                 self.advance();
                 Ok(n)
             }
-            Some(tok) => Err(self.error("ILO-P013", format!("expected number, got {:?}", tok))),
+            Some(tok) => Err(self.error(
+                "ILO-P013",
+                format!("expected number, got {}", tok.user_facing_name()),
+            )),
             None => Err(self.error("ILO-P014", "expected number, got EOF".into())),
         }
     }
@@ -9485,7 +9510,7 @@ mod tests {
         let (_, errors) = parse_str_errors(source);
         let e = errors
             .iter()
-            .find(|e| e.code == "ILO-P003" && e.message.contains("expected LBrace"))
+            .find(|e| e.code == "ILO-P003" && e.message.contains("expected `{`"))
             .expect("expected ILO-P003 LBrace error");
         let hint = e.hint.as_ref().expect("expected hint");
         assert!(
@@ -9516,7 +9541,7 @@ mod tests {
         let (_, errors) = parse_str_errors(source);
         let e = errors
             .iter()
-            .find(|e| e.code == "ILO-P003" && e.message.contains("expected LBrace"))
+            .find(|e| e.code == "ILO-P003" && e.message.contains("expected `{`"))
             .expect("expected ILO-P003 LBrace error");
         let hint = e.hint.as_ref().expect("expected hint");
         assert!(

--- a/tests/regression_dot_keywords.rs
+++ b/tests/regression_dot_keywords.rs
@@ -176,7 +176,10 @@ fn dot_keywords_snake_long_cranelift() {
 fn type_as_binding_still_errors() {
     let err = run_err("f j:t>n;type=5;type");
     assert!(
-        err.contains("reserved") || err.contains("Type") || err.contains("got Type"),
+        err.contains("reserved")
+            || err.contains("Type")
+            || err.contains("got Type")
+            || err.contains("`type`"),
         "expected reserved-word error, got: {err}"
     );
 }
@@ -185,7 +188,10 @@ fn type_as_binding_still_errors() {
 fn if_as_binding_still_errors() {
     let err = run_err("f j:t>n;if=5;if");
     assert!(
-        err.contains("reserved") || err.contains("KwIf") || err.contains("got KwIf"),
+        err.contains("reserved")
+            || err.contains("KwIf")
+            || err.contains("got KwIf")
+            || err.contains("`if`"),
         "expected reserved-word error, got: {err}"
     );
 }

--- a/tests/regression_ilo_p003_token_names.rs
+++ b/tests/regression_ilo_p003_token_names.rs
@@ -1,0 +1,259 @@
+// Regression tests for ILO-P003 (and related P-series) diagnostics that
+// previously surfaced parser-internal `TokenKind` variant names — `Greater`,
+// `PipeOp`, `LBrace`, `RParen`, `Colon`, `Number(...)`, `Ident("...")` — in
+// the message. Agents reading these messages cannot map "PipeOp" or "LBrace"
+// back to a source character without spelunking the parser, so the fix
+// surfaces the actual character(s) (`>`, `>>`, `{`, ...) wrapped in
+// backticks, plus a human label for literals (`number 42`, `identifier foo`).
+//
+// Originating signal: agent-repair-loop rerun11 saw
+// `ILO-P003: expected Greater, got PipeOp` and made three wrong guesses
+// before realising the message was about `>` vs `>>`.
+//
+// The fix adds `Token::user_facing_name()` returning the source-character
+// rendering, and routes every ILO-P003 / P004 / P005 / P007 / P009 / P011 /
+// P013 / P016 / and the P001 "expected declaration, got ..." emit site
+// through it. This regression test pins the new wording for the canonical
+// shapes so a future refactor can't silently regress.
+
+use ilo::ast::{Program, Span};
+use ilo::lexer;
+use ilo::parser::{self, ParseError};
+
+fn parse_str_errors(src: &str) -> (Program, Vec<ParseError>) {
+    let tokens = lexer::lex(src).expect("lex failed");
+    let pairs: Vec<(lexer::Token, Span)> = tokens
+        .into_iter()
+        .map(|(t, r)| {
+            (
+                t,
+                Span {
+                    start: r.start,
+                    end: r.end,
+                },
+            )
+        })
+        .collect();
+    parser::parse(pairs)
+}
+
+/// Internal parser enum names that must never appear in a user-facing
+/// diagnostic. Each is matched as a whole-word so we don't false-positive
+/// on e.g. "Plus" appearing inside a longer identifier the user actually
+/// typed.
+const LEAK_NAMES: &[&str] = &[
+    "Greater",
+    "GreaterEq",
+    "Less",
+    "LessEq",
+    "NotEq",
+    "PlusEq",
+    "PipeOp",
+    "NilCoalesce",
+    "BangBang",
+    "Plus",
+    "Minus",
+    "Star",
+    "Slash",
+    "Amp",
+    "Pipe",
+    "Question",
+    "Bang",
+    "Caret",
+    "Tilde",
+    "Dollar",
+    "Colon",
+    "Semi",
+    "DotDot",
+    "DotQuestion",
+    "Dot",
+    "Comma",
+    "LBrace",
+    "RBrace",
+    "LParen",
+    "RParen",
+    "LBracket",
+    "RBracket",
+    "Underscore",
+    "Number(",
+    "Text(",
+    "Ident(",
+    "ListType",
+    "ResultType",
+    "FnType",
+    "OptType",
+    "MapType",
+    "SumType",
+    "KwIf",
+    "KwReturn",
+    "KwLet",
+    "KwFn",
+    "KwDef",
+    "KwVar",
+    "KwConst",
+    "True",
+    "False",
+    "Nil",
+];
+
+fn assert_no_token_enum_leak(source: &str) {
+    let (_, errors) = parse_str_errors(source);
+    assert!(
+        !errors.is_empty(),
+        "expected at least one parse error for `{source}`"
+    );
+    for e in &errors {
+        for leak in LEAK_NAMES {
+            assert!(
+                !e.message.contains(leak),
+                "ILO-{code} message leaks parser-internal token name `{leak}`: {msg}\nsource: {source}",
+                code = &e.code[4..],
+                msg = e.message,
+            );
+            if let Some(h) = &e.hint {
+                assert!(
+                    !h.contains(leak),
+                    "ILO-{code} hint leaks parser-internal token name `{leak}`: {h}\nsource: {source}",
+                    code = &e.code[4..],
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn p003_pipe_op_in_return_type_position() {
+    // The originating bug: `f x:n>>n;x` — agent typed `>>` (pipe) instead of
+    // `>` (return-type separator). Old wording was
+    // `expected Greater, got PipeOp`, which mentions neither character.
+    // New wording must mention `>` and `>>`.
+    let (_, errors) = parse_str_errors("f x:n>>n;x");
+    let e = errors
+        .iter()
+        .find(|e| e.code == "ILO-P003")
+        .expect("expected ILO-P003 for `f x:n>>n;x`");
+    assert!(
+        e.message.contains("`>`"),
+        "expected literal `>` in message, got: {}",
+        e.message,
+    );
+    assert!(
+        e.message.contains("`>>`"),
+        "expected literal `>>` in message, got: {}",
+        e.message,
+    );
+    assert!(
+        !e.message.contains("Greater") && !e.message.contains("PipeOp"),
+        "message must not leak Token enum names: {}",
+        e.message,
+    );
+}
+
+#[test]
+fn p003_missing_return_arrow_with_pipe() {
+    // Variant: `f x:n|n;x` — single pipe where `>` was expected.
+    assert_no_token_enum_leak("f x:n|n;x");
+}
+
+#[test]
+fn p003_unclosed_brace_body() {
+    // Foreach without an opening brace: body of expect(LBrace) path.
+    // Was: `expected LBrace, got Semi`. Now: `expected `{`, got `;``.
+    let source = "main>n;xs=[1 2 3];@k xs;+k 1";
+    let (_, errors) = parse_str_errors(source);
+    let e = errors
+        .iter()
+        .find(|e| e.code == "ILO-P003")
+        .expect("expected ILO-P003");
+    assert!(
+        e.message.contains("`{`"),
+        "expected literal `{{` in message, got: {}",
+        e.message,
+    );
+    assert!(
+        !e.message.contains("LBrace") && !e.message.contains("Semi"),
+        "message leaks Token enum names: {}",
+        e.message,
+    );
+}
+
+#[test]
+fn p003_unclosed_paren_in_expression() {
+    // Type-position `R n` with stray `.` — was `expected RParen, got Dot`.
+    assert_no_token_enum_leak("f x:n>n;y=(+x 1.;y");
+}
+
+#[test]
+fn p005_identifier_expected_gets_source_chars() {
+    // `=42 5` — assignment to a number literal where an identifier was
+    // expected. Was `got Number(42.0)`. Now `got number `42``.
+    assert_no_token_enum_leak("=42 5");
+}
+
+#[test]
+fn p001_unexpected_token_at_top_level() {
+    // Leading operator at top level — `expected declaration, got ...`.
+    // Was `got Plus`. Now `got `+``.
+    let (_, errors) = parse_str_errors("+1 2");
+    let e = errors
+        .iter()
+        .find(|e| e.code == "ILO-P001")
+        .expect("expected ILO-P001");
+    assert!(
+        e.message.contains("`+`"),
+        "expected literal `+` in message, got: {}",
+        e.message,
+    );
+    assert!(
+        !e.message.contains("Plus"),
+        "message leaks Token enum name `Plus`: {}",
+        e.message,
+    );
+}
+
+#[test]
+fn p004_eof_renders_human() {
+    // EOF mid-fn-header — file ends before `>` / return type. The
+    // parser may surface this as P003 (`expected `>`, got ...`),
+    // P004 (true EOF after `expect`), or P020 (fn-header boundary
+    // guard), depending on which token the cursor lands on. The
+    // assertion that matters is: no parser-internal enum names
+    // leak in either message or hint.
+    assert_no_token_enum_leak("f x:n");
+    // And: at least one of the errors must mention `end of input`
+    // OR an actual source character — never `EOF` / `Greater` /
+    // `LBrace`. The leak guard above already covers the negative.
+    let (_, errors) = parse_str_errors("f x:n");
+    let has_human_eof_or_glyph = errors.iter().any(|e| {
+        e.message.contains("end of input") || e.message.contains('`') // any backtick-quoted source char
+    });
+    assert!(
+        has_human_eof_or_glyph,
+        "expected at least one error to render EOF or a glyph: {errors:?}",
+    );
+}
+
+/// Sweep test: throw a representative grid of malformed snippets at the
+/// parser and ensure no diagnostic ever leaks a `TokenKind` variant name.
+/// New parser code added in future will fail this test if it forgets to
+/// route through `user_facing_name()`.
+#[test]
+fn sweep_no_token_enum_leak_across_shapes() {
+    let snippets: &[&str] = &[
+        "f x:n>>n;x",         // PipeOp where Greater expected
+        "f x:n|n;x",          // Pipe where Greater expected
+        "f x:n>n;@k xs;+k 1", // missing `{` after foreach
+        "f x:n>n;(+x 1",      // unclosed paren in body
+        "f x:n>n;y=42.;y",    // stray dot
+        "type foo bar",       // type decl missing body
+        "f :n>n;x",           // missing param name
+        "use 42",             // use with non-string path
+        "main:>n;42",         // `:>` shape
+        "+",                  // bare operator at top level
+        "f x:>n;x",           // missing type after `:`
+        "f x:n>;x",           // missing return type after `>`
+    ];
+    for src in snippets {
+        assert_no_token_enum_leak(src);
+    }
+}


### PR DESCRIPTION
## Summary

Parser diagnostics rendered tokens as their internal `TokenKind` variants: `Greater`, `LBrace`, `PipeOp`, `Ident("foo")`, `Number(42.0)`. The wording `expected Greater, got PipeOp` told an agent nothing about what byte it had typed; it's pure parser plumbing leaking out.

Render tokens by source character now: `` `>` ``, `` `{` ``, `` `>>` ``, `` identifier `foo` ``, `` number `42` ``. So `` expected `>`, got `>>` `` points straight at the offending input. Covers ILO-P001/P003/P004/P005/P007/P009/P011/P013/P016.

Surfaced by agent-repair-loop rerun11.

## Repro

Before:
```
$ echo 'f x:n n;x' | ilo verify -
ILO-P003: expected Greater, got Ident("n")
```

After:
```
$ echo 'f x:n n;x' | ilo verify -
ILO-P003: expected `>`, got identifier `n`
```

## What's in the diff

- `src/lexer/mod.rs` - lexer surfaces source-character labels
- `src/parser/mod.rs` - parser emits source-character form in diagnostics
- `src/diagnostic/{mod,registry}.rs` - rendering tweaks
- `tests/regression_ilo_p003_token_names.rs` - cross-shape sweep so no token-enum names leak
- `examples/ilo-p003-missing-return-arrow.ilo` - canonical repro
- `CHANGELOG.md`

## Test plan

- [x] `cargo test --release --features cranelift --test regression_ilo_p003_token_names` (8 passed)
- [x] `cargo check --release --features cranelift`
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] Token budget under 5000

## Follow-ups

None.