### PR TITLE
ci: add gitleaks secret-scan gate to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,20 @@ permissions:
   contents: write
 
 jobs:
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
+
   build:
+    needs: secret-scan
     strategy:
       matrix:
         include:
@@ -71,6 +84,7 @@ jobs:
           path: ilo-${{ matrix.target }}*
 
   build-wasm:
+    needs: secret-scan
     runs-on: ubuntu-latest
 
     steps:

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,36 @@
+# gitleaks config for ilo-lang.
+#
+# Extends the default ruleset (which covers AWS, GCP, Azure, GitHub, OpenAI,
+# Anthropic, Stripe, Slack, JWT, generic high-entropy strings, etc.) and adds
+# an allowlist for the placeholder strings that ship in examples/ so the
+# release-gate scanner does not false-positive on demo code.
+#
+# Run locally:
+#   gitleaks detect --source . --no-git --redact --verbose
+#   gitleaks detect --source . --redact --verbose   # includes git history
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "ilo example placeholders and docs"
+
+# Regex matches against any string the scanner flags. Anything here is
+# explicitly NOT a real secret.
+regexes = [
+  # ScrapingBee example placeholder used in examples/apps/*.
+  '''SCRAPINGBEE_KEY_PLACEHOLDER_set_via_env_in_real_use''',
+  # OpenAI-style placeholder keys used in LLM-client examples.
+  '''sk-PLACEHOLDER[-_A-Za-z0-9]*''',
+  # Generic "REPLACE_ME" / "YOUR_*_HERE" placeholders sometimes embedded in
+  # docs to show the shape of a credential.
+  '''(?i)(REPLACE_ME|YOUR_[A-Z_]+_HERE|EXAMPLE_[A-Z_]+_KEY)''',
+]
+
+# Paths that are docs / examples / fixtures by design. We still scan them
+# (so an actual leak would surface) but tolerate the placeholder shapes
+# above and never treat the canonical demo files as authoritative secrets.
+paths = [
+  '''\.gitleaks\.toml$''',
+  '''CHANGELOG\.md$''',
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.12.1
 
+### Security
+
+- Added a gitleaks secret-scan gate to the release workflow. Every `v*` tag push now runs `gitleaks/gitleaks-action@v2` against the full repo before the build, build-wasm, release, and publish jobs fire. A leaked API key, token, or PEM blocks the tag. Whitelist lives in `.gitleaks.toml` at the repo root and covers the placeholder strings used by `examples/apps/*` (`SCRAPINGBEE_KEY_PLACEHOLDER_...`, `sk-PLACEHOLDER-...`, `YOUR_*_HERE`, `REPLACE_ME`). Default gitleaks ruleset otherwise. Run locally with `gitleaks detect --source . --no-git`.
+
 ### Breaking
 
 - `ls dir` renamed to `lsd dir`. Six rerun10 personas tripped ILO-P011 on `ls=rdl! p` because `ls` was reserved; rename frees `ls` for user code. `walk`, `glob` unchanged.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,66 @@
+# Release security
+
+This page documents the security gates that run before an ilo release tag is
+cut. The goal is simple: a leaked credential, API key, private key, or other
+secret should never make it onto a published artifact, a published crate, a
+published npm package, or a GitHub release.
+
+## Secret scan (gitleaks)
+
+Every push of a `v*` tag triggers `.github/workflows/release.yml`. The first
+job is `secret-scan`, which runs
+[`gitleaks/gitleaks-action@v2`](https://github.com/gitleaks/gitleaks-action)
+over the full repository history. All downstream jobs (`build`, `build-wasm`,
+`release`, `publish-crates`, `publish-npm`, `publish-pi`) declare
+`needs: secret-scan`, so any finding blocks the entire release.
+
+### What gets scanned
+
+- Working tree (every tracked file).
+- Full git history (`fetch-depth: 0`).
+- Default gitleaks rule pack: AWS, GCP, Azure, GitHub, OpenAI, Anthropic,
+  Stripe, Slack, JWT, generic high-entropy strings, PEM blocks, and more.
+
+### Whitelist
+
+Placeholder credentials shipped in `examples/` (especially `examples/apps/*`
+for LLM-client and ScrapingBee demos) are explicitly allowed in
+[`.gitleaks.toml`](./.gitleaks.toml). The current allow regex set:
+
+- `SCRAPINGBEE_KEY_PLACEHOLDER_set_via_env_in_real_use`
+- `sk-PLACEHOLDER[-_A-Za-z0-9]*`
+- `REPLACE_ME` / `YOUR_*_HERE` / `EXAMPLE_*_KEY`
+
+If a new example needs a placeholder credential, add it to the allowlist in
+the same PR.
+
+### Running locally
+
+Before pushing a tag, or any time you want to sanity-check the working tree:
+
+```sh
+gitleaks detect --source . --no-git --redact --verbose
+gitleaks detect --source . --redact --verbose   # includes git history
+```
+
+A clean run prints `no leaks found`. Anything else is a real finding to
+triage before the release goes out.
+
+## Why release-only, not per-PR
+
+Running gitleaks on every PR added meaningful queue time without much
+incremental safety: secrets in feature branches are caught at merge time by
+GitHub's native push-protection, and the release gate is the last guarantee
+before anything becomes public. The release-only model keeps developer
+feedback fast and still blocks the public artifact path.
+
+## If the scan finds something
+
+1. The release job will fail with `secret-scan` red. No artifacts are built.
+2. Treat the finding as a real incident: rotate the credential immediately,
+   regardless of where the leak appears (working tree, history, comment, or
+   doc).
+3. Once rotated, scrub the secret from history (`git filter-repo` or
+   BFG), force-push the cleaned history, and re-cut the tag.
+4. If the finding is a false positive on a new placeholder shape, extend the
+   allowlist in `.gitleaks.toml` in a follow-up PR and re-cut the tag.


### PR DESCRIPTION
## Summary

Adds a gitleaks secret-scan job to the release workflow that gates every `v*` tag push. Catches accidentally-committed API keys, tokens, and PEMs before any artifact is built, any crate published, or any GitHub release cut. Especially relevant now that `examples/apps/` is going to carry LLM-client and ScrapingBee demos with placeholder credentials.

## Baseline

Ran `gitleaks detect --source . --no-git --redact` and `gitleaks detect --source . --redact` (full history, 1609 commits, 13.4MB) locally with the new config before pushing. Both: `no leaks found`. The repo is clean today, so this PR's own check should be green on first run.

## What's in the diff

- `c3bee91 ci: add gitleaks config with example-placeholder allowlist` — `.gitleaks.toml` at the repo root. Extends the default ruleset (AWS, GCP, GitHub, OpenAI, Anthropic, Stripe, JWT, generic high-entropy, PEM, etc.) and allowlists the placeholder shapes used by `examples/apps/*`: `SCRAPINGBEE_KEY_PLACEHOLDER_set_via_env_in_real_use`, `sk-PLACEHOLDER[-_A-Za-z0-9]*`, `REPLACE_ME`, `YOUR_*_HERE`, `EXAMPLE_*_KEY`.
- `0f48ac5 ci: gate release workflow on gitleaks secret-scan` — new `secret-scan` job in `.github/workflows/release.yml`, with `build` and `build-wasm` declaring `needs: secret-scan`. Transitively blocks `release`, `publish-crates`, `publish-npm`, `publish-pi`. Uses `gitleaks/gitleaks-action@v2` with `fetch-depth: 0` so history is scanned.
- `00138ec docs: SECURITY.md + 0.12.1 changelog entry for secret-scan gate` — `SECURITY.md` at repo root (GitHub's well-known location; `docs/` is gitignored in this repo) documents what gets scanned, the allowlist, how to run gitleaks locally, why this is release-only, and what to do if the gate fires. CHANGELOG 0.12.1 `### Security` section points at the same.

## Test plan

- [x] `gitleaks detect --source . --no-git --config .gitleaks.toml` runs clean
- [x] `gitleaks detect --source . --config .gitleaks.toml` (full history) runs clean
- [x] `release.yml` parses as valid YAML
- [x] Job DAG verified: `build` and `build-wasm` both `needs: secret-scan`; downstream jobs already depend on those, so the whole chain blocks
- [ ] CI green on this PR (no release workflow runs on a non-tag PR, but the file change should validate)

## Follow-ups

- When `examples/apps/*` lands, double-check the placeholders match the allowlist shapes; extend `.gitleaks.toml` if a new credential format shows up.
- Consider running gitleaks weekly on `main` as well, separate from the release gate, if we want catch-on-merge rather than catch-at-tag. Out of scope here.