### PR TITLE
fix(aot): skip funcname slot in entry argv binding

### DIFF
--- a/examples/aot-funcname-argv.ilo
+++ b/examples/aot-funcname-argv.ilo
@@ -1,0 +1,15 @@
+-- AOT entry funcname-argv skip: `./bin funcname args` and `./bin args` both work.
+--
+-- The bug: `generate_main` read argv[1..=param_count] unconditionally.
+-- With `./bin main 42`, argv[1]="main" was bound as `x` instead of 42.
+-- A ternary `?(x > 10){true:1;false:0}` silently picked false because
+-- the string "main" compared incorrectly. The fix calls `ilo_aot_argv_skip`
+-- at runtime: if argv[1] matches the entry function name the arg-binding
+-- loop shifts right by one slot, so both invocation forms are handled.
+
+main x:n>n;?(x>10){true:1;false:0}
+
+-- run: main 42
+-- out: 1
+-- run: main 5
+-- out: 0

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -222,6 +222,10 @@ struct HelperFuncs {
     /// list-typed parameter (e.g. `main args:L t`). Wraps non-list shapes
     /// as `[value]` to match the binary-side `parse_cli_args_typed` path.
     aot_parse_arg_list: FuncId,
+    /// `ilo_aot_argv_skip` — detect whether argv[1] is the entry function name
+    /// and return a byte offset (0 or 8) to advance argv by before reading user
+    /// args. Lets `./bin funcname args` and `./bin args` both work correctly.
+    aot_argv_skip: FuncId,
     string_const: FuncId,
     // Linear algebra
     solve: FuncId,
@@ -419,6 +423,7 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         aot_publish_program: declare_helper(module, "ilo_aot_publish_program", 2, 1),
         aot_parse_arg: declare_helper(module, "ilo_aot_parse_arg", 1, 1),
         aot_parse_arg_list: declare_helper(module, "ilo_aot_parse_arg_list", 1, 1),
+        aot_argv_skip: declare_helper(module, "ilo_aot_argv_skip", 3, 1),
         string_const: declare_helper(module, "jit_string_const", 1, 1),
         // Linear algebra
         solve: declare_helper(module, "jit_solve", 3, 1),
@@ -582,6 +587,7 @@ pub fn compile_to_binary(
         &registry_bytes,
         &program_blob,
         &param_is_list,
+        entry_func,
     )?;
 
     // Emit object file
@@ -4329,6 +4335,7 @@ fn serialize_type_registry(registry: &super::TypeRegistry) -> Vec<u8> {
     buf
 }
 
+#[allow(clippy::too_many_arguments)]
 fn generate_main(
     module: &mut ObjectModule,
     user_func_id: FuncId,
@@ -4344,6 +4351,11 @@ fn generate_main(
     // matches the historical behaviour for entry funcs whose AST we couldn't
     // resolve (inline snippets, test harnesses).
     param_is_list: &[bool],
+    // Entry function name, e.g. "main". Used to detect the `./bin funcname
+    // args` invocation form at runtime so the arg-binding loop can skip the
+    // funcname slot when it appears. Without this, `./bin main 42` binds the
+    // string "main" as the first param instead of 42.
+    entry_name: &str,
 ) -> Result<(), String> {
     let mut sig = module.make_signature();
     sig.params.push(AbiParam::new(I32)); // argc
@@ -4365,7 +4377,7 @@ fn generate_main(
     builder.switch_to_block(entry_block);
     builder.seal_block(entry_block);
 
-    let _argc = builder.block_params(entry_block)[0];
+    let argc = builder.block_params(entry_block)[0];
     let argv = builder.block_params(entry_block)[1];
     let mf = MemFlags::new();
 
@@ -4398,19 +4410,37 @@ fn generate_main(
     let parse_arg_fref = module.declare_func_in_func(helpers.aot_parse_arg, builder.func);
     let parse_arg_list_fref = module.declare_func_in_func(helpers.aot_parse_arg_list, builder.func);
 
+    // Detect whether argv[1] is the entry function name (the `./bin funcname
+    // args` form). `ilo_aot_argv_skip` returns 8 if argc >= 2 and argv[1]
+    // matches the embedded name, 0 otherwise. We add this offset to the argv
+    // base so the per-param loop reads from the right slots in both invocation
+    // shapes: `./bin args` and `./bin funcname args`.
+    let argc_i64 = builder.ins().uextend(I64, argc);
+    let entry_name_bytes: Vec<u8> = {
+        let mut b = entry_name.as_bytes().to_vec();
+        b.push(0); // null-terminate
+        b
+    };
+    let name_ptr = create_data_section(module, &mut builder, "ilo_entry_name", &entry_name_bytes)?;
+    let argv_skip_fref = module.declare_func_in_func(helpers.aot_argv_skip, builder.func);
+    let skip_call = builder
+        .ins()
+        .call(argv_skip_fref, &[argc_i64, argv, name_ptr]);
+    let skip_offset = builder.inst_results(skip_call)[0];
+
     // Convert CLI args to NanVal. For each param, pick the right parser:
     //   - `L _` → ilo_aot_parse_arg_list (wraps non-list as `[value]`, mirrors
     //     `parse_cli_args_typed`'s tree/VM coercion path)
     //   - everything else → ilo_aot_parse_arg (number / bool / nil / string)
     //
-    // This is the canonical fix for the 0.12.1 AOT argv binding regression:
-    // before, `main args:L t` was parsed as a single string and `len args`
-    // returned the character count instead of the list length, while
-    // `cat args ","` silently produced `nil` because `cat` requires a `L t`.
+    // argv[1] is the first user arg in `./bin args` form; in `./bin funcname
+    // args` form skip_offset is 8 so we read argv[2] onward. The base offset
+    // `(i + 1) * 8` accounts for argv[0] (the binary name) being slot 0.
     let mut call_args = Vec::with_capacity(param_count);
     for i in 0..param_count {
-        let idx = builder.ins().iconst(I64, ((i + 1) * 8) as i64);
-        let arg_ptr_ptr = builder.ins().iadd(argv, idx);
+        let slot_offset = builder.ins().iconst(I64, ((i + 1) * 8) as i64);
+        let total_offset = builder.ins().iadd(slot_offset, skip_offset);
+        let arg_ptr_ptr = builder.ins().iadd(argv, total_offset);
         let arg_ptr = builder.ins().load(I64, mf, arg_ptr_ptr, 0);
         let is_list = param_is_list.get(i).copied().unwrap_or(false);
         let fref = if is_list {

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -18949,6 +18949,44 @@ pub extern "C" fn ilo_aot_parse_arg_list(ptr: u64) -> u64 {
     NanVal::from_value(&v).0
 }
 
+/// Return the byte offset to advance the argv base by before reading user args.
+///
+/// AOT binaries accept two invocation forms:
+///
+///   `./bin arg1 arg2`            -- argv[1] is the first user arg
+///   `./bin funcname arg1 arg2`   -- argv[1] is the entry function name;
+///                                    user args start at argv[2]
+///
+/// Both forms are used in the wild: `ilo run` and the tree/VM runners emit the
+/// funcname form while direct shell invocations typically omit it.
+///
+/// If `argc >= 2` and the C string at argv[1] equals `entry_name`, returns 8
+/// (one pointer width on a 64-bit host) so the caller shifts the argv base past
+/// the funcname slot. Otherwise returns 0.
+///
+/// Called from the Cranelift-generated `main` wrapper produced by `generate_main`.
+///
+/// # Safety
+///
+/// `argv` must be the argv pointer passed into `main` by the OS. When `argc >= 2`
+/// the OS guarantees argv[0] and argv[1] are valid C-string pointers. `entry_name`
+/// is a pointer to a null-terminated string embedded in the AOT binary's read-only
+/// data section by `generate_main`.
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub extern "C" fn ilo_aot_argv_skip(argc: u64, argv: u64, entry_name: u64) -> u64 {
+    if argc < 2 {
+        return 0;
+    }
+    let argv_ptr = argv as *const *const std::ffi::c_char;
+    // SAFETY: argc >= 2 guarantees argv[1] is a valid C-string pointer (OS contract).
+    let arg1_ptr = unsafe { *argv_ptr.add(1) };
+    let name_ptr = entry_name as *const std::ffi::c_char;
+    // SAFETY: both pointers are null-terminated strings as described above.
+    let cmp = unsafe { libc::strcmp(arg1_ptr, name_ptr) };
+    if cmp == 0 { 8 } else { 0 }
+}
+
 // ── Block leader analysis (shared by JIT backends) ──────────────────
 
 /// Identify basic block leaders in bytecode. A leader is:

--- a/tests/regression_aot_main_argv.rs
+++ b/tests/regression_aot_main_argv.rs
@@ -238,3 +238,137 @@ fn aot_main_zero_arg_still_works() {
 
     cleanup(&src, &bin);
 }
+
+// ── 7. funcname-argv off-by-one: `./bin main arg` must bind `arg`, not `main`
+//
+// The bug: `generate_main` read argv[1..=param_count] unconditionally, so
+// `./bin main 42` bound "main" as the first param and 42 as the second (or
+// off the end). A ternary `?(x){true:1;false:0}` silently picked false because
+// the string "main" is truthy in ilo but the binding was one slot off, feeding
+// an out-of-bounds or wrong value. The fix calls `ilo_aot_argv_skip` at runtime
+// to detect whether argv[1] matches the entry name and shifts the base by 8
+// bytes when it does, so both `./bin arg` and `./bin funcname arg` are correct.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// `./bin main 42` with a scalar numeric param — must produce 42, not bind "main".
+#[test]
+fn aot_funcname_argv_scalar_number() {
+    let (src, bin) = tmp_paths("fn-argv-num");
+    let source = "main x:n>n;x\n";
+    compile(&src, &bin, source);
+
+    // Without funcname prefix - baseline.
+    assert_eq!(run_bin(&bin, &["42"]), "42");
+
+    // With funcname prefix - the bug would have bound "main" as x.
+    assert_eq!(run_bin(&bin, &["main", "42"]), "42");
+
+    cleanup(&src, &bin);
+}
+
+/// `./bin main hello` with a scalar text param.
+#[test]
+fn aot_funcname_argv_scalar_text() {
+    let (src, bin) = tmp_paths("fn-argv-txt");
+    let source = "main s:t>t;s\n";
+    compile(&src, &bin, source);
+
+    assert_eq!(run_bin(&bin, &["hello"]), "hello");
+    assert_eq!(run_bin(&bin, &["main", "hello"]), "hello");
+
+    cleanup(&src, &bin);
+}
+
+/// Ternary branch on the bound value - this was the silent false-branch symptom.
+#[test]
+fn aot_funcname_argv_ternary_picks_correct_branch() {
+    let (src, bin) = tmp_paths("fn-argv-ternary");
+    // `?(x > 10){true:1;false:0}` - with x=42 should be 1; x bound to "main"
+    // would break the comparison and likely return 0.
+    let source = "main x:n>n;?(x>10){true:1;false:0}\n";
+    compile(&src, &bin, source);
+
+    assert_eq!(
+        run_bin(&bin, &["42"]),
+        "1",
+        "without funcname: x=42 > 10 should be true"
+    );
+    assert_eq!(
+        run_bin(&bin, &["main", "42"]),
+        "1",
+        "with funcname: x=42 > 10 should be true - was silently false before fix"
+    );
+    assert_eq!(
+        run_bin(&bin, &["5"]),
+        "0",
+        "without funcname: x=5 <= 10 should be false"
+    );
+    assert_eq!(
+        run_bin(&bin, &["main", "5"]),
+        "0",
+        "with funcname: x=5 <= 10 should be false"
+    );
+
+    cleanup(&src, &bin);
+}
+
+/// Two-param function with funcname prefix - both args must shift correctly.
+#[test]
+fn aot_funcname_argv_two_params() {
+    let (src, bin) = tmp_paths("fn-argv-2p");
+    let source = "main a:n b:n>n;a+b\n";
+    compile(&src, &bin, source);
+
+    assert_eq!(run_bin(&bin, &["3", "4"]), "7");
+    assert_eq!(run_bin(&bin, &["main", "3", "4"]), "7");
+
+    cleanup(&src, &bin);
+}
+
+/// List-typed param with funcname prefix - must use the list-parse path after skip.
+#[test]
+fn aot_funcname_argv_list_param() {
+    let (src, bin) = tmp_paths("fn-argv-list");
+    let source = "main xs:L n>n;sum xs\n";
+    compile(&src, &bin, source);
+
+    assert_eq!(run_bin(&bin, &["[1,2,3]"]), "6");
+    assert_eq!(run_bin(&bin, &["main", "[1,2,3]"]), "6");
+
+    cleanup(&src, &bin);
+}
+
+/// Zero-arg function with funcname prefix - no args to shift, must not crash.
+#[test]
+fn aot_funcname_argv_zero_params_with_funcname() {
+    let (src, bin) = tmp_paths("fn-argv-zero");
+    let source = "main>n;99\n";
+    compile(&src, &bin, source);
+
+    assert_eq!(run_bin(&bin, &[]), "99");
+    // funcname with no user args: argc=2, argv[1]="main" matches, skip=8.
+    // The param loop runs 0 times so no out-of-bounds access.
+    assert_eq!(run_bin(&bin, &["main"]), "99");
+
+    cleanup(&src, &bin);
+}
+
+/// Cross-engine pin: both invocation forms produce output matching tree and VM.
+#[test]
+fn aot_funcname_argv_cross_engine_pin() {
+    let (src, bin) = tmp_paths("fn-argv-cross");
+    let source = "main x:n>t;str x\n";
+    compile(&src, &bin, source);
+
+    let direct = run_bin(&bin, &["7"]);
+    let with_fn = run_bin(&bin, &["main", "7"]);
+    let tree = run_tree(&src, &["7"]);
+    let vm = run_vm(&src, &["7"]);
+
+    assert_eq!(direct, "7");
+    assert_eq!(with_fn, "7");
+    assert_eq!(direct, tree, "AOT vs tree diverged");
+    assert_eq!(direct, vm, "AOT vs VM diverged");
+
+    cleanup(&src, &bin);
+}


### PR DESCRIPTION
## Summary

- AOT binaries invoked as `./bin funcname args` were binding argv[1] (the function name) as the first user param instead of the first actual arg. Every subsequent arg was shifted one slot too late.
- The symptom: `?(x > 10){true:1;false:0}` silently picked false when called as `./bin main 42` because `x` was bound to the string "main" rather than 42.
- Root cause: `generate_main` hardcoded `argv[1..=param_count]` with no provision for the funcname slot.

## What's in the diff

**Commit 1 - fix:** Add `ilo_aot_argv_skip` runtime helper that compares argv[1] against the embedded entry function name and returns a byte offset of 8 when they match. `generate_main` now embeds the entry name as a null-terminated read-only data section, calls the helper at binary startup, and adds the returned offset to each per-param slot base. Both `./bin args` and `./bin funcname args` now bind correctly.

**Commit 2 - tests + example:** Seven new tests in `regression_aot_main_argv.rs` covering scalar, text, ternary-branch, two-param, list, zero-param, and cross-engine shapes - all exercising both invocation forms. `examples/aot-funcname-argv.ilo` with `-- run:` / `-- out:` assertions for the examples harness.

## Repro before / after

```sh
# program: main x:n>n;?(x>10){true:1;false:0}
# before fix
./bin main 42   # -> 0  (wrong - "main" bound as x)
./bin 42        # -> 1  (correct)

# after fix
./bin main 42   # -> 1  (correct)
./bin 42        # -> 1  (correct)
```

## Test plan

- [x] `cargo test --release --features cranelift --test regression_aot_main_argv` - 13/13 pass
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --features cranelift` no errors
- [ ] CI green

## Follow-ups

None - this is a self-contained argv-binding fix with no surface-area change to user-visible syntax or builtins.