### PR TITLE
verify: ILO-T039 hint for 0-arg fn in value position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ### Diagnostics
 
+- ILO-T039: 0-arg user function used as a bare reference in value position. When an agent writes `v = my-fn` or `+my-fn 100` and `my-fn` takes no arguments, ilo now emits ILO-T039 with a hint pointing at `my-fn()` as the correct call form. Previously the agent received a silent type error or a generic type-mismatch diagnostic with no actionable suggestion, costing one or more retries.
 - ILO-T006 on `lst` (and its `lset` alias) now carries a suggestion clarifying that `lst xs i v` is "list set at index" (3 args, returns a new list with index `i` replaced by `v`), not "last element". The 1-arg case (`lst xs`) points at the canonical `at xs -1` for last-element intent; other arities point at the 3-arg signature without misreading the call as a last-element attempt. Surfaced by git-workflow rerun11 - agents reached for `lst xs` and hit an empty-suggestion arity error.
 - ILO-T013 on `cat "a" "b"` (the string-concat instinct from Python/JS) now suggests `fmt "{}{}" a b` or `+a b` as the canonical text-concat shapes. `cat` is list-concat; the verifier used to flag the type error but leave the user to guess the fix, costing one round-trip on every new-write. Surfaced by scaffold rerun11.
 

--- a/examples/zero-arg-fn-call.ilo
+++ b/examples/zero-arg-fn-call.ilo
@@ -1,0 +1,18 @@
+-- Demonstrates correct 0-arg function call forms in ilo.
+-- A 0-arg function auto-expands in statement/assignment position,
+-- but needs explicit `name()` in value position (e.g. operand of `+`).
+--
+-- `get-now` is a 0-arg function that returns the current timestamp.
+
+get-now>n;now-ms()
+
+-- In statement position: auto-expands to a call.
+ts>n;get-now
+
+-- In value position: use get-now() explicitly.
+later>n;+(get-now()) 1000
+
+main>b;>(later) ts
+
+-- run: main
+-- out: true

--- a/examples/zero-arg-fn-call.ilo
+++ b/examples/zero-arg-fn-call.ilo
@@ -1,18 +1,17 @@
 -- Demonstrates correct 0-arg function call forms in ilo.
 -- A 0-arg function auto-expands in statement/assignment position,
 -- but needs explicit `name()` in value position (e.g. operand of `+`).
---
--- `get-now` is a 0-arg function that returns the current timestamp.
 
-get-now>n;now-ms()
+-- `stamp` returns a fixed value (not time-dependent, safe for tests).
+stamp>n;42
 
--- In statement position: auto-expands to a call.
-ts>n;get-now
+-- In statement/assignment position: auto-expands to a call. Returns 42.
+get-val>n;stamp
 
--- In value position: use get-now() explicitly.
-later>n;+(get-now()) 1000
+-- In value position: use stamp() explicitly to get the value.
+add-one>n;+(stamp()) 1
 
-main>b;>(later) ts
+main>b;=add-one() 43
 
 -- run: main
 -- out: true

--- a/skills/ilo/ilo-errors.md
+++ b/skills/ilo/ilo-errors.md
@@ -28,6 +28,7 @@ description: Use this when reading ILO-XXXX error codes or fixing failures. List
 - **T010 non-result error-propagate** - `!` in a non-`R` fn. Declare `>R t t` or use `??` / match.
 - **T013 builtin arg type** - `cat` is list-concat; text uses `fmt`/`+`.
 - **T038 non-bool ternary cond** - `?h c a b` cond must be `b`. Bind first.
+- **T039 0-arg fn as value** - `f` is a 0-arg fn used as a ref, not a call. Use `f()` in value position.
 
 ## Runtime
 

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -3670,10 +3670,34 @@ impl VerifyContext {
             Expr::Ref(name) => {
                 if let Some(ty) = scope_lookup(scope, name) {
                     ty.clone()
-                } else if let Some(sig) = self.functions.get(name) {
-                    // Function name used as a value — resolve to Ty::Fn
-                    let params: Vec<Ty> = sig.params.iter().map(|(_, t)| t.clone()).collect();
-                    Ty::Fn(params, Box::new(sig.return_type.clone()))
+                } else if let Some((params, ret)) = self.functions.get(name).map(|sig| {
+                    let p: Vec<Ty> = sig.params.iter().map(|(_, t)| t.clone()).collect();
+                    let r = sig.return_type.clone();
+                    (p, r)
+                }) {
+                    // Function name used as a value — resolve to Ty::Fn.
+                    // ILO-T039: a 0-arg user function used as a bare reference
+                    // almost always means the agent forgot to call it. In ilo,
+                    // 0-arg functions are called with a bare name in statement
+                    // position (auto-expanded) or with `name()` in value position.
+                    // A `Ref("name")` that resolves to `Fn([], ret)` is almost
+                    // never intentional — the result is a function value, not a
+                    // `ret`. Emit a hint so the agent gets the correction inline.
+                    if params.is_empty() {
+                        self.err(
+                            "ILO-T039",
+                            func,
+                            format!(
+                                "'{name}' is a 0-arg function used as a value reference, not a call"
+                            ),
+                            Some(format!(
+                                "call it with '{name}()' to get the return value; \
+                                 bare '{name}' in value position is a function reference, not a call result"
+                            )),
+                            Some(span),
+                        );
+                    }
+                    Ty::Fn(params, Box::new(ret))
                 } else if let Some(fn_ty) = builtin_as_fn_ty(name) {
                     // Pure builtin used as a value (e.g. `fld max xs 0`).
                     // Promote to Ty::Fn so HOF args type-check.

--- a/tests/regression_zero_arg_fn_hint.rs
+++ b/tests/regression_zero_arg_fn_hint.rs
@@ -1,0 +1,80 @@
+// Regression tests for ILO-T039: 0-arg function used as a bare reference
+// in value position instead of being called.
+//
+// Before this change, `ts = my-fn` where `my-fn` is a 0-arg user function
+// produced a silent type error or a confusing generic diagnostic with no
+// actionable suggestion. Agents burned retries figuring out why their
+// "timestamp" variable held a function reference instead of a number.
+//
+// After: ILO-T039 emits a targeted diagnostic pointing at `my-fn()` as
+// the correct call form.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+/// Run `ilo check` on inline source and return stderr.
+fn check_src(src: &str) -> String {
+    use std::io::Write;
+    let mut f = tempfile::NamedTempFile::new().expect("tempfile");
+    f.write_all(src.as_bytes()).expect("write");
+    let path = f.path().to_str().unwrap();
+    let out = ilo()
+        .args(["check", path])
+        .output()
+        .expect("failed to run ilo check");
+    // check may exit non-zero on errors — we check stderr content
+    String::from_utf8_lossy(&out.stderr).into_owned() + &String::from_utf8_lossy(&out.stdout)
+}
+
+#[test]
+fn zero_arg_fn_used_as_binop_operand() {
+    // `get-ts` is 0-arg but used as left operand of `+` — should trigger ILO-T039
+    let src = "get-ts>n;now-ms()\nmain>n;+get-ts 100";
+    let diag = check_src(src);
+    assert!(
+        diag.contains("ILO-T039"),
+        "expected ILO-T039 for 0-arg fn in binop operand, got: {diag}"
+    );
+    assert!(
+        diag.contains("get-ts()"),
+        "hint should mention 'get-ts()' call form, got: {diag}"
+    );
+}
+
+#[test]
+fn zero_arg_fn_in_binop_before_atom_no_expand() {
+    // `get-ts` is 0-arg. In prefix binop `+get-ts 100`, `get-ts` appears
+    // before `100` so can_start_operand is true and auto-expand does NOT fire.
+    // The verifier should emit ILO-T039.
+    let src = "get-ts>n;now-ms()\nmain>n;+get-ts 100";
+    let diag = check_src(src);
+    assert!(
+        diag.contains("ILO-T039"),
+        "expected ILO-T039 for 0-arg fn before atom in binop, got: {diag}"
+    );
+}
+
+#[test]
+fn zero_arg_fn_called_correctly_no_diagnostic() {
+    // `get-ts()` is the correct form — no ILO-T039
+    let src = "get-ts>n;now-ms()\nmain>n;get-ts()";
+    let diag = check_src(src);
+    assert!(
+        !diag.contains("ILO-T039"),
+        "ILO-T039 should not fire when 0-arg fn is called with (), got: {diag}"
+    );
+}
+
+#[test]
+fn non_zero_arg_fn_ref_no_diagnostic() {
+    // HOF refs for >0 param fns — ILO-T039 must NOT fire
+    let src = "double f:n>n;*f 2\nmain>L n;map double [1, 2, 3]";
+    let diag = check_src(src);
+    assert!(
+        !diag.contains("ILO-T039"),
+        "ILO-T039 must not fire for non-zero-arg fn ref (HOF), got: {diag}"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds ILO-T039: when a user-defined 0-arg function is used as a bare reference in value position, the verifier now emits a targeted diagnostic pointing at the `name()` call form.
- Before: `ts = get-ts` (where `get-ts` is 0-arg) produced a downstream type error with no hint about the fix.
- After: ILO-T039 fires immediately at the reference site with suggestion "call it with `get-ts()` to get the return value".

## Repro before/after

Before:
```
get-ts>n;now-ms()
main>n;+get-ts 100
```
Produced: `ILO-T003 type mismatch: expected n, got Fn([], n)` - no suggestion.

After:
```
ILO-T039: 'get-ts' is a 0-arg function used as a value reference, not a call
suggestion: call it with 'get-ts()' to get the return value; bare 'get-ts' in value position is a function reference, not a call result
```

## What's in the diff

- `src/verify.rs`: clone sig data first to avoid borrow conflict, then emit ILO-T039 for `params.is_empty()` user-fn refs
- `tests/regression_zero_arg_fn_hint.rs`: 4 regression cases (binop operand, pre-atom no-expand, correct call no-fire, HOF ref no-fire)
- `examples/zero-arg-fn-call.ilo`: in-context learning example for agents
- `CHANGELOG.md`, `skills/ilo/ilo-errors.md`: doc updates

## Test plan

- [x] `cargo test --release --test regression_zero_arg_fn_hint` - 4/4 pass
- [x] `cargo test --release` - full suite, 3245 pass (7 pre-existing AOT failures unrelated to this change)
- [x] `cargo fmt --check` passes