### PR TITLE
chore: slim SECURITY.md and move release-gate runbook to docs/

### DIFF
--- a/.github/gitleaks.toml
+++ b/.github/gitleaks.toml
@@ -5,6 +5,9 @@
 # an allowlist for the placeholder strings that ship in examples/ so the
 # release-gate scanner does not false-positive on demo code.
 #
+# For the full release-gate runbook (when to run, incident procedure, why
+# release-only) see docs/release-secret-scan.md.
+#
 # Run locally:
 #   gitleaks detect --source . --no-git --redact --verbose
 #   gitleaks detect --source . --redact --verbose   # includes git history

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thanks for your interest in contributing to ilo!
 
+For the release secret-scan gate (gitleaks, allowlist, incident procedure) see [docs/release-secret-scan.md](docs/release-secret-scan.md).
+
 ## Getting Started
 
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,66 +1,7 @@
-# Release security
+# Security policy
 
-This page documents the security gates that run before an ilo release tag is
-cut. The goal is simple: a leaked credential, API key, private key, or other
-secret should never make it onto a published artifact, a published crate, a
-published npm package, or a GitHub release.
+Found a vulnerability in ilo? Please do not open a public issue.
 
-## Secret scan (gitleaks)
+Report it privately via [GitHub's private vulnerability reporting](https://github.com/ilo-lang/ilo/security/advisories/new).
 
-Every push of a `v*` tag triggers `.github/workflows/release.yml`. The first
-job is `secret-scan`, which runs
-[`gitleaks/gitleaks-action@v2`](https://github.com/gitleaks/gitleaks-action)
-over the full repository history. All downstream jobs (`build`, `build-wasm`,
-`release`, `publish-crates`, `publish-npm`, `publish-pi`) declare
-`needs: secret-scan`, so any finding blocks the entire release.
-
-### What gets scanned
-
-- Working tree (every tracked file).
-- Full git history (`fetch-depth: 0`).
-- Default gitleaks rule pack: AWS, GCP, Azure, GitHub, OpenAI, Anthropic,
-  Stripe, Slack, JWT, generic high-entropy strings, PEM blocks, and more.
-
-### Whitelist
-
-Placeholder credentials shipped in `examples/` (especially `examples/apps/*`
-for LLM-client and ScrapingBee demos) are explicitly allowed in
-[`.github/gitleaks.toml`](./.github/gitleaks.toml). The current allow regex set:
-
-- `SCRAPINGBEE_KEY_PLACEHOLDER_set_via_env_in_real_use`
-- `sk-PLACEHOLDER[-_A-Za-z0-9]*`
-- `REPLACE_ME` / `YOUR_*_HERE` / `EXAMPLE_*_KEY`
-
-If a new example needs a placeholder credential, add it to the allowlist in
-the same PR.
-
-### Running locally
-
-Before pushing a tag, or any time you want to sanity-check the working tree:
-
-```sh
-gitleaks detect --source . --no-git --redact --verbose
-gitleaks detect --source . --redact --verbose   # includes git history
-```
-
-A clean run prints `no leaks found`. Anything else is a real finding to
-triage before the release goes out.
-
-## Why release-only, not per-PR
-
-Running gitleaks on every PR added meaningful queue time without much
-incremental safety: secrets in feature branches are caught at merge time by
-GitHub's native push-protection, and the release gate is the last guarantee
-before anything becomes public. The release-only model keeps developer
-feedback fast and still blocks the public artifact path.
-
-## If the scan finds something
-
-1. The release job will fail with `secret-scan` red. No artifacts are built.
-2. Treat the finding as a real incident: rotate the credential immediately,
-   regardless of where the leak appears (working tree, history, comment, or
-   doc).
-3. Once rotated, scrub the secret from history (`git filter-repo` or
-   BFG), force-push the cleaned history, and re-cut the tag.
-4. If the finding is a false positive on a new placeholder shape, extend the
-   allowlist in `.github/gitleaks.toml` in a follow-up PR and re-cut the tag.
+We aim to acknowledge reports within 72 hours.

--- a/docs/release-secret-scan.md
+++ b/docs/release-secret-scan.md
@@ -1,0 +1,66 @@
+# Release secret scan runbook
+
+This document covers the gitleaks gate that runs before every ilo release tag
+is cut. The goal: a leaked credential, API key, private key, or other secret
+should never make it onto a published artifact, crate, npm package, or GitHub
+release.
+
+## Secret scan (gitleaks)
+
+Every push of a `v*` tag triggers `.github/workflows/release.yml`. The first
+job is `secret-scan`, which runs
+[`gitleaks/gitleaks-action@v2`](https://github.com/gitleaks/gitleaks-action)
+over the full repository history. All downstream jobs (`build`, `build-wasm`,
+`release`, `publish-crates`, `publish-npm`, `publish-pi`) declare
+`needs: secret-scan`, so any finding blocks the entire release.
+
+### What gets scanned
+
+- Working tree (every tracked file).
+- Full git history (`fetch-depth: 0`).
+- Default gitleaks rule pack: AWS, GCP, Azure, GitHub, OpenAI, Anthropic,
+  Stripe, Slack, JWT, generic high-entropy strings, PEM blocks, and more.
+
+### Allowlist
+
+Placeholder credentials shipped in `examples/` (especially `examples/apps/*`
+for LLM-client and ScrapingBee demos) are explicitly allowed in
+[`.gitleaks.toml`](./../.gitleaks.toml). The current allow regex set:
+
+- `SCRAPINGBEE_KEY_PLACEHOLDER_set_via_env_in_real_use`
+- `sk-PLACEHOLDER[-_A-Za-z0-9]*`
+- `REPLACE_ME` / `YOUR_*_HERE` / `EXAMPLE_*_KEY`
+
+If a new example needs a placeholder credential, add it to the allowlist in
+the same PR.
+
+### Running locally
+
+Before pushing a tag, or any time you want to sanity-check the working tree:
+
+```sh
+gitleaks detect --source . --no-git --redact --verbose
+gitleaks detect --source . --redact --verbose   # includes git history
+```
+
+A clean run prints `no leaks found`. Anything else is a real finding to
+triage before the release goes out.
+
+## Why release-only, not per-PR
+
+Running gitleaks on every PR added meaningful queue time without much
+incremental safety: secrets in feature branches are caught at merge time by
+GitHub's native push-protection, and the release gate is the last guarantee
+before anything becomes public. The release-only model keeps developer
+feedback fast and still blocks the public artifact path.
+
+## If the scan finds something
+
+1. The release job will fail with `secret-scan` red. No artifacts are built.
+2. Treat the finding as a real incident: rotate the credential immediately,
+   regardless of where the leak appears (working tree, history, comment, or
+   doc).
+3. Once rotated, scrub the secret from history (`git filter-repo` or
+   BFG), force-push the cleaned history, and re-cut the tag.
+4. If the finding is a false positive on a new placeholder shape, extend the
+   allowlist in `.gitleaks.toml` in a follow-up PR and re-cut the tag.


### PR DESCRIPTION
## Summary

- `SECURITY.md` was a 2.7 KB internal release-engineering runbook mixed with the one thing researchers actually need: a private report channel. Split them.
- `SECURITY.md` is now 5 lines - GitHub private-reporting link only (no email per Dan's decision).
- `docs/release-secret-scan.md` holds the full runbook: gitleaks gate, allowlist, local commands, incident procedure, why release-only.
- `.gitleaks.toml` header gets a cross-link comment to the new runbook.
- `CONTRIBUTING.md` gets a one-line link to the new runbook.

## Action item before merge

Flip on **Private Vulnerability Reporting** in repo settings before merging:

> Repo Settings -> Code security and analysis -> "Private vulnerability reporting" -> Enable

This adds a "Report a vulnerability" button to the Security tab that opens a private form - the canonical reporting channel referenced in the new SECURITY.md. The agent cannot enable this via CLI without admin token scope.

## Notes

- No doc-sync needed: no ilo language surface change (no builtins, CLI flags, or syntax). SPEC.md, ai.txt, skills, site builtins all untouched.
- `docs/` is gitignored as scratch space, so `docs/release-secret-scan.md` is force-tracked via `git add -f`. Consider adding `!docs/release-secret-scan.md` to `.gitignore` as a follow-up to make the exception explicit.

## Test plan

- [ ] GitHub Security tab shows the slim 5-line SECURITY.md after merge
- [ ] "Report a vulnerability" button appears once Private Vulnerability Reporting is enabled
- [ ] `git grep -nP 'SECURITY\.md'` returns no hits (nothing points to old runbook content)
- [ ] `docs/release-secret-scan.md` renders correctly on GitHub