### PR TITLE
ci: run rust workflow on next branch PRs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "next" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "next" ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

Currently `rust.yml` only fires on PRs targeting `main`. PRs targeting `next` (e.g. #406, #473, #476) have zero CI runs which means we ship 0.13.0 / 26.X work without CI gating.

One-line fix: add `next` to push + pull_request branch triggers.

## Test plan

- After merge, push to `next` triggers the Rust workflow
- New PR to `next` runs build / coverage / lint / skill-validate