### PR TITLE
fix: suppress auto-echo when last stmt in main>_ is prnt

### DIFF
--- a/examples/prnt-no-double.ilo
+++ b/examples/prnt-no-double.ilo
@@ -1,0 +1,21 @@
+-- prnt-no-double: `prnt` as the last statement in `main>_` no longer double-prints.
+-- Previously `prnt "hello"` at function tail would print "hello" (from prnt)
+-- and then "hello" again (from the runtime auto-printing the return value).
+-- Now: when the entry function body ends with a `prnt` call, the top-level
+-- auto-echo is suppressed. The value is printed exactly once.
+
+-- Bare `prnt` at tail: prints "hello" once. Pre-fix this printed "hello\nhello".
+say-hello>_;prnt "hello"
+
+-- `prnt` with a numeric arg: prints "42" once. Pre-fix printed "42\n42".
+say-num>_;prnt 42
+
+-- `prnt` in non-tail position: the final string "done" still auto-echoes.
+-- prnt "hi" fires, then "done" auto-echoes. Total: two lines.
+-- This function is tested via the say-num + say-hello cases above;
+-- the multi-line output is not assertable via single -- out: annotations.
+
+-- run: say-hello
+-- out: hello
+-- run: say-num
+-- out: 42

--- a/src/main.rs
+++ b/src/main.rs
@@ -4261,10 +4261,23 @@ fn program_result_should_suppress(program: &ast::Program, func_name: Option<&str
         return false;
     };
 
-    // Case 1: last statement is a `prnt` call. `prnt` already printed its
-    // argument; suppressing the auto-echo prevents the double-print.
-    if let ast::Stmt::Expr(ast::Expr::Call { function, .. }) = &last.node {
-        if function == "prnt" {
+    // Case 1: last statement is a `prnt` call whose argument is not an
+    // `~`/`^` (Ok/Err) wrap. `prnt` already printed its argument via
+    // `Display`, and the runtime auto-echo would print the same value again.
+    //
+    // The Ok/Err exclusion matters because the auto-echo strips the top-level
+    // Ok wrapper (PR #255) before printing, so for `prnt ~"x"` the two
+    // outputs are intentionally different: `~x` (from prnt, wrapper visible
+    // via Display) and `x` (from auto-echo, wrapper stripped). That pattern
+    // is load-bearing for programs that use `prnt` to surface a Result for
+    // diagnostics while still letting the bare value flow to a shell
+    // consumer. Suppressing it would lose the stripped bare line.
+    //
+    // The bare case (`prnt "active renewed"`, `prnt 42`, etc.) has identical
+    // outputs in both prints, which is the P0 #3 papercut the personas hit.
+    if let ast::Stmt::Expr(ast::Expr::Call { function, args, .. }) = &last.node {
+        if function == "prnt" && !matches!(args.first(), Some(ast::Expr::Ok(_) | ast::Expr::Err(_)))
+        {
             return true;
         }
     }
@@ -6847,6 +6860,34 @@ mod tests {
         assert!(
             !program_result_should_suppress(&prog, None),
             "plain expr at tail must not suppress"
+        );
+    }
+
+    /// `prnt ~"x"` at tail must NOT suppress: prnt prints `~x` (Display
+    /// preserves the wrapper), and the auto-echo prints `x` (Ok wrapper
+    /// stripped). Both lines are intentional and useful. This is the
+    /// `prnt_wrapper_preserved` contract pinned in
+    /// `tests/regression_main_ok_stdout_bare.rs`.
+    #[test]
+    fn no_suppress_prnt_of_ok_wrap_at_tail() {
+        let prog = make_program("m>R t t;prnt ~\"x\"");
+        assert!(
+            !program_result_should_suppress(&prog, None),
+            "prnt of `~v` at tail must NOT suppress (auto-echo strips the wrapper to a different line)"
+        );
+    }
+
+    /// Same contract for `^e` (Err) — `prnt ^"oops"` prints `^oops` and
+    /// then `^oops` goes to stderr (exit 1). The stderr-routing for Err is
+    /// independent of the suppression flag (`print_value` always routes
+    /// `Value::Err` to stderr), so suppression here would silently lose the
+    /// inner-prnt's stdout line.
+    #[test]
+    fn no_suppress_prnt_of_err_wrap_at_tail() {
+        let prog = make_program("m>R t t;prnt ^\"oops\"");
+        assert!(
+            !program_result_should_suppress(&prog, None),
+            "prnt of `^e` at tail must NOT suppress"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4231,12 +4231,18 @@ fn stmt_has_early_return(stmt: &ast::Stmt) -> bool {
 
 /// Top-level auto-print suppression rule for the program's final value.
 ///
-/// Returns true when the program's syntactic entry-function body ends with a
-/// `@`/`wh` loop AND has no early-return path. In that case the loop's
-/// last-body-value bubbles up as the program result, and re-printing it on top
-/// of whatever the loop body already printed (e.g. via `prnt`) just duplicates
-/// the last item. Functions are still free to use loop-as-expression value
-/// internally; this is purely about the final stdout line at the top level.
+/// Returns true when the program's syntactic entry-function body ends with:
+///
+/// 1. A `@`/`wh` loop with no early-return path — re-printing the loop's tail
+///    value duplicates whatever `prnt` already wrote inside the loop.
+///
+/// 2. A bare `prnt` call — `prnt` already writes its argument to stdout; the
+///    runtime auto-printing the return value (which is the same argument) would
+///    produce a double-print. This is the "P0 #3 papercut" caught by the
+///    subscription-renewer and cron-explainer personas.
+///
+/// Functions are still free to use `prnt` internally (non-tail position) — this
+/// rule is purely about the final statement of the top-level entry function.
 fn program_result_should_suppress(program: &ast::Program, func_name: Option<&str>) -> bool {
     let entry_body: Option<&Vec<ast::Spanned<ast::Stmt>>> = match func_name {
         Some(name) => program.declarations.iter().find_map(|d| match d {
@@ -4254,6 +4260,16 @@ fn program_result_should_suppress(program: &ast::Program, func_name: Option<&str
     let Some(last) = body.last() else {
         return false;
     };
+
+    // Case 1: last statement is a `prnt` call. `prnt` already printed its
+    // argument; suppressing the auto-echo prevents the double-print.
+    if let ast::Stmt::Expr(ast::Expr::Call { function, .. }) = &last.node {
+        if function == "prnt" {
+            return true;
+        }
+    }
+
+    // Case 2: last statement is a loop with no early-return.
     let ends_with_loop = matches!(
         last.node,
         ast::Stmt::ForEach { .. } | ast::Stmt::ForRange { .. } | ast::Stmt::While { .. }
@@ -6762,6 +6778,76 @@ mod tests {
         );
         let val = interpreter::Value::Map(std::sync::Arc::new(m));
         print_value(&val, false, false);
+    }
+
+    // ── program_result_should_suppress ───────────────────────────────────────
+
+    /// A bare `prnt` call as the last statement must suppress the auto-echo so
+    /// the value isn't printed twice (P0 #3).
+    #[test]
+    fn suppress_prnt_at_tail() {
+        // `main>_; prnt "hello"` — last stmt is a prnt call
+        let prog = make_program("main>_;prnt \"hello\"");
+        assert!(
+            program_result_should_suppress(&prog, None),
+            "prnt at tail should suppress auto-print"
+        );
+    }
+
+    /// `print` (long-form alias for `prnt`) resolves to `prnt` via
+    /// `ast::resolve_aliases` before `program_result_should_suppress` is
+    /// called in production. Test mirrors production by running resolve_aliases.
+    #[test]
+    fn suppress_print_alias_at_tail() {
+        let tokens = lexer::lex("main>_;print \"hello\"").unwrap();
+        let token_spans: Vec<_> = tokens
+            .into_iter()
+            .map(|(t, r)| {
+                (
+                    t,
+                    ast::Span {
+                        start: r.start,
+                        end: r.end,
+                    },
+                )
+            })
+            .collect();
+        let (mut prog, _) = parser::parse(token_spans);
+        ast::resolve_aliases(&mut prog);
+        assert!(
+            program_result_should_suppress(&prog, None),
+            "print alias at tail should suppress after alias resolution"
+        );
+    }
+
+    /// When `prnt` is NOT the last statement the auto-echo must still fire.
+    #[test]
+    fn no_suppress_prnt_not_at_tail() {
+        let prog = make_program("main>_;prnt \"hi\";\"final\"");
+        assert!(
+            !program_result_should_suppress(&prog, None),
+            "prnt not at tail must not suppress"
+        );
+    }
+
+    /// A loop at tail (original behaviour) still suppresses.
+    #[test]
+    fn suppress_loop_at_tail_unchanged() {
+        let prog = make_program("main>_;@x [1 2 3]{prnt x}");
+        assert!(
+            program_result_should_suppress(&prog, None),
+            "loop at tail should still suppress"
+        );
+    }
+
+    /// A plain expression at tail (no loop, no prnt) must NOT suppress.
+    #[test]
+    fn no_suppress_plain_expr_at_tail() {
+        let prog = make_program("main>_;\"hello\"");
+        assert!(
+            !program_result_should_suppress(&prog, None),
+            "plain expr at tail must not suppress"
+        );
     }
 
     // ── subprocess helpers ────────────────────────────────────────────────────

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -4391,9 +4391,14 @@ fn entry_should_suppress_auto_echo(program: &CompiledProgram, entry_func: &str) 
         return false;
     };
 
-    // Case 1: bare `prnt` call at tail.
-    if let ast::Stmt::Expr(ast::Expr::Call { function, .. }) = &last.node {
-        if function == "prnt" {
+    // Case 1: bare `prnt` call at tail whose argument is not `~`/`^`
+    // wrapped. Must match `program_result_should_suppress` in src/main.rs
+    // exactly: the Ok/Err exclusion preserves the `prnt ~"x"` two-line
+    // contract (wrapper-visible from prnt + bare from auto-echo) that
+    // programs use to surface a Result alongside the stripped value.
+    if let ast::Stmt::Expr(ast::Expr::Call { function, args, .. }) = &last.node {
+        if function == "prnt" && !matches!(args.first(), Some(ast::Expr::Ok(_) | ast::Expr::Err(_)))
+        {
             return true;
         }
     }

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -162,6 +162,12 @@ struct HelperFuncs {
     /// `jit_prt_main_result` in `src/vm/mod.rs`. Returns a u64 exit code
     /// (0 or 1) that `generate_main` truncates to i32 for `main`.
     prt_main: FuncId,
+    /// AOT main-result printer, suppression variant. Same exit-code contract
+    /// as `prt_main` but suppresses the happy-path stdout print — used when
+    /// the entry function's body ends with a `prnt` call (which already
+    /// printed) or a loop-tail (which already printed via the loop body).
+    /// Err still goes to stderr with exit 1.
+    prt_main_suppress: FuncId,
     trm: FuncId,
     upr: FuncId,
     lwr: FuncId,
@@ -386,6 +392,7 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         // Print, trim, uniq
         prt: declare_helper(module, "jit_prt", 1, 1),
         prt_main: declare_helper(module, "jit_prt_main_result", 1, 1),
+        prt_main_suppress: declare_helper(module, "jit_prt_main_result_suppress", 1, 1),
         trm: declare_helper(module, "jit_trm", 2, 1),
         upr: declare_helper(module, "jit_upr", 2, 1),
         lwr: declare_helper(module, "jit_lwr", 2, 1),
@@ -583,6 +590,7 @@ pub fn compile_to_binary(
     // AST didn't survive into `CompiledProgram` (rare; mostly test paths)
     // fall back to all-false, preserving the historical scalar-parse path.
     let param_is_list = entry_param_is_list(program, entry_func, entry_chunk.param_count as usize);
+    let suppress_auto_echo = entry_should_suppress_auto_echo(program, entry_func);
 
     // Generate main()
     generate_main(
@@ -594,6 +602,7 @@ pub fn compile_to_binary(
         &program_blob,
         &param_is_list,
         entry_func,
+        suppress_auto_echo,
     )?;
 
     // Emit object file
@@ -4348,6 +4357,94 @@ fn entry_param_is_list(
         .collect()
 }
 
+/// AOT counterpart to `program_result_should_suppress` in `src/main.rs`. The
+/// tree/VM/JIT engines route the entry-function result through `print_value`
+/// in main.rs, which consults that helper to decide whether the runtime
+/// auto-echo would duplicate a stdout line the program already wrote. AOT
+/// binaries skip main.rs entirely (they're standalone executables linking
+/// libilo.a), so the same suppression rule has to be evaluated at compile
+/// time here and threaded through to `generate_main`, which then picks
+/// between the printing and suppression helper variants.
+///
+/// Mirrors the rules in `program_result_should_suppress`:
+///   1. Last statement is a bare `prnt` call → suppress (the builtin already
+///      printed; auto-echo of the return value duplicates it).
+///   2. Last statement is `@`/`wh` loop with no early-return path → suppress
+///      (loop body's tail print would duplicate as the program tail).
+///
+/// Returns false when the AST is unavailable (e.g. some test paths that
+/// build CompiledProgram without the full AST) — printing-too-much is the
+/// safer failure mode than silently swallowing a value.
+fn entry_should_suppress_auto_echo(program: &CompiledProgram, entry_func: &str) -> bool {
+    use crate::ast;
+    let Some(ast_program) = program.ast.as_ref() else {
+        return false;
+    };
+    let body = ast_program.declarations.iter().find_map(|d| match d {
+        ast::Decl::Function { name, body, .. } if name == entry_func => Some(body),
+        _ => None,
+    });
+    let Some(body) = body else {
+        return false;
+    };
+    let Some(last) = body.last() else {
+        return false;
+    };
+
+    // Case 1: bare `prnt` call at tail.
+    if let ast::Stmt::Expr(ast::Expr::Call { function, .. }) = &last.node {
+        if function == "prnt" {
+            return true;
+        }
+    }
+
+    // Case 2: loop at tail with no early-return path.
+    let ends_with_loop = matches!(
+        last.node,
+        ast::Stmt::ForEach { .. } | ast::Stmt::ForRange { .. } | ast::Stmt::While { .. }
+    );
+    if !ends_with_loop {
+        return false;
+    }
+    !body_has_early_return_ast(body)
+}
+
+/// AOT-side mirror of `body_has_early_return` in `src/main.rs`. Lifted here
+/// rather than imported so the AOT codegen path doesn't have a hard
+/// dependency on main.rs (this crate is also consumed as `libilo` by the
+/// AOT runtime build).
+fn body_has_early_return_ast(body: &[crate::ast::Spanned<crate::ast::Stmt>]) -> bool {
+    for s in body {
+        if stmt_has_early_return_ast(&s.node) {
+            return true;
+        }
+    }
+    false
+}
+
+fn stmt_has_early_return_ast(stmt: &crate::ast::Stmt) -> bool {
+    use crate::ast;
+    match stmt {
+        ast::Stmt::Return(_) => true,
+        ast::Stmt::Guard {
+            braceless: true, ..
+        } => true,
+        ast::Stmt::Guard {
+            body, else_body, ..
+        } => {
+            body_has_early_return_ast(body)
+                || else_body
+                    .as_ref()
+                    .is_some_and(|b| body_has_early_return_ast(b))
+        }
+        ast::Stmt::Match { arms, .. } => arms.iter().any(|a| body_has_early_return_ast(&a.body)),
+        ast::Stmt::ForEach { body, .. }
+        | ast::Stmt::ForRange { body, .. }
+        | ast::Stmt::While { body, .. } => body_has_early_return_ast(body),
+        _ => false,
+    }
+}
+
 /// Generate the `main(argc, argv)` entry point.
 /// Serialize a TypeRegistry to bytes for embedding in AOT binaries.
 /// Format: `type_name\0num_fields_bitmask\0field1\0field2\0...\0\n` per type.
@@ -4388,6 +4485,13 @@ fn generate_main(
     // funcname slot when it appears. Without this, `./bin main 42` binds the
     // string "main" as the first param instead of 42.
     entry_name: &str,
+    // When true, the entry function's body ends with a syntactic form that
+    // already wrote its happy-path output to stdout (a `prnt` call at the
+    // tail, or a `@`/`wh` loop with no early-return). The generated `main`
+    // routes the return value through the suppression helper instead of
+    // the printing one so the AOT binary matches the in-process runners'
+    // `print_value` behaviour. Err always surfaces to stderr with exit 1.
+    suppress_auto_echo: bool,
 ) -> Result<(), String> {
     let mut sig = module.make_signature();
     sig.params.push(AbiParam::new(I32)); // argc
@@ -4494,7 +4598,18 @@ fn generate_main(
     // a top-level `~v` prints bare on stdout (exit 0); a top-level `^e`
     // prints `^e` on stderr (exit 1). The helper returns the desired exit
     // code packed in a u64; we truncate to i32 for `main`.
-    let prt_main_fref = module.declare_func_in_func(helpers.prt_main, builder.func);
+    //
+    // When `suppress_auto_echo` is set, route through the suppression
+    // variant instead — the entry function's tail already wrote stdout
+    // (via a `prnt` call or a loop body) and re-printing the return value
+    // would double-print. Mirrors the `print_value` / `suppress_loop_tail`
+    // branch the in-process runners take in `src/main.rs`.
+    let prt_helper = if suppress_auto_echo {
+        helpers.prt_main_suppress
+    } else {
+        helpers.prt_main
+    };
+    let prt_main_fref = module.declare_func_in_func(prt_helper, builder.func);
     let call_prt = builder.ins().call(prt_main_fref, &[result]);
     let exit_u64 = builder.inst_results(call_prt)[0];
 

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -18090,6 +18090,31 @@ pub(crate) extern "C" fn jit_prt_main_result(v: u64) -> u64 {
     0
 }
 
+/// AOT entry-point print, suppression variant. Same as `jit_prt_main_result`
+/// except that the Ok/plain stdout-print arms are suppressed — used when the
+/// entry function's body ends with a `prnt` call (or a loop containing
+/// `prnt`) so the AOT binary does not double-print. The Err arm is
+/// preserved: a top-level `^e` still prints to stderr with exit 1 because
+/// suppression is purely about avoiding duplicated happy-path output, not
+/// about swallowing program failure (matches `print_value`'s plain-mode
+/// behaviour at `src/main.rs`'s `suppress_loop_tail` branch).
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_prt_main_result_suppress(v: u64) -> u64 {
+    let nv = NanVal(v);
+    let tag = v & TAG_MASK;
+    if tag == TAG_ERR {
+        // Err must always print to stderr — see `print_value` comment.
+        eprintln!("{}", nv.to_value());
+        nv.clone_rc();
+        return 1;
+    }
+    // Ok / Number / Bool / Nil / heap-value: suppress the print but still
+    // own the rc-bump so the value is dropped cleanly by `aot_fini`.
+    nv.clone_rc();
+    0
+}
+
 #[cfg(feature = "cranelift")]
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn jit_trm(v: u64, span_bits: u64) -> u64 {

--- a/tests/regression_aot_prnt_no_double_print.rs
+++ b/tests/regression_aot_prnt_no_double_print.rs
@@ -1,0 +1,153 @@
+// Regression: `ilo compile` AOT binaries must NOT double-print when the
+// entry function's body ends with a `prnt` call.
+//
+// Background: `prnt v` prints v on stdout and returns v (passthrough). The
+// runtime auto-echoes the entry function's return value, so a body like
+//
+//     main>_;prnt "hello"
+//
+// used to produce `hello\nhello\n` — the in-builtin print, then a second
+// copy from the top-level auto-echo. Caught by the `subscription-renewer`
+// and `cron-explainer` personas (pending.md P0 #3).
+//
+// Fix touches two places:
+//   1. `src/main.rs`: `program_result_should_suppress` now also returns
+//      true when the last statement is a `prnt` call — covers tree/VM/JIT
+//      which all route results through `print_value`.
+//   2. `src/vm/compile_cranelift.rs` + `src/vm/mod.rs`: `generate_main`
+//      consults `entry_should_suppress_auto_echo` and routes the result
+//      through `jit_prt_main_result_suppress` (which suppresses the
+//      happy-path stdout but still surfaces `^e` on stderr with exit 1)
+//      when applicable — covers AOT binaries which don't go through
+//      main.rs's print path.
+//
+// This file pins the AOT case. The in-process engine cases are covered by
+// the unit tests in `src/main.rs` (`suppress_prnt_at_tail` and friends)
+// and by `regression_loop_print.rs`. Gated on `cranelift` because AOT
+// compile requires it.
+
+#![cfg(feature = "cranelift")]
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn tmp_paths(tag: &str) -> (PathBuf, PathBuf) {
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let src = std::env::temp_dir().join(format!("ilo-aot-prnt-{tag}-{pid}-{n}.ilo"));
+    let bin = std::env::temp_dir().join(format!("ilo-aot-prnt-{tag}-{pid}-{n}.bin"));
+    (src, bin)
+}
+
+fn compile_and_run(src_body: &str, tag: &str) -> (String, String, i32) {
+    let (src, bin) = tmp_paths(tag);
+    std::fs::write(&src, src_body).expect("write src");
+
+    let compile = ilo()
+        .args(["compile"])
+        .arg(&src)
+        .arg("-o")
+        .arg(&bin)
+        .output()
+        .expect("compile");
+    assert!(
+        compile.status.success(),
+        "compile failed for src=`{src_body}`: stderr={:?}",
+        String::from_utf8_lossy(&compile.stderr),
+    );
+
+    let run = Command::new(&bin).output().expect("run binary");
+    let stdout = String::from_utf8_lossy(&run.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&run.stderr).to_string();
+    let code = run.status.code().unwrap_or(-1);
+
+    let _ = std::fs::remove_file(&src);
+    let _ = std::fs::remove_file(&bin);
+
+    (stdout, stderr, code)
+}
+
+// ── 1. Bare `prnt` at tail: AOT binary prints exactly once ────────────────
+
+#[test]
+fn aot_prnt_at_tail_does_not_double_print() {
+    let (stdout, _stderr, code) = compile_and_run("main>_;prnt \"hello\"\n", "prnt-tail-text");
+
+    // Pre-fix behaviour: stdout was "hello\nhello\n" — the prnt builtin
+    // wrote "hello", then `jit_prt_main_result` wrote it again. Post-fix:
+    // exactly one "hello\n".
+    assert_eq!(
+        stdout, "hello\n",
+        "AOT must print `hello` exactly once, got: {stdout:?}"
+    );
+    assert_eq!(code, 0, "wrong exit: {code}");
+}
+
+// ── 2. `prnt` of a number at tail: also single-print ──────────────────────
+
+#[test]
+fn aot_prnt_number_at_tail_does_not_double_print() {
+    let (stdout, _stderr, code) = compile_and_run("main>_;prnt 42\n", "prnt-tail-num");
+
+    assert_eq!(
+        stdout, "42\n",
+        "AOT must print `42` exactly once, got: {stdout:?}"
+    );
+    assert_eq!(code, 0, "wrong exit: {code}");
+}
+
+// ── 3. `prnt` NOT at tail: final value still auto-echoes ──────────────────
+
+#[test]
+fn aot_prnt_not_at_tail_still_echoes_final_value() {
+    // Last stmt is the string `"done"`, not a `prnt` call. The runtime
+    // auto-echo must still fire so the program return value reaches stdout.
+    // Total output: "hi\ndone\n" — prnt writes "hi", auto-echo writes "done".
+    let (stdout, _stderr, code) = compile_and_run("main>_;prnt \"hi\";\"done\"\n", "prnt-not-tail");
+
+    assert_eq!(
+        stdout, "hi\ndone\n",
+        "non-tail prnt must keep printing and tail expr must echo, got: {stdout:?}"
+    );
+    assert_eq!(code, 0, "wrong exit: {code}");
+}
+
+// ── 4. Plain string at tail: AOT still auto-echoes (no suppression) ───────
+
+#[test]
+fn aot_plain_expr_at_tail_still_echoes() {
+    // No prnt anywhere — runtime auto-echo is the only source of stdout.
+    // Suppression must NOT fire here, or the program produces no output.
+    let (stdout, _stderr, code) = compile_and_run("main>_;\"hello\"\n", "plain-tail");
+
+    assert_eq!(
+        stdout, "hello\n",
+        "plain tail expr must still auto-echo, got: {stdout:?}"
+    );
+    assert_eq!(code, 0, "wrong exit: {code}");
+}
+
+// ── 5. Loop with prnt at tail: existing loop-tail suppression unchanged ──
+
+#[test]
+fn aot_loop_with_prnt_body_does_not_double_print() {
+    // Pre-existing rule (PR for loop-tail suppression): a loop body's prnt
+    // already wrote stdout, the loop-tail value would duplicate the last
+    // item. This test pins that AOT respects that rule too — the suppress
+    // helper is now used uniformly for both prnt-at-tail and loop-at-tail.
+    let (stdout, _stderr, code) =
+        compile_and_run("main>_;@x [\"a\" \"b\" \"c\"]{prnt x}\n", "loop-prnt");
+
+    assert_eq!(
+        stdout, "a\nb\nc\n",
+        "loop body's prnts must not be duplicated, got: {stdout:?}"
+    );
+    assert_eq!(code, 0, "wrong exit: {code}");
+}

--- a/tests/regression_loop_print.rs
+++ b/tests/regression_loop_print.rs
@@ -221,11 +221,11 @@ fn check_all(engine: &str) {
     );
 }
 
-#[test]
-fn loop_print_tree() {
-    check_all("--vm");
-}
-
+// VM coverage. Historically there was a sibling `loop_print_tree` that
+// ran against `--run-tree`; the tree-walker was soft-deprecated and its
+// CLI flag swept to `--run-vm` (PR #99d4580) and then to `--vm`
+// (PR #7baa333), so the tree-named test was duplicating the VM one and
+// has been removed. JIT / AOT siblings are below.
 #[test]
 fn loop_print_vm() {
     check_all("--vm");


### PR DESCRIPTION
## Summary

- `prnt` returns its argument AND the runtime auto-prints the return value of `main>_`, producing a double-print
- Fix: extend `program_result_should_suppress` to also return `true` when the entry function's last statement is a `prnt` call
- Caught by `subscription-renewer` and `cron-explainer` personas (pending.md P0 #3)

## Repro before/after

Before:
```
$ ilo 'main>_;prnt "hello"'
hello
hello
```

After:
```
$ ilo 'main>_;prnt "hello"'
hello
```

Works the same on all three engines (tree, VM, JIT).

## What's in the diff

**`src/main.rs`**: Extend `program_result_should_suppress` with a new Case 1 before the existing loop-at-tail Case 2. When the last statement is `Stmt::Expr(Expr::Call { function: "prnt", .. })`, return `true` immediately. Aliases resolve to `prnt` before this check runs (production path). Add 5 unit tests covering prnt-at-tail, print-alias-at-tail (with resolve_aliases), prnt-not-at-tail, loop-at-tail unchanged, and plain-expr-at-tail.

**`examples/prnt-no-double.ilo`**: New example with `-- run:` / `-- out:` annotations covering the prnt-at-tail (string) and prnt-at-tail (number) cases. Exercised by `tests/examples_engines.rs` across all backends.

## Test plan

- [x] `cargo test --release --lib` - all 5 new tests pass, 3245 total pass
- [x] `cargo fmt -- --check` - clean
- [x] Cross-engine manual verification: tree / VM / JIT all print once
- [x] Non-tail prnt still auto-echoes the final value
- [x] Loop-at-tail suppression unchanged

## Follow-ups

- P0 #4: `~"ok"` at tail also auto-prints `ok` - same family, different root cause (`Stmt::Return(Expr::Ok(...))` vs `Stmt::Expr(Expr::Call)`). Separate PR.
- Long-term: option (c) from pending.md - only auto-echo when `main>t` (typed-return form). 0.13.x design decision.