### PR TITLE
docs: standardise on -dev.N versioning, drop RC tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,27 +121,26 @@ CalVer. Releases are `YY.M` (e.g. `26.5`), patches within a month are `YY.M.P` (
 
 ### Branches
 
-| Branch | Purpose              | Tags                              |
-|--------|----------------------|-----------------------------------|
-| `main` | Current release line | `26.5`, `26.5.1`, `26.5.2-rc.1`   |
-| `next` | Upcoming release     | `26.6-dev.1`, `26.6-dev.2`        |
+| Branch | Purpose                     | Tags                                       |
+|--------|-----------------------------|--------------------------------------------|
+| `main` | Current release line, patches | `26.5`, `26.5.1`, `26.5.1-dev.N`         |
+| `next` | Next release                  | `26.6-dev.N`, then clean `26.6` on cut    |
 
-- `main` never carries `-dev` tags
-- `next` never carries stable tags — it merges to `main` first
+Universal scheme: `-dev.N` is the only in-flight marker on either branch. Clean (no suffix) means soaked, ready, published. No RC tag.
 
-### Release flow
+### Release flow (next release)
 
 1. Work lands on `next`
-2. Optional dev snapshots tagged `26.6-dev.N`
-3. Ship: merge `next` → `main`, tag `26.6` on `main`
-4. `next` continues for `26.7`
+2. Iterations tagged `26.6-dev.1`, `26.6-dev.2`, …
+3. When soaked: merge `next` → `main`, cut clean `26.6` tag on `main`
+4. `next` continues for `26.7-dev.1`
 
-### Patch flow
+### Patch flow (current release fix)
 
 1. Fix lands on `main` (direct or short-lived fix branch)
-2. Tag `26.5.1` on `main`
-3. Merge `main` → `next` to carry the fix forward
-4. RCs cut from `main` only, tagged `26.5.2-rc.1`
+2. Iterations tagged `26.5.1-dev.1`, `26.5.1-dev.2`, …
+3. When soaked: cut clean `26.5.1` tag on `main`
+4. Merge `main` → `next` to carry the fix forward (auto via `sync-next.yml`)
 
 ### Migration from 0.x
 


### PR DESCRIPTION
## Summary

- Universal in-flight marker: `-dev.N` on both `main` (patches) and `next` (next release)
- Drop RC tag — soaked clean tag is the only "ready" signal
- Aligns with Dan's intent to use dev tag uniformly across release process

## Files

- `README.md` Versioning section: branches table updated, RC mentions removed, patch flow rewritten

## Follow-up

Separate brief incoming for `release.yml` to skip crates/npm publish on `-dev.N` tags.