### PR TITLE
docs: regex builtin signatures (rgx, rgxall, rgxall1, rgxsub)

### DIFF
--- a/skills/ilo/ilo-builtins-text.md
+++ b/skills/ilo/ilo-builtins-text.md
@@ -17,7 +17,14 @@ Prefix-call: `name arg1 arg2 ...`. Cross-engine unless noted.
 
 ## Regex
 
-`rgx s pat` first match, `rgxall s pat` all matches, `rgxall1 s pat` first capture group of each match, `rgxall-multi pats s` multi-pattern flat-match (each pattern follows rgxall1 semantics; results concat in pattern order), `rgxsub s pat repl` substitute.
+Signatures (pat first, string last):
+
+- `rgx pat s > L t` — first match: list of [whole, cap1, cap2, ...]
+- `rgxall pat s > L t` — all whole matches
+- `rgxall1 pat s > L t` — capture-group 1 of every match
+- `rgxsub pat repl s > t` — substitute first match
+- `rgxsuball pat repl s > t` — substitute all matches
+- `rgxall-multi pats s > L t` — multi-pattern flat-match (each pattern follows rgxall1 semantics; results concat in pattern order)
 
 ## Formatting
 


### PR DESCRIPTION
## Summary

- Adds explicit signature lines for all regex builtins in `skills/ilo/ilo-builtins-text.md`
- Fixes wrong arg order in the old prose line (`s pat` -> `pat s`)
- Adds missing `rgxsuball` entry

The html-scraper persona guessed `rgxall1 s pat` and got wrong results. This makes `pat s` unambiguous at a glance.

## What's in the diff

Single commit: replaces the old one-liner with a bullet list, each line showing `name args > return-type` plus a terse description. Token count unchanged at 6612 (within cap).

## Test plan

- [x] `python3 scripts/check-skill-tokens.py` passes (6612 tokens)
- [x] Signatures match actual interpreter dispatch (pat first, string last)