### PR TITLE
feature: --allow-net/read/write/run CLI capability flags

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,9 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Interpreter tests exercise deep recursion (e.g. fib(10)), which can blow
+  # the 8 MiB default thread stack on Linux debug builds. 16 MiB is enough.
+  RUST_MIN_STACK: 16777216
 
 jobs:
   lint:

--- a/src/caps.rs
+++ b/src/caps.rs
@@ -27,7 +27,6 @@
 /// assert!(caps.check_net("evil.example").is_err());
 /// assert!(caps.check_net("good.example").is_err()); // still blocked — list is empty
 /// ```
-
 /// Allowlist policy for a single capability dimension.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Policy {
@@ -38,9 +37,10 @@ pub enum Policy {
 }
 
 /// Per-process capability set derived from `--allow-*` CLI flags.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum Caps {
     /// No `--allow-*` flags were passed; all IO is permitted (legacy behaviour).
+    #[default]
     Permissive,
     /// At least one `--allow-*` flag was passed; enforce the sub-policies.
     Restricted {
@@ -49,12 +49,6 @@ pub enum Caps {
         write: Policy,
         run: Policy,
     },
-}
-
-impl Default for Caps {
-    fn default() -> Self {
-        Caps::Permissive
-    }
 }
 
 impl Caps {

--- a/src/caps.rs
+++ b/src/caps.rs
@@ -1,0 +1,468 @@
+/// CLI capability flags — Deno-style operator sandbox.
+///
+/// When any `--allow-*` flag is present the policy switches from permissive
+/// (the default, matching pre-0.13 behaviour) to restrictive: every IO
+/// builtin checks whether the target host/path/command falls inside the
+/// caller-supplied allowlist before executing. An empty allowlist (`""`)
+/// means *no* targets are permitted; `"*"` means all targets are permitted.
+///
+/// # Default behaviour
+///
+/// `Caps::default()` returns `Caps::Permissive`, which **never** blocks.
+/// This preserves full backwards compatibility: scripts that do not pass any
+/// `--allow-*` flags continue to run without restriction.
+///
+/// # Example
+///
+/// ```
+/// use ilo::caps::{Caps, Policy};
+///
+/// // Block all network access
+/// let caps = Caps {
+///     net:   Policy::List(vec![]),
+///     read:  Policy::All,
+///     write: Policy::All,
+///     run:   Policy::All,
+/// };
+/// assert!(caps.check_net("evil.example").is_err());
+/// assert!(caps.check_net("good.example").is_err()); // still blocked — list is empty
+/// ```
+
+/// Allowlist policy for a single capability dimension.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Policy {
+    /// No restriction — all targets are allowed (the legacy default).
+    All,
+    /// Only targets in this list are permitted.  An empty list blocks everything.
+    List(Vec<String>),
+}
+
+/// Per-process capability set derived from `--allow-*` CLI flags.
+#[derive(Debug, Clone)]
+pub enum Caps {
+    /// No `--allow-*` flags were passed; all IO is permitted (legacy behaviour).
+    Permissive,
+    /// At least one `--allow-*` flag was passed; enforce the sub-policies.
+    Restricted {
+        net: Policy,
+        read: Policy,
+        write: Policy,
+        run: Policy,
+    },
+}
+
+impl Default for Caps {
+    fn default() -> Self {
+        Caps::Permissive
+    }
+}
+
+impl Caps {
+    /// Parse a comma-separated `--allow-*` value.
+    ///
+    /// `"*"` or `"all"` → `Policy::All`.
+    /// `""` → `Policy::List([])` (block everything).
+    /// `"a,b,c"` → `Policy::List(["a","b","c"])`.
+    pub fn parse_allow(val: &str) -> Policy {
+        let trimmed = val.trim();
+        if trimmed == "*" || trimmed.eq_ignore_ascii_case("all") {
+            return Policy::All;
+        }
+        let items: Vec<String> = if trimmed.is_empty() {
+            vec![]
+        } else {
+            trimmed
+                .split(',')
+                .map(|s| s.trim().to_owned())
+                .filter(|s| !s.is_empty())
+                .collect()
+        };
+        Policy::List(items)
+    }
+
+    // ── Check helpers ─────────────────────────────────────────────────────────
+
+    /// Returns `Ok(())` if a network request to `url` is allowed, or an
+    /// `Err` with a human-readable policy message.
+    pub fn check_net(&self, url: &str) -> Result<(), String> {
+        let Caps::Restricted { net, .. } = self else {
+            return Ok(());
+        };
+        match net {
+            Policy::All => Ok(()),
+            Policy::List(allowed) => {
+                let host = extract_host(url);
+                if allowed.iter().any(|h| host_matches(h, host)) {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "blocked by --allow-net policy: host={host} is not in the allowlist"
+                    ))
+                }
+            }
+        }
+    }
+
+    /// Returns `Ok(())` if reading `path` is allowed.
+    pub fn check_read(&self, path: &str) -> Result<(), String> {
+        let Caps::Restricted { read, .. } = self else {
+            return Ok(());
+        };
+        match read {
+            Policy::All => Ok(()),
+            Policy::List(allowed) => {
+                if allowed.iter().any(|prefix| path_matches(prefix, path)) {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "blocked by --allow-read policy: path={path} is not in the allowlist"
+                    ))
+                }
+            }
+        }
+    }
+
+    /// Returns `Ok(())` if writing `path` is allowed.
+    pub fn check_write(&self, path: &str) -> Result<(), String> {
+        let Caps::Restricted { write, .. } = self else {
+            return Ok(());
+        };
+        match write {
+            Policy::All => Ok(()),
+            Policy::List(allowed) => {
+                if allowed.iter().any(|prefix| path_matches(prefix, path)) {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "blocked by --allow-write policy: path={path} is not in the allowlist"
+                    ))
+                }
+            }
+        }
+    }
+
+    /// Returns `Ok(())` if executing `cmd` is allowed.
+    pub fn check_run(&self, cmd: &str) -> Result<(), String> {
+        let Caps::Restricted { run, .. } = self else {
+            return Ok(());
+        };
+        match run {
+            Policy::All => Ok(()),
+            Policy::List(allowed) => {
+                // Basename comparison: if `cmd` is `/usr/bin/ls`, also check `ls`.
+                let base = cmd.rsplit('/').next().unwrap_or(cmd);
+                if allowed.iter().any(|c| c == cmd || c == base) {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "blocked by --allow-run policy: cmd={cmd} is not in the allowlist"
+                    ))
+                }
+            }
+        }
+    }
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+/// Extract the host portion from a URL string.
+///
+/// Strips the scheme (`https://`, `http://`), then takes everything up to the
+/// first `/`, `?`, or `#`.  Falls back to the full string when no scheme is
+/// present, which covers raw hostnames like `"example.com"`.
+fn extract_host(url: &str) -> &str {
+    // Strip scheme.
+    let rest = if let Some(s) = url.strip_prefix("https://") {
+        s
+    } else if let Some(s) = url.strip_prefix("http://") {
+        s
+    } else {
+        url
+    };
+    // Trim path/query/fragment.
+    rest.split(['/', '?', '#']).next().unwrap_or(rest)
+}
+
+/// True if `pattern` matches `host`.
+///
+/// Supports a leading `*.` wildcard (e.g. `*.example.com` matches
+/// `api.example.com` and `example.com`).  Exact match is always tried first.
+fn host_matches(pattern: &str, host: &str) -> bool {
+    if pattern == host {
+        return true;
+    }
+    // Wildcard: `*.example.com` matches `sub.example.com` and `example.com`.
+    if let Some(suffix) = pattern.strip_prefix("*.") {
+        return host == suffix || host.ends_with(&format!(".{suffix}"));
+    }
+    false
+}
+
+/// True if `prefix` is a path prefix of `path`.
+///
+/// Empty prefix blocks everything (empty string is never a prefix of a
+/// non-empty path via this check).  An exact match is always permitted.
+/// Trailing-slash normalisation: `/tmp` is a prefix of `/tmp/foo` but not
+/// `/tmpfoo`.
+fn path_matches(prefix: &str, path: &str) -> bool {
+    if prefix.is_empty() {
+        return false;
+    }
+    if path == prefix {
+        return true;
+    }
+    // prefix=/tmp  path=/tmp/foo → true
+    // prefix=/tmp  path=/tmpfoo  → false
+    let with_sep = if prefix.ends_with('/') {
+        prefix.to_owned()
+    } else {
+        format!("{prefix}/")
+    };
+    path.starts_with(&with_sep)
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── parse_allow ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_star_is_all() {
+        assert_eq!(Caps::parse_allow("*"), Policy::All);
+    }
+
+    #[test]
+    fn parse_all_word_is_all() {
+        assert_eq!(Caps::parse_allow("all"), Policy::All);
+    }
+
+    #[test]
+    fn parse_empty_is_empty_list() {
+        assert_eq!(Caps::parse_allow(""), Policy::List(vec![]));
+    }
+
+    #[test]
+    fn parse_single_item() {
+        assert_eq!(
+            Caps::parse_allow("example.com"),
+            Policy::List(vec!["example.com".to_owned()])
+        );
+    }
+
+    #[test]
+    fn parse_comma_separated() {
+        assert_eq!(
+            Caps::parse_allow("a.com,b.com,c.com"),
+            Policy::List(vec![
+                "a.com".to_owned(),
+                "b.com".to_owned(),
+                "c.com".to_owned()
+            ])
+        );
+    }
+
+    #[test]
+    fn parse_whitespace_trimmed() {
+        assert_eq!(
+            Caps::parse_allow(" a.com , b.com "),
+            Policy::List(vec!["a.com".to_owned(), "b.com".to_owned()])
+        );
+    }
+
+    // ── default is permissive ─────────────────────────────────────────────────
+
+    #[test]
+    fn default_caps_permit_everything() {
+        let caps = Caps::default();
+        assert!(caps.check_net("https://evil.example").is_ok());
+        assert!(caps.check_read("/etc/passwd").is_ok());
+        assert!(caps.check_write("/etc/passwd").is_ok());
+        assert!(caps.check_run("rm").is_ok());
+    }
+
+    // ── check_net ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn net_all_policy_allows_any() {
+        let caps = Caps::Restricted {
+            net: Policy::All,
+            read: Policy::List(vec![]),
+            write: Policy::List(vec![]),
+            run: Policy::List(vec![]),
+        };
+        assert!(caps.check_net("https://evil.example").is_ok());
+    }
+
+    #[test]
+    fn net_empty_list_blocks_all() {
+        let caps = Caps::Restricted {
+            net: Policy::List(vec![]),
+            read: Policy::All,
+            write: Policy::All,
+            run: Policy::All,
+        };
+        let err = caps.check_net("https://example.com").unwrap_err();
+        assert!(err.contains("--allow-net"), "msg={err}");
+        assert!(err.contains("example.com"), "msg={err}");
+    }
+
+    #[test]
+    fn net_allowlisted_host_passes() {
+        let caps = Caps::Restricted {
+            net: Policy::List(vec!["example.com".to_owned()]),
+            read: Policy::All,
+            write: Policy::All,
+            run: Policy::All,
+        };
+        assert!(caps.check_net("https://example.com/api").is_ok());
+    }
+
+    #[test]
+    fn net_non_allowlisted_host_blocked() {
+        let caps = Caps::Restricted {
+            net: Policy::List(vec!["example.com".to_owned()]),
+            read: Policy::All,
+            write: Policy::All,
+            run: Policy::All,
+        };
+        let err = caps.check_net("https://evil.example").unwrap_err();
+        assert!(err.contains("--allow-net"), "msg={err}");
+    }
+
+    #[test]
+    fn net_wildcard_subdomain() {
+        let caps = Caps::Restricted {
+            net: Policy::List(vec!["*.example.com".to_owned()]),
+            read: Policy::All,
+            write: Policy::All,
+            run: Policy::All,
+        };
+        assert!(caps.check_net("https://api.example.com/data").is_ok());
+        assert!(caps.check_net("https://example.com/data").is_ok());
+        assert!(caps.check_net("https://other.org").is_err());
+    }
+
+    // ── check_read ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn read_empty_list_blocks_all() {
+        let caps = Caps::Restricted {
+            net: Policy::All,
+            read: Policy::List(vec![]),
+            write: Policy::All,
+            run: Policy::All,
+        };
+        assert!(caps.check_read("/etc/passwd").is_err());
+    }
+
+    #[test]
+    fn read_prefix_allows_subpath() {
+        let caps = Caps::Restricted {
+            net: Policy::All,
+            read: Policy::List(vec!["/tmp".to_owned()]),
+            write: Policy::All,
+            run: Policy::All,
+        };
+        assert!(caps.check_read("/tmp/foo.txt").is_ok());
+        assert!(caps.check_read("/tmp").is_ok());
+    }
+
+    #[test]
+    fn read_prefix_does_not_allow_sibling() {
+        let caps = Caps::Restricted {
+            net: Policy::All,
+            read: Policy::List(vec!["/tmp".to_owned()]),
+            write: Policy::All,
+            run: Policy::All,
+        };
+        assert!(caps.check_read("/tmpfoo").is_err());
+        assert!(caps.check_read("/etc/passwd").is_err());
+    }
+
+    // ── check_write ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn write_prefix_enforced() {
+        let caps = Caps::Restricted {
+            net: Policy::All,
+            read: Policy::All,
+            write: Policy::List(vec!["/tmp".to_owned()]),
+            run: Policy::All,
+        };
+        assert!(caps.check_write("/tmp/out.txt").is_ok());
+        assert!(caps.check_write("/etc/passwd").is_err());
+    }
+
+    // ── check_run ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn run_empty_list_blocks_all() {
+        let caps = Caps::Restricted {
+            net: Policy::All,
+            read: Policy::All,
+            write: Policy::All,
+            run: Policy::List(vec![]),
+        };
+        assert!(caps.check_run("ls").is_err());
+    }
+
+    #[test]
+    fn run_allowlisted_cmd_passes() {
+        let caps = Caps::Restricted {
+            net: Policy::All,
+            read: Policy::All,
+            write: Policy::All,
+            run: Policy::List(vec!["ls".to_owned()]),
+        };
+        assert!(caps.check_run("ls").is_ok());
+        assert!(caps.check_run("/usr/bin/ls").is_ok()); // basename match
+        assert!(caps.check_run("rm").is_err());
+    }
+
+    // ── extract_host ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn extract_host_https() {
+        assert_eq!(extract_host("https://example.com/path?q=1"), "example.com");
+    }
+
+    #[test]
+    fn extract_host_http() {
+        assert_eq!(extract_host("http://api.example.com"), "api.example.com");
+    }
+
+    #[test]
+    fn extract_host_no_scheme() {
+        assert_eq!(extract_host("example.com"), "example.com");
+    }
+
+    // ── path_matches ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn path_matches_exact() {
+        assert!(path_matches("/tmp", "/tmp"));
+    }
+
+    #[test]
+    fn path_matches_sub() {
+        assert!(path_matches("/tmp", "/tmp/foo/bar.txt"));
+    }
+
+    #[test]
+    fn path_matches_no_sibling() {
+        assert!(!path_matches("/tmp", "/tmpfoo"));
+    }
+
+    #[test]
+    fn path_matches_empty_prefix_never() {
+        assert!(!path_matches("", "/anything"));
+    }
+
+    #[test]
+    fn path_matches_trailing_slash_prefix() {
+        assert!(path_matches("/tmp/", "/tmp/foo"));
+    }
+}

--- a/src/caps.rs
+++ b/src/caps.rs
@@ -18,7 +18,7 @@
 /// use ilo::caps::{Caps, Policy};
 ///
 /// // Block all network access
-/// let caps = Caps {
+/// let caps = Caps::Restricted {
 ///     net:   Policy::List(vec![]),
 ///     read:  Policy::All,
 ///     write: Policy::All,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -168,6 +168,24 @@ pub struct RunArgs {
     #[arg(long = "mcp")]
     pub mcp_path: Option<String>,
 
+    /// Allow network access. Comma-separated host list, or `*` for all.
+    /// Omitting this flag leaves behaviour unchanged (permissive).
+    /// Passing the flag with an empty value (`--allow-net=`) blocks all net.
+    #[arg(long = "allow-net", value_name = "HOSTS")]
+    pub allow_net: Option<String>,
+
+    /// Allow file reads. Comma-separated path prefix list, or `*` for all.
+    #[arg(long = "allow-read", value_name = "PATHS")]
+    pub allow_read: Option<String>,
+
+    /// Allow file writes. Comma-separated path prefix list, or `*` for all.
+    #[arg(long = "allow-write", value_name = "PATHS")]
+    pub allow_write: Option<String>,
+
+    /// Allow process execution. Comma-separated command list, or `*` for all.
+    #[arg(long = "allow-run", value_name = "CMDS")]
+    pub allow_run: Option<String>,
+
     /// Remaining positional args: optional function name + call arguments.
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub rest: Vec<String>,
@@ -866,6 +884,10 @@ mod tests {
             ast: false,
             tools_path: None,
             mcp_path: None,
+            allow_net: None,
+            allow_read: None,
+            allow_write: None,
+            allow_run: None,
             rest: vec![],
         };
         assert_eq!(r.effective_engine(), Engine::Default);

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -236,7 +236,7 @@ struct Env {
     #[cfg(feature = "tools")]
     tokio_runtime: Option<std::sync::Arc<tokio::runtime::Runtime>>,
     /// CLI capability policy — checked at IO builtin call sites.
-    caps: Caps,
+    caps: Arc<Caps>,
 }
 
 impl Env {
@@ -249,11 +249,11 @@ impl Env {
             tool_provider: None,
             #[cfg(feature = "tools")]
             tokio_runtime: None,
-            caps: Caps::default(),
+            caps: Arc::new(Caps::default()),
         }
     }
 
-    fn with_caps(caps: Caps) -> Self {
+    fn with_caps(caps: Arc<Caps>) -> Self {
         Env {
             vars: Vec::new(),
             scope_marks: vec![0],
@@ -278,14 +278,14 @@ impl Env {
             tool_provider: Some(provider),
             #[cfg(feature = "tools")]
             tokio_runtime: Some(runtime),
-            caps: Caps::default(),
+            caps: Arc::new(Caps::default()),
         }
     }
 
     fn with_tools_and_caps(
         provider: std::sync::Arc<dyn crate::tools::ToolProvider>,
         #[cfg(feature = "tools")] runtime: std::sync::Arc<tokio::runtime::Runtime>,
-        caps: Caps,
+        caps: Arc<Caps>,
     ) -> Self {
         Env {
             vars: Vec::new(),
@@ -392,7 +392,7 @@ pub fn run_with_caps(
     program: &Program,
     func_name: Option<&str>,
     args: Vec<Value>,
-    caps: Caps,
+    caps: Arc<Caps>,
 ) -> Result<Value> {
     run_with_env(program, func_name, args, Env::with_caps(caps))
 }
@@ -463,7 +463,7 @@ pub fn run_with_tools_and_caps(
     args: Vec<Value>,
     provider: std::sync::Arc<dyn crate::tools::ToolProvider>,
     #[cfg(feature = "tools")] runtime: std::sync::Arc<tokio::runtime::Runtime>,
-    caps: Caps,
+    caps: Arc<Caps>,
 ) -> Result<Value> {
     let env = Env::with_tools_and_caps(
         provider,
@@ -9309,13 +9309,10 @@ mod tests {
 
     #[test]
     fn interpret_braceless_guard_fibonacci() {
-        // Use fib(7)=13 rather than fib(10)=55 to stay within the default
-        // debug-build stack on CI Linux runners. The recursion depth of ~12
-        // still exercises the braceless-guard path end-to-end.
         let source = "fib n:n>n;<=n 1 n;a=fib -n 1;b=fib -n 2;+a b";
         assert_eq!(
-            run_str(source, Some("fib"), vec![Value::Number(7.0)]),
-            Value::Number(13.0)
+            run_str(source, Some("fib"), vec![Value::Number(10.0)]),
+            Value::Number(55.0)
         );
     }
 

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1,5 +1,6 @@
 use crate::ast::*;
 use crate::builtins::{Builtin, CharAtResult, char_at_signed};
+use crate::caps::Caps;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -234,6 +235,8 @@ struct Env {
     tool_provider: Option<std::sync::Arc<dyn crate::tools::ToolProvider>>,
     #[cfg(feature = "tools")]
     tokio_runtime: Option<std::sync::Arc<tokio::runtime::Runtime>>,
+    /// CLI capability policy — checked at IO builtin call sites.
+    caps: Caps,
 }
 
 impl Env {
@@ -246,6 +249,20 @@ impl Env {
             tool_provider: None,
             #[cfg(feature = "tools")]
             tokio_runtime: None,
+            caps: Caps::default(),
+        }
+    }
+
+    fn with_caps(caps: Caps) -> Self {
+        Env {
+            vars: Vec::new(),
+            scope_marks: vec![0],
+            functions: HashMap::new(),
+            call_stack: Vec::new(),
+            tool_provider: None,
+            #[cfg(feature = "tools")]
+            tokio_runtime: None,
+            caps,
         }
     }
 
@@ -261,6 +278,24 @@ impl Env {
             tool_provider: Some(provider),
             #[cfg(feature = "tools")]
             tokio_runtime: Some(runtime),
+            caps: Caps::default(),
+        }
+    }
+
+    fn with_tools_and_caps(
+        provider: std::sync::Arc<dyn crate::tools::ToolProvider>,
+        #[cfg(feature = "tools")] runtime: std::sync::Arc<tokio::runtime::Runtime>,
+        caps: Caps,
+    ) -> Self {
+        Env {
+            vars: Vec::new(),
+            scope_marks: vec![0],
+            functions: HashMap::new(),
+            call_stack: Vec::new(),
+            tool_provider: Some(provider),
+            #[cfg(feature = "tools")]
+            tokio_runtime: Some(runtime),
+            caps,
         }
     }
 
@@ -351,6 +386,17 @@ pub fn run(program: &Program, func_name: Option<&str>, args: Vec<Value>) -> Resu
     run_with_env(program, func_name, args, Env::new())
 }
 
+/// Run with a capability policy. Operations that violate the policy return
+/// `Value::Err(...)` rather than executing; they do NOT panic or abort.
+pub fn run_with_caps(
+    program: &Program,
+    func_name: Option<&str>,
+    args: Vec<Value>,
+    caps: Caps,
+) -> Result<Value> {
+    run_with_env(program, func_name, args, Env::with_caps(caps))
+}
+
 /// Dispatch a builtin call from the VM/Cranelift tree-bridge (`OP_CALL_BUILTIN_TREE`).
 ///
 /// Used by `--run-vm` and `--jit` to delegate tree-only builtins
@@ -406,6 +452,24 @@ pub fn run_with_tools(
         provider,
         #[cfg(feature = "tools")]
         runtime,
+    );
+    run_with_env(program, func_name, args, env)
+}
+
+/// Run with tools AND a capability policy.
+pub fn run_with_tools_and_caps(
+    program: &Program,
+    func_name: Option<&str>,
+    args: Vec<Value>,
+    provider: std::sync::Arc<dyn crate::tools::ToolProvider>,
+    #[cfg(feature = "tools")] runtime: std::sync::Arc<tokio::runtime::Runtime>,
+    caps: Caps,
+) -> Result<Value> {
+    let env = Env::with_tools_and_caps(
+        provider,
+        #[cfg(feature = "tools")]
+        runtime,
+        caps,
     );
     run_with_env(program, func_name, args, env)
 }
@@ -3358,6 +3422,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 ));
             }
         };
+        if let Err(msg) = env.caps.check_net(url.as_str()) {
+            return Ok(Value::Err(Box::new(Value::Text(Arc::new(msg)))));
+        }
         let headers = if args.len() == 2 {
             match &args[1] {
                 Value::Map(m) => m
@@ -3435,6 +3502,13 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 ));
             }
         };
+        // Cap check: verify each URL before issuing any requests.
+        for url in &urls {
+            if let Err(msg) = env.caps.check_net(url) {
+                // Return the first blocked URL as a single Err in the list's envelope.
+                return Ok(Value::Err(Box::new(Value::Text(Arc::new(msg)))));
+            }
+        }
         return Ok(Value::List(Arc::new(get_many_fetch(&urls))));
     }
     if builtin == Some(Builtin::Post) && (args.len() == 2 || args.len() == 3) {
@@ -3447,6 +3521,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 ));
             }
         };
+        if let Err(msg) = env.caps.check_net(url.as_str()) {
+            return Ok(Value::Err(Box::new(Value::Text(Arc::new(msg)))));
+        }
         let headers = if args.len() == 3 {
             match &args[2] {
                 Value::Map(m) => m
@@ -3639,6 +3716,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 ));
             }
         };
+        if let Err(msg) = env.caps.check_run(cmd.as_str()) {
+            return Ok(Value::Err(Box::new(Value::Text(Arc::new(msg)))));
+        }
         return Ok(run_spawn(cmd.as_str(), &argv));
     }
     if builtin == Some(Builtin::Trm) && args.len() == 1 {
@@ -3967,6 +4047,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 ));
             }
         };
+        if let Err(msg) = env.caps.check_read(dir.as_str()) {
+            return Ok(Value::Err(Box::new(Value::Text(Arc::new(msg)))));
+        }
         let root = std::path::PathBuf::from(dir.as_str());
         match walk_collect(&root) {
             Ok(out) => {
@@ -4003,6 +4086,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 ));
             }
         };
+        if let Err(msg) = env.caps.check_read(dir.as_str()) {
+            return Ok(Value::Err(Box::new(Value::Text(Arc::new(msg)))));
+        }
         let root = std::path::PathBuf::from(dir.as_str());
         match walk_collect(&root) {
             Ok(all) => {
@@ -4225,6 +4311,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 ));
             }
         };
+        if let Err(msg) = env.caps.check_read(path.as_str()) {
+            return Ok(Value::Err(Box::new(Value::Text(Arc::new(msg)))));
+        }
         let fmt = if args.len() == 2 {
             match &args[1] {
                 Value::Text(s) => s.as_str().to_owned(),
@@ -4277,16 +4366,21 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
     }
     if builtin == Some(Builtin::Rdl) && args.len() == 1 {
         return match &args[0] {
-            Value::Text(path) => match std::fs::read_to_string(path.as_str()) {
-                Ok(content) => {
-                    let lines: Vec<Value> = content
-                        .lines()
-                        .map(|l| Value::Text(Arc::new(l.to_string())))
-                        .collect();
-                    Ok(Value::Ok(Box::new(Value::List(Arc::new(lines)))))
+            Value::Text(path) => {
+                if let Err(msg) = env.caps.check_read(path.as_str()) {
+                    return Ok(Value::Err(Box::new(Value::Text(Arc::new(msg)))));
                 }
-                Err(e) => Ok(Value::Err(Box::new(Value::Text(Arc::new(e.to_string()))))),
-            },
+                match std::fs::read_to_string(path.as_str()) {
+                    Ok(content) => {
+                        let lines: Vec<Value> = content
+                            .lines()
+                            .map(|l| Value::Text(Arc::new(l.to_string())))
+                            .collect();
+                        Ok(Value::Ok(Box::new(Value::List(Arc::new(lines)))))
+                    }
+                    Err(e) => Ok(Value::Err(Box::new(Value::Text(Arc::new(e.to_string()))))),
+                }
+            }
             other => Err(RuntimeError::new(
                 "ILO-R009",
                 format!("rdl requires text path, got {:?}", other),
@@ -4313,6 +4407,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 ));
             }
         };
+        if let Err(msg) = env.caps.check_write(path.as_str()) {
+            return Ok(Value::Err(Box::new(Value::Text(Arc::new(msg)))));
+        }
         let content = if args.len() == 3 {
             let fmt = match &args[2] {
                 Value::Text(s) => s.clone(),
@@ -4396,6 +4493,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 ));
             }
         };
+        if let Err(msg) = env.caps.check_write(path.as_str()) {
+            return Ok(Value::Err(Box::new(Value::Text(Arc::new(msg)))));
+        }
         let content = match &args[1] {
             Value::Text(s) => (**s).clone(),
             other => {
@@ -4419,6 +4519,11 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         };
     }
     if builtin == Some(Builtin::Wrl) && args.len() == 2 {
+        if let Value::Text(path) = &args[0] {
+            if let Err(msg) = env.caps.check_write(path.as_str()) {
+                return Ok(Value::Err(Box::new(Value::Text(Arc::new(msg)))));
+            }
+        }
         return match (&args[0], &args[1]) {
             (Value::Text(path), Value::List(lines)) => {
                 let mut content = String::new();

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -9309,10 +9309,13 @@ mod tests {
 
     #[test]
     fn interpret_braceless_guard_fibonacci() {
+        // Use fib(7)=13 rather than fib(10)=55 to stay within the default
+        // debug-build stack on CI Linux runners. The recursion depth of ~12
+        // still exercises the braceless-guard path end-to-end.
         let source = "fib n:n>n;<=n 1 n;a=fib -n 1;b=fib -n 2;+a b";
         assert_eq!(
-            run_str(source, Some("fib"), vec![Value::Number(10.0)]),
-            Value::Number(55.0)
+            run_str(source, Some("fib"), vec![Value::Number(7.0)]),
+            Value::Number(13.0)
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod ast;
 pub mod builtins;
+pub mod caps;
 pub mod cli_parse;
 pub mod codegen;
 pub mod diagnostic;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use ilo::parser;
 use ilo::tools;
 use ilo::verify;
 use ilo::vm;
+use std::sync::Arc;
 
 use clap::Parser as _;
 use cli::args::OutputMode;
@@ -3292,15 +3293,15 @@ fn check_cmd(source_arg: &str, mode: OutputMode, _explicit_json: bool, strict: b
 /// unrestricted mode). As soon as any `--allow-*` flag is set, the policy
 /// switches to `Caps::Restricted` and only explicitly permitted targets are
 /// allowed.
-fn build_caps(r: &cli::RunArgs) -> Caps {
+fn build_caps(r: &cli::RunArgs) -> Arc<Caps> {
     let any = r.allow_net.is_some()
         || r.allow_read.is_some()
         || r.allow_write.is_some()
         || r.allow_run.is_some();
     if !any {
-        return Caps::Permissive;
+        return Arc::new(Caps::Permissive);
     }
-    Caps::Restricted {
+    Arc::new(Caps::Restricted {
         net: r
             .allow_net
             .as_deref()
@@ -3321,7 +3322,7 @@ fn build_caps(r: &cli::RunArgs) -> Caps {
             .as_deref()
             .map(Caps::parse_allow)
             .unwrap_or(Policy::All),
-    }
+    })
 }
 
 /// Dispatch the `run` subcommand via parsed RunArgs.  Returns exit code.
@@ -4089,7 +4090,7 @@ fn run_vm_with_provider(
     mode: OutputMode,
     explicit_json: bool,
     suppress_loop_tail: bool,
-    caps: Caps,
+    caps: Arc<Caps>,
 ) -> i32 {
     #[cfg(feature = "tools")]
     if let Some(provider) = mcp_provider {
@@ -4164,7 +4165,7 @@ fn run_interp_with_provider(
     source: &str,
     mode: OutputMode,
     explicit_json: bool,
-    caps: Caps,
+    caps: Arc<Caps>,
 ) -> i32 {
     let suppress = program_result_should_suppress(program, func_name);
     #[cfg(feature = "tools")]
@@ -4277,7 +4278,7 @@ fn run_default(
     source: &str,
     mode: OutputMode,
     explicit_json: bool,
-    caps: Caps,
+    caps: Arc<Caps>,
 ) -> i32 {
     // CLI-boundary arity guard. Restores the strict arity contract the tree
     // interpreter has enforced since v0.11.5 (interpreter/mod.rs:4152) at the
@@ -6125,7 +6126,7 @@ mod tests {
             OutputMode::Text,
             false,
             false,
-            Caps::default(),
+            Arc::new(Caps::default()),
         );
     }
 
@@ -6145,7 +6146,7 @@ mod tests {
             OutputMode::Json,
             true,
             false,
-            Caps::default(),
+            Arc::new(Caps::default()),
         );
     }
 
@@ -6166,7 +6167,7 @@ mod tests {
             "f x:n>n;*x 2",
             OutputMode::Text,
             false,
-            Caps::default(),
+            Arc::new(Caps::default()),
         );
     }
 
@@ -6185,7 +6186,7 @@ mod tests {
             "f x:n>n;+x 1",
             OutputMode::Json,
             true,
-            Caps::default(),
+            Arc::new(Caps::default()),
         );
     }
 
@@ -6201,7 +6202,7 @@ mod tests {
             "f x:n>n;*x 2",
             OutputMode::Text,
             false,
-            Caps::default(),
+            Arc::new(Caps::default()),
         );
     }
 
@@ -6215,7 +6216,7 @@ mod tests {
             "greet name:t>t;cat \"hi \" name",
             OutputMode::Text,
             false,
-            Caps::default(),
+            Arc::new(Caps::default()),
         );
     }
 
@@ -6229,7 +6230,7 @@ mod tests {
             "double x:n>n;*x 2",
             OutputMode::Text,
             false,
-            Caps::default(),
+            Arc::new(Caps::default()),
         );
     }
 
@@ -9590,7 +9591,7 @@ mod tests {
             "",
             OutputMode::Text,
             false,
-            Caps::default(),
+            Arc::new(Caps::default()),
         );
         // VM ran the program → exit 0.
         assert_eq!(code, 0);
@@ -9669,7 +9670,7 @@ mod tests {
             OutputMode::Text,
             false,
             false,
-            Caps::default(),
+            Arc::new(Caps::default()),
         );
         assert_eq!(code, 1);
     }
@@ -9691,7 +9692,7 @@ mod tests {
             "f>n;/1 0",
             OutputMode::Text,
             false,
-            Caps::default(),
+            Arc::new(Caps::default()),
         );
         assert_eq!(code, 1);
     }
@@ -9709,7 +9710,7 @@ mod tests {
             "f>n;g 1",
             OutputMode::Text,
             false,
-            Caps::default(),
+            Arc::new(Caps::default()),
         );
         assert_eq!(code, 1);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 mod cli;
 
 use ilo::ast;
+use ilo::caps::{Caps, Policy};
 use ilo::codegen;
 use ilo::diagnostic;
 use ilo::graph;
@@ -2954,6 +2955,10 @@ fn dispatch_bare_args(raw_args: Vec<String>, global: &cli::Global) -> i32 {
                     ast: false,
                     tools_path: tools_config_path,
                     mcp_path: mcp_config_path,
+                    allow_net: None,
+                    allow_read: None,
+                    allow_write: None,
+                    allow_run: None,
                     rest: args[m + 1..].to_vec(),
                 };
                 return dispatch_run(run_args, mode, explicit_json, no_hints);
@@ -2975,6 +2980,10 @@ fn dispatch_bare_args(raw_args: Vec<String>, global: &cli::Global) -> i32 {
                     ast: false,
                     tools_path: tools_config_path,
                     mcp_path: mcp_config_path,
+                    allow_net: None,
+                    allow_read: None,
+                    allow_write: None,
+                    allow_run: None,
                     rest: vec![],
                 };
                 return dispatch_run(run_args, mode, explicit_json, no_hints);
@@ -3001,6 +3010,10 @@ fn dispatch_bare_args(raw_args: Vec<String>, global: &cli::Global) -> i32 {
                     ast: false,
                     tools_path: tools_config_path,
                     mcp_path: mcp_config_path,
+                    allow_net: None,
+                    allow_read: None,
+                    allow_write: None,
+                    allow_run: None,
                     rest: vec![],
                 };
                 return dispatch_run(run_args, mode, explicit_json, no_hints);
@@ -3022,6 +3035,10 @@ fn dispatch_bare_args(raw_args: Vec<String>, global: &cli::Global) -> i32 {
                     ast: false,
                     tools_path: tools_config_path,
                     mcp_path: mcp_config_path,
+                    allow_net: None,
+                    allow_read: None,
+                    allow_write: None,
+                    allow_run: None,
                     rest: vec![],
                 };
                 return dispatch_run(run_args, mode, explicit_json, no_hints);
@@ -3043,6 +3060,10 @@ fn dispatch_bare_args(raw_args: Vec<String>, global: &cli::Global) -> i32 {
                     ast: false,
                     tools_path: tools_config_path,
                     mcp_path: mcp_config_path,
+                    allow_net: None,
+                    allow_read: None,
+                    allow_write: None,
+                    allow_run: None,
                     rest: vec![],
                 };
                 return dispatch_run(run_args, mode, explicit_json, no_hints);
@@ -3076,6 +3097,10 @@ fn dispatch_bare_args(raw_args: Vec<String>, global: &cli::Global) -> i32 {
         ast: pre_ast,
         tools_path: tools_config_path,
         mcp_path: mcp_config_path,
+        allow_net: None,
+        allow_read: None,
+        allow_write: None,
+        allow_run: None,
         rest,
     };
     dispatch_run(run_args, mode, explicit_json, no_hints)
@@ -3261,6 +3286,44 @@ fn check_cmd(source_arg: &str, mode: OutputMode, _explicit_json: bool, strict: b
     }
 }
 
+/// Build a `Caps` from the `--allow-*` flags on a `RunArgs`.
+///
+/// If none of the flags are present, returns `Caps::Permissive` (backwards-compatible
+/// unrestricted mode). As soon as any `--allow-*` flag is set, the policy
+/// switches to `Caps::Restricted` and only explicitly permitted targets are
+/// allowed.
+fn build_caps(r: &cli::RunArgs) -> Caps {
+    let any = r.allow_net.is_some()
+        || r.allow_read.is_some()
+        || r.allow_write.is_some()
+        || r.allow_run.is_some();
+    if !any {
+        return Caps::Permissive;
+    }
+    Caps::Restricted {
+        net: r
+            .allow_net
+            .as_deref()
+            .map(Caps::parse_allow)
+            .unwrap_or(Policy::All),
+        read: r
+            .allow_read
+            .as_deref()
+            .map(Caps::parse_allow)
+            .unwrap_or(Policy::All),
+        write: r
+            .allow_write
+            .as_deref()
+            .map(Caps::parse_allow)
+            .unwrap_or(Policy::All),
+        run: r
+            .allow_run
+            .as_deref()
+            .map(Caps::parse_allow)
+            .unwrap_or(Policy::All),
+    }
+}
+
 /// Dispatch the `run` subcommand via parsed RunArgs.  Returns exit code.
 fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints: bool) -> i32 {
     // Reject unknown `--flag` tokens in the positional tail. `RunArgs::rest`
@@ -3281,6 +3344,9 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
     if let Some(idx) = r.rest.iter().position(|s| s == "--") {
         r.rest.remove(idx);
     }
+
+    // Build capability policy from --allow-* flags.
+    let caps = build_caps(&r);
 
     let source_arg = &r.source;
 
@@ -3553,6 +3619,7 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
                     mode,
                     explicit_json,
                     suppress,
+                    caps,
                 )
             }
             cli::Engine::Tree => {
@@ -3582,6 +3649,7 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
                     &source,
                     mode,
                     explicit_json,
+                    caps,
                 )
             }
             cli::Engine::Default => {
@@ -3726,7 +3794,15 @@ fn dispatch_run(r: cli::RunArgs, mode: OutputMode, explicit_json: bool, no_hints
                     }
                 };
 
-                run_default(&program, func_name, run_args, &source, mode, explicit_json)
+                run_default(
+                    &program,
+                    func_name,
+                    run_args,
+                    &source,
+                    mode,
+                    explicit_json,
+                    caps,
+                )
             }
         }
     };
@@ -4013,6 +4089,7 @@ fn run_vm_with_provider(
     mode: OutputMode,
     explicit_json: bool,
     suppress_loop_tail: bool,
+    caps: Caps,
 ) -> i32 {
     #[cfg(feature = "tools")]
     if let Some(provider) = mcp_provider {
@@ -4062,7 +4139,7 @@ fn run_vm_with_provider(
         };
     }
 
-    match vm::run(compiled, func_name, args) {
+    match vm::run_with_caps(compiled, func_name, args, caps) {
         Ok(val) => {
             print_value(&val, explicit_json, suppress_loop_tail);
             program_exit_code(&val)
@@ -4087,17 +4164,19 @@ fn run_interp_with_provider(
     source: &str,
     mode: OutputMode,
     explicit_json: bool,
+    caps: Caps,
 ) -> i32 {
     let suppress = program_result_should_suppress(program, func_name);
     #[cfg(feature = "tools")]
     if let Some(provider) = mcp_provider {
         let rt = std::sync::Arc::new(mcp_rt.expect("runtime present with mcp_provider"));
-        match interpreter::run_with_tools(
+        match interpreter::run_with_tools_and_caps(
             program,
             func_name,
             args,
             std::sync::Arc::new(provider),
             rt,
+            caps,
         ) {
             Ok(val) => {
                 print_value(&val, explicit_json, suppress);
@@ -4126,13 +4205,14 @@ fn run_interp_with_provider(
                 .build()
                 .expect("tokio runtime"),
         );
-        return match interpreter::run_with_tools(
+        return match interpreter::run_with_tools_and_caps(
             program,
             func_name,
             args,
             provider,
             #[cfg(feature = "tools")]
             runtime,
+            caps,
         ) {
             Ok(val) => {
                 print_value(&val, explicit_json, suppress);
@@ -4145,7 +4225,7 @@ fn run_interp_with_provider(
         };
     }
 
-    match interpreter::run(program, func_name, args) {
+    match interpreter::run_with_caps(program, func_name, args, caps) {
         Ok(val) => {
             print_value(&val, explicit_json, suppress);
             program_exit_code(&val)
@@ -4197,6 +4277,7 @@ fn run_default(
     source: &str,
     mode: OutputMode,
     explicit_json: bool,
+    caps: Caps,
 ) -> i32 {
     // CLI-boundary arity guard. Restores the strict arity contract the tree
     // interpreter has enforced since v0.11.5 (interpreter/mod.rs:4152) at the
@@ -4220,7 +4301,7 @@ fn run_default(
     // reference semantics and the last-resort fallback for any program the
     // VM compile/run rejects (e.g. shapes the VM doesn't yet support).
     if let Ok(compiled) = vm::compile(program) {
-        match vm::run(&compiled, func_name, args.clone()) {
+        match vm::run_with_caps(&compiled, func_name, args.clone(), caps.clone()) {
             Ok(val) => {
                 print_value(&val, explicit_json, suppress);
                 return program_exit_code(&val);
@@ -4236,7 +4317,7 @@ fn run_default(
     }
 
     // Fall back to interpreter
-    match interpreter::run(program, func_name, args) {
+    match interpreter::run_with_caps(program, func_name, args, caps) {
         Ok(val) => {
             print_value(&val, explicit_json, suppress);
             program_exit_code(&val)
@@ -6044,6 +6125,7 @@ mod tests {
             OutputMode::Text,
             false,
             false,
+            Caps::default(),
         );
     }
 
@@ -6063,6 +6145,7 @@ mod tests {
             OutputMode::Json,
             true,
             false,
+            Caps::default(),
         );
     }
 
@@ -6083,6 +6166,7 @@ mod tests {
             "f x:n>n;*x 2",
             OutputMode::Text,
             false,
+            Caps::default(),
         );
     }
 
@@ -6101,6 +6185,7 @@ mod tests {
             "f x:n>n;+x 1",
             OutputMode::Json,
             true,
+            Caps::default(),
         );
     }
 
@@ -6116,6 +6201,7 @@ mod tests {
             "f x:n>n;*x 2",
             OutputMode::Text,
             false,
+            Caps::default(),
         );
     }
 
@@ -6129,6 +6215,7 @@ mod tests {
             "greet name:t>t;cat \"hi \" name",
             OutputMode::Text,
             false,
+            Caps::default(),
         );
     }
 
@@ -6142,6 +6229,7 @@ mod tests {
             "double x:n>n;*x 2",
             OutputMode::Text,
             false,
+            Caps::default(),
         );
     }
 
@@ -9028,6 +9116,10 @@ mod tests {
             ast: false,
             tools_path: None,
             mcp_path: None,
+            allow_net: None,
+            allow_read: None,
+            allow_write: None,
+            allow_run: None,
             rest: vec![],
         };
         let code = dispatch_run(run_args, OutputMode::Text, false, false);
@@ -9054,6 +9146,10 @@ mod tests {
             ast: false,
             tools_path: Some("/tmp/t.json".to_string()),
             mcp_path: Some("/tmp/m.json".to_string()),
+            allow_net: None,
+            allow_read: None,
+            allow_write: None,
+            allow_run: None,
             rest: vec![],
         };
         let code = dispatch_run(run_args, OutputMode::Text, false, false);
@@ -9084,6 +9180,10 @@ mod tests {
             ast: false,
             tools_path: None,
             mcp_path: None,
+            allow_net: None,
+            allow_read: None,
+            allow_write: None,
+            allow_run: None,
             rest: vec![],
         };
         let code = dispatch_run(run_args, OutputMode::Text, false, false);
@@ -9111,6 +9211,10 @@ mod tests {
             ast: false,
             tools_path: None,
             mcp_path: None,
+            allow_net: None,
+            allow_read: None,
+            allow_write: None,
+            allow_run: None,
             rest: vec!["f".to_string(), "1".to_string()],
         };
         // no_hints = false → hints emitted (to stderr, so just verify no panic)
@@ -9136,6 +9240,10 @@ mod tests {
             ast: false,
             tools_path: None,
             mcp_path: None,
+            allow_net: None,
+            allow_read: None,
+            allow_write: None,
+            allow_run: None,
             rest: vec!["f".to_string(), "1".to_string()],
         };
         // no_hints = true → hints suppressed
@@ -9163,6 +9271,10 @@ mod tests {
             ast: false,
             tools_path: None,
             mcp_path: None,
+            allow_net: None,
+            allow_read: None,
+            allow_write: None,
+            allow_run: None,
             rest: vec![],
         };
         let code = dispatch_run(run_args, OutputMode::Text, false, false);
@@ -9190,6 +9302,10 @@ mod tests {
             ast: false,
             tools_path: None,
             mcp_path: None,
+            allow_net: None,
+            allow_read: None,
+            allow_write: None,
+            allow_run: None,
             rest: vec!["f".to_string(), "1".to_string()],
         };
         let code = dispatch_run(run_args, OutputMode::Text, false, false);
@@ -9474,6 +9590,7 @@ mod tests {
             "",
             OutputMode::Text,
             false,
+            Caps::default(),
         );
         // VM ran the program → exit 0.
         assert_eq!(code, 0);
@@ -9552,6 +9669,7 @@ mod tests {
             OutputMode::Text,
             false,
             false,
+            Caps::default(),
         );
         assert_eq!(code, 1);
     }
@@ -9573,6 +9691,7 @@ mod tests {
             "f>n;/1 0",
             OutputMode::Text,
             false,
+            Caps::default(),
         );
         assert_eq!(code, 1);
     }
@@ -9590,6 +9709,7 @@ mod tests {
             "f>n;g 1",
             OutputMode::Text,
             false,
+            Caps::default(),
         );
         assert_eq!(code, 1);
     }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -1,5 +1,6 @@
 use crate::ast::*;
 use crate::builtins::{Builtin, CharAtResult, char_at_signed};
+use crate::caps::Caps;
 use crate::interpreter::{MapKey, Value};
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -7493,6 +7494,37 @@ pub fn compile(program: &Program) -> Result<CompiledProgram, CompileError> {
     Ok(prog)
 }
 
+/// Run the VM with a capability policy applied. IO ops that violate the policy
+/// return `Value::Err(...)` rather than executing.
+pub fn run_with_caps(
+    compiled: &CompiledProgram,
+    func_name: Option<&str>,
+    args: Vec<Value>,
+    caps: Caps,
+) -> Result<Value, VmRuntimeError> {
+    let target = match func_name {
+        Some(name) => name.to_string(),
+        None => compiled
+            .func_names
+            .first()
+            .ok_or_else(|| VmRuntimeError {
+                error: VmError::NoFunctionsDefined,
+                span: None,
+                call_stack: Vec::new(),
+            })?
+            .clone(),
+    };
+    let func_idx = compiled.func_index(&target).ok_or_else(|| VmRuntimeError {
+        error: VmError::UndefinedFunction {
+            name: target.clone(),
+        },
+        span: None,
+        call_stack: Vec::new(),
+    })?;
+    check_entry_arity(compiled, func_idx, &target, args.len())?;
+    VM::new_with_caps(compiled, caps).call(func_idx, args)
+}
+
 pub fn run(
     compiled: &CompiledProgram,
     func_name: Option<&str>,
@@ -7658,6 +7690,8 @@ struct VM<'a> {
     tool_provider: Option<&'a dyn crate::tools::ToolProvider>,
     #[cfg(feature = "tools")]
     tokio_runtime: Option<&'a tokio::runtime::Runtime>,
+    /// CLI capability policy.
+    caps: Caps,
 }
 
 impl<'a> Drop for VM<'a> {
@@ -7680,6 +7714,22 @@ impl<'a> VM<'a> {
             tool_provider: None,
             #[cfg(feature = "tools")]
             tokio_runtime: None,
+            caps: Caps::default(),
+        }
+    }
+
+    fn new_with_caps(program: &'a CompiledProgram, caps: Caps) -> Self {
+        VM {
+            program,
+            stack: Vec::with_capacity(4096),
+            frames: Vec::with_capacity(64),
+            arena: BumpArena::new(),
+            last_ci: 0,
+            last_ip: 0,
+            tool_provider: None,
+            #[cfg(feature = "tools")]
+            tokio_runtime: None,
+            caps,
         }
     }
 
@@ -7698,6 +7748,7 @@ impl<'a> VM<'a> {
             tool_provider: Some(provider),
             #[cfg(feature = "tools")]
             tokio_runtime: Some(runtime),
+            caps: Caps::default(),
         }
     }
 
@@ -8411,6 +8462,10 @@ impl<'a> VM<'a> {
                             _ => unreachable!(),
                         }
                     };
+                    if let Err(msg) = self.caps.check_read(&path) {
+                        reg_set!(a, NanVal::heap_err(NanVal::heap_string(msg)));
+                        continue;
+                    }
                     let fmt = std::path::Path::new(&path)
                         .extension()
                         .and_then(|e| e.to_str())
@@ -8439,6 +8494,10 @@ impl<'a> VM<'a> {
                             _ => unreachable!(),
                         }
                     };
+                    if let Err(msg) = self.caps.check_read(&path) {
+                        reg_set!(a, NanVal::heap_err(NanVal::heap_string(msg)));
+                        continue;
+                    }
                     let result = match std::fs::read_to_string(&path) {
                         Ok(content) => {
                             let lines: Vec<NanVal> = content
@@ -8475,6 +8534,10 @@ impl<'a> VM<'a> {
                         };
                         (p, c)
                     };
+                    if let Err(msg) = self.caps.check_write(&path) {
+                        reg_set!(a, NanVal::heap_err(NanVal::heap_string(msg)));
+                        continue;
+                    }
                     let result = match std::fs::write(&path, &content) {
                         Ok(()) => NanVal::heap_ok(NanVal::heap_string(path)),
                         Err(e) => NanVal::heap_err(NanVal::heap_string(e.to_string())),
@@ -8497,6 +8560,10 @@ impl<'a> VM<'a> {
                             _ => unreachable!(),
                         }
                     };
+                    if let Err(msg) = self.caps.check_write(&path) {
+                        reg_set!(a, NanVal::heap_err(NanVal::heap_string(msg)));
+                        continue;
+                    }
                     let result = if (vc.0 & TAG_MASK) == TAG_LIST && vc.is_heap() {
                         // SAFETY: TAG_LIST + is_heap() → live List/View Rc.
                         let lines: &[NanVal] = slice_of(unsafe { vc.as_heap_ref() });
@@ -10845,16 +10912,20 @@ impl<'a> VM<'a> {
                     if !v.is_string() {
                         vm_err!(VmError::Type("get requires a string"));
                     }
+                    // SAFETY: is_string() confirmed heap-tagged string with live RC.
+                    let url_str: String = unsafe {
+                        match v.as_heap_ref() {
+                            HeapObj::Str(s) => s.as_str().to_owned(),
+                            _ => unreachable!(),
+                        }
+                    };
+                    if let Err(msg) = self.caps.check_net(&url_str) {
+                        reg_set!(a, NanVal::heap_err(NanVal::heap_string(msg)));
+                        continue;
+                    }
                     #[cfg(feature = "http")]
                     let result = {
-                        // SAFETY: is_string() confirmed heap-tagged string with live RC.
-                        let url = unsafe {
-                            match v.as_heap_ref() {
-                                HeapObj::Str(s) => s,
-                                _ => unreachable!(),
-                            }
-                        };
-                        match minreq::get(url.as_str()).send() {
+                        match minreq::get(&url_str).send() {
                             Ok(resp) => match resp.as_str() {
                                 Ok(body) => NanVal::heap_ok(NanVal::heap_string(body.to_string())),
                                 Err(e) => NanVal::heap_err(NanVal::heap_string(format!(
@@ -10879,22 +10950,25 @@ impl<'a> VM<'a> {
                     if !vb.is_string() || !vc.is_string() {
                         vm_err!(VmError::Type("pst requires two strings (url, body)"));
                     }
+                    // SAFETY: is_string() confirmed heap-tagged string with live RC.
+                    let (url_str, body_str) = unsafe {
+                        let u = match vb.as_heap_ref() {
+                            HeapObj::Str(s) => s.as_str().to_owned(),
+                            _ => unreachable!(),
+                        };
+                        let b = match vc.as_heap_ref() {
+                            HeapObj::Str(s) => s.as_str().to_owned(),
+                            _ => unreachable!(),
+                        };
+                        (u, b)
+                    };
+                    if let Err(msg) = self.caps.check_net(&url_str) {
+                        reg_set!(a, NanVal::heap_err(NanVal::heap_string(msg)));
+                        continue;
+                    }
                     #[cfg(feature = "http")]
                     let result = {
-                        // SAFETY: is_string() confirmed heap-tagged string with live RC.
-                        let url = unsafe {
-                            match vb.as_heap_ref() {
-                                HeapObj::Str(s) => s,
-                                _ => unreachable!(),
-                            }
-                        };
-                        let body = unsafe {
-                            match vc.as_heap_ref() {
-                                HeapObj::Str(s) => s,
-                                _ => unreachable!(),
-                            }
-                        };
-                        match minreq::post(url.as_str()).with_body(body.as_str()).send() {
+                        match minreq::post(&url_str).with_body(body_str.as_str()).send() {
                             Ok(resp) => match resp.as_str() {
                                 Ok(b) => NanVal::heap_ok(NanVal::heap_string(b.to_string())),
                                 Err(e) => NanVal::heap_err(NanVal::heap_string(format!(
@@ -10928,6 +11002,10 @@ impl<'a> VM<'a> {
                                 _ => unreachable!(),
                             }
                         };
+                        if let Err(msg) = self.caps.check_net(&url) {
+                            reg_set!(a, NanVal::heap_err(NanVal::heap_string(msg)));
+                            continue;
+                        }
                         let mut req = minreq::get(url.as_str());
                         if vc.is_heap()
                             && let HeapObj::Map(m) = unsafe { vc.as_heap_ref() }
@@ -10984,6 +11062,18 @@ impl<'a> VM<'a> {
                         };
                         urls.push(s);
                     }
+                    // Cap check: block if any URL violates the net policy.
+                    let mut cap_blocked = false;
+                    for url in &urls {
+                        if let Err(msg) = self.caps.check_net(url) {
+                            reg_set!(a, NanVal::heap_err(NanVal::heap_string(msg)));
+                            cap_blocked = true;
+                            break;
+                        }
+                    }
+                    if cap_blocked {
+                        continue;
+                    }
                     let values = crate::interpreter::get_many_fetch(&urls);
                     let nan_items: Vec<NanVal> = values.iter().map(NanVal::from_value).collect();
                     let result = NanVal::heap_list(nan_items);
@@ -11012,6 +11102,10 @@ impl<'a> VM<'a> {
                                 _ => unreachable!(),
                             }
                         };
+                        if let Err(msg) = self.caps.check_net(&url) {
+                            reg_set!(a, NanVal::heap_err(NanVal::heap_string(msg)));
+                            continue;
+                        }
                         let body_str = unsafe {
                             match vc.as_heap_ref() {
                                 HeapObj::Str(s) => s.as_str().to_owned(),

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -7500,7 +7500,7 @@ pub fn run_with_caps(
     compiled: &CompiledProgram,
     func_name: Option<&str>,
     args: Vec<Value>,
-    caps: Caps,
+    caps: Arc<Caps>,
 ) -> Result<Value, VmRuntimeError> {
     let target = match func_name {
         Some(name) => name.to_string(),
@@ -7691,7 +7691,7 @@ struct VM<'a> {
     #[cfg(feature = "tools")]
     tokio_runtime: Option<&'a tokio::runtime::Runtime>,
     /// CLI capability policy.
-    caps: Caps,
+    caps: Arc<Caps>,
 }
 
 impl<'a> Drop for VM<'a> {
@@ -7714,11 +7714,11 @@ impl<'a> VM<'a> {
             tool_provider: None,
             #[cfg(feature = "tools")]
             tokio_runtime: None,
-            caps: Caps::default(),
+            caps: Arc::new(Caps::default()),
         }
     }
 
-    fn new_with_caps(program: &'a CompiledProgram, caps: Caps) -> Self {
+    fn new_with_caps(program: &'a CompiledProgram, caps: Arc<Caps>) -> Self {
         VM {
             program,
             stack: Vec::with_capacity(4096),
@@ -7748,7 +7748,7 @@ impl<'a> VM<'a> {
             tool_provider: Some(provider),
             #[cfg(feature = "tools")]
             tokio_runtime: Some(runtime),
-            caps: Caps::default(),
+            caps: Arc::new(Caps::default()),
         }
     }
 
@@ -22290,11 +22290,10 @@ mod tests {
 
     #[test]
     fn vm_braceless_guard_fibonacci() {
-        // Use fib(7)=13; see interpreter version for rationale.
         let source = "fib n:n>n;<=n 1 n;a=fib -n 1;b=fib -n 2;+a b";
         assert_eq!(
-            vm_run(source, Some("fib"), vec![Value::Number(7.0)]),
-            Value::Number(13.0)
+            vm_run(source, Some("fib"), vec![Value::Number(10.0)]),
+            Value::Number(55.0)
         );
     }
 

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -22290,10 +22290,11 @@ mod tests {
 
     #[test]
     fn vm_braceless_guard_fibonacci() {
+        // Use fib(7)=13; see interpreter version for rationale.
         let source = "fib n:n>n;<=n 1 n;a=fib -n 1;b=fib -n 2;+a b";
         assert_eq!(
-            vm_run(source, Some("fib"), vec![Value::Number(10.0)]),
-            Value::Number(55.0)
+            vm_run(source, Some("fib"), vec![Value::Number(7.0)]),
+            Value::Number(13.0)
         );
     }
 

--- a/tests/capability_flags.rs
+++ b/tests/capability_flags.rs
@@ -7,7 +7,6 @@
 use ilo::caps::{Caps, Policy};
 use ilo::interpreter::{self, Value};
 use ilo::{lexer, parser, vm};
-use std::sync::Arc;
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 

--- a/tests/capability_flags.rs
+++ b/tests/capability_flags.rs
@@ -1,0 +1,336 @@
+/// Integration tests for CLI capability flags (`--allow-net`, `--allow-read`,
+/// `--allow-write`, `--allow-run`).
+///
+/// Each test runs programs through `interpreter::run_with_caps` and
+/// `vm::run_with_caps` to verify enforcement at both backends, then also
+/// exercises the `Caps` unit helpers directly for clarity.
+use ilo::caps::{Caps, Policy};
+use ilo::interpreter::{self, Value};
+use ilo::{lexer, parser, vm};
+use std::sync::Arc;
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn make_program(src: &str) -> ilo::ast::Program {
+    let tokens = lexer::lex(src).unwrap();
+    let token_spans: Vec<(ilo::lexer::Token, ilo::ast::Span)> = tokens
+        .into_iter()
+        .map(|(t, r)| {
+            (
+                t,
+                ilo::ast::Span {
+                    start: r.start,
+                    end: r.end,
+                },
+            )
+        })
+        .collect();
+    let (mut program, _) = parser::parse(token_spans);
+    ilo::ast::resolve_aliases(&mut program);
+    ilo::ast::desugar_dot_var_index(&mut program);
+    program
+}
+
+/// Run a 0-arg function through interpreter + VM with given caps.
+/// Returns the result value for both backends.
+fn run_both(src: &str, caps: Caps) -> (Value, Value) {
+    let program = make_program(src);
+    let tree_result = interpreter::run_with_caps(&program, None, vec![], caps.clone()).unwrap();
+    let compiled = vm::compile(&program).unwrap();
+    let vm_result = vm::run_with_caps(&compiled, None, vec![], caps).unwrap();
+    (tree_result, vm_result)
+}
+
+fn is_err_value(v: &Value) -> bool {
+    matches!(v, Value::Err(_))
+}
+
+fn err_text(v: &Value) -> String {
+    match v {
+        Value::Err(inner) => match inner.as_ref() {
+            Value::Text(s) => s.to_string(),
+            other => format!("{other:?}"),
+        },
+        other => panic!("expected Err value, got {other:?}"),
+    }
+}
+
+// ── default permissive mode ───────────────────────────────────────────────────
+
+#[test]
+fn default_caps_does_not_block_file_read() {
+    // Write a temp file and read it — should succeed with no caps flags.
+    let path = "/tmp/ilo_cap_test_read.txt";
+    std::fs::write(path, "hello caps").unwrap();
+    let src = format!("f>R t t;rd \"{path}\"");
+    let (tree, vm) = run_both(&src, Caps::default());
+    // With permissive caps, rd returns Ok(text) — not Err.
+    assert!(
+        !is_err_value(&tree),
+        "tree: unexpected Err with default caps"
+    );
+    assert!(!is_err_value(&vm), "vm: unexpected Err with default caps");
+}
+
+// ── --allow-net: empty list blocks all network ────────────────────────────────
+
+/// Core test from the task brief: `--allow-net=` (empty list) + `get` → Err.
+/// Network call is blocked before any HTTP request is issued.
+#[test]
+fn allow_net_empty_blocks_get() {
+    let caps = Caps::Restricted {
+        net: Policy::List(vec![]),
+        read: Policy::All,
+        write: Policy::All,
+        run: Policy::All,
+    };
+    let src = "f>R t t;get \"https://example.com\"";
+    let (tree, vm_val) = run_both(src, caps);
+    assert!(is_err_value(&tree), "tree: expected Err, got {tree:?}");
+    assert!(is_err_value(&vm_val), "vm: expected Err, got {vm_val:?}");
+    let msg = err_text(&tree);
+    assert!(
+        msg.contains("--allow-net"),
+        "err should mention --allow-net, got: {msg}"
+    );
+    assert!(
+        msg.contains("example.com"),
+        "err should mention host, got: {msg}"
+    );
+}
+
+#[test]
+fn allow_net_empty_blocks_get_vm_message() {
+    let caps = Caps::Restricted {
+        net: Policy::List(vec![]),
+        read: Policy::All,
+        write: Policy::All,
+        run: Policy::All,
+    };
+    let src = "f>R t t;get \"https://example.com\"";
+    let program = make_program(src);
+    let compiled = vm::compile(&program).unwrap();
+    let result = vm::run_with_caps(&compiled, None, vec![], caps).unwrap();
+    let msg = err_text(&result);
+    assert!(
+        msg.contains("--allow-net"),
+        "vm err should mention --allow-net; got: {msg}"
+    );
+}
+
+// ── --allow-net: specific host allowlist ─────────────────────────────────────
+
+#[test]
+fn allow_net_blocks_non_allowlisted_host() {
+    let caps = Caps::Restricted {
+        net: Policy::List(vec!["allowed.example".to_owned()]),
+        read: Policy::All,
+        write: Policy::All,
+        run: Policy::All,
+    };
+    let src = "f>R t t;get \"https://evil.example\"";
+    let (tree, vm_val) = run_both(src, caps);
+    assert!(
+        is_err_value(&tree),
+        "tree: expected Err for non-allowlisted host"
+    );
+    assert!(
+        is_err_value(&vm_val),
+        "vm: expected Err for non-allowlisted host"
+    );
+}
+
+// ── --allow-read: prefix enforcement ─────────────────────────────────────────
+
+/// Core test from the task brief: `--allow-read=/tmp` + `rd "/etc/passwd"` → Err.
+#[test]
+fn allow_read_blocks_outside_prefix() {
+    let caps = Caps::Restricted {
+        net: Policy::All,
+        read: Policy::List(vec!["/tmp".to_owned()]),
+        write: Policy::All,
+        run: Policy::All,
+    };
+    let src = "f>R t t;rd \"/etc/passwd\"";
+    let (tree, vm_val) = run_both(src, caps);
+    assert!(
+        is_err_value(&tree),
+        "tree: expected Err for /etc/passwd when read limited to /tmp"
+    );
+    assert!(
+        is_err_value(&vm_val),
+        "vm: expected Err for /etc/passwd when read limited to /tmp"
+    );
+    let msg = err_text(&tree);
+    assert!(
+        msg.contains("--allow-read"),
+        "err should mention --allow-read, got: {msg}"
+    );
+}
+
+#[test]
+fn allow_read_permits_inside_prefix() {
+    let path = "/tmp/ilo_cap_test_read2.txt";
+    std::fs::write(path, "ok").unwrap();
+    let caps = Caps::Restricted {
+        net: Policy::All,
+        read: Policy::List(vec!["/tmp".to_owned()]),
+        write: Policy::All,
+        run: Policy::All,
+    };
+    let src = format!("f>R t t;rd \"{path}\"");
+    let (tree, vm_val) = run_both(&src, caps);
+    // /tmp is in the allowlist so rd should succeed (returns Ok, not Err).
+    assert!(
+        !is_err_value(&tree),
+        "tree: /tmp should be permitted, got {tree:?}"
+    );
+    assert!(
+        !is_err_value(&vm_val),
+        "vm: /tmp should be permitted, got {vm_val:?}"
+    );
+}
+
+// ── --allow-write: enforcement ────────────────────────────────────────────────
+
+#[test]
+fn allow_write_blocks_outside_prefix() {
+    let caps = Caps::Restricted {
+        net: Policy::All,
+        read: Policy::All,
+        write: Policy::List(vec!["/tmp/ilo_allowed".to_owned()]),
+        run: Policy::All,
+    };
+    let src = "f>R t t;wr \"/etc/evil.txt\" \"data\"";
+    let (tree, vm_val) = run_both(src, caps);
+    assert!(
+        is_err_value(&tree),
+        "tree: expected Err for write outside prefix"
+    );
+    assert!(
+        is_err_value(&vm_val),
+        "vm: expected Err for write outside prefix"
+    );
+    let msg = err_text(&tree);
+    assert!(
+        msg.contains("--allow-write"),
+        "err should mention --allow-write, got: {msg}"
+    );
+}
+
+// ── --allow-run: enforcement ──────────────────────────────────────────────────
+
+#[test]
+fn allow_run_empty_blocks_run() {
+    let caps = Caps::Restricted {
+        net: Policy::All,
+        read: Policy::All,
+        write: Policy::All,
+        run: Policy::List(vec![]),
+    };
+    let src = "f>R (M t t) t;run \"echo\" [\"hello\"]";
+    // Only test via tree interpreter (run goes through tree-bridge in VM).
+    let program = make_program(src);
+    let result = interpreter::run_with_caps(&program, None, vec![], caps).unwrap();
+    assert!(
+        is_err_value(&result),
+        "expected Err when run allowlist is empty, got {result:?}"
+    );
+    let msg = err_text(&result);
+    assert!(
+        msg.contains("--allow-run"),
+        "err should mention --allow-run, got: {msg}"
+    );
+}
+
+#[test]
+fn allow_run_permits_allowlisted_cmd() {
+    let caps = Caps::Restricted {
+        net: Policy::All,
+        read: Policy::All,
+        write: Policy::All,
+        run: Policy::List(vec!["echo".to_owned()]),
+    };
+    let src = "f>R (M t t) t;run \"echo\" [\"hello\"]";
+    let program = make_program(src);
+    let result = interpreter::run_with_caps(&program, None, vec![], caps).unwrap();
+    // echo is in the allowlist — should return Ok(...), not Err.
+    assert!(
+        !is_err_value(&result),
+        "echo should be permitted, got {result:?}"
+    );
+}
+
+// ── No --allow-* flags → permissive (backwards compat) ───────────────────────
+
+#[test]
+fn no_allow_flags_is_permissive_for_file_read() {
+    let path = "/tmp/ilo_cap_permissive.txt";
+    std::fs::write(path, "permissive").unwrap();
+    let src = format!("f>R t t;rd \"{path}\"");
+    let (tree, vm_val) = run_both(&src, Caps::Permissive);
+    assert!(
+        !is_err_value(&tree),
+        "tree: Permissive caps should allow rd, got {tree:?}"
+    );
+    assert!(
+        !is_err_value(&vm_val),
+        "vm: Permissive caps should allow rd, got {vm_val:?}"
+    );
+}
+
+// ── `Caps::parse_allow` round-trip ───────────────────────────────────────────
+
+#[test]
+fn parse_allow_star_is_all() {
+    assert_eq!(Caps::parse_allow("*"), Policy::All);
+}
+
+#[test]
+fn parse_allow_empty_is_empty_list() {
+    assert_eq!(Caps::parse_allow(""), Policy::List(vec![]));
+}
+
+#[test]
+fn parse_allow_comma_list() {
+    assert_eq!(
+        Caps::parse_allow("a.com,b.com"),
+        Policy::List(vec!["a.com".to_owned(), "b.com".to_owned()])
+    );
+}
+
+// ── `build_caps` semantics through Caps API ───────────────────────────────────
+
+/// When no --allow-* flags are present, caps is Permissive (no restriction).
+#[test]
+fn permissive_caps_allow_everything() {
+    let caps = Caps::Permissive;
+    assert!(caps.check_net("https://any.host").is_ok());
+    assert!(caps.check_read("/etc/passwd").is_ok());
+    assert!(caps.check_write("/etc/passwd").is_ok());
+    assert!(caps.check_run("rm").is_ok());
+}
+
+/// When any --allow-* flag is set, undefined dimensions default to Policy::All.
+#[test]
+fn one_flag_restricts_only_that_dimension() {
+    let caps = Caps::Restricted {
+        net: Policy::List(vec![]), // net blocked
+        read: Policy::All,         // read unrestricted
+        write: Policy::All,        // write unrestricted
+        run: Policy::All,          // run unrestricted
+    };
+    assert!(
+        caps.check_net("https://any.host").is_err(),
+        "net should be blocked"
+    );
+    assert!(
+        caps.check_read("/etc/passwd").is_ok(),
+        "read should be unrestricted"
+    );
+    assert!(
+        caps.check_write("/tmp/x").is_ok(),
+        "write should be unrestricted"
+    );
+    assert!(caps.check_run("rm").is_ok(), "run should be unrestricted");
+}

--- a/tests/capability_flags.rs
+++ b/tests/capability_flags.rs
@@ -7,6 +7,7 @@
 use ilo::caps::{Caps, Policy};
 use ilo::interpreter::{self, Value};
 use ilo::{lexer, parser, vm};
+use std::sync::Arc;
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -33,8 +34,10 @@ fn make_program(src: &str) -> ilo::ast::Program {
 /// Run a 0-arg function through interpreter + VM with given caps.
 /// Returns the result value for both backends.
 fn run_both(src: &str, caps: Caps) -> (Value, Value) {
+    let caps = Arc::new(caps);
     let program = make_program(src);
-    let tree_result = interpreter::run_with_caps(&program, None, vec![], caps.clone()).unwrap();
+    let tree_result =
+        interpreter::run_with_caps(&program, None, vec![], Arc::clone(&caps)).unwrap();
     let compiled = vm::compile(&program).unwrap();
     let vm_result = vm::run_with_caps(&compiled, None, vec![], caps).unwrap();
     (tree_result, vm_result)
@@ -109,7 +112,7 @@ fn allow_net_empty_blocks_get_vm_message() {
     let src = "f>R t t;get \"https://example.com\"";
     let program = make_program(src);
     let compiled = vm::compile(&program).unwrap();
-    let result = vm::run_with_caps(&compiled, None, vec![], caps).unwrap();
+    let result = vm::run_with_caps(&compiled, None, vec![], Arc::new(caps)).unwrap();
     let msg = err_text(&result);
     assert!(
         msg.contains("--allow-net"),
@@ -230,7 +233,7 @@ fn allow_run_empty_blocks_run() {
     let src = "f>R (M t t) t;run \"echo\" [\"hello\"]";
     // Only test via tree interpreter (run goes through tree-bridge in VM).
     let program = make_program(src);
-    let result = interpreter::run_with_caps(&program, None, vec![], caps).unwrap();
+    let result = interpreter::run_with_caps(&program, None, vec![], Arc::new(caps)).unwrap();
     assert!(
         is_err_value(&result),
         "expected Err when run allowlist is empty, got {result:?}"
@@ -252,7 +255,7 @@ fn allow_run_permits_allowlisted_cmd() {
     };
     let src = "f>R (M t t) t;run \"echo\" [\"hello\"]";
     let program = make_program(src);
-    let result = interpreter::run_with_caps(&program, None, vec![], caps).unwrap();
+    let result = interpreter::run_with_caps(&program, None, vec![], Arc::new(caps)).unwrap();
     // echo is in the allowlist — should return Ok(...), not Err.
     assert!(
         !is_err_value(&result),


### PR DESCRIPTION
## Summary

- Adds Deno-style `--allow-net`, `--allow-read`, `--allow-write`, `--allow-run` flags that sandbox ilo programs at the CLI level.
- Default (no flags) is fully permissive - zero behaviour change for existing scripts.
- When any flag is present, the specified dimension is restricted to the allowlist; other dimensions default to allow-all.
- Blocked operations return `Value::Err(...)` rather than panicking, so callers can handle them with ilo's normal result operators.

## Repro before / after

Before (no change to existing behaviour):
```
ilo run script.ilo           # reads /etc/passwd, makes network calls - works as before
```

After (new capability):
```
ilo run --allow-net= script.ilo           # net blocked; get returns Err
ilo run --allow-read=/tmp script.ilo      # rd "/etc/passwd" returns Err; rd "/tmp/x" succeeds
ilo run --allow-write=/tmp/out script.ilo # wr outside /tmp/out returns Err
ilo run --allow-run=echo script.ilo       # only echo permitted; other commands return Err
ilo run --allow-net=* --allow-read=/data script.ilo  # net unrestricted, reads restricted
```

## What's in the diff

- `src/caps.rs` (new) - `Policy` enum (All / List), `Caps` enum (Permissive / Restricted), `parse_allow`, `check_net/read/write/run`, host wildcard matching, path prefix matching, 30+ unit tests.
- `src/lib.rs` - re-exports `caps` module.
- `src/interpreter/mod.rs` - `caps` field on `Env`, `run_with_caps` / `run_with_tools_and_caps` entry points, policy checks at all IO builtin call sites (get, post, rd, rdl, wr, wra, wrl, run, walk, glob).
- `src/vm/mod.rs` - `caps` field on `VM`, `run_with_caps` entry point, policy checks at OP_RD, OP_RDL, OP_WR, OP_WRL, OP_GET, OP_GETH, OP_GETMANY, OP_POST, OP_POSTH.
- `src/cli/args.rs` - four optional `--allow-*` Clap args added to `RunArgs`.
- `src/main.rs` - `build_caps()` helper, caps threaded through all dispatch paths.
- `tests/capability_flags.rs` (new) - integration tests covering both backends.

## Test plan

- [x] `cargo test --release` passes (all non-AOT tests green)
- [x] `cargo test --release --features cranelift` passes
- [x] New `tests/capability_flags.rs` covers: empty net list blocks get, host allowlist, read prefix enforcement (inside + outside), write prefix enforcement, run allowlist (empty + permitted), permissive default, `Caps::parse_allow` round-trips
- [x] `cargo fmt` clean
- [x] `cargo clippy --release` clean

## Notes

- 9 pre-existing AOT test failures (`aot_compile_*`, `build_verb_produces_binary`, `positional_compile_still_works`) are unrelated - they hardcode `target/release/libilo.a` paths that don't exist when using an isolated build cache. Same failures exist on main with the same cache config.
- `OP_GETH` / `OP_POSTH` cap checks are placed inside their `#[cfg(feature = "http")]` blocks since URL extraction only happens there.
- Host wildcard: `*.example.com` matches both `api.example.com` and `example.com` itself.
- Path prefix: `/tmp` allows `/tmp/foo` but not `/tmpfoo` (requires trailing `/` or exact match).