### PR TITLE
chore: bump ilo-language skill token cap to 1500 (total 8500)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,9 +29,11 @@ jobs:
     - name: Install tiktoken
       run: pip install tiktoken
     - name: Enforce modular-skill token budget (cl100k_base)
-      # Each ilo-*.md skill must be ≤ 1,000 tokens; total ≤ 5,000. The
-      # in-binary tests/skill_modular.rs enforces a byte proxy for the same
-      # limit, but this step is the canonical check using the same tokeniser
+      # Each ilo-*.md skill must be ≤ 1,000 tokens, with one exception:
+      # ilo-language (the foundational module) is capped at ≤ 1,500.
+      # Aggregate across all modules ≤ 8,500. The in-binary
+      # tests/skill_modular.rs enforces a byte proxy for the same limit,
+      # but this step is the canonical check using the same tokeniser
       # an agent host uses to size the context window.
       run: python3 scripts/check-skill-tokens.py
 

--- a/scripts/check-skill-tokens.py
+++ b/scripts/check-skill-tokens.py
@@ -3,13 +3,16 @@
 Enforce the modular-skill token budget.
 
 Each `skills/ilo/ilo-*.md` module must encode to <= 1,000 tokens under
-`cl100k_base`. The aggregate across all modules must be <= 8,000.
+`cl100k_base`, with one exception: `ilo-language` is the foundational
+module every agent loads first, so it carries a higher 1,500-token cap
+to accommodate core syntax that doesn't split cleanly. The aggregate
+across all modules must be <= 8,500.
 
 The budget exists because the whole point of splitting the monolithic
 ~16,000-token compact spec into modules was to let agents load only the
 slices their current task needs (typical: 1-2 modules ~ 2,000 tokens). If
-a module drifts past 1,000 tokens, the per-task economics regress, so the
-guard is a CI gate, not advisory.
+a category module drifts past 1,000 tokens, the per-task economics regress,
+so the guard is a CI gate, not advisory.
 
 `ilo-builtins` was split into four category files (core, math, io, text)
 to give headroom as the language grows (PR: skill-split-by-category).
@@ -40,7 +43,13 @@ SKILL_NAMES = [
 ]
 
 PER_MODULE_LIMIT = 1000
-TOTAL_LIMIT = 8000
+# `ilo-language` is the foundational module every agent loads first; it
+# carries a higher cap because core syntax doesn't split cleanly into
+# smaller files. All other modules stay at PER_MODULE_LIMIT.
+PER_MODULE_OVERRIDES = {
+    "ilo-language": 1500,
+}
+TOTAL_LIMIT = 8500
 
 
 def main() -> int:
@@ -57,12 +66,13 @@ def main() -> int:
             continue
         tokens = len(enc.encode(path.read_text()))
         total += tokens
-        flag = "  OVER" if tokens > PER_MODULE_LIMIT else ""
-        print(f"  {name:<14} {tokens:5d} tokens{flag}")
-        if tokens > PER_MODULE_LIMIT:
+        limit = PER_MODULE_OVERRIDES.get(name, PER_MODULE_LIMIT)
+        flag = f"  OVER (cap {limit})" if tokens > limit else ""
+        print(f"  {name:<22} {tokens:5d} tokens{flag}")
+        if tokens > limit:
             failed = True
 
-    print(f"  {'TOTAL':<14} {total:5d} tokens")
+    print(f"  {'TOTAL':<22} {total:5d} tokens")
     if total > TOTAL_LIMIT:
         print(
             f"ERROR: total {total} exceeds aggregate budget {TOTAL_LIMIT}",

--- a/tests/skill_modular.rs
+++ b/tests/skill_modular.rs
@@ -15,7 +15,8 @@
 //   - every `description` starts with `Use this when`, the routing key agents
 //     match against
 //   - per-module byte budget is respected (≈ proxy for the hard 1,000-token
-//     cap; the exact tiktoken count is verified by the `skills-tokens` job in
+//     cap on category modules, or 1,500 tokens for `ilo-language`; the exact
+//     tiktoken count is verified by the `skills-tokens` job in
 //     `.github/workflows/rust.yml`)
 //   - the marketplace manifest lists every skill that's bundled
 
@@ -44,13 +45,14 @@ const SKILL_NAMES: &[&str] = &[
 /// Conservative byte budget per module. cl100k_base averages ~3.4 bytes/token
 /// on dense reference-style markdown like ours, so 4_000 bytes ≈ 1,180 tokens
 /// in the worst case. The Python tiktoken job in CI enforces the precise
-/// 1,000-token cap; this in-binary check is a defence-in-depth tripwire that
-/// catches drift even when CI is bypassed.
+/// per-module cap (1,000 tokens for category modules, 1,500 for the
+/// foundational `ilo-language`); this in-binary check is a defence-in-depth
+/// tripwire that catches drift even when CI is bypassed.
 const BYTE_BUDGET_PER_MODULE: usize = 4_000;
 
 /// Total bytes across all twelve. ~31,200 bytes ≈ 9,000 tokens at ~3.4 bytes
 /// per cl100k_base token on our content; the tighter tiktoken job in CI
-/// enforces the actual 8,000-token cap. Leaving the byte tripwire a few
+/// enforces the actual 8,500-token cap. Leaving the byte tripwire a few
 /// hundred tokens of slack avoids spurious failures when a single-character
 /// edit lands locally without re-running the Python counter.
 const BYTE_BUDGET_TOTAL: usize = 31_200;
@@ -136,7 +138,8 @@ fn per_module_byte_budget_respected() {
         assert!(
             len <= BYTE_BUDGET_PER_MODULE,
             "{n}.md is {len} bytes, over the per-module budget of {BYTE_BUDGET_PER_MODULE}. \
-             Trim or split. The hard 1,000-token cap is enforced by the tiktoken CI job."
+             Trim or split. The hard per-module token cap (1,000 for category modules, \
+             1,500 for ilo-language) is enforced by the tiktoken CI job."
         );
     }
 }
@@ -147,7 +150,7 @@ fn total_byte_budget_respected() {
     assert!(
         total <= BYTE_BUDGET_TOTAL,
         "total skills size is {total} bytes, over the aggregate budget of {BYTE_BUDGET_TOTAL}. \
-         The hard 8,000-token cap is enforced by the tiktoken CI job."
+         The hard 8,500-token cap is enforced by the tiktoken CI job."
     );
 }
 


### PR DESCRIPTION
## Summary

Raise the per-module skill-token cap to 1500 for `ilo-language` only. Other category modules stay at 1000. Aggregate budget bumps from 8000 to 8500.

`ilo-language` is the foundational module every agent loads first, and it doesn't split cleanly into smaller files. Current size is 987 tokens, 13 shy of the old cap. The in-flight multi-line-body fix (`feature/multiline-fn-body`) needs to add doc content for the new newline-as-separator rule and would otherwise trip the cap. This PR unblocks it.

## What's in the diff

- `scripts/check-skill-tokens.py`: introduce `PER_MODULE_OVERRIDES = {"ilo-language": 1500}`, bump `TOTAL_LIMIT` to 8500, update docstring + output formatting to show the per-module cap on overage.
- `.github/workflows/rust.yml`: update the comment above the tiktoken step to describe the new policy.
- `tests/skill_modular.rs`: update comments / assertion messages to reference the new caps. Byte-tripwire constants left as-is, they still provide useful headroom and aren't the canonical check.

Deliberately scoped:
- Only `ilo-language` gets 1500. Category files keep the 1000 cap so they stay lean.
- No skill `.md` content touched.
- Not rewriting the script in ilo, that's a separate larger PR pending a `tokcount` builtin.

## Test plan

- [x] `python3 scripts/check-skill-tokens.py` passes locally (ilo-language 987 < 1500, total 6727 < 8500).
- [ ] `skills-tokens` CI job green
- [ ] `skill_modular` test job green