### PR TITLE
doc jpar! auto-unwrap, the most-cited persona friction

### DIFF
--- a/examples/jpar-bang.ilo
+++ b/examples/jpar-bang.ilo
@@ -1,0 +1,29 @@
+-- jpar!: parse JSON and auto-unwrap the Result in one step.
+-- Saves the `?r{~v:v;^e:^e}` boilerplate that every JSON-parsing function
+-- would otherwise need after `jpar`. The enclosing function must return R
+-- (Propagate) — `jpar!!` panics instead, for scripts that treat parse
+-- failure as fatal.
+--
+-- Mirrors the existing `!` family (`rd!`, `get!`, `pst!`, `num!`, ...).
+-- Cross-engine: tree / VM / Cranelift produce identical output.
+
+-- Happy path: parse, extract field, wrap back as Ok.
+get-name body:t>R t t;r=jpar! body;~r.name
+
+get-age body:t>R n t;r=jpar! body;~r.age
+
+-- Err path: invalid JSON propagates out of the function before `~r.tag`
+-- runs. Same shape as `jpar body ?r{~v:v;^e:^e}` but ~15 tokens shorter.
+try-parse body:t>R t t;r=jpar! body;~r.tag
+
+-- run: get-name {"name":"alice","age":30}
+-- out: alice
+
+-- run: get-age {"name":"alice","age":30}
+-- out: 30
+
+-- run: try-parse {"tag":"ok"}
+-- out: ok
+
+-- run: try-parse not-json
+-- err: ^expected ident at line 1 column 2

--- a/skills/ilo/ilo-builtins-io.md
+++ b/skills/ilo/ilo-builtins-io.md
@@ -26,6 +26,8 @@ Timeout variants round up to the nearest second. Err on timeout or connection fa
 
 `jpar s` parse (`R _ t`), `jpar-list s` parse and assert array (`R (L _) t` — use when you know the response is an array: `@x (jpar-list! body){...}`), `jpth s path` dot-path (typed), `jkeys s path` sorted object keys, `jdmp v` serialize. Numeric keys stringified in `jdmp`.
 
+`!` auto-unwraps the Result on any of these. Inside an `R`-returning function `r=jpar! body;r.x` is the common shape — saves the `?r{~v:v;^e:^e}` boilerplate per call site. `jpar! body` propagates parse errors out of the enclosing function; `jpar!! body` panics on parse error instead. Same for `jpar-list!`, `jpth!`, `jkeys!`.
+
 ## Environment / process
 
 `env name` (var), `env-all` (`R (M t t) t`), `exit code`.

--- a/tests/regression_jpar_bang.rs
+++ b/tests/regression_jpar_bang.rs
@@ -1,0 +1,105 @@
+// Cross-engine regression tests for `jpar!` — JSON parse with `!`
+// auto-unwrap.
+//
+// `jpar s` returns `R _ t`; the `!` suffix is the generic auto-unwrap
+// operator on any Result-returning call. There is no dedicated
+// `JparBang` builtin variant — `!` is parsed/lowered uniformly across
+// builtins — but `jpar!` is the single most-cited shape in persona
+// dogfooding so it earns its own dedicated cross-engine assertions
+// distinct from the existing incidental coverage in
+// coverage_vm_mod / coverage_cranelift_compile / regression_dot_keywords.
+//
+// Contract under test:
+//   1. `jpar! good` returns the parsed value (field access works).
+//   2. `jpar! bad` propagates `^e` out of the enclosing R-returning fn.
+//   3. Same byte-identical answer on every engine that ships in this
+//      build (VM always, JIT when `cranelift` is enabled).
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn engines() -> Vec<&'static str> {
+    let mut v = vec!["--vm"];
+    if cfg!(feature = "cranelift") {
+        v.push("--jit");
+    }
+    v
+}
+
+fn run_ok(engine: &str, src: &str, entry: &str, arg: &str) -> String {
+    let out = ilo()
+        .arg(src)
+        .arg(engine)
+        .arg(entry)
+        .arg(arg)
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for entry={entry} arg={arg}: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn run_err(engine: &str, src: &str, entry: &str, arg: &str) -> String {
+    let out = ilo()
+        .arg(src)
+        .arg(engine)
+        .arg(entry)
+        .arg(arg)
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "ilo {engine} unexpectedly succeeded for entry={entry} arg={arg}: stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    String::from_utf8_lossy(&out.stderr).trim().to_string()
+}
+
+// Ok path: jpar! unwraps inside an R-returning fn and field access
+// works on the resulting json record.
+const GOOD: &str = "f body:t>R t t;r=jpar! body;~r.name";
+
+#[test]
+fn jpar_bang_ok_unwraps_to_record() {
+    for engine in engines() {
+        let got = run_ok(engine, GOOD, "f", "{\"name\":\"alice\"}");
+        assert_eq!(got, "alice", "engine={engine}");
+    }
+}
+
+// Err path: malformed JSON makes jpar! propagate the parse error as
+// the enclosing function's return value. The CLI surfaces a propagated
+// `^e` as a non-zero exit with the error text on stderr.
+const BAD: &str = "f body:t>R t t;r=jpar! body;~r.name";
+
+#[test]
+fn jpar_bang_err_propagates_parse_error() {
+    for engine in engines() {
+        let stderr = run_err(engine, BAD, "f", "not-json");
+        assert!(
+            stderr.contains("expected ident")
+                || stderr.contains("expected")
+                || stderr.contains("parse"),
+            "engine={engine}: stderr did not look like a parse error: {stderr:?}"
+        );
+    }
+}
+
+// `jpar!` on an array body produces a list that `len` can measure.
+// Mirrors the persona use-case where the response shape is known and
+// the agent wants to skip the Result handshake.
+const LIST_LEN: &str = "f body:t>R n t;xs=jpar-list! body;~len xs";
+
+#[test]
+fn jpar_list_bang_iterates_top_level_array() {
+    for engine in engines() {
+        let got = run_ok(engine, LIST_LEN, "f", "[\"a\",\"b\",\"c\"]");
+        assert_eq!(got, "3", "engine={engine}");
+    }
+}


### PR DESCRIPTION
## Summary

Pending #5y called out `jpar!` as the single most-cited friction across 7+ persona dogfood runs: `jpar s` returns `R _ t`, every JSON-handling persona reached for `jpar!`, and when the docs didn't confirm it, they fell back to the full `jpar body ?r{~v:v;^e:^e}` shape, paying roughly 15 tokens of boilerplate per call site.

The surprise: `jpar!` already works. The `!` operator is generic across every R-returning builtin, lowered uniformly in the parser, so there is no per-builtin `JparBang` variant to add. SPEC.md and ai.txt both already showed `jpar!` in their examples. The gap was in the discoverability docs personas actually load (`skills/ilo/ilo-builtins-io.md`) and on the site reference, plus the absence of any focused regression test or example tying the contract together.

This PR is therefore docs + tests, no language change. Manifesto framing: every persona that finds `jpar!` documented saves ~15 tokens versus the Result-handling fallback; multiplied across the seven hit personas plus future runs, that compounds quickly.

## Repro before/after

Before: persona reads `skills/ilo/ilo-builtins-io.md`, sees `jpar` returning `R _ t`, sees `jpar-list!` in an example but no `jpar!`, falls back to `?r{~v:v;^e:^e}`.

After: same paragraph plus one explicit sentence that names `jpar!`, `jpar!!`, `jpar-list!`, `jpth!`, `jkeys!` and shows the `r=jpar! body;r.x` idiom. Plus an `examples/jpar-bang.ilo` agents can grep for, plus a dedicated cross-engine test pinning the contract.

## What's in the diff

- `add tests and example for jpar! auto-unwrap` — new `examples/jpar-bang.ilo` exercised by the engine harness (Ok path on two fields, Err path via `-- err:` annotation) and a new `tests/regression_jpar_bang.rs` asserting `jpar! good` → record-field access, `jpar! bad` → propagated `^e`, and `jpar-list! arr` → iterable list, on VM and (when built) JIT.
- `doc jpar! discoverability in skills/ilo` — one new sentence in `skills/ilo/ilo-builtins-io.md` calling out the `!` auto-unwrap family for `jpar`/`jpar-list`/`jpth`/`jkeys`.

Site repo got the matching `jpar!` row in `data-io.md` (separate push to ilo-site main per CLAUDE.md 6b).

## Test plan

- [x] `cargo test --release --features cranelift` — full suite green locally
- [x] `cargo fmt --check`
- [x] `cargo clippy --release --features cranelift --all-targets -- -D warnings`
- [x] New `regression_jpar_bang.rs` passes on VM and JIT
- [x] `examples/jpar-bang.ilo` picked up by `tests/examples_engines.rs` and passes
- [ ] CI green on push

## Follow-ups

Pending #5f (`jpar!` result can't be used as list in `@` loop) and #5ah (`num` on JSON numeric leaves) are still open; both are real language-level issues that would need actual implementation changes, separate from this discoverability fix.