### PR TITLE
fix(jit): register jit_prod symbol so prod xs runs on JIT without VM fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- `prod xs` on the Cranelift JIT no longer falls back to the bytecode VM. The `jit_prod` extern-C helper existed and the JIT codegen emitted a call to it, but `register_helpers` in `src/vm/jit_cranelift.rs` was missing the `("jit_prod", jit_prod as *const u8)` symbol entry, so the JIT panicked with `can't resolve symbol jit_prod` and silently bailed. Output was still correct but acceleration was defeated. `sum`, `avg`, `min`, `max` were unaffected — only `prod` got missed when it was added. Surfaced by the monte-carlo persona.
+
 ### Changed
 
 - Versioning scheme: semver → CalVer. Releases are `YY.M` (e.g. `26.5`), patches `YY.M.P` (e.g. `26.5.1`). The version string carries recency so an agent loading `ilo spec --json ai` knows which spec applies without a changelog lookup. Last semver release is `0.12.1`; first CalVer release cuts on the next breaking change as `26.X`. Hard cut, no `0.13` bridge. Branching model splits: `main` carries stable + RC tags (`26.5`, `26.5.1`, `26.5.2-rc.1`), `next` carries dev tags only (`26.6-dev.N`). See `README.md#versioning` for the full release / patch flow.

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -336,6 +336,7 @@ fn register_helpers(builder: &mut JITBuilder) {
         ("jit_stdev", jit_stdev as *const u8),
         ("jit_variance", jit_variance as *const u8),
         ("jit_sum", jit_sum as *const u8),
+        ("jit_prod", jit_prod as *const u8),
         ("jit_avg", jit_avg as *const u8),
         ("jit_flat", jit_flat as *const u8),
         ("jit_slc", jit_slc as *const u8),

--- a/tests/regression_jit_prod.rs
+++ b/tests/regression_jit_prod.rs
@@ -1,0 +1,119 @@
+// Regression: `prod xs` must execute on the Cranelift JIT without falling
+// back to the bytecode VM.
+//
+// Before this fix, `register_helpers` in `src/vm/jit_cranelift.rs` was missing
+// the `("jit_prod", jit_prod as *const u8)` entry. The JIT codegen emitted a
+// call to the `jit_prod` symbol (the dispatch arm + `declare_helper` for
+// `jit_prod` were both wired up), but the JITBuilder had no symbol resolver
+// for it, so the module emitted
+//
+//   [ilo:jit-fallback] Cranelift JIT panicked (can't resolve symbol jit_prod);
+//   falling back to bytecode VM.
+//
+// Output was still correct (the VM has its own working `prod`), but the JIT
+// silently bailed and acceleration was defeated. The cross-engine tests in
+// `regression_prod_cprod.rs` already pinned the numeric result on `--jit`;
+// they passed because the fallback masked the bug. This file adds the
+// missing stderr-aware assertion to catch the regression directly.
+//
+// Other math-list reducers (`sum`, `avg`, `min`, `max`) already have their
+// symbol entries, so this test pattern can be generalised if the same gap
+// reappears elsewhere.
+
+#![cfg(feature = "cranelift")]
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+/// Run `ilo <src> <engine> <entry>` and return (stdout, stderr). Asserts the
+/// process exits successfully so callers can focus on the streams themselves.
+fn run(engine: &str, src: &str, entry: &str) -> (String, String) {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to spawn ilo");
+    let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert!(
+        out.status.success(),
+        "ilo {engine} {src:?} failed: stdout={stdout} stderr={stderr}"
+    );
+    (stdout, stderr)
+}
+
+fn assert_no_jit_fallback(stderr: &str, ctx: &str) {
+    assert!(
+        !stderr.contains("[ilo:jit-fallback]"),
+        "JIT unexpectedly fell back to VM ({ctx}); stderr was:\n{stderr}"
+    );
+    // Catch the underlying cause too, in case the fallback marker is ever
+    // renamed but the symbol-resolution panic remains.
+    assert!(
+        !stderr.contains("can't resolve symbol jit_prod"),
+        "JIT failed to resolve jit_prod ({ctx}); stderr was:\n{stderr}"
+    );
+}
+
+#[test]
+fn prod_runs_on_jit_without_fallback() {
+    let src = "f>n;prod [2.0 3.0 4.0]";
+    let (stdout, stderr) = run("--jit", src, "f");
+    assert_eq!(stdout, "24", "prod [2,3,4] should equal 24 on JIT");
+    assert_no_jit_fallback(&stderr, "prod basic floats");
+}
+
+#[test]
+fn prod_integers_on_jit_without_fallback() {
+    let src = "f>n;prod [1, 2, 3, 4]";
+    let (stdout, stderr) = run("--jit", src, "f");
+    assert_eq!(stdout, "24", "prod [1..4] should equal 24 on JIT");
+    assert_no_jit_fallback(&stderr, "prod integers");
+}
+
+#[test]
+fn prod_empty_on_jit_without_fallback() {
+    // Multiplicative identity: prod [] = 1.
+    let src = "f>n;prod []";
+    let (stdout, stderr) = run("--jit", src, "f");
+    assert_eq!(stdout, "1", "prod [] should equal 1 on JIT");
+    assert_no_jit_fallback(&stderr, "prod empty");
+}
+
+#[test]
+fn prod_cross_engine_parity_with_no_fallback() {
+    // Pin parity across the default engine, the explicit VM, and the JIT
+    // for the same expression, and confirm the JIT path stays on the JIT.
+    let src = "f>n;prod [2.0 3.0 4.0]";
+
+    // Default engine (no flag): exercises the entry-pick path agents hit
+    // most often.
+    let default_out = ilo()
+        .args([src, "f"])
+        .output()
+        .expect("failed to spawn ilo");
+    assert!(default_out.status.success(), "default engine failed");
+    let default_stdout = String::from_utf8_lossy(&default_out.stdout)
+        .trim()
+        .to_string();
+
+    let (vm_stdout, _) = run("--run-vm", src, "f");
+    let (jit_stdout, jit_stderr) = run("--jit", src, "f");
+
+    assert_eq!(default_stdout, "24", "default-engine result");
+    assert_eq!(vm_stdout, "24", "vm result");
+    assert_eq!(jit_stdout, "24", "jit result");
+    assert_no_jit_fallback(&jit_stderr, "cross-engine parity");
+}
+
+#[test]
+fn prod_composed_with_sum_on_jit_without_fallback() {
+    // Exercises both helper-call numeric opcodes in one compiled chunk so
+    // we'd catch a regression where adding more symbols breaks the table.
+    let src = "f>n;+(prod [2, 3, 4]) (sum [1, 2, 3])";
+    let (stdout, stderr) = run("--jit", src, "f");
+    assert_eq!(stdout, "30", "prod + sum should equal 30 on JIT");
+    assert_no_jit_fallback(&stderr, "prod + sum composed");
+}


### PR DESCRIPTION
## Summary

`prod xs` (#470) works on the VM but the Cranelift JIT panics with `[ilo:jit-fallback] Cranelift JIT panicked (can't resolve symbol jit_prod)` and silently falls back to the bytecode VM. Output is correct (the VM has a working `prod`), but JIT acceleration is defeated. Surfaced today by the monte-carlo persona.

The `extern "C" jit_prod` helper, the `declare_helper(module, "jit_prod", …)` call, and the OP_PROD dispatch arm were all already wired up when #470 landed. Only the `("jit_prod", jit_prod as *const u8)` entry in `register_helpers` (`src/vm/jit_cranelift.rs`) was missed, so the JITBuilder symbol table had no resolver for the call. `sum`, `avg`, `min`, `max` were unaffected because their entries were added correctly.

## Repro

Before:

```
$ ilo "f>n;prod [2.0 3.0 4.0]" --jit f
[ilo:jit-fallback] Cranelift JIT panicked (can't resolve symbol jit_prod); falling back to bytecode VM. Subsequent fallbacks in this process will be silent (count reported on exit).
24
```

After:

```
$ ilo "f>n;prod [2.0 3.0 4.0]" --jit f
24
```

Stderr is empty; the JIT runs `prod` natively.

## What's in the diff

- `src/vm/jit_cranelift.rs`: one line in the `register_helpers` symbol table — `("jit_prod", jit_prod as *const u8),` next to `jit_sum` / `jit_avg`.
- `tests/regression_jit_prod.rs`: 5 new tests asserting both the numeric result AND the absence of `[ilo:jit-fallback]` on stderr across the default engine, `--run-vm`, and `--jit`. The existing tests in `regression_prod_cprod.rs` already pinned the numeric result on `--jit` but passed despite the bug because the fallback masked it; the new tests pin the JIT path directly. Verified: all 5 fail on pristine `main`, all 5 pass with the one-line fix.
- `CHANGELOG.md`: `Unreleased > Fixed` entry.

AOT (`src/vm/compile_cranelift.rs`) is unaffected — ObjectModule links against `libilo.a` where `jit_prod` is exported with `#[unsafe(no_mangle)]`, so symbol resolution there goes through the linker, not the JITBuilder table.

## Test plan

- [x] `cargo test --release --features cranelift --test regression_jit_prod` — 5/5 passing
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --release --features cranelift --all-targets -- -D warnings` clean
- [x] Verified new tests fail on pristine `main` (5/5 failing) and pass with fix (5/5 passing)
- [x] Verified verbatim that the `[ilo:jit-fallback]` line no longer appears on `--jit` runs of `prod`

## Follow-ups

None — the other math-list reducers (`sum`, `avg`, `min`, `max`, plus the stats family) already have their symbol entries. If we add more JIT helpers, the new stderr-aware test pattern in `regression_jit_prod.rs` is the template for catching the same regression earlier.