### PR TITLE
ci: pin GitHub Actions to commit SHAs (#5br)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,11 @@ jobs:
   secret-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - name: gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: .github/gitleaks.toml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           sparse-checkout: |
             src
@@ -51,7 +51,7 @@ jobs:
             skills
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
 
@@ -78,7 +78,7 @@ jobs:
         shell: bash
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ilo-${{ matrix.target }}
           path: ilo-${{ matrix.target }}*
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           sparse-checkout: |
             src
@@ -99,7 +99,7 @@ jobs:
             skills
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: wasm32-wasip1
 
@@ -107,7 +107,7 @@ jobs:
         run: cargo build --release --target wasm32-wasip1 --no-default-features
 
       - name: Upload WASM artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ilo-wasm
           path: target/wasm32-wasip1/release/ilo.wasm
@@ -118,7 +118,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           merge-multiple: true
 
@@ -126,7 +126,7 @@ jobs:
         run: sha256sum ilo-* > checksums-sha256.txt
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           generate_release_notes: true
           files: |
@@ -138,10 +138,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Publish to crates.io
         run: |
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           sparse-checkout: |
             npm
@@ -167,13 +167,13 @@ jobs:
         run: cp README.md npm/README.md
 
       - name: Download WASM artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ilo-wasm
           path: npm/
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
@@ -197,7 +197,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           sparse-checkout: |
             pi
@@ -209,7 +209,7 @@ jobs:
           cp skills/ilo/SKILL.md pi/skills/ilo/SKILL.md
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,13 +13,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
     - name: Check formatting
       run: cargo fmt --all -- --check
     - name: Clippy
       run: cargo clippy --workspace --all-targets -- -D warnings
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.12'
     - name: Install skills-ref (agentskills.io reference validator)
@@ -43,7 +43,7 @@ jobs:
     # (Claude Code, Claude Desktop, Codex, etc.) before the Rust tests run.
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
     - name: Install skills-ref
       run: npm install -g skills-ref
     - name: Validate skill
@@ -54,9 +54,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
     - name: Install cargo-nextest
-      uses: taiki-e/install-action@v2
+      uses: taiki-e/install-action@65851e10cd6c377f11a60e600abc07cb08643468 # v2
       with:
         tool: nextest
     - name: Build
@@ -69,7 +69,7 @@ jobs:
       run: cargo nextest run --profile ci
     - name: Upload test results to Codecov
       if: ${{ !cancelled() }}
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
       with:
         files: target/nextest/ci/junit.xml
         report_type: test_results
@@ -78,9 +78,9 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
     - name: Install cargo-llvm-cov
-      uses: taiki-e/install-action@v2
+      uses: taiki-e/install-action@65851e10cd6c377f11a60e600abc07cb08643468 # v2
       with:
         tool: cargo-llvm-cov
     - name: Build libilo.a (needed by AOT tests)
@@ -88,7 +88,7 @@ jobs:
     - name: Generate coverage
       run: cargo llvm-cov --workspace --lcov --output-path lcov.info
     - name: Upload to Codecov
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
       with:
         files: lcov.info
         fail_ci_if_error: false

--- a/.github/workflows/sync-next.yml
+++ b/.github/workflows/sync-next.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: next
           fetch-depth: 0
@@ -30,7 +30,7 @@ jobs:
           fi
       - name: Open sync PR if diverged
         if: steps.ff.outputs.result == 'diverged'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           branch: chore/sync-next-from-main
           base: next


### PR DESCRIPTION
## Summary

Every `uses: foo/bar@vN` reference across the three workflow files is now pinned to a full 40-char commit SHA, with the original tag preserved as a trailing `# vN` comment. Borrowed from Zero's rocicorp/mono#5998.

## Why

GitHub tags are mutable. A compromised maintainer account, a leaked publish token, or a typo-squatted action can silently re-point `v4` at malicious code, and our CI would pick it up on the next run with no visible diff. SHAs are immutable: pinning means an attacker who overwrites the tag can't change what our workflows actually execute. The cost is small (lose automatic minor-version updates) and dependabot covers the maintenance gap.

If you have dependabot enabled on the repo, add a `.github/dependabot.yml` config for `package-ecosystem: github-actions` so it opens PRs whenever a pinned action publishes a new SHA under its tag. That keeps us patched without giving the supply chain a free hand.

## What's in the diff

- `.github/workflows/rust.yml` - pinned `actions/checkout@v5`, `actions/setup-python@v5`, `taiki-e/install-action@v2`, `codecov/codecov-action@v6`
- `.github/workflows/release.yml` - pinned `actions/checkout@v4`, `dtolnay/rust-toolchain@stable`, `actions/upload-artifact@v4`, `actions/download-artifact@v4`, `actions/setup-node@v4`, `softprops/action-gh-release@v2`, `gitleaks/gitleaks-action@v2`
- `.github/workflows/sync-next.yml` - pinned `actions/checkout@v4`, `peter-evans/create-pull-request@v6`

12 unique action references resolved via `gh api repos/<owner>/<repo>/git/refs/tags/<tag>` (annotated tags followed to their target commit). YAML re-parses cleanly.

## Test plan

- [ ] `Rust / lint` workflow passes (uses the new pinned `actions/checkout@93cb6e...`, `actions/setup-python@a26af6...`)
- [ ] `Rust / skill-validate` passes
- [ ] `Rust / build` passes (`taiki-e/install-action@65851e...`, `codecov/codecov-action@e79a69...`)
- [ ] `Rust / coverage` passes
- [ ] Release workflow not exercised here; will be exercised on next tag push

## Follow-ups

- Add `.github/dependabot.yml` with a `github-actions` ecosystem block so dependabot opens PRs for SHA bumps as new versions land. Tracking separately to keep this PR purely about pinning.