### PR TITLE
docs: contrast rnd vs rndn, show uniform-int idiom (#5ay)

### DIFF
--- a/skills/ilo/ilo-builtins-math.md
+++ b/skills/ilo/ilo-builtins-math.md
@@ -23,7 +23,7 @@ Prefix-call: `name arg1 arg2 ...`. Cross-engine unless noted.
 
 ## Random
 
-`rnd` = random float [0,1) (aliases `rand`, `random`); `rndn` = sample from Normal `N(mu, sigma)` (Box-Muller). For cryptographic randomness (jti, CSRF tokens, session IDs, nonces) use `rand-bytes n > t` — CSPRNG bytes encoded as base64url-no-pad; URL-safe drop-in for headers / cookies / query strings.
+`rnd > n` = uniform float `[0,1)` (aliases `rand`, `random`); `rnd a b > n` = uniform integer in `[a,b]` inclusive (use this for dice / bucket IDs, NOT `rndn 0 n`); `rndn mu sigma > n` = ONE sample from Normal `N(mu, sigma)` (Box-Muller, can be negative / unbounded). `rndn 0 n` is Gaussian noise, not a uniform int. For cryptographic randomness (jti, CSRF tokens, session IDs, nonces) use `rand-bytes n > t` — CSPRNG bytes encoded as base64url-no-pad; URL-safe drop-in for headers / cookies / query strings.
 
 ## Statistics
 


### PR DESCRIPTION
## Summary

Personas in three different domains (k-means, mempool-fee, markov-chain) reached for `rndn 0 n` expecting `uniform_int(0, n)` and instead got Normal-distributed noise (sometimes negative, often outside `[0, n)`). The math skill doc only mentioned `rndn` at a high level and never surfaced that `rnd a b` already returns a uniform integer in `[a, b]` inclusive — the right tool for dice rolls, bucket IDs, and any uniform-int-in-range work.

Manifesto framing: every persona that wrote `rndn 0 n` then debugged the resulting garbage was burning tokens on a confusion the doc could have prevented in one line. Cost of the doc: one sentence. Cost of NOT having it: three personas hit the same trap.

## Repro before/after

Before, an agent reading `skills/ilo/ilo-builtins-math.md` saw only:
- ``rnd`` = random float `[0,1)`
- ``rndn`` = sample from Normal

No mention of `rnd a b`. Easy to assume `rndn 0 n` is the obvious uniform-int form by analogy with `rnd a b` in other languages.

After: all three forms appear in one line with explicit signatures and an inline warning that `rndn 0 n` is Gaussian noise, not a uniform int.

## What's in the diff

- `skills/ilo/ilo-builtins-math.md` Random section: rewrite the one-liner to cover `rnd > n`, `rnd a b > n`, `rndn mu sigma > n` with a NOT-this-NOT-that warning between them.

`rnd a b` and `rndn` are already documented correctly in `SPEC.md` and `ai.txt`; the gap was only in the skill doc that agents see at write-time.

## Test plan

- [x] `git diff` shows only the math skill doc changed (1 line)
- [x] Doc still under token budget for the file
- [x] No code change so no `cargo test` impact; CI will run the standard suite anyway

## Follow-ups

- When `seed` lands on `main` (currently on another branch), add a one-line note that `seed n` makes both `rnd` and `rndn` deterministic.

Closes ilo_assessment_feedback.md entry #5ay.