### PR TITLE
docs: surface default-on-err in Result skills (#5bf)

### DIFF
--- a/skills/ilo/ilo-builtins-core.md
+++ b/skills/ilo/ilo-builtins-core.md
@@ -15,6 +15,15 @@ Prefix-call: `name arg1 arg2 ...`. Cross-engine unless noted.
 
 `default-on-err r d` - unwrap `R T E` to `T`, returning `d` if Err. Mirror of `??` for Result (`??` is nil-coalesce for `O T` only). `default-on-err (num s) 0` replaces `?r{~v:v;^_:0}`. Verifier enforces `d` matches Ok type (ILO-T040). Using `??` on a Result triggers ILO-T041 pointing here.
 
+Use when the error payload is discardable and you want a one-liner instead of a `?r{~v:v;^_:d}` match. Works inside any fn (no `R`-return requirement, unlike `!`).
+
+```
+port = default-on-err (num "8080") 0                -- text→num with fallback
+name = default-on-err (jpth body "user.name") "anon" -- missing/typed path → fallback
+```
+
+See `examples/default-on-err.ilo` for the full pattern set.
+
 ## List
 
 `len hd tl at lst take drop slc`; `rev srt rsrt unq uniqby flat grp zip enumerate range`; `chunks window flatmap partition`; `setunion setinter setdiff`. `at xs i` floors floats; negative indexes from end (same for `slc take drop`). Bounds clamp. `lst xs i v` = set index (alias `lset`); last element = `at xs -1`.

--- a/skills/ilo/ilo-builtins-io.md
+++ b/skills/ilo/ilo-builtins-io.md
@@ -28,9 +28,9 @@ Timeout variants round up to the nearest second. Err on timeout or connection fa
 
 `jpar s` parse (`R _ t`), `jpar-list s` parse and assert array (`R (L _) t` — use when you know the response is an array: `@x (jpar-list! body){...}`), `jpth s path` dot-path (typed), `jkeys s path` sorted object keys, `jdmp v` serialize. Numeric keys stringified in `jdmp`.
 
-`!` auto-unwraps the Result on any of these. Inside an `R`-returning function `r=jpar! body;r.x` is the common shape — saves the `?r{~v:v;^e:^e}` boilerplate per call site. `jpar! body` propagates parse errors out of the enclosing function; `jpar!! body` panics on parse error instead. Same for `jpar-list!`, `jpth!`, `jkeys!`.
+`!` auto-unwraps the Result on any of these. Inside an `R`-returning function `r=jpar! body;r.x` is the common shape — saves the `?r{~v:v;^e:^e}` boilerplate per call site. `jpar! body` propagates parse errors out of the enclosing function; `jpar!! body` panics instead. Same for `jpar-list!`, `jpth!`, `jkeys!`.
 
-When the caller is **not** `R`-returning (so `!` is unavailable) and the error payload is discardable, use `default-on-err` (see `ilo-builtins-core`): `name=default-on-err (jpth body "user.name") "anon"`.
+Non-`R` callers can't use `!`; reach for `default-on-err` (in `ilo-builtins-core`) when the error is discardable: `name=default-on-err (jpth body "user.name") "anon"`.
 
 ## Environment / process
 

--- a/skills/ilo/ilo-builtins-io.md
+++ b/skills/ilo/ilo-builtins-io.md
@@ -30,6 +30,8 @@ Timeout variants round up to the nearest second. Err on timeout or connection fa
 
 `!` auto-unwraps the Result on any of these. Inside an `R`-returning function `r=jpar! body;r.x` is the common shape — saves the `?r{~v:v;^e:^e}` boilerplate per call site. `jpar! body` propagates parse errors out of the enclosing function; `jpar!! body` panics on parse error instead. Same for `jpar-list!`, `jpth!`, `jkeys!`.
 
+When the caller is **not** `R`-returning (so `!` is unavailable) and the error payload is discardable, use `default-on-err` (see `ilo-builtins-core`): `name=default-on-err (jpth body "user.name") "anon"`.
+
 ## Environment / process
 
 `env name` (var), `env-all` (`R (M t t) t`), `exit code`.


### PR DESCRIPTION
## Summary

`default-on-err r d` has been a builtin since PR #490, but agents running the persona harness still can't find it from the current skill docs. The jpth-typed-stress persona surfaced this as pending #5bf: 'no default-on-err builtin found despite memory reference.' It's there — it just sits as a single dense one-liner in `ilo-builtins-core.md` with no example matching the shape agents actually reach for (Result-from-jpth fallback inside a non-R fn).

Doc-only fix. Add a worked-example block to `ilo-builtins-core.md` with the two canonical shapes:
- `port = default-on-err (num "8080") 0` (text→num fallback)
- `name = default-on-err (jpth body "user.name") "anon"` (typed jpth Err fallback)

Plus a cross-link from `ilo-builtins-io.md`'s JSON section to point agents back to it for the non-`R`-returning caller case (where `!` is unavailable, so the question 'how do I handle a jpth Err here' has a non-obvious answer today).

No code changes, no spec changes. `default-on-err` is already in `ai.txt` and `SPEC.md`.

## Repro before / after

Before: persona dispatched on jpth payload extraction in a `>t` main writes `?r{~v:v;^_:"fallback"}` boilerplate or gives up and uses `!!`, because nothing in the skill docs surfaces the one-liner.

After: an agent reading `ilo-builtins-core` Result-unwrap section sees the jpth/num examples and reaches for `default-on-err` directly. Same agent reading `ilo-builtins-io` JSON section gets pointed at `default-on-err` for the non-`R`-returning case.

## What's in the diff

- `skills/ilo/ilo-builtins-core.md` — append a usage paragraph + 2-line worked example block + pointer to `examples/default-on-err.ilo`
- `skills/ilo/ilo-builtins-io.md` — one-line cross-link in JSON section for the non-`R` caller case

## Test plan

- [ ] `cargo check --release` passes (skill files are include_str!'d into the binary)
- [ ] CI green
- [ ] grep `default-on-err` in `skills/ilo/ilo-builtins-core.md` now returns the new example block
- [ ] grep `default-on-err` in `skills/ilo/ilo-builtins-io.md` now returns the cross-link

## Follow-ups

- Consider adding `default-on-err` to the reserved-names list in `skills/ilo/SKILL.md` (separate doc PR — it is a builtin, so it should be there for ILO-P011 awareness).
- Verifier hints ILO-T040 / ILO-T041 aren't in `skills/ilo/ilo-errors.md` yet; worth its own pass.