### PR TITLE
docs: add dtfmt/dtparse/dtparse-rel to SKILL.md (#23)

### DIFF
--- a/skills/ilo/SKILL.md
+++ b/skills/ilo/SKILL.md
@@ -88,6 +88,10 @@ Agents reach for these names constantly — pick the listed alternative and move
 
 When in doubt: pick a 4+ char descriptive name. The token cost of an extra character is dwarfed by the cost of an ILO-P011 retry round-trip.
 
+## Date/time builtins
+
+`now` and `now-ms` are not the whole surface. Full set: `now` (Unix seconds), `now-ms` (Unix ms), `dtfmt ts fmt` (timestamp to text), `dtparse s fmt` (text to timestamp, `R n t`), `dtparse-rel s now` (relative phrase like `"in 3 days"` / `"last monday"` anchored at `now`, `R n t`). Reach for `dtparse-rel` before hand-rolling phrase parsers. Details in `ilo skill get ilo-builtins-text`.
+
 ## Compatibility note
 
 ilo has no borrow checker, no lifetime annotations, no ownership rules. Values are RC-managed; the type checker enforces shape only. There is no `&`, no `&mut`, no `'a`. If an agent is reaching for lifetime-style reasoning in ilo, it has the wrong mental model.


### PR DESCRIPTION
## Summary

The bootstrap `skills/ilo/SKILL.md` only mentioned `now` as a date/time builtin in the rename-suggestion section. Personas loading just the bootstrap repeatedly missed `dtfmt`, `dtparse`, and `dtparse-rel`, even though those names appear in the reserved-names list and the `ilo-builtins-text` skill. Multiple personas hand-rolled phrase parsers for relative dates because `dtparse-rel` wasn't surfaced.

Add a compact "Date/time builtins" section listing the full surface in one paragraph: `now`, `now-ms`, `dtfmt`, `dtparse`, `dtparse-rel`, with signatures and a pointer to the detailed skill. Token-cap aware: one short section, no example bloat.

## Repro

Before: search SKILL.md for date/time semantic mention - only `now` shows up outside the reserved-names list.

After: a dedicated section names all five builtins with their signatures, so agents grepping for "date" or "dtparse" in the bootstrap find it immediately.

## What's in the diff

- `skills/ilo/SKILL.md`: new "Date/time builtins" section between "Reserved names" and "Compatibility note".

Verified against `src/builtins.rs::Builtin::ALL`: only `Dtfmt`, `Dtparse`, `DtparseRel` are on main (TzOffset, calendar arithmetic etc. live on feature branches, so they're intentionally not mentioned here).

## Test plan

- [ ] CI green (docs-only change, no code paths touched)
- [ ] `grep -F dtparse-rel skills/ilo/SKILL.md` returns the new section
- [ ] No em dashes introduced in the added text

## Follow-ups

- When `tz-offset` / calendar arithmetic land, extend this section to cover them.

Closes pending feedback #23.