### PR TITLE
docs: contrast Optional ?? vs Result ~/^ (#26a)

### DIFF
--- a/skills/ilo/ilo-language.md
+++ b/skills/ilo/ilo-language.md
@@ -35,6 +35,13 @@ Flat early returns: `cls sp:n>t;>=sp 1000 "gold";>=sp 500 "silver";"bronze"`. Br
 
 `div a:n b:n>R n t;=b 0 ^"divide by zero";~/a b`. `!` auto-unwraps in `R`-fns. `!!` panics on `^e`/`nil`. `default-on-err r d` unwraps `R T E` to `T` with `d` on Err (Result `??`).
 
+## optional vs result
+
+Two distinct types, two distinct unwraps. `O T` = maybe-value (`nil` or `T`), no error payload; unwrap with `?? x d`. `R T E` = ok-or-err with payload; unwrap with `~`/`^` match arms, `!`, `!!`, or `default-on-err r d`. Using `??` on `R T E` is ILO-T041; using `default-on-err` on `O T` is ILO-T040.
+
+`O t`: `name = ?? name-opt "default"` — nil-coalesce, `O t -> t`.
+`R t t`: `name = default-on-err r "fallback"`, or `?r{~v:v;^_:"fallback"}` — Result unwrap, `R t e -> t`.
+
 ## loops
 
 `@x xs{body}` foreach, `@i 0..5{body}` range, `wh <i 10{...}` while. `brk`, `cnt`, `ret v`. Tail user-fn calls trampoline (no stack growth); deep iter: `cd n:n>n;=n 0 0;cd -n 1`. Direct name, no `!`/`!!`.


### PR DESCRIPTION
## Summary

The block-validator persona burned ~30 errors converging on the difference between `O t` (Optional, unwrap with `??`) and `R t t` (Result, unwrap with `~`/`^`/`!`/`default-on-err`). The contrast was already documented in passing in the dense `## types` line in `skills/ilo/ilo-language.md`, but an agent skimming the skill for the right idiom doesn't land on it.

This adds a small dedicated `## optional vs result` section right after `## results` that contrasts the two types side-by-side with one example each, plus the relevant ILO-T040 / ILO-T041 codes so the diagnostic loop is one read away from the fix. Pending feedback entry #26a.

## What's in the diff

- `skills/ilo/ilo-language.md`: +7 lines, new `## optional vs result` section with the two canonical idioms (`?? name-opt "default"` for `O t`, `default-on-err r "fallback"` and `?r{~v:v;^_:"fallback"}` for `R t t`) and the cross-type error codes.

## Why not SPEC / ai.txt / site

Behaviour-restoration is doc-only on the skill side. SPEC.md already covers both unwrap forms with full prose, ai.txt mirrors that, and the manifesto-aligned change is just to make the contrast unmissable for an agent that has loaded only the skill. No surface area changes.

## Token budget

`scripts/check-skill-tokens.py` clean:

- `ilo-language`: 1207 / 1500 (was 1200)
- TOTAL: 8653 / 9000

## Test plan

- [x] `python3 scripts/check-skill-tokens.py` green
- [x] CI green