### PR TITLE
docs: trailing ';' on multi-line fn header (#25)

### DIFF
--- a/skills/ilo/ilo-language.md
+++ b/skills/ilo/ilo-language.md
@@ -11,6 +11,8 @@ Prefix-notation, strongly-typed, verified pre-run. Bodies `;`-separated or newli
 
 `tot p:n q:n r:n>n;s=*p q;t=*s r;+s t`. No param parens. `>` returns, `;` separates, last expr returns. Zero-arg: `make-id()`.
 
+Single-line: `f x:n>n;+x 1`. Multi-line: `f x:n>n` then indented body, newline = `;` (PR #501 also normalises CRLF). Trailing `;` on header (`f x:n>n;\n  a=+x 1\n  *a 2`) is optional; both forms parse.
+
 ## types
 
 `n` num, `t` text, `b` bool, `_` nil/any. `L n` list, `M t n` map, `R n t` result, `O n` optional, `S a b c` sum (closed, runtime `t`), `F n t` fn-type. Named: `order`. Type vars: any letter except `n t b`. `?? x d` nil-coalesce; unwraps `O T` only. For `R T E` use `default-on-err r d`.


### PR DESCRIPTION
## Summary

Pending #25 asked for the multi-line fn rule to be made obvious in `skills/ilo/ilo-language.md`. The skill currently only shows the single-line form `tot p:n q:n r:n>n;s=*p q;...` so an agent has to guess what a multi-line body looks like.

This adds one tight line to the `## fn` section showing both forms side by side, and notes the trailing `;` on the header is optional (newline acts as `;` inside the indented body). References PR #501 so the CRLF normalisation is discoverable from the same spot.

## Before / after

Before, an agent reading `ilo-language.md` saw only the one-liner header form. Both these programs parse to the same AST, but only the first was documented:

```
-- documented
f x:n>n;+x 1

-- not documented, equally valid
f x:n>n
  a=+x 1
  *a 2
```

After: both forms appear in the `## fn` section with a one-liner noting the trailing `;` on the header is optional in multi-line bodies.

## What's in the diff

- `docs: trailing ';' on multi-line fn header is optional` - 2-line addition under the existing fn paragraph in `skills/ilo/ilo-language.md`. No code changes.

## Test plan

- [x] `cargo run -- /tmp/multi_a.ilo main` with header `f x:n>n` (no semi) - prints `8`
- [x] `cargo run -- /tmp/multi_b.ilo main` with header `f x:n>n;` (with semi) - prints `8`
- [x] `examples/multiline-fn-body.ilo` already covers the no-semi form in the engines harness (PR #501)

## Follow-ups

None. Pending #25 can move to Addressed on merge.