### PR TITLE
ci: verify install.sh artifacts against published sha256 (#42)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,6 +39,12 @@ jobs:
       # but this step is the canonical check using the same tokeniser
       # an agent host uses to size the context window.
       run: python3 scripts/check-skill-tokens.py
+    - name: Shellcheck install.sh
+      run: shellcheck -s sh scripts/install/install.sh
+    - name: Verify install.sh sha256 verification (offline regression test)
+      # Stubs curl and exercises happy / tamper / missing-asset paths so a
+      # refactor can't silently drop the supply-chain integrity check.
+      run: bash scripts/install/test-install-sh.sh
 
   skill-validate:
     # Validate skills/ilo/SKILL.md against the agentskills.io reference

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ AI agents pay three costs per program: generation tokens, error feedback, retrie
 curl -fsSL https://ilo-lang.ai/install.sh | sh
 ```
 
+The installer downloads the release binary plus its `checksums-sha256.txt` from the matching GitHub release and refuses to install if the SHA-256 doesn't match. Source: [`scripts/install/install.sh`](./scripts/install/install.sh).
+
 </details>
 
 <details>
@@ -44,6 +46,8 @@ curl -fsSL https://ilo-lang.ai/install.sh | sh
 ```powershell
 iwr -useb https://ilo-lang.ai/install.ps1 | iex
 ```
+
+Same checksum verification as the Unix installer. Source: [`scripts/install/install.ps1`](./scripts/install/install.ps1).
 
 </details>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,6 +46,20 @@ gitleaks detect --source . --redact --verbose   # includes git history
 A clean run prints `no leaks found`. Anything else is a real finding to
 triage before the release goes out.
 
+## Install-script integrity verification
+
+The release workflow's `release` job runs `sha256sum ilo-* > checksums-sha256.txt`
+and uploads the resulting file alongside every published binary. The
+`curl ... | sh` installers shipped from `https://ilo-lang.ai/install.sh` and
+`/install.ps1` (canonical source in [`scripts/install/`](./scripts/install/))
+fetch that checksum file together with the binary and refuse to install if
+the SHA-256 doesn't match. This closes the standard supply-chain attack
+window on the curl-pipe install path: a tampered binary on GitHub's CDN, a
+TLS-intercepted download, or a mirrored asset all fail the check before the
+binary is made executable. An offline regression test
+(`scripts/install/test-install-sh.sh`) runs on every CI push and exercises
+the happy, tamper, and missing-asset code paths.
+
 ## Why release-only, not per-PR
 
 Running gitleaks on every PR added meaningful queue time without much

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -1,0 +1,68 @@
+#!/usr/bin/env pwsh
+# ilo installer (Windows) — downloads the latest release binary from GitHub and
+# verifies its sha256 against the checksums file published with the same release
+# before placing it on $PATH. Aborts on mismatch.
+#
+# Canonical source: https://github.com/ilo-lang/ilo/blob/main/scripts/install/install.ps1
+# Served from:      https://ilo-lang.ai/install.ps1
+$ErrorActionPreference = 'Stop'
+
+$Repo = "ilo-lang/ilo"
+$Target = "x86_64-pc-windows-msvc"
+$Asset = "ilo-$Target.exe"
+$ReleaseBase = "https://github.com/$Repo/releases/latest/download"
+$BinUrl  = "$ReleaseBase/$Asset"
+$SumsUrl = "$ReleaseBase/checksums-sha256.txt"
+
+$InstallDir = "$env:USERPROFILE\.ilo\bin"
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+
+$TmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ("ilo-install-" + [System.Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Force -Path $TmpDir | Out-Null
+
+try {
+    $BinPath  = Join-Path $TmpDir $Asset
+    $SumsPath = Join-Path $TmpDir "checksums-sha256.txt"
+
+    Write-Host "Downloading ilo for $Target..."
+    Invoke-WebRequest -Uri $BinUrl  -OutFile $BinPath  -UseBasicParsing
+    Invoke-WebRequest -Uri $SumsUrl -OutFile $SumsPath -UseBasicParsing
+
+    # Pull the expected hash for this asset out of the combined checksum file.
+    $line = Select-String -Path $SumsPath -Pattern ("\s" + [regex]::Escape($Asset) + "$") | Select-Object -First 1
+    if (-not $line) {
+        throw "Could not find $Asset in checksums-sha256.txt; aborting."
+    }
+    $expected = ($line.Line -split '\s+')[0].ToLower()
+
+    $actual = (Get-FileHash -Path $BinPath -Algorithm SHA256).Hash.ToLower()
+
+    if ($expected -ne $actual) {
+        Write-Host "Checksum mismatch for ${Asset}:" -ForegroundColor Red
+        Write-Host "  expected: $expected" -ForegroundColor Red
+        Write-Host "  actual:   $actual"   -ForegroundColor Red
+        throw "Refusing to install. The binary may be corrupted or tampered with."
+    }
+
+    Write-Host "Checksum OK ($actual)."
+
+    $Dest = Join-Path $InstallDir "ilo.exe"
+    Move-Item -Force -Path $BinPath -Destination $Dest
+
+    $Version = & $Dest --version 2>$null
+    if ($Version) { Write-Host "Installed $Version to $Dest" }
+    else { Write-Host "Installed ilo to $Dest" }
+
+    # Add to PATH for current user if not already there
+    $UserPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if ($UserPath -notlike "*$InstallDir*") {
+        [Environment]::SetEnvironmentVariable('Path', "$UserPath;$InstallDir", 'User')
+        $env:Path = "$env:Path;$InstallDir"
+        Write-Host "Added $InstallDir to your PATH"
+    }
+
+    Write-Host "Run 'ilo --version' to verify (restart your terminal if needed)"
+}
+finally {
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $TmpDir
+}

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -41,7 +41,12 @@ else
   exit 1
 fi
 
-if [ -w /usr/local/bin ]; then
+# Allow callers (and tests) to override the install location. Otherwise
+# prefer /usr/local/bin if it's writable, else fall back to ~/.local/bin.
+if [ -n "${ILO_INSTALL_DIR:-}" ]; then
+  INSTALL_DIR="$ILO_INSTALL_DIR"
+  mkdir -p "$INSTALL_DIR"
+elif [ -w /usr/local/bin ]; then
   INSTALL_DIR="/usr/local/bin"
 else
   INSTALL_DIR="${HOME}/.local/bin"

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+# ilo installer — downloads the latest release binary from GitHub and verifies
+# its sha256 against the checksums file published with the same release before
+# placing it on $PATH. Aborts on mismatch.
+#
+# Canonical source: https://github.com/ilo-lang/ilo/blob/main/scripts/install/install.sh
+# Served from:     https://ilo-lang.ai/install.sh
+set -eu
+
+REPO="ilo-lang/ilo"
+RELEASE_BASE="https://github.com/${REPO}/releases/latest/download"
+
+OS=$(uname -s)
+ARCH=$(uname -m)
+
+case "$OS" in
+  Linux)  OS_TARGET="unknown-linux-gnu" ;;
+  Darwin) OS_TARGET="apple-darwin" ;;
+  *)      echo "Unsupported OS: $OS" >&2; exit 1 ;;
+esac
+
+case "$ARCH" in
+  x86_64|amd64)  ARCH_TARGET="x86_64" ;;
+  aarch64|arm64) ARCH_TARGET="aarch64" ;;
+  *)             echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+
+TARGET="${ARCH_TARGET}-${OS_TARGET}"
+ASSET="ilo-${TARGET}"
+BIN_URL="${RELEASE_BASE}/${ASSET}"
+SUMS_URL="${RELEASE_BASE}/checksums-sha256.txt"
+
+# Pick a sha256 tool. macOS ships `shasum`; most Linuxes ship `sha256sum`.
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256_cmd="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+  sha256_cmd="shasum -a 256"
+else
+  echo "Neither sha256sum nor shasum found; cannot verify download integrity." >&2
+  echo "Install one of them and re-run, or install ilo manually." >&2
+  exit 1
+fi
+
+if [ -w /usr/local/bin ]; then
+  INSTALL_DIR="/usr/local/bin"
+else
+  INSTALL_DIR="${HOME}/.local/bin"
+  mkdir -p "$INSTALL_DIR"
+fi
+
+TMPDIR_ILO=$(mktemp -d 2>/dev/null || mktemp -d -t ilo-install)
+# shellcheck disable=SC2064
+trap "rm -rf \"$TMPDIR_ILO\"" EXIT INT HUP TERM
+
+echo "Downloading ilo for ${TARGET}..."
+curl -fsSL "$BIN_URL"  -o "${TMPDIR_ILO}/${ASSET}"
+curl -fsSL "$SUMS_URL" -o "${TMPDIR_ILO}/checksums-sha256.txt"
+
+# Pull the expected hash for this asset out of the combined checksum file.
+expected=$(grep " ${ASSET}\$" "${TMPDIR_ILO}/checksums-sha256.txt" | awk '{print $1}')
+if [ -z "$expected" ]; then
+  echo "Could not find ${ASSET} in checksums-sha256.txt; aborting." >&2
+  exit 1
+fi
+
+# Compute the actual hash, isolating just the hex digest.
+actual=$(cd "$TMPDIR_ILO" && $sha256_cmd "$ASSET" | awk '{print $1}')
+
+if [ "$expected" != "$actual" ]; then
+  echo "Checksum mismatch for ${ASSET}:" >&2
+  echo "  expected: $expected" >&2
+  echo "  actual:   $actual" >&2
+  echo "Refusing to install. The binary may be corrupted or tampered with." >&2
+  exit 1
+fi
+
+echo "Checksum OK (${actual})."
+
+mv "${TMPDIR_ILO}/${ASSET}" "${INSTALL_DIR}/ilo"
+chmod +x "${INSTALL_DIR}/ilo"
+
+VERSION=$("${INSTALL_DIR}/ilo" --version 2>/dev/null || echo "ilo (unknown version)")
+echo "Installed ${VERSION} to ${INSTALL_DIR}/ilo"
+
+if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
+  echo "Add ${INSTALL_DIR} to your PATH to use ilo"
+fi

--- a/scripts/install/test-install-sh.sh
+++ b/scripts/install/test-install-sh.sh
@@ -80,11 +80,12 @@ run_case() {
   local name="$1"; shift
   local expected_exit="$1"; shift
   local fixture_dir="$1"; shift
-  local home_dir="$WORKROOT/home-$name"
-  mkdir -p "$home_dir/.local/bin"
+  local install_dir="$WORKROOT/install-$name"
   set +e
+  # Pin install destination via ILO_INSTALL_DIR so the test result doesn't
+  # depend on whether /usr/local/bin happens to be writable on the host.
   PATH="$WORKROOT/bin:$PATH" \
-    HOME="$home_dir" \
+    ILO_INSTALL_DIR="$install_dir" \
     FIXTURE_DIR="$fixture_dir" \
     sh "$INSTALL_SH" > "$WORKROOT/$name.out" 2> "$WORKROOT/$name.err"
   local code=$?
@@ -108,7 +109,7 @@ run_case happy 0 "$HAPPY"
 
 # Verify the binary actually landed (in $HOME/.local/bin since /usr/local/bin
 # probably isn't writable in the test sandbox).
-if ! [ -x "$WORKROOT/home-happy/.local/bin/ilo" ]; then
+if ! [ -x "$WORKROOT/install-happy/ilo" ]; then
   echo "FAIL: happy path didn't install the binary" >&2
   exit 1
 fi
@@ -122,7 +123,7 @@ printf 'fake-binary-contents' > "$TAMPER/$ASSET"
 bad=$(printf 'something-else' | $sha256_cmd | awk '{print $1}')
 printf '%s  %s\n' "$bad" "$ASSET" > "$TAMPER/checksums-sha256.txt"
 run_case tamper 1 "$TAMPER"
-if [ -e "$WORKROOT/home-tamper/.local/bin/ilo" ]; then
+if [ -e "$WORKROOT/install-tamper/ilo" ]; then
   echo "FAIL: tamper path installed the binary anyway" >&2
   exit 1
 fi
@@ -140,7 +141,7 @@ printf 'fake-binary-contents' > "$MISSING/$ASSET"
 # Checksum file references a different asset name, so the grep returns empty.
 printf '%s  %s\n' "$sum" "ilo-some-other-target" > "$MISSING/checksums-sha256.txt"
 run_case missing 1 "$MISSING"
-if [ -e "$WORKROOT/home-missing/.local/bin/ilo" ]; then
+if [ -e "$WORKROOT/install-missing/ilo" ]; then
   echo "FAIL: missing-asset path installed the binary anyway" >&2
   exit 1
 fi

--- a/scripts/install/test-install-sh.sh
+++ b/scripts/install/test-install-sh.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Offline regression test for scripts/install/install.sh.
+#
+# We can't make real network requests to GitHub Releases from CI on every PR,
+# but we can verify the script's integrity-checking behaviour by stubbing out
+# `curl` and feeding it a known fixture. The test runs the script in a sandbox
+# directory with a stub `curl` on PATH that serves a fake binary + checksum
+# file from a temp dir, then asserts:
+#
+#   - happy path: a matching checksum installs the binary
+#   - tamper path: a mismatching checksum aborts before chmod+install
+#   - missing-asset path: a checksum file that doesn't list the asset aborts
+#
+# This is a structural test of the install.sh logic, not an end-to-end install.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INSTALL_SH="$SCRIPT_DIR/install.sh"
+
+if [ ! -f "$INSTALL_SH" ]; then
+  echo "install.sh not found at $INSTALL_SH" >&2
+  exit 1
+fi
+
+# Detect OS/ARCH the same way install.sh does, so we know which asset name to fake.
+OS=$(uname -s)
+ARCH=$(uname -m)
+case "$OS" in
+  Linux)  OS_TARGET="unknown-linux-gnu" ;;
+  Darwin) OS_TARGET="apple-darwin" ;;
+  *)      echo "test skipped on unsupported OS: $OS"; exit 0 ;;
+esac
+case "$ARCH" in
+  x86_64|amd64)  ARCH_TARGET="x86_64" ;;
+  aarch64|arm64) ARCH_TARGET="aarch64" ;;
+  *) echo "test skipped on unsupported arch: $ARCH"; exit 0 ;;
+esac
+ASSET="ilo-${ARCH_TARGET}-${OS_TARGET}"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256_cmd="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+  sha256_cmd="shasum -a 256"
+else
+  echo "no sha256 tool available; cannot run test" >&2
+  exit 1
+fi
+
+WORKROOT=$(mktemp -d)
+# shellcheck disable=SC2064
+trap "rm -rf '$WORKROOT'" EXIT
+
+# Build a curl stub that serves files out of $FIXTURE_DIR. The real script
+# calls `curl -fsSL <URL> -o <PATH>`; the stub maps the URL's basename to a
+# file in $FIXTURE_DIR.
+mkdir -p "$WORKROOT/bin"
+cat > "$WORKROOT/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+# curl stub for install.sh tests. Honours `-o <path>` and ignores other flags.
+out=""
+url=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    -*) shift ;;
+    *)  url="$1"; shift ;;
+  esac
+done
+base=$(basename "$url")
+src="$FIXTURE_DIR/$base"
+if [ ! -f "$src" ]; then
+  echo "curl-stub: missing fixture $src" >&2
+  exit 22
+fi
+cp "$src" "$out"
+STUB
+chmod +x "$WORKROOT/bin/curl"
+
+run_case() {
+  local name="$1"; shift
+  local expected_exit="$1"; shift
+  local fixture_dir="$1"; shift
+  local home_dir="$WORKROOT/home-$name"
+  mkdir -p "$home_dir/.local/bin"
+  set +e
+  PATH="$WORKROOT/bin:$PATH" \
+    HOME="$home_dir" \
+    FIXTURE_DIR="$fixture_dir" \
+    sh "$INSTALL_SH" > "$WORKROOT/$name.out" 2> "$WORKROOT/$name.err"
+  local code=$?
+  set -e
+  if [ "$code" -ne "$expected_exit" ]; then
+    echo "FAIL: $name exited $code, expected $expected_exit" >&2
+    echo "--- stdout ---" >&2; cat "$WORKROOT/$name.out" >&2
+    echo "--- stderr ---" >&2; cat "$WORKROOT/$name.err" >&2
+    exit 1
+  fi
+  echo "ok: $name (exit $code)"
+}
+
+# ---------- happy path ----------
+HAPPY="$WORKROOT/fixture-happy"
+mkdir -p "$HAPPY"
+printf 'fake-binary-contents' > "$HAPPY/$ASSET"
+sum=$(cd "$HAPPY" && $sha256_cmd "$ASSET" | awk '{print $1}')
+printf '%s  %s\n' "$sum" "$ASSET" > "$HAPPY/checksums-sha256.txt"
+run_case happy 0 "$HAPPY"
+
+# Verify the binary actually landed (in $HOME/.local/bin since /usr/local/bin
+# probably isn't writable in the test sandbox).
+if ! [ -x "$WORKROOT/home-happy/.local/bin/ilo" ]; then
+  echo "FAIL: happy path didn't install the binary" >&2
+  exit 1
+fi
+echo "ok: happy path installed the binary"
+
+# ---------- tamper path ----------
+TAMPER="$WORKROOT/fixture-tamper"
+mkdir -p "$TAMPER"
+printf 'fake-binary-contents' > "$TAMPER/$ASSET"
+# Hash a different payload so the checksum won't match what we actually serve.
+bad=$(printf 'something-else' | $sha256_cmd | awk '{print $1}')
+printf '%s  %s\n' "$bad" "$ASSET" > "$TAMPER/checksums-sha256.txt"
+run_case tamper 1 "$TAMPER"
+if [ -e "$WORKROOT/home-tamper/.local/bin/ilo" ]; then
+  echo "FAIL: tamper path installed the binary anyway" >&2
+  exit 1
+fi
+if ! grep -q "Checksum mismatch" "$WORKROOT/tamper.err"; then
+  echo "FAIL: tamper path didn't print the mismatch message" >&2
+  cat "$WORKROOT/tamper.err" >&2
+  exit 1
+fi
+echo "ok: tamper path refused to install"
+
+# ---------- missing-asset path ----------
+MISSING="$WORKROOT/fixture-missing"
+mkdir -p "$MISSING"
+printf 'fake-binary-contents' > "$MISSING/$ASSET"
+# Checksum file references a different asset name, so the grep returns empty.
+printf '%s  %s\n' "$sum" "ilo-some-other-target" > "$MISSING/checksums-sha256.txt"
+run_case missing 1 "$MISSING"
+if [ -e "$WORKROOT/home-missing/.local/bin/ilo" ]; then
+  echo "FAIL: missing-asset path installed the binary anyway" >&2
+  exit 1
+fi
+if ! grep -q "Could not find" "$WORKROOT/missing.err"; then
+  echo "FAIL: missing-asset path didn't print the expected diagnostic" >&2
+  cat "$WORKROOT/missing.err" >&2
+  exit 1
+fi
+echo "ok: missing-asset path refused to install"
+
+echo "all install.sh tests passed"


### PR DESCRIPTION
## Summary

Closes pending #42. The `curl ... | sh` installer linked from the README had no integrity check: a tampered binary on GitHub's CDN, a MITM'd download, or a mirrored asset would have installed silently. Standard supply-chain attack surface, and a small one to close.

The release workflow already publishes `checksums-sha256.txt` alongside every binary (`.github/workflows/release.yml:125-126` — `sha256sum ilo-* > checksums-sha256.txt`), so the fix is install-side only. No release-workflow change needed.

Both installers (`install.sh` and `install.ps1`) now:

1. Download the binary AND `checksums-sha256.txt` from the same GitHub release.
2. Grep the expected SHA-256 for the platform asset out of the combined checksum file.
3. Compute the local SHA-256 of the downloaded binary.
4. Refuse to `chmod +x` / install if the hashes don't match, or if the checksum file doesn't list the asset.

## Repro before / after

Before this PR, with a tampered ilo binary on the release CDN, the install would complete and the user would be running attacker code. After this PR, the installer aborts with:

```
Checksum mismatch for ilo-x86_64-unknown-linux-gnu:
  expected: <hex>
  actual:   <hex>
Refusing to install. The binary may be corrupted or tampered with.
```

and exits non-zero before `chmod +x` runs.

## What's in the diff

Four commits:

- `add canonical install.sh and install.ps1 with sha256 verification` — the script changes, living under `scripts/install/` so they're version-controlled with the workflow that produces the artifacts they verify. Mirrors of these ship from `site/public/install.{sh,ps1}` on `ilo-lang.ai` (companion PR in the site repo).
- `test: cover install.sh happy, tamper, and missing-asset paths` — offline regression test that stubs `curl` and exercises all three code paths against a synthesized fake release fixture. Runs in <1s, no network.
- `ci: shellcheck install.sh and run the integrity-check regression` — two new steps in the `lint` job of `.github/workflows/rust.yml`. shellcheck is preinstalled on ubuntu-latest runners.
- `docs: note install-script sha256 verification in README and SECURITY` — README install snippets link to the script source and call out the verification; SECURITY.md gets a new section describing the release-time emission, install-time verification, and the regression test.

## Test plan

- [x] `shellcheck -s sh scripts/install/install.sh` — clean
- [x] `shellcheck scripts/install/test-install-sh.sh` — clean
- [x] `bash scripts/install/test-install-sh.sh` — all three cases pass (happy / tamper / missing-asset)
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI green on the PR

## Follow-ups

- Companion update in the `ilo-lang/site` repo to ship the new `install.sh` / `install.ps1` from `https://ilo-lang.ai/install.sh`. Will land in the site repo alongside this PR; the canonical source stays here.
- Optional future hardening: GPG-sign the checksum file from the release workflow and verify the signature in the installer. Higher ceremony, only worth doing if the threat model ever needs it.