### PR TITLE
chore: bump skill token TOTAL_LIMIT to 10000

### DIFF
--- a/scripts/check-skill-tokens.py
+++ b/scripts/check-skill-tokens.py
@@ -52,7 +52,7 @@ PER_MODULE_OVERRIDES = {
     "ilo-language": 1500,
     "ilo-builtins-io": 1500,
 }
-TOTAL_LIMIT = 9000
+TOTAL_LIMIT = 10000
 
 
 def main() -> int:


### PR DESCRIPTION
Unblocks the merge queue — ilo-builtins-io cap was bumped to 1500 in #535 but TOTAL_LIMIT stayed at 9000. Cumulative growth has overflowed by ~23 tokens; every in-flight PR's lint step is failing on this.