### PR TITLE
fix(vm): resolve OP_SEED/OP_TAILCALL opcode collision

### DIFF
--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -173,7 +173,7 @@ pub(crate) const OP_SRT: u8 = 54; // R[A] = srt(R[B])  (sort list or text)
 pub(crate) const OP_SLC: u8 = 55; // R[A] = slc(R[B], R[C], R[D])  (slice; D in data word A field)
 pub(crate) const OP_RND0: u8 = 57; // R[A] = random float in [0,1)
 pub(crate) const OP_RND2: u8 = 58; // R[A] = random int in [R[B], R[C]]
-pub(crate) const OP_SEED: u8 = 189; // seed(R[B]) — set shared PRNG state; R[A] = Nil
+pub(crate) const OP_SEED: u8 = 190; // seed(R[B]) — set shared PRNG state; R[A] = Nil
 pub(crate) const OP_NOW: u8 = 59; // R[A] = current unix timestamp (seconds, float)
 pub(crate) const OP_NOWMS: u8 = 177; // R[A] = current unix timestamp (milliseconds, float)
 pub(crate) const OP_ENV: u8 = 60; // R[A] = env(R[B])  (returns R t t)


### PR DESCRIPTION
## Summary

PR #503 (seed builtin) and PR #518 (VM tail-call optimisation) both assigned opcode `189` in `src/vm/mod.rs`. `OP_SEED` is listed first in the dispatch match and silently shadows `OP_TAILCALL`, so VM tail-call dispatch has been broken on `main` since TCO landed.

The collision also produces a clippy `unreachable_patterns` warning. With `-D warnings` in CI that becomes an error, blocking every PR's lint check until this lands.

## Fix

Renumber `OP_SEED` from 189 to 190 (next free opcode byte, verified by a `grep -n "u8 = 19[0-9]"` scan). `OP_TAILCALL` keeps 189 because it is on the hot dispatch path and has been wired up longer.

No call sites need updating - the opcode is referenced via the `OP_SEED` symbol in `src/vm/compile_vm.rs`, `src/vm/jit_cranelift.rs`, and `src/vm/compile_cranelift.rs`, so the constant change is enough.

## Test plan

- [x] `cargo build --release --features cranelift` clean
- [x] `cargo clippy --release --features cranelift --all-targets -- -D warnings` clean (no more unreachable_patterns)
- [x] `cargo test --release --features cranelift --test regression_tco --test regression_tco_vm --test regression_rng_parity --test regression_rand_bytes` all pass
- [x] Full `cargo test --release --features cranelift` green except for one pre-existing failure in `regression_reserved_names_doc::spec_reserved_short_names_match_builtin_registry`, caused by the crypto-primitives PR that just landed adding `b64`/`hex` builtins without updating SPEC.md - unrelated to this fix