### PR TITLE
docs: tighten experimental banner in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 *A programming language AI agents write, not humans. Named from [Toki Pona](https://sona.pona.la/wiki/ilo) for "tool".*
 
-> Experimental pre 1.0 language, expect breaking changes
+> Experimental language. Expect breaking changes.
 
 [![CI](https://github.com/ilo-lang/ilo/actions/workflows/rust.yml/badge.svg)](https://github.com/ilo-lang/ilo/actions/workflows/rust.yml)  [![codecov](https://codecov.io/gh/ilo-lang/ilo/graph/badge.svg?token=4W1SWFLXNW)](https://codecov.io/gh/ilo-lang/ilo)  [![crates.io](https://img.shields.io/crates/v/ilo)](https://crates.io/crates/ilo)  [![npm](https://img.shields.io/npm/v/ilo-lang)](https://www.npmjs.com/package/ilo-lang)  [![skills.sh](https://skills.sh/badge/ilo-lang/ilo)](https://skills.sh/ilo-lang/ilo)  [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 


### PR DESCRIPTION
## Summary

Replace the existing `> Experimental pre 1.0 language, expect breaking changes` banner with the punchier `> Experimental language. Expect breaking changes.` recommended by the external ilo-lang analysis (pending.md #44).

## Rationale

- "Experimental language" is honest scoping, not apology. "Expect breaking changes" sets expectation without qualification.
- Removes the `pre 1.0` qualifier, which reads as defensive. Zero's equivalent warning increased professional perception; honesty signals maturity.
- Top recommendation from `Downloads/ilo-lang-analysis.md`. Without it, every breaking change between versions feels like a regression instead of expected dev-phase churn.

## Diff

One-line copy edit at `README.md:5`. No SPEC, ai.txt, or skills impact.

## Test plan

- [x] README renders cleanly on GitHub (blockquote stays between the Toki Pona tagline and the badge row).

## Follow-ups

None.