### PR TITLE
examples: tail-recursive find-idx pattern (clarifies #5ba)

### DIFF
--- a/examples/find-idx-tail-recursive.ilo
+++ b/examples/find-idx-tail-recursive.ilo
@@ -1,0 +1,27 @@
+-- Recursive linear search: return index of `target` in `xs`, or -1 if absent.
+-- Idiom: base cases as braceless guards FIRST, then the recursive call as the
+-- last statement (tail position). A trailing fallthrough literal would put the
+-- recursive call out of tail position and silently discard its return value.
+--
+-- The common footgun is writing
+--   find-idx xs target i; =target (at xs i) i; find-idx xs target +i 1; -1
+-- The `-1` tail means the recursive call is NOT in tail position (SPEC tail-
+-- call rules), so its return is discarded; the function always falls through
+-- to -1 unless the very first call's guard fires. Fix by making the bounds
+-- check the base case so the recursive call is the tail.
+
+find-idx xs:L n target:n i:n>n
+  ln=len xs
+  >=i ln{ret -1}
+  v=at xs i
+  =v target i
+  find-idx xs target +i 1
+
+-- run: find-idx [10,20,30,40,50] 30 0
+-- out: 2
+-- run: find-idx [10,20,30,40,50] 99 0
+-- out: -1
+-- run: find-idx [10,20,30,40,50] 10 0
+-- out: 0
+-- run: find-idx [] 5 0
+-- out: -1


### PR DESCRIPTION
## Summary

Adds `examples/find-idx-tail-recursive.ilo` showing the canonical recursive linear-search idiom, and documents the footgun that surfaced as pending #5ba.

The interp1d persona (2026-05-21) reported a braceless-guard bug in recursive functions: `=target i i; find-idx xs target +i 1; -1` was returning -1 always, never short-circuiting on match. The persona's mental model was that `=target i i` was a non-firing braceless guard.

**Verified false.** The braceless guard itself fires correctly. The actual issue is documented in SPEC line 1805:

> A call is in tail position when its return value is the function's return value: the last statement of the body, the expression of a `ret` statement, an arm of a tail-position `?` match, or the body of a braceless guard. Calls inside `@` foreach, `@` range, `wh` loops, or as operands of further computation are NOT in tail position.

A recursive `find-idx ...` followed by `-1` is **not** in tail position. The recursive call's return is discarded; the function always falls through to `-1` unless the very first call's guard fires. The persona's ternary workaround worked because the recursive call ended up as the last statement (tail position).

## Repro before/after

Before (persona's shape, silently wrong):
```
find-idx xs:L n target:n i:n>n
  =target i i
  find-idx xs target +i 1     -- NOT tail position; return discarded
  -1
```
`find-idx [10 20 30 40 50] 30 0` returns -1 instead of 2 on every engine.

After (this example, correct):
```
find-idx xs:L n target:n i:n>n
  ln=len xs
  >=i ln{ret -1}
  v=at xs i
  =v target i
  find-idx xs target +i 1     -- tail position; result is the return
```
Returns 2 on tree/VM/JIT/AOT, pinned by `tests/examples_engines.rs`.

## What's in the diff

- `examples/find-idx-tail-recursive.ilo`: canonical recursive search with `-- run:` / `-- out:` cross-engine assertions for hit, miss, first-element, and empty-list cases. Header comment documents the footgun in narrative form so future agents reading the example as in-context learning don't fall into the same trap.

## Test plan

- [x] `ilo check examples/find-idx-tail-recursive.ilo` clean
- [x] Manual cross-engine smoke (default VM / `--vm` / `--jit`) returns 2, -1, 0, -1 for the four assertions
- [ ] CI: `tests/examples_engines.rs` exercises the new file across every engine
- [ ] CI: full suite green

## Follow-ups

- Consider a verifier warning (new `ILO-T0xx`) when a user-fn call's return value is discarded at non-tail position AND the called fn is the enclosing fn (recursion). Today `ILO-T032`/`T033` cover this for specific builtins (`fmt`/`fmt2`/`+=`/`mset`/`mdel`) but recursive user-fn discards get no diagnostic. The persona had no signal that anything was off. Tracking separately, will dispatch as #5bc.