### PR TITLE
docs: multi-request HTTP flow patterns (OAuth + paginated)

### DIFF
--- a/examples/oauth-token-cache.ilo
+++ b/examples/oauth-token-cache.ilo
@@ -1,0 +1,32 @@
+-- File-backed token cache: state survives the program.
+--
+-- OAuth refresh tokens have multi-hour TTLs and outlive a single
+-- ilo run. ilo has no globals; the canonical pattern is `wr`/`rd`
+-- a state file. Read cached token, attempt the request, write back
+-- the (possibly refreshed) token.
+--
+-- The shape generalises to any cross-run cache: rate-limit windows,
+-- ETags for conditional GETs, session cookies. The HTTP call here is
+-- omitted so the example runs offline; the cache lifecycle is what
+-- agents copy.
+
+-- Read cached token from disk; default sentinel when the file is absent.
+load tok-path:t>t;?h (isfile tok-path) (rd!! tok-path) "NO-TOKEN"
+
+-- Write the (refreshed) token back to disk for the next run.
+save tok-path:t tok:t>t;wr!! tok-path tok;tok
+
+-- Simulated refresh: in a real flow this would `pst!` to the IdP's
+-- token endpoint with the refresh_token grant. Here we just produce
+-- a new value so the test is hermetic.
+refresh old:t>t;+"refreshed:" old
+
+-- One cache cycle: load, refresh, save. Returns the new token.
+cycle tok-path:t>t;cur=load tok-path;new=refresh cur;save tok-path new
+
+-- Each run uses a unique tmp path so the example is hermetic across
+-- re-invocations and engines (tree/VM/Cranelift run sequentially).
+main>t;p=fmt "/tmp/ilo-oauth-cache-{}.txt" now-ms;cycle p
+
+-- run: main
+-- out: refreshed:NO-TOKEN

--- a/examples/paginated-fetch.ilo
+++ b/examples/paginated-fetch.ilo
@@ -1,0 +1,26 @@
+-- Paginated fetch via closure-threading: state lives one run.
+--
+-- ilo has no globals. Multi-request flows thread state as a function
+-- argument: pass the cursor in, return the accumulated result out.
+-- Each recursive call advances the cursor; the base case is "no more
+-- pages" (empty cursor).
+--
+-- Real-world: each page would be a `get!` returning a JSON body with
+-- `items` + `next` cursor. Here we use a deterministic fake page so the
+-- example runs offline cross-engine without hitting the network. The
+-- shape of `fetch-loop` is the part agents copy.
+
+-- Fake server: page 0 -> two items + cursor "1"; page 1 -> two items +
+-- cursor "2"; page 2 -> two items, no next.
+fake-page cur:t>L t;?h (=cur "0") ["a","b"] (?h (=cur "1") ["c","d"] ["e","f"])
+
+next-cur cur:t>t;?h (=cur "0") "1" (?h (=cur "1") "2" "")
+
+-- Closure-threading loop: cur is the per-call state, acc is the carry.
+-- The recursive call passes both forward; the base case returns acc.
+fetch-loop cur:t acc:L t>L t;page=fake-page cur;acc=+acc page;nxt=next-cur cur;?h (=nxt "") acc (fetch-loop nxt acc)
+
+main>L t;fetch-loop "0" []
+
+-- run: main
+-- out: [a, b, c, d, e, f]

--- a/skills/ilo/ilo-builtins-io.md
+++ b/skills/ilo/ilo-builtins-io.md
@@ -38,9 +38,29 @@ Parsing `;`-delimited headers (Content-Type, Cache-Control, Cookie): no `ct-pars
 `jpth`/`jpth!` returns the leaf **already typed**: numbers as `n`, text as `t`, bools as `b`, arrays as `L _`, objects as record. Don't wrap in `num`/`str` or re-`jpar`: `age=jpth! body "user.age"` is already `n`. `num (str (jpth! body "x"))` is pure waste (~30 tokens).
 
 `!` auto-unwraps on all of these. Common shape inside `R`-returning fn: `r=jpar! body;r.x`. `jpar!` propagates errors; `jpar!!` panics. Same for `jpar-list!`, `jpth!`, `jkeys!`. Non-`R` callers: use `default-on-err` (in `ilo-builtins-core`): `name=default-on-err (jpth body "user.name") "anon"`.
-`!` auto-unwraps the Result on any of these. Inside an `R`-returning function `r=jpar! body;r.x` is the common shape — saves the `?r{~v:v;^e:^e}` boilerplate per call site. `jpar! body` propagates parse errors out of the enclosing function; `jpar!! body` panics on parse error instead. Same for `jpar-list!`, `jpth!`, `jkeys!`.
-`jpth` Ok variant is the actual leaf type: JSON number → `n`, string → `t`, bool → `b`, array → `L _` (iterable), object → record. No re-parse needed. Don't write `num (str (jpth! body "x"))` — `jpth! body "x"` is already `n` when the leaf is numeric.
-`!` auto-unwraps the Result. Inside an `R`-returning fn, `r=jpar! body;r.x` saves `?r{~v:v;^e:^e}` boilerplate; `jpar! body` propagates parse errors, `jpar!!` panics. Same for `jpar-list!`, `jpth!`, `jkeys!`.
+
+## Multi-request flows
+
+ilo has no globals. Thread state through function args (in-run) or persist to a file (cross-run). See `examples/paginated-fetch.ilo` and `examples/oauth-token-cache.ilo`.
+
+**Closure-threading** (in-run cache, paginated fetch, rate-limit window). Pass state in, return state out:
+
+```
+-- Paginated fetch: cursor + accumulator thread through recursion.
+fetch-page url:t cur:t acc:L _>R (L _) t;u=fmt "{}?cursor={}" url cur;b=get! u;page=jpar-list! b;acc=+acc page;nxt=default-on-err (jpth b "next") "";=nxt "" ~acc;fetch-page url nxt acc
+```
+
+**File-backed** (cross-run OAuth token, refresh on expiry). Read cached value, do work, write refreshed value back. `wr`/`rd` survive across runs; `now-ms` gives a TTL stamp.
+
+```
+load path:t>t;?h (isfile path) (rd!! path) "NO-TOKEN"
+save path:t tok:t>t;wr!! path tok;tok
+-- Per request: load, attach as bearer, on 401 refresh + save + retry.
+-- See examples/oauth-token-cache.ilo for the worked refresh loop.
+```
+
+Pick file-backed when state must outlive the program (OAuth refresh tokens, multi-hour TTLs). Pick closure-threading when state lives one run (pagination, rate-limit windows).
+
 ## Process spawn
 
 `run cmd argv` (`R (M t t) t`) - argv-list spawn; loose Map with text fields `stdout`, `stderr`, `code` (exit as text). `$cmd argv` is the sigil shortcut.
@@ -57,13 +77,7 @@ r.exit    -- number (0 = success)
 
 `env name` (var), `env-all` (`R (M t t) t`), `exit code`.
 
-`run cmd argv` (`R (M t t) t`) spawns `cmd` with `argv` (`L t`). No shell, no glob, no interpolation. `$` is the sigil shortcut. `Ok` map keys (all text): `stdout`, `stderr`, `code` (decimal; signal -> `signal:<n>`, else `unknown`). Non-zero exit is **not** `Err`; branch on `mget m "code"`. `Err` = spawn failure or 10 MiB/stream cap. Stdin closed; inherits parent env + cwd. WASM Errs.
-
-```
-m=run!! "echo" ["hi"]            -- {"stdout":"hi\n","stderr":"","code":"0"}
-out=mget m "stdout"              -- "hi\n"
-code=mget m "code"               -- "0"
-```
+`run` details: no shell, no glob, no interpolation. argv passed to `Command::args`. `code` is decimal (signal -> `signal:<n>`). Non-zero exit is not `Err`; branch on `mget m "code"`. Err = spawn failure or 10 MiB/stream cap. Stdin closed; inherits env + cwd. WASM Errs.
 
 ## Time
 


### PR DESCRIPTION
## Summary

Closes #26d (pending.md). Multi-request HTTP flows had no documented idiom: agents were either declaring top-level vars (rejected), shelling out, or misusing closures. Hit by bearer-token-client persona 2026-05-20.

ilo has no globals by design. The two canonical patterns are now spelled out in `skills/ilo/ilo-builtins-io.md`:

- **Closure-threading** for in-run state (paginated fetch, rate-limit windowing). Pass state in, return state out, recurse with the new value.
- **File-backed** for cross-run state (OAuth refresh tokens with multi-hour TTLs). `wr`/`rd` survive the program.

## What's in the diff

- `skills/ilo/ilo-builtins-io.md`: new \"Multi-request flows\" section between JSON and Process spawn. Plus three accidental-duplicate JSON paragraphs and a duplicated `run` block trimmed, so the file is net **-55 tokens** despite adding a new section.
- `examples/paginated-fetch.ilo`: worked closure-threading via recursion. Deterministic fake-page makes it offline-runnable across all engines.
- `examples/oauth-token-cache.ilo`: worked file-backed lifecycle. `now-ms` in the path keeps re-invocations hermetic.

Both examples verified across tree (transitive via VM bridge), VM, and JIT.

## Test plan

- [x] `paginated-fetch.ilo` passes `-- run: main` / `-- out: [a, b, c, d, e, f]` on VM (`examples_engines` harness)
- [x] `oauth-token-cache.ilo` passes `-- run: main` / `-- out: refreshed:NO-TOKEN`
- [x] Both examples manually spot-checked on `--vm` and `--jit`
- [x] Doc snippets parse clean via `ilo check`
- [x] `cargo test --test skill_modular` green
- [x] Token budget on `ilo-builtins-io.md` moved down (1837 -> 1782), but file is still over its 1500 cap due to pre-existing PR #566 lint regression (tracked separately; not introduced here)

## Follow-ups

- Pre-existing CI regressions from PR #566 (`ilo-builtins-io` token cap, `examples/crypto-primitives.ilo` VM panic) will likely show red on this PR too. Not introduced here; tracked in `in_progress.md` under the main-CI hotfix entry.