### PR TITLE
fix(vm): wire B64Dec into tree_bridge_returns_result

### DIFF
--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -870,6 +870,7 @@ pub(crate) fn tree_bridge_returns_result(b: crate::builtins::Builtin) -> bool {
             | Builtin::Opt
             | Builtin::Urldec
             | Builtin::B64uDec
+            | Builtin::B64Dec
             | Builtin::TzOffset
     )
 }


### PR DESCRIPTION
## Summary
One-line fix: #560 added the standard base64 cluster but missed wiring `B64Dec` into the `returns_result` list in `src/vm/mod.rs`. `b64-dec!` (with bang) tripped the `debug_assert!(tree_bridge_returns_result(builtin))` at line 1887 because the bridge thought it returned a plain value.

## Why this matters
`examples/crypto-primitives.@` has been failing on `main` since #560 merged. Every PR's `coverage` job has inherited the failure. This one-line edit unblocks the whole queue.

## Verification
- Build + clippy clean.
- `cargo test --release --features cranelift --test examples_engines` passes (was panicking).