### PR TITLE
Fix: dot-index reattaches to multi-arg call result

### DIFF
--- a/examples/call-dot-index.ilo
+++ b/examples/call-dot-index.ilo
@@ -1,0 +1,36 @@
+-- Postfix `.N` / `.field` access correctly reattaches to the call
+-- result even when the last argument is a bare variable reference.
+--
+-- Before ILO-52 was fixed, `spl s d .1` parsed as
+-- `Call(spl, [Ref(s), Index(Ref(d), 1)])` — the `.1` was stolen by
+-- the bare-ident arm of `parse_atom` before the outer call could
+-- claim it.  The fix adds an `in_call_args` context flag that
+-- suppresses field-chain consumption on bare Refs while the greedy
+-- arg loops are running, leaving `.N` for the outer
+-- `parse_field_chain` call that wraps the assembled call result.
+--
+-- `spl s d .1`    → Index(Call(spl, [s, d]), 1)       ✓
+-- `at xs i .1`    → Index(Call(at,  [xs, i]), 1)      ✓
+-- `num spl s d .1`→ Call(num, [Index(Call(spl,[s,d]),1)]) ✓
+
+-- Split on delimiter and return the second piece.
+-- `spl s d .1` — both args are bare idents; `.1` attaches to the
+-- call result, not to `d`.
+second-part s:t d:t>t
+  spl s d .1
+
+-- Pick a single element out of a nested list.
+-- `at xs i .1` — same pattern with `at`.
+pick-col xs:L L i:n>n
+  at xs i .1
+
+-- `num (spl s d .1)` — nested: spl result indexed, then converted.
+second-as-num s:t d:t>n
+  num spl s d .1
+
+-- run: second-part "hello/world" "/"
+-- out: world
+-- run: pick-col [[1,2,3],[4,5,6]] 0
+-- out: 2
+-- run: second-as-num "price=42" "="
+-- out: 42

--- a/examples/call-result-dot-index.ilo
+++ b/examples/call-result-dot-index.ilo
@@ -30,13 +30,8 @@ second-segment s:t>t
 -- `(at rows 0).1` and reads naturally left-to-right. The trailing
 -- `.N` reattaches to the `at` call result rather than dangling.
 --
--- Heads-up: the `.N` only reattaches when it follows a literal arg
--- (number / string / list literal) at the call's last slot. If the
--- last arg is a bare ident like `i`, the lexer-parser glues `.N` to
--- the ident as field access on the variable, not on the call result.
--- Bind the call result or wrap in parens in that case:
---   r=at rows i;r.1     -- bind first
---   (at rows i).1        -- parens force the grouping
+-- This works regardless of whether the last argument is a literal or
+-- a bare ident. `at rows i .1` is equivalent to `(at rows i).1`.
 col-from-row rows:L L n>n
   at rows 0 .1
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -69,6 +69,14 @@ pub struct Parser {
     /// parsed as a bare Ref (list element) rather than a function call.
     /// Set only inside list-literal element parsing.
     no_whitespace_call: bool,
+    /// When true, `parse_atom_body` suppresses the automatic `.field`/`.N`
+    /// chain on a bare Ref ident. Set while collecting call arguments inside
+    /// the greedy arg loops of `parse_call_or_atom` and `parse_call_arg` so
+    /// that `spl s d .1` parses as `Index(Call(spl,[s,d]),1)` rather than
+    /// `Call(spl,[s,Index(d,1)])`.  The outer `parse_field_chain` call that
+    /// follows every greedy-call loop is responsible for consuming the chain
+    /// once the full call is assembled.
+    in_call_args: bool,
     /// Synthetic top-level decls emitted by inline-lambda lifting. Appended to
     /// `Program.declarations` after the main parse. Each inline lambda
     /// `(p:t>r;body)` becomes a `Decl::Function { name: "__lit_N", ... }` here
@@ -143,6 +151,7 @@ impl Parser {
             fn_arity,
             fn_param_is_fn,
             no_whitespace_call: false,
+            in_call_args: false,
             lifted_decls: Vec::new(),
             lambda_counter: 0,
             parse_failed_fns: HashMap::new(),
@@ -3109,6 +3118,8 @@ or write `({fmt_name} \"...\" ...)` so its args are grouped."
                 // fmt requires a template (its declared arity 1); if no
                 // operand follows, leave the underfilled call for the
                 // verifier to flag with its usual ILO-T013 error.
+                let prev_in_call_args = self.in_call_args;
+                self.in_call_args = true;
                 while self.can_start_operand() {
                     // fmt's own slots are all value positions (no fn-refs),
                     // and nested fmt-in-fmt is the same trailing slot of its
@@ -3125,6 +3136,7 @@ or write `({fmt_name} \"...\" ...)` so its args are grouped."
                         break;
                     }
                 }
+                self.in_call_args = prev_in_call_args;
                 let call = Expr::Call {
                     function: fmt_name,
                     args: fmt_args,
@@ -3166,6 +3178,8 @@ or write `({fmt_name} \"...\" ...)` so its args are grouped."
                 let inner_name = name.clone();
                 self.advance(); // consume the inner function ident
                 let mut inner_args = Vec::with_capacity(arity);
+                let prev_in_call_args = self.in_call_args;
+                self.in_call_args = true;
                 for i in 0..arity {
                     if !self.can_start_operand() {
                         // Underfilled — let the verifier report arity mismatch.
@@ -3175,6 +3189,7 @@ or write `({fmt_name} \"...\" ...)` so its args are grouped."
                     inner_args
                         .push(self.parse_call_arg(inner_fn_pos, Some((&inner_name, arity, i)))?);
                 }
+                self.in_call_args = prev_in_call_args;
                 let call = Expr::Call {
                     function: inner_name,
                     args: inner_args,
@@ -3240,6 +3255,8 @@ or write `({fmt_name} \"...\" ...)` so its args are grouped."
                 }
                 let mut args = Vec::new();
                 let outer_arity_known = self.fn_arity.get(&name).copied();
+                let prev_in_call_args = self.in_call_args;
+                self.in_call_args = true;
                 while self.can_start_operand() {
                     let arg_idx = args.len();
                     let in_fn_pos = self.is_fn_ref_position(&name, arg_idx);
@@ -3248,6 +3265,7 @@ or write `({fmt_name} \"...\" ...)` so its args are grouped."
                         .map(|k| (name.as_str(), k, arg_idx));
                     args.push(self.parse_call_arg(in_fn_pos, outer_ctx)?);
                 }
+                self.in_call_args = prev_in_call_args;
                 let call = Expr::Call {
                     function: name,
                     args,
@@ -3341,6 +3359,8 @@ or write `({fmt_name} \"...\" ...)` so its args are grouped."
                     return Ok(atom);
                 }
                 let mut args = Vec::with_capacity(arity);
+                let prev_in_call_args = self.in_call_args;
+                self.in_call_args = true;
                 for i in 0..arity {
                     if !self.can_start_operand() {
                         // Underfilled - let the verifier report arity
@@ -3350,6 +3370,7 @@ or write `({fmt_name} \"...\" ...)` so its args are grouped."
                     let inner_fn_pos = self.is_fn_ref_position(&name, i);
                     args.push(self.parse_call_arg(inner_fn_pos, Some((&name, arity, i)))?);
                 }
+                self.in_call_args = prev_in_call_args;
                 let call = Expr::Call {
                     function: name,
                     args,
@@ -3378,6 +3399,12 @@ or write `({fmt_name} \"...\" ...)` so its args are grouped."
                 }
                 let mut args = Vec::new();
                 let outer_arity_known = self.fn_arity.get(&name).copied();
+                // Suppress bare-ident field-chain consumption inside the arg
+                // loop so that the trailing `.N` in `spl s d .1` is left for
+                // the outer `parse_field_chain` call below to attach to the
+                // assembled call result.  Save/restore around the loop.
+                let prev_in_call_args = self.in_call_args;
+                self.in_call_args = true;
                 while self.can_start_operand() {
                     let arg_idx = args.len();
                     let in_fn_pos = self.is_fn_ref_position(&name, arg_idx);
@@ -3399,6 +3426,7 @@ or write `({fmt_name} \"...\" ...)` so its args are grouped."
                         break;
                     }
                 }
+                self.in_call_args = prev_in_call_args;
                 let call = Expr::Call {
                     function: name,
                     args,
@@ -4050,7 +4078,21 @@ results first: `r={first_op}a b;…r` keeps each step explicit."
                     });
                 }
                 // Check for field access chain: ident.field.field...
+                // When inside a call-argument context (`in_call_args`), suppress
+                // the greedy `.N`/`.field` consumption here.  The outer
+                // `parse_field_chain` call that follows every greedy-call loop in
+                // `parse_call_or_atom` will pick up the chain on the assembled
+                // call result instead.  Without this suppression `spl s d .1`
+                // parses as `Call(spl,[s,Index(d,1)])` because the bare-ident arm
+                // for `d` greedily steals `.1` before the outer loop can see it.
+                //
+                // Standalone `x.1` (not inside call args) and chained
+                // `x.field.1` are unaffected because `in_call_args` is false
+                // outside call-arg contexts.
                 let expr = Expr::Ref(name.clone());
+                if self.in_call_args {
+                    return Ok(expr);
+                }
                 let expr = self.parse_field_chain(expr, Some(&name))?;
                 Ok(expr)
             }

--- a/tests/parser_call_index.rs
+++ b/tests/parser_call_index.rs
@@ -1,0 +1,150 @@
+// Regression tests for ILO-52: `.N` reattaches to the call result when
+// the last argument is a bare identifier (variable reference).
+//
+// Before this fix, `spl s d .1` parsed as `Call(spl, [Ref(s), Index(Ref(d), 1)])`
+// because `parse_atom_body`'s bare-ident branch greedily consumed the `.1`
+// via `parse_field_chain` while still inside the outer call's arg loop.
+//
+// Fix: the `in_call_args` flag suppresses bare-ident field-chain consumption
+// during arg collection.  The outer `parse_field_chain` call that follows
+// every greedy-call loop in `parse_call_or_atom` and `parse_call_arg`
+// then attaches the `.N` to the assembled Call result instead.
+//
+// Verified-broken cases (must all now produce the same value as the
+// explicit-parens equivalent):
+//   `spl s d .1`       was Call(spl, [s, Index(d,1)])
+//   `at xs i .1`       was Call(at,  [xs, Index(i,1)])
+//   `num spl s d .1`   was Call(num, [Call(spl,[s,Index(d,1)])])
+//
+// Previously-working cases that must not regress:
+//   `spl "1.2.3" "." .1`   (literal last arg — already worked)
+//   `(spl s d).1`           (explicit parens — always worked)
+//   `x.1` standalone        (bare ident not in call args — must still work)
+//   `at xs 0 .1`            (literal last arg — already worked)
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_ok(engine: &str, src: &str, entry: &str, args: &[&str]) -> String {
+    let mut cmd = ilo();
+    cmd.args([src, engine, entry]);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{entry}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+const ENGINES: &[&str] = &[
+    "--vm",
+    #[cfg(feature = "cranelift")]
+    "--jit",
+];
+
+// ILO-52 core case: `spl s d .1` where both args are bare idents.
+// Must parse as Index(Call(spl,[s,d]),1) not Call(spl,[s,Index(d,1)]).
+#[test]
+fn spl_bare_idents_dot_index() {
+    // The function splits on the delimiter variable and picks element 1.
+    let src = "f s:t d:t>t;spl s d .1";
+    for engine in ENGINES {
+        assert_eq!(
+            run_ok(engine, src, "f", &["hello/world", "/"]),
+            "world",
+            "engine={engine}"
+        );
+    }
+}
+
+// Confirm equivalence with the explicit-parens workaround.
+#[test]
+fn spl_bare_idents_matches_parens() {
+    let bare = "f s:t d:t>t;spl s d .1";
+    let parens = "f s:t d:t>t;(spl s d).1";
+    for engine in ENGINES {
+        let a = run_ok(engine, bare, "f", &["hello/world", "/"]);
+        let b = run_ok(engine, parens, "f", &["hello/world", "/"]);
+        assert_eq!(a, b, "engine={engine}: bare={a:?} parens={b:?}");
+    }
+}
+
+// `at xs i .1` — two bare ident args, pick column 1 from a nested list.
+#[test]
+fn at_bare_idents_dot_index() {
+    let src = "f xs:L L n i:n>n;at xs i .1";
+    for engine in ENGINES {
+        assert_eq!(
+            run_ok(engine, src, "f", &["[[10,20,30],[40,50,60]]", "0"]),
+            "20",
+            "engine={engine}"
+        );
+    }
+}
+
+// `num spl s d .1` — nested case: spl's bare-ident last arg must not
+// steal `.1`; `.1` goes on the spl call result, then num converts it.
+#[test]
+fn nested_num_spl_bare_idents_dot_index() {
+    let src = "f s:t d:t>R n t;num spl s d .1";
+    for engine in ENGINES {
+        assert_eq!(
+            run_ok(engine, src, "f", &["price=42", "="]),
+            "42",
+            "engine={engine}"
+        );
+    }
+}
+
+// Previously-working: literal last arg. Must not regress.
+#[test]
+fn spl_literal_last_arg_dot_index_unchanged() {
+    let src = "main>t;spl \"1.2.3\" \".\" .1";
+    for engine in ENGINES {
+        assert_eq!(run_ok(engine, src, "main", &[]), "2", "engine={engine}");
+    }
+}
+
+// Previously-working: explicit parens. Must not regress.
+#[test]
+fn explicit_parens_dot_index_unchanged() {
+    let src = "f s:t d:t>t;(spl s d).1";
+    for engine in ENGINES {
+        assert_eq!(
+            run_ok(engine, src, "f", &["hello/world", "/"]),
+            "world",
+            "engine={engine}"
+        );
+    }
+}
+
+// Previously-working: bare ident standalone (not in call args). Must
+// still produce Index(Ref(x), 1), not break.
+#[test]
+fn standalone_bare_ident_dot_index_unchanged() {
+    let src = "main>t;xs=spl \"a.b\" \".\";xs.1";
+    for engine in ENGINES {
+        assert_eq!(run_ok(engine, src, "main", &[]), "b", "engine={engine}");
+    }
+}
+
+// `at xs 0 .1` — literal index arg (already worked pre-fix). Stays
+// as Index(Call(at,[xs,0]),1).
+#[test]
+fn at_literal_arg_dot_index_unchanged() {
+    let src = "f xs:L L n>n;at xs 0 .1";
+    for engine in ENGINES {
+        assert_eq!(
+            run_ok(engine, src, "f", &["[[10,20,30],[40,50,60]]"]),
+            "20",
+            "engine={engine}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes ILO-52. `spl s d .1` (where both args are bare variable references) previously parsed as `Call(spl, [Ref(s), Index(Ref(d), 1)])` — the `.1` was stolen by the bare-ident arm of `parse_atom_body` before the outer call loop could claim it.

## Root cause

`parse_atom_body`'s bare-`Ident` branch unconditionally called `parse_field_chain`, greedily consuming `.N` even while inside the arg collection loop of an outer call.

## Fix

Added an `in_call_args: bool` context flag to `Parser`. Set to `true` for the duration of every greedy arg loop in `parse_call_or_atom` and `parse_call_arg` (save/restore pattern). In `parse_atom_body`'s bare-ident branch, when `in_call_args` is true, field-chain consumption is suppressed — the outer `parse_field_chain` call at the end of each loop then attaches the `.N` to the assembled call result.

## Before / After

```
spl s d .1

Before: Call { function: "spl", args: [Ref("s"), Index { object: Ref("d"), index: 1 }] }
After:  Index { object: Call { function: "spl", args: [Ref("s"), Ref("d")] }, index: 1 }
```

```
num spl s d .1

Before: Call { function: "num", args: [Call { function: "spl", args: [Ref("s"), Index { object: Ref("d"), index: 1 }] }] }
After:  Call { function: "num", args: [Index { object: Call { function: "spl", args: [Ref("s"), Ref("d")] }, index: 1 }] }
```

## Verified no-regression cases

- `spl "1.2.3" "." .1` — literal last arg (already worked)
- `(spl s d).1` — explicit parens (always worked)
- `x.1` standalone — bare ident not in call args (still works)
- `at xs 0 .1` — literal last arg (already worked)

## Changes

- `src/parser/mod.rs` — `in_call_args` flag + save/restore in 4 arg loops + suppression in bare-ident atom branch
- `tests/parser_call_index.rs` — new regression test file covering the broken and no-regression cases
- `examples/call-dot-index.ilo` — new example demonstrating the fix
- `examples/call-result-dot-index.ilo` — removed the now-obsolete "heads-up" note about bare-ident last args

🤖 Generated with [Claude Code](https://claude.com/claude-code)