### PR TITLE
test: ILO-50 regression guard for fld multi-statement lambda body

### DIFF
--- a/tests/regression_inline_lambda.rs
+++ b/tests/regression_inline_lambda.rs
@@ -130,6 +130,27 @@ fn fld_inline_sum_of_squares() {
     run_all(src, "f", &["[1,2,3,4]"], "30");
 }
 
+// ── fld: multi-statement body (let + final expression) — ILO-50 regression ─
+// Reported: `fld (m:_ a:n>_;b=*a 2;+m b) xs init` allegedly dropped the let
+// statement from the lambda body. Verified cannot reproduce; this test locks
+// the correct behaviour so any future parser regression is caught immediately.
+
+#[test]
+fn fld_multi_stmt_lambda_body_preserves_let() {
+    // Both `b=*a 2` (let) and `+m b` (expr) must survive in the lifted decl.
+    // If the let is dropped, doubling is skipped and the result is 6 (not 12).
+    let src = "f xs:L n>n;fld (m:_ a:n>_;b=*a 2;+m b) xs 0";
+    run_all(src, "f", &["[1,2,3]"], "12");
+}
+
+#[test]
+fn fld_multi_stmt_lambda_three_stmts() {
+    // Three-statement body: two lets + final expr. Ensures the `;` loop in
+    // `parse_lambda_body` iterates past the first let without stopping early.
+    let src = "f xs:L n>n;fld (m:_ a:n>_;x=a;y=*x 2;+m y) xs 0";
+    run_all(src, "f", &["[1,2,3]"], "12");
+}
+
 // ── multi-statement body (let + final expression) ──────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- Adds two regression tests to `tests/regression_inline_lambda.rs` for the shape reported in ILO-50: a `fld` inline lambda with a `let`-stmt + final-expr body (`fld (m:_ a:n>_;b=*a 2;+m b) xs 0`)
- Could not reproduce the reported ambiguity after thorough testing (see ILO-50 comment); tests lock the correct behaviour so any future parser regression is caught immediately

## Shapes tested (all correct on `main`)

| Shape | Body stmts | Result `[1,2,3]` |
|---|---|---|
| `(m:_ a:n>_;b=*a 2;+m b)` | 2 | 12 |
| `(m:_ a:n>_;x=a;y=*x 2;+m y)` | 3 | 12 |
| `(m:_ a:n>_;+m a)` | 1 | 6 |
| actual multiline newlines | 2 | 12 |
| typed acc `(m:n a:n>n;b=*a 2;+m b)` | 2 | 12 |
| `_` typed both params | 2 | 12 |
| nested call in let `b=spl a ","` | 2 | ok |

## Test plan

- [x] `cargo test --test regression_inline_lambda fld_multi_stmt` → 2 passed

Closes ILO-50 (cannot reproduce; regression guard added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)