### PR TITLE
Fix: ILO-P101 hint also mentions paren-form (closes ILO-92)

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3424,7 +3424,7 @@ or write `({fmt_name} \"...\" ...)` so its args are grouped."
                                 "list literal element starts with builtin `{name}` followed by operands; wrap the call in parens or bind it first"
                             ),
                             format!(
-                                "list-literal elements are atoms by default. Either write `({name} <args>)` to call as one element, or bind first: `x={name} <args>;[... x ...]`"
+                                "list-literal elements are atoms by default. Either write `({name} <args>)` or `{name}(<args>)` to call as one element, or bind first: `x={name} <args>;[... x ...]`"
                             ),
                         ));
                     }


### PR DESCRIPTION
## Summary

- Updates the ILO-P101 diagnostic hint in `src/parser/mod.rs` to mention both call shapes introduced by ILO-51
- Before: only suggested `({name} <args>)` postfix-around-call form
- After: also suggests `{name}(<args>)` paren-form alongside the existing options

## Changes

Single-line change to the hint string in `src/parser/mod.rs:3427`.

No test changes needed — the existing regression tests (`regression_listlit_builtin_call_hint.rs`) assert on presence of `(` or `bind` keywords, which the new text still satisfies.

## Test plan

- [x] `cargo test --test regression_listlit_builtin_call_hint` — 2 tests pass (vm + cranelift)
- [x] Full `cargo test` — 3329 pass; only pre-existing failures (fibonacci stack overflow, AOT tests requiring missing `libilo.a`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)