### PR TITLE
docs: skills/ilo/ilo-builtins-io.md uses pst as canonical (closes ILO-80)

### DIFF
--- a/skills/ilo/ilo-builtins-io.md
+++ b/skills/ilo/ilo-builtins-io.md
@@ -20,7 +20,7 @@ Prefix-call: `name arg1 arg2 ...`. Cross-engine unless noted.
 **Every verb takes an optional trailing `M t t` headers map** for Authorization, Accept, X-API-Key. No wrapper needed - pass the map as the last arg (`get url hs`, `pst url body hs`).
 
 `get url` (`R t t`), `get url headers` (with `M t t` custom headers), `get-to url timeout-ms` (explicit ms timeout).
-`pst url body` (`R t t`), `pst url body headers`, `pst-to url body timeout-ms`.
+`pst url body` (`R t t`), `pst url body headers`, `pst-to url body timeout-ms`. (`pst` is the canonical name since 0.12.0; the old name `post` is not accepted.)
 `put url body` / `pat url body` mirror `pst` (PUT / PATCH); accept optional headers map.
 `del url` / `hed url` / `opt url` mirror `get` (DELETE / HEAD / OPTIONS); accept optional headers map.
 `get-many urls` (parallel fan-out, `L (R t t)`).


### PR DESCRIPTION
## Summary

- `ilo-builtins.md` was split into category files; the HTTP section in `ilo-builtins-io.md` already used `pst` as the builtin name but did not explicitly call out that `post` (pre-0.12.0) is not accepted
- Added an inline note on the `pst` line: `(pst is the canonical name since 0.12.0; the old name post is not accepted.)`
- PRs #581/#589 (post alias) have not landed, so no alias mention is included
- No other stale lowercase `post` references found in `skills/`; all uppercase `POST` occurrences are HTTP method names and are correct

## Test plan

- [ ] Load `ilo-builtins-io.md` in a skill context and verify agent uses `pst` not `post`
- [ ] Confirm no other lowercase `post` builtin references remain: `grep -rn 'post ' skills/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)