### PR TITLE
Add aliases: delete/patch (HTTP), keys/values (map), join (string)

### DIFF
--- a/examples/string-aliases.ilo
+++ b/examples/string-aliases.ilo
@@ -1,0 +1,21 @@
+-- string-aliases.ilo: demonstrates muscle-memory long-form aliases for
+-- string case-conversion builtins, added in 0.12.1 (ILO-79, ILO-81).
+--
+-- Canonical names:  upr  lwr  cap
+-- Alias names:      upper  lower  capitalize
+--
+-- On first run with an alias the runtime emits a one-time hint pointing to
+-- the canonical short form. Subsequent runs are silent.
+--
+-- run: demo "> demo"
+--
+-- Expected output (modulo hint lines on first run):
+--   HELLO
+--   hello
+--   Hello
+
+demo > t
+s = "hello"
+prnt upper s    -- alias for upr: "HELLO"
+prnt lower (upr s)  -- alias for lwr: back to "hello"
+capitalize s    -- alias for cap: "Hello"

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -503,7 +503,19 @@ const BUILTIN_ALIASES: &[(&str, &str)] = &[
     // call `ct` directly when they want the builtin.
     ("flatten", "flat"),
     ("concat", "cat"),
+    // `join` mirrors Python str.join / JS Array.join muscle memory. Canonical
+    // name `cat` (2-arg: list + separator) is unchanged in bytecode and fmt
+    // output; `concat` already aliases `cat` for list-concat mental models, and
+    // `join` covers the string-join mental model from Python/JS. (ILO-266)
+    ("join", "cat"),
     ("contains", "has"),
+    // `keys` and `values` mirror universal map-accessor names (Python
+    // dict.keys()/.values(), JS Object.keys(), Go maps.Keys, Rust
+    // HashMap::keys). Canonical m-prefixed names `mkeys`/`mvals` stay
+    // unchanged in bytecode and fmt output; these aliases close the
+    // discoverability gap for newcomers. (ILO-265)
+    ("keys", "mkeys"),
+    ("values", "mvals"),
     // `upper`/`lower` mirror the Python/JS/Go/Rust method names for case
     // conversion. Canonical 3-char names `upr`/`lwr` stay unchanged in
     // bytecode and fmt output; these aliases only rewrite the parse-time
@@ -523,6 +535,12 @@ const BUILTIN_ALIASES: &[(&str, &str)] = &[
     // without widening the canonical surface (bytecode, fmt, docs all stay
     // on `pst`).
     ("post", "pst"),
+    // `delete` and `patch` mirror the HTTP-verb names agents from Python/JS/Rust
+    // reach for first. Canonical 3-char short forms are `del` and `pat`; these
+    // long-form aliases give discoverability without changing bytecode or fmt
+    // output. (ILO-264)
+    ("delete", "del"),
+    ("patch", "pat"),
     ("print", "prnt"),
     ("trim", "trm"),
     ("split", "spl"),

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -504,8 +504,25 @@ const BUILTIN_ALIASES: &[(&str, &str)] = &[
     ("flatten", "flat"),
     ("concat", "cat"),
     ("contains", "has"),
+    // `upper`/`lower` mirror the Python/JS/Go/Rust method names for case
+    // conversion. Canonical 3-char names `upr`/`lwr` stay unchanged in
+    // bytecode and fmt output; these aliases only rewrite the parse-time
+    // name so newcomers from those languages don't hit an unknown-builtin
+    // error on first run.
+    ("upper", "upr"),
+    ("lower", "lwr"),
+    // `capitalize` mirrors the Python/Ruby method name. Canonical name
+    // stays `cap`; alias is long-form discoverability only.
+    ("capitalize", "cap"),
     ("group", "grp"),
     ("average", "avg"),
+    // `post` was the canonical HTTP-POST verb name before 0.12.0 when it
+    // was renamed to the 3-char `pst` to match the short-form convention.
+    // Personas that learned the language on pre-0.12.0 examples reach for
+    // `post` as muscle memory; aliasing it back to `pst` closes that gap
+    // without widening the canonical surface (bytecode, fmt, docs all stay
+    // on `pst`).
+    ("post", "pst"),
     ("print", "prnt"),
     ("trim", "trm"),
     ("split", "spl"),

--- a/tests/regression_aliases_batch2.rs
+++ b/tests/regression_aliases_batch2.rs
@@ -1,0 +1,375 @@
+// Regression tests pinning the second batch of muscle-memory aliases
+// (ILO-264, ILO-265, ILO-266).
+//
+// ILO-264: HTTP verb aliases `delete` → `del` and `patch` → `pat`.
+//   Agents from Python/JS/Rust reach for the full HTTP verb names; these
+//   aliases resolve at parse time to the canonical 3-char short forms so
+//   they work without modification.
+//
+// ILO-265: Map accessor aliases `keys` → `mkeys` and `values` → `mvals`.
+//   Universal map-accessor names (Python dict.keys()/.values(), JS
+//   Object.keys(), Rust HashMap::keys) that newcomers expect. Canonical
+//   m-prefixed names stay in bytecode and fmt output.
+//
+// ILO-266: `join` → `cat` string-join alias. Python str.join / JS
+//   Array.join muscle memory. `append` is NOT added because there is no
+//   canonical `app` builtin — list appending is the `+=` operator
+//   (OP_LISTAPPEND), not a named function.
+//
+// Contracts locked in for each alias:
+//   1. The alias resolves to the correct canonical in the alias table.
+//   2. The canonical name remains in the builtin registry; the alias does not.
+//   3. The alias is rejected as a binding/function name (ILO-P011).
+//   4. Cross-engine execution (tree/vm/jit) produces the same result as the
+//      canonical.
+
+use ilo::ast::resolve_alias;
+use ilo::builtins::Builtin;
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+// ── ILO-264: delete → del ────────────────────────────────────────────────────
+
+#[test]
+fn del_remains_the_canonical_name_for_delete() {
+    let b = Builtin::from_name("del").expect("`del` must be a canonical builtin");
+    assert_eq!(b.name(), "del", "canonical name is `del`");
+    assert!(
+        Builtin::from_name("delete").is_none(),
+        "`delete` must not be a canonical name; it is an alias for `del`"
+    );
+    assert_eq!(
+        resolve_alias("delete"),
+        Some("del"),
+        "`delete` must resolve to canonical `del`"
+    );
+}
+
+#[test]
+fn delete_rejected_as_binding_name() {
+    let out = ilo()
+        .args(["main>t;delete=\"val\";delete"])
+        .output()
+        .expect("failed to run ilo");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "expected `delete=\"val\"` to fail at parse time"
+    );
+    assert!(
+        stderr.contains("ILO-P011"),
+        "expected ILO-P011 reserved-name error, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("delete") && stderr.contains("del"),
+        "error must name the alias and the canonical builtin, got: {stderr}"
+    );
+}
+
+#[test]
+fn delete_rejected_as_user_function_name() {
+    let out = ilo()
+        .args(["delete url:t>R t t;del url"])
+        .output()
+        .expect("failed to run ilo");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "expected `delete url:t>...` to fail at parse time"
+    );
+    assert!(
+        stderr.contains("ILO-P011"),
+        "expected ILO-P011 reserved-name error, got: {stderr}"
+    );
+}
+
+// ── ILO-264: patch → pat ─────────────────────────────────────────────────────
+
+#[test]
+fn pat_remains_the_canonical_name_for_patch() {
+    let b = Builtin::from_name("pat").expect("`pat` must be a canonical builtin");
+    assert_eq!(b.name(), "pat", "canonical name is `pat`");
+    assert!(
+        Builtin::from_name("patch").is_none(),
+        "`patch` must not be a canonical name; it is an alias for `pat`"
+    );
+    assert_eq!(
+        resolve_alias("patch"),
+        Some("pat"),
+        "`patch` must resolve to canonical `pat`"
+    );
+}
+
+#[test]
+fn patch_rejected_as_binding_name() {
+    let out = ilo()
+        .args(["main>t;patch=\"val\";patch"])
+        .output()
+        .expect("failed to run ilo");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "expected `patch=\"val\"` to fail at parse time"
+    );
+    assert!(
+        stderr.contains("ILO-P011"),
+        "expected ILO-P011 reserved-name error, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("patch") && stderr.contains("pat"),
+        "error must name the alias and the canonical builtin, got: {stderr}"
+    );
+}
+
+#[test]
+fn patch_rejected_as_user_function_name() {
+    let out = ilo()
+        .args(["patch url:t body:t>R t t;pat url body"])
+        .output()
+        .expect("failed to run ilo");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "expected `patch url:t body:t>...` to fail at parse time"
+    );
+    assert!(
+        stderr.contains("ILO-P011"),
+        "expected ILO-P011 reserved-name error, got: {stderr}"
+    );
+}
+
+// ── ILO-265: keys → mkeys ────────────────────────────────────────────────────
+
+#[test]
+fn mkeys_remains_the_canonical_name_for_keys() {
+    let b = Builtin::from_name("mkeys").expect("`mkeys` must be a canonical builtin");
+    assert_eq!(b.name(), "mkeys", "canonical name is `mkeys`");
+    assert!(
+        Builtin::from_name("keys").is_none(),
+        "`keys` must not be a canonical name; it is an alias for `mkeys`"
+    );
+    assert_eq!(
+        resolve_alias("keys"),
+        Some("mkeys"),
+        "`keys` must resolve to canonical `mkeys`"
+    );
+}
+
+const KEYS_ALIAS_SRC: &str = "f>L t;m=mset (mset mmap \"a\" 1) \"b\" 2;keys m";
+
+#[test]
+fn keys_alias_vm_tree() {
+    let result = run("--vm", KEYS_ALIAS_SRC, "f");
+    assert!(
+        result.contains("a") && result.contains("b"),
+        "keys alias must return map keys via vm (tree-walk), got: {result}"
+    );
+}
+
+#[test]
+fn keys_alias_vm() {
+    let result = run("--vm", KEYS_ALIAS_SRC, "f");
+    assert!(
+        result.contains("a") && result.contains("b"),
+        "keys alias must return map keys via vm, got: {result}"
+    );
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn keys_alias_jit() {
+    let result = run("--jit", KEYS_ALIAS_SRC, "f");
+    assert!(
+        result.contains("a") && result.contains("b"),
+        "keys alias must return map keys via jit, got: {result}"
+    );
+}
+
+#[test]
+fn keys_canonical_mkeys_still_works() {
+    let result = run("--vm", "f>L t;m=mset mmap \"x\" 99;mkeys m", "f");
+    assert!(result.contains("x"), "canonical `mkeys` must still work, got: {result}");
+}
+
+#[test]
+fn keys_rejected_as_binding_name() {
+    let out = ilo()
+        .args(["main>t;keys=[];keys"])
+        .output()
+        .expect("failed to run ilo");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "expected `keys=[]` to fail at parse time"
+    );
+    assert!(
+        stderr.contains("ILO-P011"),
+        "expected ILO-P011 reserved-name error, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("keys") && stderr.contains("mkeys"),
+        "error must name the alias and the canonical builtin, got: {stderr}"
+    );
+}
+
+// ── ILO-265: values → mvals ──────────────────────────────────────────────────
+
+#[test]
+fn mvals_remains_the_canonical_name_for_values() {
+    let b = Builtin::from_name("mvals").expect("`mvals` must be a canonical builtin");
+    assert_eq!(b.name(), "mvals", "canonical name is `mvals`");
+    assert!(
+        Builtin::from_name("values").is_none(),
+        "`values` must not be a canonical name; it is an alias for `mvals`"
+    );
+    assert_eq!(
+        resolve_alias("values"),
+        Some("mvals"),
+        "`values` must resolve to canonical `mvals`"
+    );
+}
+
+const VALUES_ALIAS_SRC: &str = "f>L n;m=mset (mset mmap \"a\" 10) \"b\" 20;values m";
+
+#[test]
+fn values_alias_vm_tree() {
+    let result = run("--vm", VALUES_ALIAS_SRC, "f");
+    assert!(
+        result.contains("10") && result.contains("20"),
+        "values alias must return map values via vm (tree-walk), got: {result}"
+    );
+}
+
+#[test]
+fn values_alias_vm() {
+    let result = run("--vm", VALUES_ALIAS_SRC, "f");
+    assert!(
+        result.contains("10") && result.contains("20"),
+        "values alias must return map values via vm, got: {result}"
+    );
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn values_alias_jit() {
+    let result = run("--jit", VALUES_ALIAS_SRC, "f");
+    assert!(
+        result.contains("10") && result.contains("20"),
+        "values alias must return map values via jit, got: {result}"
+    );
+}
+
+#[test]
+fn values_canonical_mvals_still_works() {
+    let result = run("--vm", "f>L n;m=mset mmap \"x\" 42;mvals m", "f");
+    assert!(result.contains("42"), "canonical `mvals` must still work, got: {result}");
+}
+
+#[test]
+fn values_rejected_as_binding_name() {
+    let out = ilo()
+        .args(["main>t;values=[];values"])
+        .output()
+        .expect("failed to run ilo");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "expected `values=[]` to fail at parse time"
+    );
+    assert!(
+        stderr.contains("ILO-P011"),
+        "expected ILO-P011 reserved-name error, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("values") && stderr.contains("mvals"),
+        "error must name the alias and the canonical builtin, got: {stderr}"
+    );
+}
+
+// ── ILO-266: join → cat (string-join) ────────────────────────────────────────
+//
+// Note: `append` is NOT aliased. There is no canonical `app` builtin;
+// list appending is the `+=` operator (OP_LISTAPPEND), not a named function.
+// That gap is tracked as a separate ticket if needed.
+
+#[test]
+fn cat_remains_the_canonical_name_for_join() {
+    let b = Builtin::from_name("cat").expect("`cat` must be a canonical builtin");
+    assert_eq!(b.name(), "cat", "canonical name is `cat`");
+    assert!(
+        Builtin::from_name("join").is_none(),
+        "`join` must not be a canonical name; it is an alias for `cat`"
+    );
+    assert_eq!(
+        resolve_alias("join"),
+        Some("cat"),
+        "`join` must resolve to canonical `cat`"
+    );
+}
+
+const JOIN_ALIAS_SRC: &str = "f>t;join [\"a\",\"b\",\"c\"] \",\"";
+
+#[test]
+fn join_alias_vm() {
+    assert_eq!(
+        run("--vm", JOIN_ALIAS_SRC, "f"),
+        "a,b,c",
+        "`join` alias must produce same output as `cat` via vm"
+    );
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn join_alias_jit() {
+    assert_eq!(
+        run("--jit", JOIN_ALIAS_SRC, "f"),
+        "a,b,c",
+        "`join` alias must produce same output as `cat` via jit"
+    );
+}
+
+#[test]
+fn join_canonical_cat_still_works() {
+    assert_eq!(
+        run("--vm", "f>t;cat [\"x\",\"y\"] \"-\"", "f"),
+        "x-y",
+        "canonical `cat` must still work"
+    );
+}
+
+#[test]
+fn join_rejected_as_binding_name() {
+    let out = ilo()
+        .args(["main>t;join=\"val\";join"])
+        .output()
+        .expect("failed to run ilo");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "expected `join=\"val\"` to fail at parse time"
+    );
+    assert!(
+        stderr.contains("ILO-P011"),
+        "expected ILO-P011 reserved-name error, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("join") && stderr.contains("cat"),
+        "error must name the alias and the canonical builtin, got: {stderr}"
+    );
+}

--- a/tests/regression_capitalize_alias.rs
+++ b/tests/regression_capitalize_alias.rs
@@ -1,0 +1,122 @@
+// Regression tests pinning the `capitalize` → `cap` alias contract (ILO-81).
+//
+// `capitalize` is the standard method name for title-casing the first letter
+// in Python and Ruby. Personas from those languages reach for the long form.
+// The alias rewrites `capitalize` to canonical `cap` at parse time; bytecode
+// and fmt output stay on `cap`.
+//
+// Contracts to lock in:
+// 1. `capitalize` resolves to `cap` at the alias-table level.
+// 2. `cap` remains canonical in the builtin registry.
+// 3. `capitalize "hello"` runs correctly cross-engine and produces "Hello".
+// 4. `capitalize` as a binding name is rejected with ILO-P011.
+// 5. A hint mentioning both `capitalize` and `cap` is emitted on first use.
+
+use ilo::ast::resolve_alias;
+use ilo::builtins::Builtin;
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} {src:?} failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+#[cfg(feature = "cranelift")]
+const ENGINES_ALL: &[&str] = &["--vm", "--jit"];
+#[cfg(not(feature = "cranelift"))]
+const ENGINES_ALL: &[&str] = &["--vm"];
+
+#[test]
+fn cap_remains_canonical() {
+    let b = Builtin::from_name("cap").expect("`cap` must be a canonical builtin");
+    assert_eq!(b.name(), "cap");
+    assert!(
+        Builtin::from_name("capitalize").is_none(),
+        "`capitalize` must not be a canonical name; it is an alias for `cap`"
+    );
+    assert_eq!(
+        resolve_alias("capitalize"),
+        Some("cap"),
+        "`capitalize` must resolve to canonical `cap`"
+    );
+}
+
+#[test]
+fn capitalize_dispatches_cross_engine() {
+    for engine in ENGINES_ALL {
+        let out = run(engine, "f>t;capitalize \"hello\"", "f");
+        assert_eq!(
+            out, "Hello",
+            "{engine}: `capitalize \"hello\"` expected Hello, got {out}"
+        );
+    }
+}
+
+#[test]
+fn cap_canonical_still_works() {
+    for engine in ENGINES_ALL {
+        let out = run(engine, "f>t;cap \"world\"", "f");
+        assert_eq!(out, "World");
+    }
+}
+
+#[test]
+fn capitalize_rejected_as_binding_name() {
+    let out = ilo()
+        .args(["main>t;capitalize=\"hi\";capitalize"])
+        .output()
+        .expect("failed to run ilo");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(!out.status.success());
+    assert!(
+        stderr.contains("ILO-P011"),
+        "expected ILO-P011, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("capitalize") && stderr.contains("cap"),
+        "error must name alias and canonical, got: {stderr}"
+    );
+}
+
+#[test]
+fn capitalize_rejected_as_user_function_name() {
+    let out = ilo()
+        .args(["capitalize s:t>t;cap s"])
+        .output()
+        .expect("failed to run ilo");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(!out.status.success());
+    assert!(
+        stderr.contains("ILO-P011"),
+        "expected ILO-P011, got: {stderr}"
+    );
+}
+
+#[test]
+fn capitalize_emits_canonical_hint() {
+    let out = ilo()
+        .args(["f>t;capitalize \"world\"", "--vm", "f"])
+        .output()
+        .expect("failed to run ilo");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        combined.contains("capitalize") && combined.contains("cap"),
+        "expected hint mentioning `capitalize` and `cap`, got: {combined}"
+    );
+}

--- a/tests/regression_post_alias.rs
+++ b/tests/regression_post_alias.rs
@@ -1,0 +1,84 @@
+// Regression tests pinning the `post` → `pst` alias contract (ILO-78).
+//
+// `post` was the canonical HTTP-POST verb name before 0.12.0 when it was
+// renamed to the 3-char `pst` to match the short-form convention. Users who
+// learned the language pre-0.12.0 have `post` as muscle memory. The alias
+// resolves `post` → `pst` at parse time so those users get a canonical-name
+// hint on first run and keep working without modification.
+//
+// Contracts to lock in:
+// 1. `post` resolves to `pst` at the alias-table level.
+// 2. `pst` remains the canonical name in the builtin registry.
+// 3. `post` as a binding name is rejected at parse time with ILO-P011.
+// 4. A hint mentioning both `post` and `pst` is emitted on first use.
+
+use ilo::ast::resolve_alias;
+use ilo::builtins::Builtin;
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+#[test]
+fn pst_remains_the_canonical_name() {
+    let b = Builtin::from_name("pst").expect("`pst` must be a canonical builtin");
+    assert_eq!(b.name(), "pst", "canonical name is `pst`");
+    assert!(
+        Builtin::from_name("post").is_none(),
+        "`post` must not be a canonical name; it is an alias for `pst`"
+    );
+    assert_eq!(
+        resolve_alias("post"),
+        Some("pst"),
+        "`post` must resolve to canonical `pst`"
+    );
+}
+
+#[test]
+fn post_rejected_as_binding_name() {
+    let out = ilo()
+        .args(["main>t;post=\"body\";post"])
+        .output()
+        .expect("failed to run ilo");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "expected `post=\"body\"` to fail at parse time"
+    );
+    assert!(
+        stderr.contains("ILO-P011"),
+        "expected ILO-P011 reserved-name error, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("post") && stderr.contains("pst"),
+        "error must name the alias and the canonical builtin, got: {stderr}"
+    );
+}
+
+#[test]
+fn post_rejected_as_user_function_name() {
+    let out = ilo()
+        .args(["post url:t body:t>R t t;pst url body"])
+        .output()
+        .expect("failed to run ilo");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "expected `post url:t body:t>...` to fail at parse time"
+    );
+    assert!(
+        stderr.contains("ILO-P011"),
+        "expected ILO-P011 reserved-name error, got: {stderr}"
+    );
+}
+
+#[test]
+fn post_alias_hint_data_is_correct() {
+    // The hint system calls `resolve_alias(word)` on each lexed identifier and
+    // emits "hint: `word` → `canonical` (canonical form)" on successful runs.
+    // We verify the alias-table data that drives the hint rather than firing a
+    // real HTTP request in tests (which would be network-dependent).
+    let alias = resolve_alias("post").expect("`post` must be in BUILTIN_ALIASES");
+    assert_eq!(alias, "pst", "hint would say `post` → `pst`");
+}

--- a/tests/regression_upper_lower_alias.rs
+++ b/tests/regression_upper_lower_alias.rs
@@ -1,0 +1,168 @@
+// Regression tests pinning the `upper` → `upr` and `lower` → `lwr` alias
+// contracts (ILO-79).
+//
+// `upper`/`lower` are the standard method names for case conversion in
+// Python, JavaScript, Go, and Rust. Personas from those languages reach for
+// the verbose forms first. The aliases rewrite to canonical 3-char `upr`/`lwr`
+// at parse time; bytecode and fmt output stay on the canonical names.
+//
+// Contracts to lock in:
+// 1. `upper` resolves to `upr` and `lower` resolves to `lwr` at alias-table level.
+// 2. `upr` and `lwr` remain canonical in the builtin registry.
+// 3. `upper`/`lower` run correctly cross-engine and produce the right output.
+// 4. `upper`/`lower` as binding names are rejected with ILO-P011.
+// 5. A hint mentioning both forms is emitted on first use.
+
+use ilo::ast::resolve_alias;
+use ilo::builtins::Builtin;
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} {src:?} failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+#[cfg(feature = "cranelift")]
+const ENGINES_ALL: &[&str] = &["--vm", "--jit"];
+#[cfg(not(feature = "cranelift"))]
+const ENGINES_ALL: &[&str] = &["--vm"];
+
+#[test]
+fn upr_lwr_remain_canonical() {
+    let b = Builtin::from_name("upr").expect("`upr` must be a canonical builtin");
+    assert_eq!(b.name(), "upr");
+    let b = Builtin::from_name("lwr").expect("`lwr` must be a canonical builtin");
+    assert_eq!(b.name(), "lwr");
+
+    assert!(
+        Builtin::from_name("upper").is_none(),
+        "`upper` must not be a canonical name"
+    );
+    assert!(
+        Builtin::from_name("lower").is_none(),
+        "`lower` must not be a canonical name"
+    );
+
+    assert_eq!(resolve_alias("upper"), Some("upr"));
+    assert_eq!(resolve_alias("lower"), Some("lwr"));
+}
+
+#[test]
+fn upper_dispatches_cross_engine() {
+    for engine in ENGINES_ALL {
+        let out = run(engine, "f>t;upper \"hello\"", "f");
+        assert_eq!(
+            out, "HELLO",
+            "{engine}: `upper \"hello\"` expected HELLO, got {out}"
+        );
+    }
+}
+
+#[test]
+fn lower_dispatches_cross_engine() {
+    for engine in ENGINES_ALL {
+        let out = run(engine, "f>t;lower \"HELLO\"", "f");
+        assert_eq!(
+            out, "hello",
+            "{engine}: `lower \"HELLO\"` expected hello, got {out}"
+        );
+    }
+}
+
+#[test]
+fn upr_canonical_still_works() {
+    for engine in ENGINES_ALL {
+        let out = run(engine, "f>t;upr \"world\"", "f");
+        assert_eq!(out, "WORLD");
+    }
+}
+
+#[test]
+fn lwr_canonical_still_works() {
+    for engine in ENGINES_ALL {
+        let out = run(engine, "f>t;lwr \"WORLD\"", "f");
+        assert_eq!(out, "world");
+    }
+}
+
+#[test]
+fn upper_rejected_as_binding_name() {
+    let out = ilo()
+        .args(["main>t;upper=\"hi\";upper"])
+        .output()
+        .expect("failed to run ilo");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(!out.status.success());
+    assert!(
+        stderr.contains("ILO-P011"),
+        "expected ILO-P011, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("upper") && stderr.contains("upr"),
+        "error must name alias and canonical, got: {stderr}"
+    );
+}
+
+#[test]
+fn lower_rejected_as_binding_name() {
+    let out = ilo()
+        .args(["main>t;lower=\"hi\";lower"])
+        .output()
+        .expect("failed to run ilo");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(!out.status.success());
+    assert!(
+        stderr.contains("ILO-P011"),
+        "expected ILO-P011, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("lower") && stderr.contains("lwr"),
+        "error must name alias and canonical, got: {stderr}"
+    );
+}
+
+#[test]
+fn upper_emits_canonical_hint() {
+    let out = ilo()
+        .args(["f>t;upper \"abc\"", "--vm", "f"])
+        .output()
+        .expect("failed to run ilo");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        combined.contains("upper") && combined.contains("upr"),
+        "expected hint mentioning `upper` and `upr`, got: {combined}"
+    );
+}
+
+#[test]
+fn lower_emits_canonical_hint() {
+    let out = ilo()
+        .args(["f>t;lower \"ABC\"", "--vm", "f"])
+        .output()
+        .expect("failed to run ilo");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        combined.contains("lower") && combined.contains("lwr"),
+        "expected hint mentioning `lower` and `lwr`, got: {combined}"
+    );
+}


### PR DESCRIPTION
## Summary

- **ILO-264**: `delete` → `del`, `patch` → `pat` — HTTP verb long-form aliases so agents from Python/JS/Rust don't hit unknown-builtin errors on first run
- **ILO-265**: `keys` → `mkeys`, `values` → `mvals` — universal map-accessor names (Python dict.keys()/.values(), JS Object.keys(), Rust HashMap::keys)
- **ILO-266**: `join` → `cat` — Python str.join / JS Array.join string-join muscle memory; `append` skipped (no canonical `app` builtin — list appending is the `+=` operator / OP_LISTAPPEND, not a named function)

All aliases resolve at parse time only; canonical names, bytecode, and fmt output are unchanged.

## Changes

- `src/ast/mod.rs`: 6 new entries in `BUILTIN_ALIASES` with rationale comments
- `tests/regression_aliases_batch2.rs`: 23 regression tests covering alias-table resolution, canonical-name preservation, ILO-P011 binding rejection, and cross-engine (vm/jit) execution

## Test plan

- [ ] `cargo test --test regression_aliases_batch2` — all 23 pass
- [ ] `cargo test --test regression_post_alias` (existing alias tests) — no regressions
- [ ] `cargo test --test regression_alias_binding_shadow` — no regressions
- [ ] Pre-existing `interpret_braceless_guard_fibonacci` stack overflow in lib tests is unrelated (reproduces on base branch)

Closes ILO-264, ILO-265, ILO-266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)