### PR TITLE
chore: enforce 16 MiB test stack + explicit guard on fib canary (partial ILO-289)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+RUST_MIN_STACK = "16777216"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 .cargo/
+!.cargo/config.toml
 npm/ilo.wasm
 .env
 __pycache__/

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -10995,11 +10995,22 @@ mod tests {
 
     #[test]
     fn interpret_braceless_guard_fibonacci() {
-        let source = "fib n:n>n;<=n 1 n;a=fib -n 1;b=fib -n 2;+a b";
-        assert_eq!(
-            run_str(source, Some("fib"), vec![Value::Number(10.0)]),
-            Value::Number(55.0)
-        );
+        // fib(10) recurses deeply enough to blow the 2 MiB default test-thread
+        // stack on some platforms. Run it on an explicit 8 MiB stack so the
+        // test passes independently of RUST_MIN_STACK. Mirrors the pattern used
+        // in tests/parser_depth_cap.rs.
+        std::thread::Builder::new()
+            .stack_size(8 * 1024 * 1024)
+            .spawn(|| {
+                let source = "fib n:n>n;<=n 1 n;a=fib -n 1;b=fib -n 2;+a b";
+                assert_eq!(
+                    run_str(source, Some("fib"), vec![Value::Number(10.0)]),
+                    Value::Number(55.0)
+                );
+            })
+            .expect("spawn test thread")
+            .join()
+            .expect("thread panicked");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `.cargo/config.toml` with `RUST_MIN_STACK = "16777216"` so local `cargo test` runs match the `RUST_MIN_STACK` env var already set in `.github/workflows/rust.yml`.
- Wraps `interpret_braceless_guard_fibonacci` (the deep-recursion canary) with an explicit 8 MiB `std::thread::Builder` stack, mirroring the `run_on_fat_stack` pattern in `tests/parser_depth_cap.rs`. The test now passes independently of the env var.
- Unignores `.cargo/config.toml` in `.gitignore` via a negation rule (`.cargo/` was globally ignored).

Partial fix for ILO-289. The CI lint for oversized match arms (~1-2 hours) is deferred to a follow-up ticket.

## Test plan

- [x] `cargo test interpret_braceless_guard_fibonacci` passes
- [x] Full `cargo test` passes (3330 tests; 7 pre-existing cranelift AOT failures unrelated to this change — those require `libilo.a` built via `cargo build --release --features cranelift`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)