### PR TITLE
docs: add quantile worked example (closes ILO-55)

### DIFF
--- a/skills/ilo/ilo-builtins-math.md
+++ b/skills/ilo/ilo-builtins-math.md
@@ -31,6 +31,18 @@ Prefix-call: `name arg1 arg2 ...`. Cross-engine unless noted.
 
 `sum avg median quantile stdev variance cumsum frq argmax argmin argsort prod cprod`.
 
+`quantile xs p > n` — sample quantile using linear interpolation; `p` is clamped to `[0, 1]`. `p=0` returns the minimum, `p=1` returns the maximum, `p=0.5` matches `median`. For a fractional index the result is linearly interpolated between the two surrounding sorted values.
+
+```
+xs = [3, 1, 4, 1, 5, 9, 2, 6]   -- unsorted input is fine
+
+quantile xs 0      -- 1   (minimum)
+quantile xs 1      -- 9   (maximum)
+quantile xs 0.5    -- 3.5 (median: avg of 4th and 5th sorted values 3 and 4)
+quantile xs 0.25   -- 1.75  (linear interp between sorted[1]=1 and sorted[2]=2)
+quantile xs 0.75   -- 5.25  (linear interp between sorted[5]=5 and sorted[6]=6)
+```
+
 ## Linear algebra
 
 `transpose matmul matvec dot solve inv det fft ifft lstsq`. Row-major matrices are `L (L n)`, flat vectors are `L n`. `matvec xm ys` is matrix-vector product, returning a flat vector - use it instead of the `flatten matmul xm (map (y:n>L n;[y]) ys)` wrap-as-column ceremony. `solve inv det` use LU decomposition with partial pivoting and error on singular / non-square inputs.


### PR DESCRIPTION
## Summary

- Adds a worked example for `quantile xs p` to `skills/ilo/ilo-builtins-math.md`
- Explains the linear interpolation semantics and p clamping behavior
- Covers `p=0` (min), `p=1` (max), `p=0.5` (median), and fractional indices requiring interpolation (`p=0.25`, `p=0.75`)

## Test plan

- [ ] `cargo test docs` passes
- [ ] `cargo test examples` passes
- [ ] Verify computed values against implementation (`pos = p * (n-1)`, linear interp between floor/ceil indices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)