### PR TITLE
ci: add dispatch-arm size lint (ILO-339)

### DIFF
--- a/scripts/check-dispatch-arms.sh
+++ b/scripts/check-dispatch-arms.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# check-dispatch-arms.sh
+#
+# Lints the `call_function` dispatch in src/interpreter/mod.rs.
+# Fires if any `if builtin == Some(Builtin::...)` block inside call_function
+# exceeds THRESHOLD lines.
+#
+# Background: large inline arms in call_function inflate the debug-build
+# stack frame and cause stack-overflow in deep-recursion tests (ILO-339).
+# Engineers should extract oversized arms into `#[inline(never)]` helpers.
+#
+# Usage:
+#   bash scripts/check-dispatch-arms.sh [--threshold N]
+#   Default threshold: 40 lines.
+
+set -euo pipefail
+
+THRESHOLD=40
+FILE="src/interpreter/mod.rs"
+TARGET_FN="call_function"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --threshold) THRESHOLD="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ ! -f "$FILE" ]]; then
+  echo "ERROR: $FILE not found. Run from the repository root." >&2
+  exit 1
+fi
+
+# --- locate call_function boundaries ---
+fn_start=$(grep -n "^fn ${TARGET_FN}(" "$FILE" | head -1 | cut -d: -f1)
+if [[ -z "$fn_start" ]]; then
+  echo "ERROR: could not find 'fn ${TARGET_FN}(' in $FILE" >&2
+  exit 1
+fi
+
+# Find the next top-level fn after call_function to bound our search
+fn_end=$(awk -v start="$fn_start" 'NR>start && /^fn [a-z]/{print NR; exit}' "$FILE")
+if [[ -z "$fn_end" ]]; then
+  fn_end=$(wc -l < "$FILE")
+fi
+
+# --- extract line numbers of each `if builtin ==` arm inside call_function ---
+arm_lines=$(awk -v s="$fn_start" -v e="$fn_end" \
+  'NR>=s && NR<=e && /^    if builtin == /{print NR}' "$FILE")
+
+if [[ -z "$arm_lines" ]]; then
+  echo "No 'if builtin ==' arms found in ${TARGET_FN} — nothing to check."
+  exit 0
+fi
+
+# Build array of arm start line numbers, append fn_end as sentinel
+mapfile -t starts <<< "$arm_lines"
+starts+=("$fn_end")
+
+fail=0
+max_arm=0
+max_arm_start=0
+
+for (( i=0; i<${#starts[@]}-1; i++ )); do
+  arm_s=${starts[$i]}
+  arm_e=${starts[$((i+1))]}
+  arm_len=$(( arm_e - arm_s ))
+
+  if (( arm_len > max_arm )); then
+    max_arm=$arm_len
+    max_arm_start=$arm_s
+  fi
+
+  if (( arm_len > THRESHOLD )); then
+    # Extract the builtin name for a helpful message
+    arm_label=$(sed -n "${arm_s}p" "$FILE" | grep -oP 'Builtin::\w+' | head -1)
+    echo "FAIL: ${FILE}:${arm_s}: arm '${arm_label}' is ${arm_len} lines (threshold: ${THRESHOLD})."
+    echo "      Extract the body into a #[inline(never)] helper function to reduce"
+    echo "      call_function's stack frame and prevent debug-build stack overflows."
+    fail=1
+  fi
+done
+
+if (( fail == 0 )); then
+  echo "OK: all ${#starts[@]} dispatch arms in ${TARGET_FN} are within ${THRESHOLD}-line threshold."
+  echo "    (largest arm: ${max_arm} lines at line ${max_arm_start})"
+fi
+
+exit $fail


### PR DESCRIPTION
## Summary

- Adds `scripts/check-dispatch-arms.sh` — a bash/awk script that scans `src/interpreter/mod.rs` for `if builtin == Some(Builtin::...)` arms inside `call_function` and fails if any arm exceeds **40 lines**
- Provides actionable error messages directing engineers to extract oversized arms into `#[inline(never)]` helpers
- Prevents recurrence of the stack-pressure bug where large inline arms inflate the debug-build stack frame (see ILO-339)

## Workflow file (apply manually — token lacks `workflow` scope)

Add the following step to the `lint` job in `.github/workflows/rust.yml`, before the `Shellcheck install.sh` step:

```yaml
    - name: Check call_function dispatch arm sizes (ILO-339)
      # Flags any `if builtin == Some(Builtin::...)` block inside call_function
      # that exceeds 40 lines. Large inline arms inflate the debug-build stack
      # frame and can cause stack-overflows in deep-recursion tests.
      # If this fires, extract the arm body into a `#[inline(never)]` helper.
      #
      # continue-on-error: true while existing violations are being cleaned up
      # (49 arms currently exceed 40 lines). Flip to false once resolved.
      # Tracking issue: ILO-339.
      continue-on-error: true
      run: bash scripts/check-dispatch-arms.sh --threshold 40
```

## Current violation count

There are currently **49 arms** in `call_function` that exceed 40 lines (largest: 207 lines, `Builtin::Ifft`). The CI step uses `continue-on-error: true` until these are cleaned up; flip it to `false` once resolved to make the lint blocking.

## Usage

```
bash scripts/check-dispatch-arms.sh [--threshold N]
```

Default threshold is 40 lines. Pass `--threshold 60` to temporarily relax during a large refactor.

## Test plan

- [ ] Run `bash scripts/check-dispatch-arms.sh` from repo root — should report 49 FAILs with named builtins and line numbers
- [ ] Run `bash scripts/check-dispatch-arms.sh --threshold 300` — should report OK
- [ ] Verify the workflow YAML snippet applies cleanly to `rust.yml` lint job
- [ ] After first cleanup PR lands, flip `continue-on-error` to `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)