### PR TITLE
chore: document dev vs release tag convention

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,21 @@ permissions:
   contents: write
 
 jobs:
+  validate-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate tag format
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-dev\.[0-9]+)?$ ]]; then
+            echo "Tag '$TAG' is valid."
+          else
+            echo "ERROR: Tag '$TAG' does not match allowed formats: vX.Y.Z or vX.Y.Z-dev.N"
+            exit 1
+          fi
+
   secret-scan:
+    needs: validate-tag
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -129,6 +143,7 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-dev.') }}
           files: |
             ilo-*
             checksums-sha256.txt
@@ -136,6 +151,7 @@ jobs:
   publish-crates:
     needs: [release]
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.ref_name, '-dev.') }}
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -155,6 +171,7 @@ jobs:
   publish-npm:
     needs: [build-wasm]
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.ref_name, '-dev.') }}
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -195,6 +212,7 @@ jobs:
   publish-pi:
     needs: [release]
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.ref_name, '-dev.') }}
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,60 @@
+# Releasing ilo
+
+## Tag conventions
+
+| Tag format | Meaning | Published to |
+|------------|---------|-------------|
+| `vX.Y.Z` | Clean release | GitHub Releases, crates.io, npm |
+| `vX.Y.Z-dev.N` | Dev iteration (testable build) | GitHub Releases (git tag only) |
+
+- `N` in `-dev.N` is a monotonically increasing integer that **resets to 1 on each new minor version** (i.e. the first dev build for `0.14.0` is `0.14.0-dev.1`).
+- Dev tags are pushed to the repo and get a GitHub release with binaries, but are **never published to crates.io or npm**.
+- Only clean `vX.Y.Z` tags trigger crates.io / npm publishing (enforced by CI tag validation — see below).
+
+## Soaked release definition
+
+A release is considered "soaked" and ready for a clean `vX.Y.Z` tag when all of the following are true:
+
+1. The full test suite passes (`cargo test --all-features`).
+2. Cross-engine tests pass (`tests/examples_engines` or equivalent).
+3. Examples engines test suite passes.
+4. At least one full persona run has been completed against Opus without regressions.
+
+Only soaked builds should receive a clean release tag.
+
+## Release-prep checklist
+
+1. Bump the version in `Cargo.toml` (and `npm/package.json` / `pi/package.json` if they track it manually).
+2. Update `CHANGELOG.md` — move entries from `Unreleased` to the new version heading.
+3. Run the full test suite locally:
+   ```
+   cargo test --all-features
+   ```
+4. Confirm the build is soaked (see definition above).
+5. Create and push the tag:
+   ```
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+6. CI will build, create the GitHub release, and publish to crates.io and npm.
+
+## Dev iteration workflow
+
+When you want a testable build without cutting a real release:
+
+```
+git tag vX.Y.Z-dev.N
+git push origin vX.Y.Z-dev.N
+```
+
+CI will build binaries and create a GitHub pre-release, but will **skip** crates.io and npm publishing. The GitHub release is marked as a pre-release automatically.
+
+## CI tag validation
+
+The release workflow validates the pushed tag before doing anything else. The rules are:
+
+- Allowed: `vX.Y.Z` (e.g. `v0.13.0`)
+- Allowed: `vX.Y.Z-dev.N` (e.g. `v0.13.0-dev.3`)
+- Any other tag format matching `v*` will cause the workflow to fail immediately.
+
+This prevents accidental publishes from experimental or malformed tags.


### PR DESCRIPTION
## Summary
Closes ILO-66. Documents the versioning convention to separate dev iterations from real releases.

- `vX.Y.Z` for releases; `vX.Y.Z-dev.N` for dev iterations (N resets per minor bump)
- Documents soaked-release definition (full test suite + cross-engine + examples_engines + persona run on Opus)
- Updates release workflow with tag validation regex
- Dev iterations are git-tag only — not published to crates.io / npm

## Test plan
- [ ] Tag a `-dev.N` and confirm CI validates it
- [ ] Tag a clean release and confirm publish-only-on-clean flow

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>