### PR TITLE
feat: ilo trace — JSON-line value snapshots (ILO-72)

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,66 @@
+# Debugging ilo programs
+
+## `ilo trace` — JSON-line value snapshots
+
+`ilo trace <file.ilo> [func] [args...]` runs a program through the
+tree-walking interpreter and emits one JSON line to stdout after every
+statement executes.  This gives agents (and humans) a machine-readable
+execution trace they can pipe into `jq`, store in a file, or compare
+across runs.
+
+```
+ilo trace examples/trace-demo.ilo add 3 4
+```
+
+Output (one JSON object per line, pretty-printed here for readability):
+
+```json
+{"schemaVersion":1,"line":2,"stmt":"a = + x y","bindings":{"a":7,"x":3,"y":4},"result":7}
+{"schemaVersion":1,"line":3,"stmt":"b = * a 2","bindings":{"a":7,"b":14,"x":3,"y":4},"result":14}
+{"schemaVersion":1,"line":4,"stmt":"b","bindings":{"a":7,"b":14,"x":3,"y":4},"result":14}
+```
+
+### Event schema (schemaVersion 1)
+
+| Field           | Type    | Description |
+|-----------------|---------|-------------|
+| `schemaVersion` | integer | Always `1`. Increment if the schema changes incompatibly. |
+| `line`          | integer | 1-based source line number of the statement. |
+| `stmt`          | string  | Source text of that line (trimmed). |
+| `bindings`      | object  | All variable bindings visible in scope after the statement. |
+| `result`        | any     | Value produced by the statement (`null` for statements with no value). For `let` assignments this is the assigned value; for expression statements it is the expression value. |
+
+### Consuming traces with jq
+
+```sh
+# Show only lines where a binding changes to a number > 10
+ilo trace prog.ilo | jq 'select(.result > 10)'
+
+# Extract all result values in order
+ilo trace prog.ilo | jq -r '.result'
+
+# Show what bindings looked like at line 5
+ilo trace prog.ilo | jq 'select(.line == 5) | .bindings'
+```
+
+### Notes
+
+- `ilo trace` always uses the **tree-walking interpreter**.  The VM and
+  JIT engines do not yet support tracing.
+- Traces can be large for programs with loops.  Pipe through `head` or
+  use `jq 'first(…)'` to limit output while iterating.
+- Functions called by the entry function are also traced.  Each
+  statement in every called function body emits its own event.
+- The `bindings` object reflects the innermost scope at the point of
+  the statement.  If the same name appears in multiple nested scopes,
+  the innermost binding is shown.
+- `FnRef` and `Closure` values cannot be serialised to JSON; they
+  appear as `null` in `bindings` and `result`.
+
+### v1 limitations / follow-ups
+
+- Expression-level granularity (sub-statement snapshots) is not yet
+  supported.
+- Watchpoints and conditional breakpoints are not yet supported.
+- DAP (Debug Adapter Protocol) integration is not yet supported.
+- The VM / JIT trace path is not yet implemented.

--- a/examples/trace-demo.ilo
+++ b/examples/trace-demo.ilo
@@ -1,0 +1,4 @@
+add x:n y:n>n
+  a = + x y
+  b = * a 2
+  b

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -118,6 +118,9 @@ pub enum Cmd {
 
     /// Print version.
     Version,
+
+    /// Trace program execution, emitting one JSON line per statement.
+    Trace(TraceArgs),
 }
 
 // ── Run ────────────────────────────────────────────────────────────────────────
@@ -419,6 +422,21 @@ pub enum SkillCmd {
     Path { name: String },
     /// Print a skill with a formatted header.
     Show { name: String },
+}
+
+// ── Trace ──────────────────────────────────────────────────────────────────────
+
+#[derive(Args, Debug)]
+pub struct TraceArgs {
+    /// Source file to trace.
+    pub source: String,
+
+    /// Entry function name (defaults to first function).
+    pub func: Option<String>,
+
+    /// Call arguments passed to the entry function.
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    pub rest: Vec<String>,
 }
 
 // ── OutputMode resolution ──────────────────────────────────────────────────────

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,5 @@
 pub mod args;
 pub mod test_runner;
+pub mod trace;
 
 pub use args::*;

--- a/src/cli/trace.rs
+++ b/src/cli/trace.rs
@@ -1,0 +1,125 @@
+//! `ilo trace` — run a program and emit one JSON line per statement.
+//!
+//! Each line has the schema:
+//! ```json
+//! {"schemaVersion":1,"line":7,"stmt":"a = +x y","bindings":{"x":3,"y":4,"a":7},"result":7}
+//! ```
+//!
+//! Touch points: ILO-72.
+
+use super::args::TraceArgs;
+use crate::ast;
+use crate::interpreter::{TraceEvent, Value, run_with_trace};
+use crate::lexer;
+use crate::parser;
+
+/// Entry point for `ilo trace <file.ilo> [func] [args...]`.
+/// Returns the process exit code (0 = success).
+pub fn run(t: TraceArgs) -> i32 {
+    trace_run(t)
+}
+
+#[inline(never)]
+fn trace_run(t: TraceArgs) -> i32 {
+    let source_arg = &t.source;
+
+    // Read source from file.
+    let source = match std::fs::read_to_string(source_arg) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("ilo trace: cannot read '{}': {}", source_arg, e);
+            return 1;
+        }
+    };
+
+    // Lex.
+    let tokens = match lexer::lex(&source) {
+        Ok(ts) => ts,
+        Err(e) => {
+            eprintln!("ilo trace: lex error: [{}] {}", e.code, e.snippet);
+            return 1;
+        }
+    };
+
+    let token_spans: Vec<(lexer::Token, ast::Span)> = tokens
+        .into_iter()
+        .map(|(tok, r)| {
+            (
+                tok,
+                ast::Span {
+                    start: r.start,
+                    end: r.end,
+                },
+            )
+        })
+        .collect();
+
+    // Parse.
+    let (mut program, parse_errors) = parser::parse(token_spans);
+    for e in &parse_errors {
+        eprintln!("ilo trace: parse error: {}", e.message);
+    }
+    if !parse_errors.is_empty() {
+        return 1;
+    }
+
+    ast::resolve_aliases(&mut program);
+    ast::desugar_dot_var_index(&mut program);
+    program.source = Some(source.clone());
+
+    // Resolve entry function and args.
+    let func_name: Option<&str> = t.func.as_deref();
+
+    // Convert string args to ilo Values (best-effort: try number, else text).
+    let call_args: Vec<Value> = t
+        .rest
+        .iter()
+        .map(|s| {
+            if let Ok(n) = s.parse::<f64>() {
+                Value::Number(n)
+            } else {
+                Value::Text(std::sync::Arc::new(s.clone()))
+            }
+        })
+        .collect();
+
+    // Run with trace hook — each event is serialised to one stdout JSON line.
+    let result = run_with_trace(&program, func_name, call_args, emit_event);
+
+    match result {
+        Ok(_) => 0,
+        Err(e) => {
+            eprintln!("ilo trace: runtime error [{}]: {}", e.code, e.message);
+            1
+        }
+    }
+}
+
+/// Serialise a single `TraceEvent` as a JSON line to stdout.
+fn emit_event(ev: TraceEvent) {
+    // Build the bindings object.
+    let mut bindings = serde_json::Map::new();
+    // Deduplicate: if a name appears multiple times (shadowed), take the last
+    // (innermost) binding, which is what the interpreter sees.
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for (name, val) in ev.bindings.iter().rev() {
+        if seen.contains(name) {
+            continue;
+        }
+        seen.insert(name.clone());
+        let json_val = val.to_json().unwrap_or(serde_json::Value::Null);
+        bindings.insert(name.clone(), json_val);
+    }
+
+    let result_json = ev.result.to_json().unwrap_or(serde_json::Value::Null);
+
+    let event = serde_json::json!({
+        "schemaVersion": 1,
+        "line": ev.line,
+        "stmt": ev.stmt,
+        "bindings": serde_json::Value::Object(bindings),
+        "result": result_json,
+    });
+
+    println!("{event}");
+}

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -26,12 +26,13 @@ pub struct TraceEvent {
 // Thread-local trace sink. When `Some`, `eval_body` fires it after each
 // statement. Set to `Some` by `run_with_trace` and cleared on return.
 std::thread_local! {
+    #[allow(clippy::type_complexity)]
     static TRACE_HOOK: std::cell::RefCell<Option<Box<dyn FnMut(TraceEvent)>>> =
-        std::cell::RefCell::new(None);
+        const { std::cell::RefCell::new(None) };
 
     // Source text used to look up statement spans; set alongside TRACE_HOOK.
     static TRACE_SOURCE: std::cell::RefCell<Option<String>> =
-        std::cell::RefCell::new(None);
+        const { std::cell::RefCell::new(None) };
 }
 
 /// Run `program` with a per-statement trace callback.
@@ -40,14 +41,14 @@ pub fn run_with_trace<F>(
     program: &Program,
     func_name: Option<&str>,
     args: Vec<Value>,
-    mut on_event: F,
+    on_event: F,
 ) -> Result<Value>
 where
     F: FnMut(TraceEvent) + 'static,
 {
     // Install the hook.
     TRACE_HOOK.with(|h| {
-        *h.borrow_mut() = Some(Box::new(move |e| on_event(e)));
+        *h.borrow_mut() = Some(Box::new(on_event));
     });
     TRACE_SOURCE.with(|s| {
         *s.borrow_mut() = program.source.clone();

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -6,6 +6,66 @@ use std::sync::Arc;
 
 pub mod json;
 
+// ── Trace hook ────────────────────────────────────────────────────────────────
+
+/// One trace event emitted after each statement executes.
+/// Schema matches the ILO-72 proposal:
+/// `{"schemaVersion":1,"line":N,"stmt":"...","bindings":{...},"result":...}`
+#[derive(Debug)]
+pub struct TraceEvent {
+    /// 1-based source line of the statement start, or 0 if unknown.
+    pub line: usize,
+    /// Source text of the statement (trimmed), or empty if unavailable.
+    pub stmt: String,
+    /// All variable bindings visible in the current scope after the statement.
+    pub bindings: Vec<(String, Value)>,
+    /// The value produced by the statement (Nil for side-effect statements).
+    pub result: Value,
+}
+
+// Thread-local trace sink. When `Some`, `eval_body` fires it after each
+// statement. Set to `Some` by `run_with_trace` and cleared on return.
+std::thread_local! {
+    static TRACE_HOOK: std::cell::RefCell<Option<Box<dyn FnMut(TraceEvent)>>> =
+        std::cell::RefCell::new(None);
+
+    // Source text used to look up statement spans; set alongside TRACE_HOOK.
+    static TRACE_SOURCE: std::cell::RefCell<Option<String>> =
+        std::cell::RefCell::new(None);
+}
+
+/// Run `program` with a per-statement trace callback.
+/// `on_event` is called after each statement in the entry function body.
+pub fn run_with_trace<F>(
+    program: &Program,
+    func_name: Option<&str>,
+    args: Vec<Value>,
+    mut on_event: F,
+) -> Result<Value>
+where
+    F: FnMut(TraceEvent) + 'static,
+{
+    // Install the hook.
+    TRACE_HOOK.with(|h| {
+        *h.borrow_mut() = Some(Box::new(move |e| on_event(e)));
+    });
+    TRACE_SOURCE.with(|s| {
+        *s.borrow_mut() = program.source.clone();
+    });
+
+    let result = run_with_env(program, func_name, args, Env::new());
+
+    // Always clear the hook, even on error.
+    TRACE_HOOK.with(|h| {
+        *h.borrow_mut() = None;
+    });
+    TRACE_SOURCE.with(|s| {
+        *s.borrow_mut() = None;
+    });
+
+    result
+}
+
 /// A typed key for `Value::Map` and `HeapObj::Map`.
 ///
 /// Two variants — `Text` for string keys and `Int` for integer keys.
@@ -7904,14 +7964,41 @@ fn eval_body(env: &mut Env, stmts: &[Spanned<Stmt>], is_tail: bool) -> Result<Bo
         // statements are not in tail position by definition.
         let stmt_is_tail = is_tail && i + 1 == n;
         match eval_stmt(env, &spanned.node, stmt_is_tail) {
-            Ok(Some(BodyResult::Return(v))) => return Ok(BodyResult::Return(v)),
-            Ok(Some(BodyResult::Break(v))) => return Ok(BodyResult::Break(v)),
-            Ok(Some(BodyResult::Continue)) => return Ok(BodyResult::Continue),
+            Ok(Some(BodyResult::Return(v))) => {
+                fire_trace_event(env, spanned, v.clone());
+                return Ok(BodyResult::Return(v));
+            }
+            Ok(Some(BodyResult::Break(v))) => {
+                fire_trace_event(env, spanned, v.clone());
+                return Ok(BodyResult::Break(v));
+            }
+            Ok(Some(BodyResult::Continue)) => {
+                fire_trace_event(env, spanned, Value::Nil);
+                return Ok(BodyResult::Continue);
+            }
             Ok(Some(BodyResult::TailCall { callee, args })) => {
+                fire_trace_event(env, spanned, Value::Nil);
                 return Ok(BodyResult::TailCall { callee, args });
             }
-            Ok(Some(BodyResult::Value(v))) => last = v,
-            Ok(None) => {}
+            Ok(Some(BodyResult::Value(v))) => {
+                fire_trace_event(env, spanned, v.clone());
+                last = v;
+            }
+            Ok(None) => {
+                // For Let statements the assigned value is available in env.
+                // Use it as the result so the trace shows what was bound.
+                let result = if let Stmt::Let { name, .. } = &spanned.node {
+                    env.vars
+                        .iter()
+                        .rev()
+                        .find(|(k, _)| k == name)
+                        .map(|(_, v)| v.clone())
+                        .unwrap_or(Value::Nil)
+                } else {
+                    Value::Nil
+                };
+                fire_trace_event(env, spanned, result);
+            }
             Err(mut e) => {
                 // Auto-unwrap propagation: convert to early return
                 if let Some(val) = e.propagate_value.take() {
@@ -7928,6 +8015,48 @@ fn eval_body(env: &mut Env, stmts: &[Spanned<Stmt>], is_tail: bool) -> Result<Bo
         }
     }
     Ok(BodyResult::Value(last))
+}
+
+/// Fire the TRACE_HOOK (if installed) after a statement executes.
+/// Extracts line number from the span and collects current bindings.
+#[inline]
+fn fire_trace_event(env: &Env, spanned: &Spanned<Stmt>, result: Value) {
+    let has_hook = TRACE_HOOK.with(|h| h.borrow().is_some());
+    if !has_hook {
+        return;
+    }
+
+    let span = spanned.span;
+
+    // Resolve 1-based line number from the span.
+    let (line, stmt_text) = TRACE_SOURCE.with(|src| {
+        if let Some(ref source) = *src.borrow() {
+            let sm = crate::ast::SourceMap::new(source);
+            let (line, _col) = sm.lookup(span.start);
+            let text = sm.line_text(source, line).trim().to_string();
+            (line, text)
+        } else {
+            (0, String::new())
+        }
+    });
+
+    // Snapshot current bindings.
+    let bindings: Vec<(String, Value)> = env
+        .vars
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+
+    TRACE_HOOK.with(|h| {
+        if let Some(ref mut hook) = *h.borrow_mut() {
+            hook(TraceEvent {
+                line,
+                stmt: stmt_text,
+                bindings,
+                result,
+            });
+        }
+    });
 }
 
 /// If `value` is the self-rebind accumulator shape `name = mset name k v`,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2561,6 +2561,10 @@ fn main() {
                 eprintln!("Usage: ilo build <file.ilo> [-o out] [func]");
                 std::process::exit(1);
             }
+            "trace" => {
+                eprintln!("Usage: ilo trace <file.ilo> [func] [args...]");
+                std::process::exit(1);
+            }
             // `ilo test` with no path arg is valid (defaults to `examples/`)
             // and is handled in the runner; no usage stub needed here.
             _ => {}
@@ -2747,6 +2751,7 @@ fn dispatch_cli(cli: cli::Cli, bare_has_bin: bool) -> i32 {
             }
         }
         Some(cli::Cmd::Test(t)) => cli::test_runner::run(t),
+        Some(cli::Cmd::Trace(t)) => cli::trace::run(t),
         Some(cli::Cmd::Version) => version_cmd(cli.global.explicit_json()),
         Some(cli::Cmd::Run(r)) => {
             let mode = cli.global.output_mode();

--- a/tests/cli_trace.rs
+++ b/tests/cli_trace.rs
@@ -14,10 +14,7 @@ fn ilo() -> Command {
 }
 
 fn run_args(args: &[&str]) -> (bool, String, String) {
-    let out = ilo()
-        .args(args)
-        .output()
-        .expect("failed to run ilo");
+    let out = ilo().args(args).output().expect("failed to run ilo");
     let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
     let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
     (out.status.success(), stdout, stderr)
@@ -27,13 +24,7 @@ fn run_args(args: &[&str]) -> (bool, String, String) {
 
 #[test]
 fn trace_demo_emits_valid_jsonl() {
-    let (ok, stdout, _stderr) = run_args(&[
-        "trace",
-        "examples/trace-demo.ilo",
-        "add",
-        "3",
-        "4",
-    ]);
+    let (ok, stdout, _stderr) = run_args(&["trace", "examples/trace-demo.ilo", "add", "3", "4"]);
     assert!(ok, "expected exit 0");
 
     // Must have at least one line.
@@ -42,37 +33,39 @@ fn trace_demo_emits_valid_jsonl() {
 
     // Every line must be valid JSON with required keys.
     for line in &lines {
-        let v: serde_json::Value =
-            serde_json::from_str(line).unwrap_or_else(|e| panic!("invalid JSON on line {line:?}: {e}"));
+        let v: serde_json::Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("invalid JSON on line {line:?}: {e}"));
 
         // Required keys.
-        assert!(v.get("schemaVersion").is_some(), "missing schemaVersion in {line}");
-        assert!(v.get("line").is_some(),          "missing line in {line}");
-        assert!(v.get("stmt").is_some(),           "missing stmt in {line}");
-        assert!(v.get("bindings").is_some(),       "missing bindings in {line}");
-        assert!(v.get("result").is_some(),         "missing result in {line}");
+        assert!(
+            v.get("schemaVersion").is_some(),
+            "missing schemaVersion in {line}"
+        );
+        assert!(v.get("line").is_some(), "missing line in {line}");
+        assert!(v.get("stmt").is_some(), "missing stmt in {line}");
+        assert!(v.get("bindings").is_some(), "missing bindings in {line}");
+        assert!(v.get("result").is_some(), "missing result in {line}");
 
         // schemaVersion must be 1.
         assert_eq!(v["schemaVersion"], 1, "schemaVersion must be 1 in {line}");
 
         // line must be a positive integer.
-        let ln = v["line"].as_u64().expect("line must be a non-negative integer");
+        let ln = v["line"]
+            .as_u64()
+            .expect("line must be a non-negative integer");
         assert!(ln > 0, "line number must be > 0, got {ln}");
 
         // bindings must be an object.
-        assert!(v["bindings"].is_object(), "bindings must be an object in {line}");
+        assert!(
+            v["bindings"].is_object(),
+            "bindings must be an object in {line}"
+        );
     }
 }
 
 #[test]
 fn trace_demo_bindings_contain_expected_vars() {
-    let (ok, stdout, _stderr) = run_args(&[
-        "trace",
-        "examples/trace-demo.ilo",
-        "add",
-        "3",
-        "4",
-    ]);
+    let (ok, stdout, _stderr) = run_args(&["trace", "examples/trace-demo.ilo", "add", "3", "4"]);
     assert!(ok, "expected exit 0");
 
     // The last line should have bindings for x, y, a, b and result = 14.

--- a/tests/cli_trace.rs
+++ b/tests/cli_trace.rs
@@ -1,0 +1,111 @@
+// CLI integration tests for `ilo trace` (ILO-72).
+//
+// Tests verify:
+//   - Each output line is valid JSON.
+//   - Each line has the required keys: schemaVersion, line, stmt, bindings, result.
+//   - The schemaVersion is 1.
+//   - The line numbers are positive integers.
+//   - `ilo trace` with no args exits non-zero with usage hint.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_args(args: &[&str]) -> (bool, String, String) {
+    let out = ilo()
+        .args(args)
+        .output()
+        .expect("failed to run ilo");
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    (out.status.success(), stdout, stderr)
+}
+
+// ── trace command: basic JSONL shape ─────────────────────────────────────────
+
+#[test]
+fn trace_demo_emits_valid_jsonl() {
+    let (ok, stdout, _stderr) = run_args(&[
+        "trace",
+        "examples/trace-demo.ilo",
+        "add",
+        "3",
+        "4",
+    ]);
+    assert!(ok, "expected exit 0");
+
+    // Must have at least one line.
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(!lines.is_empty(), "expected at least one trace line");
+
+    // Every line must be valid JSON with required keys.
+    for line in &lines {
+        let v: serde_json::Value =
+            serde_json::from_str(line).unwrap_or_else(|e| panic!("invalid JSON on line {line:?}: {e}"));
+
+        // Required keys.
+        assert!(v.get("schemaVersion").is_some(), "missing schemaVersion in {line}");
+        assert!(v.get("line").is_some(),          "missing line in {line}");
+        assert!(v.get("stmt").is_some(),           "missing stmt in {line}");
+        assert!(v.get("bindings").is_some(),       "missing bindings in {line}");
+        assert!(v.get("result").is_some(),         "missing result in {line}");
+
+        // schemaVersion must be 1.
+        assert_eq!(v["schemaVersion"], 1, "schemaVersion must be 1 in {line}");
+
+        // line must be a positive integer.
+        let ln = v["line"].as_u64().expect("line must be a non-negative integer");
+        assert!(ln > 0, "line number must be > 0, got {ln}");
+
+        // bindings must be an object.
+        assert!(v["bindings"].is_object(), "bindings must be an object in {line}");
+    }
+}
+
+#[test]
+fn trace_demo_bindings_contain_expected_vars() {
+    let (ok, stdout, _stderr) = run_args(&[
+        "trace",
+        "examples/trace-demo.ilo",
+        "add",
+        "3",
+        "4",
+    ]);
+    assert!(ok, "expected exit 0");
+
+    // The last line should have bindings for x, y, a, b and result = 14.
+    let last = stdout.lines().last().expect("at least one line");
+    let v: serde_json::Value = serde_json::from_str(last).unwrap();
+    let bindings = &v["bindings"];
+    assert_eq!(bindings["x"], 3, "x should be 3");
+    assert_eq!(bindings["y"], 4, "y should be 4");
+    assert_eq!(bindings["a"], 7, "a should be 7 (+3 4)");
+    assert_eq!(bindings["b"], 14, "b should be 14 (*a 2)");
+    assert_eq!(v["result"], 14, "final result should be 14");
+}
+
+// ── trace command: no-args usage ──────────────────────────────────────────────
+
+#[test]
+fn trace_no_args_exits_nonzero() {
+    let (ok, _stdout, stderr) = run_args(&["trace"]);
+    assert!(!ok, "expected non-zero exit when no args");
+    assert!(
+        stderr.contains("Usage") || stderr.contains("usage") || stderr.contains("trace"),
+        "expected usage hint in stderr, got: {stderr}"
+    );
+}
+
+// ── trace command: missing file ───────────────────────────────────────────────
+
+#[test]
+fn trace_missing_file_exits_nonzero() {
+    let (ok, _stdout, stderr) = run_args(&["trace", "nonexistent_file_xyz.ilo"]);
+    assert!(!ok, "expected non-zero exit for missing file");
+    assert!(
+        stderr.contains("cannot read") || stderr.contains("No such file") || !stderr.is_empty(),
+        "expected error message, got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `ilo trace <file.ilo> [func] [args...]` subcommand that runs the tree-walking interpreter and emits one JSON line per statement execution
- Each line has schema: `{"schemaVersion":1,"line":N,"stmt":"...","bindings":{...},"result":...}`
- New files: `src/cli/trace.rs`, `examples/trace-demo.ilo`, `tests/cli_trace.rs`, `docs/debugging.md`
- Modified: `src/interpreter/mod.rs` (thread-local trace hook in `eval_body`), `src/cli/args.rs` + `mod.rs`, `src/main.rs` (dispatch arm)

## What shipped

- Full `ilo trace` CLI subcommand
- Statement-level snapshots with line number, source text, bindings, and result value
- `schemaVersion: 1` on every event
- `docs/debugging.md` documenting the schema and `jq` usage
- `examples/trace-demo.ilo` (multi-statement add/multiply example)
- 4 integration tests in `tests/cli_trace.rs` (valid JSONL shape, expected bindings, no-args usage hint, missing-file error)

## What was scaled back

- Expression-level granularity (sub-statement snapshots) — follow-up
- VM/JIT trace path — follow-up
- Watchpoints / conditional breakpoints — v2

## Test plan

- [ ] `cargo test --test cli_trace` — all 4 pass
- [ ] `cargo test --lib` — all 3330 pass, no regressions
- [ ] `ilo trace examples/trace-demo.ilo add 3 4` emits 3 valid JSON lines
- [ ] `ilo trace examples/trace-demo.ilo add 3 4 | jq .bindings` works

Closes ILO-72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)