### PR TITLE
fix: gate named-args desugar on known user fn

### DIFF
--- a/examples/named-args-and-lambda.@
+++ b/examples/named-args-and-lambda.@
@@ -1,0 +1,25 @@
+-- Inline lambdas as the first positional argument to a builtin HOF
+-- (`flt (x:n>b; > x 0) xs`) must still parse, even on the agent-natural
+-- surface where user-fn calls can use named-args (`scale(xs:..., factor:...)`).
+--
+-- The two shapes overlap textually after the callee name (both start
+-- `( Ident :`). The parser disambiguates by checking whether the callee
+-- is a known user-defined function — only then is it a named-args call.
+-- Builtins fall through to positional parsing, so the inline lambda is
+-- parsed as a bare-atom argument.
+--
+-- This file exercises BOTH shapes side by side, so a future parser
+-- refactor can't regress one without the other.
+
+scale factor:n xs:L n>L n
+  map (x:n c:n>n; *x c) factor xs
+
+posnums xs:L n>L n
+  flt (x:n>b; >x 0) xs
+
+main>L n
+  doubled = scale(xs: [1, 2, 3], factor: 2)
+  posnums doubled
+
+-- run: main
+-- out: [2, 4, 6]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3467,10 +3467,20 @@ or write `({fmt_name} \"...\" ...)` so its args are grouped."
             // `Expr::Call`. The verifier and every backend see exactly the
             // same AST as the positional form.
             //
-            // Detection: `( Ident :` immediately after the name. This is
-            // unambiguous at this point because:
-            //   * inline lambdas only appear as bare atoms in `parse_atom`,
-            //     not as callees, so the same shape can't trigger here;
+            // Detection: `( Ident :` immediately after the name, AND `name`
+            // is a known user-defined function (we have its declared param
+            // names). The user-fn gate is load-bearing: without it, an
+            // inline lambda passed as the first positional argument to a
+            // builtin HOF (`flt (x:n>b;x > 0) xs`) gets cannibalised here
+            // because `( Ident :` also opens an inline lambda atom.
+            //
+            // For unknown idents (typo of a user fn) we deliberately fall
+            // through to positional parsing — the natural ILO-T004
+            // "undefined function" at verify time is the same diagnostic
+            // we'd get on a positional call, and is more valuable than
+            // breaking inline-lambda parsing.
+            //
+            // Other ambiguity sources are already ruled out:
             //   * zero-arg `name()` is matched above;
             //   * `(expr)` as a grouped first arg of a positional call never
             //     starts with `Ident :` (the `:` is exclusive to record
@@ -3479,6 +3489,7 @@ or write `({fmt_name} \"...\" ...)` so its args are grouped."
             if self.peek() == Some(&Token::LParen)
                 && matches!(self.token_at(self.pos + 1), Some(Token::Ident(_)))
                 && self.token_at(self.pos + 2) == Some(&Token::Colon)
+                && self.fn_param_names.contains_key(&name)
             {
                 return self.parse_named_args_call(name, unwrap);
             }

--- a/tests/regression_agent_natural.rs
+++ b/tests/regression_agent_natural.rs
@@ -25,6 +25,19 @@ fn run(engine: &str, src: &str, entry: &str, arg: &str) -> String {
     String::from_utf8_lossy(&out.stdout).trim().to_string()
 }
 
+fn run0(engine: &str, src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
 // ── match arm block bodies ──────────────────────────────────────────────────
 //
 // Multi-statement match arm bodies via `pat:{stmt;stmt;expr}` already live in
@@ -233,4 +246,77 @@ fn for_range_matches_at_jit() {
 fn hyphen_ident_with_keyword_prefix_vm() {
     let src = "for-each xs:Lt>t;cat xs \"|\"\ngo s:t>t;ws=spl s \",\";for-each ws\n";
     assert_eq!(run("--vm", src, "go", "a,b,c"), "a|b|c");
+}
+
+// ── named-args desugar must not eat inline lambdas ──────────────────────────
+//
+// Regression for the parser dispatch added in c7b8f8a6. Detection of
+// `name( ident :` for named-args calls also matches the shape of an inline
+// lambda passed as the first positional arg to a builtin HOF
+// (`flt (x:n>b;x > 0) xs`). The fix gates named-args on the callee being a
+// known user-defined function. Builtins and unknown idents fall through to
+// positional parsing.
+//
+// Cross-engine to confirm the parser change produces the same AST every
+// backend already handles for inline lambdas.
+//
+// `(n)>n` etc. is the inline lambda return type. Sources keep the original
+// repro shape (`flt (x:n>b;x > 0) xs`) plus map/fld variants.
+
+const LAMBDA_AS_FIRST_ARG_FLT: &str = "main>L n;flt (x:n>b;>x 0) [-1, 2, -3, 4]\n";
+
+#[test]
+fn lambda_as_first_arg_flt_vm() {
+    assert_eq!(run0("--vm", LAMBDA_AS_FIRST_ARG_FLT, "main"), "[2, 4]");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn lambda_as_first_arg_flt_jit() {
+    assert_eq!(run0("--jit", LAMBDA_AS_FIRST_ARG_FLT, "main"), "[2, 4]");
+}
+
+const LAMBDA_AS_FIRST_ARG_MAP: &str = "main>L n;map (x:n>n;*x 2) [1, 2, 3]\n";
+
+#[test]
+fn lambda_as_first_arg_map_vm() {
+    assert_eq!(run0("--vm", LAMBDA_AS_FIRST_ARG_MAP, "main"), "[2, 4, 6]");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn lambda_as_first_arg_map_jit() {
+    assert_eq!(run0("--jit", LAMBDA_AS_FIRST_ARG_MAP, "main"), "[2, 4, 6]");
+}
+
+const LAMBDA_AS_FIRST_ARG_FLD: &str = "main>n;fld (a:n b:n>n;+a b) [1, 2, 3] 0\n";
+
+#[test]
+fn lambda_as_first_arg_fld_vm() {
+    assert_eq!(run0("--vm", LAMBDA_AS_FIRST_ARG_FLD, "main"), "6");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn lambda_as_first_arg_fld_jit() {
+    assert_eq!(run0("--jit", LAMBDA_AS_FIRST_ARG_FLD, "main"), "6");
+}
+
+// Named-args on a user-defined function must still desugar correctly,
+// AND co-exist with an inline-lambda call to a builtin in the same module.
+
+const NAMED_ARGS_AND_LAMBDA: &str = concat!(
+    "scale factor:n xs:L n>L n;map (x:n c:n>n;*x c) factor xs\n",
+    "main>L n;scale(xs: [1, 2, 3], factor: 10)\n",
+);
+
+#[test]
+fn named_args_coexists_with_lambda_vm() {
+    assert_eq!(run0("--vm", NAMED_ARGS_AND_LAMBDA, "main"), "[10, 20, 30]");
+}
+
+#[test]
+#[cfg(feature = "cranelift")]
+fn named_args_coexists_with_lambda_jit() {
+    assert_eq!(run0("--jit", NAMED_ARGS_AND_LAMBDA, "main"), "[10, 20, 30]");
 }


### PR DESCRIPTION
## Summary

The WIP named-args desugar on `compat/agent-natural` (c7b8f8a6) cannibalised inline-lambda syntax when an inline lambda appeared as the first positional argument to a builtin HOF. The detector matched `( Ident :` after the callee unconditionally, but that same shape also opens an inline lambda atom (`(x:n>b; ...)`). Gating the detector on the callee being a known user fn restores documented behaviour while keeping named-args working on user fns.

## Repro before/after

```
printf 'main>L n;flt (x:n>b;>x 0) [-1, 2, -3, 4]\n' > /tmp/lam.@
ilo /tmp/lam.@ --vm main
```

Before:
```
{"code":"ILO-P023","message":"named-args call on `flt` but no declared parameter names are known", ...}
```

After:
```
[2, 4]
```

Identical on VM and Cranelift JIT.

## What's in the diff

- `fix: gate named-args desugar on known user fn` (parser/mod.rs): adds `&& self.fn_param_names.contains_key(&name)` to the named-args dispatch in `parse_postfix`. Comment expanded to record why the gate is load-bearing and what the fall-through gives for unknown idents (natural ILO-T004 at verify time).
- `test: cover inline lambda as first arg to builtin HOF` (regression_agent_natural.rs + examples/named-args-and-lambda.@): cross-engine tests for flt / map / fld with an inline lambda as the first positional arg, plus a co-existence test mixing named-args on a user fn with an inline-lambda call in the same module. The example file pins both shapes side by side so `examples_engines.rs` runs it on every engine.

For an unknown ident (typo of a user fn) the fall-through gives the same ILO-T004 \"undefined function\" diagnostic a positional call would produce. That's a worthwhile trade for not breaking inline-lambda parsing - the ILO-P023 hint for unknown-fn is lower value than not regressing inline lambdas.

## Test plan

- [x] `cargo build --release --features cranelift`
- [x] `cargo test --release --features cranelift --test regression_agent_natural` (31 passed)
- [x] `cargo test --release --features cranelift` (only pre-existing `post_is_undefined_after_pst_rename` failure, unrelated to this change - the recent muscle-memory aliases commit f0d9682e re-added `post`)
- [x] Manual repro: `flt`, `map`, `fld` with inline lambda as first arg all return correct results on `--vm` and `--jit`
- [x] `examples/named-args-and-lambda.@` runs on `--vm` and `--jit`

## Follow-ups

- No doc update needed because this restores pre-regression behaviour; SPEC.md / ai.txt / skills/ilo/SKILL.md surface is unchanged.
- The `post_is_undefined_after_pst_rename` test breakage on this branch is independent and should be fixed in a separate commit (the test predates the muscle-memory alias additions and now contradicts them).