### PR TITLE
Lift map/flt/fld closure-bind to native VM dispatch (PR A of ILO-45)

### DIFF
--- a/examples/closure-bind.@
+++ b/examples/closure-bind.@
@@ -21,10 +21,24 @@ prices pm:M t n syms:L t>L n;map look pm syms
 
 prices-demo>L n;m=mset mmap "a" 10;m=mset m "b" 20;prices m ["a","b","a"]
 
--- jit lacks HOF dispatch entirely (see regression_builtins_as_hof.rs).
--- vm + cranelift route closure-bind through the tree-bridge from PR 3c.
--- engine-skip: jit
+-- flt closure-bind: keep elements above a threshold.
+above x:n t:n>b;x > t
+keep-above t:n xs:L n>L n;flt above t xs
+above-demo>L n;keep-above 2 [1,2,3,4,5]
+
+-- fld closure-bind: weighted sum. fn signature is (acc, item, ctx).
+wadd acc:n item:n w:n>n;acc + item * w
+weighted xs:L n w:n>n;fld wadd w xs 0
+weighted-demo>n;weighted [1,2,3,4,5] 2
+
+-- PR A of ILO-45 lifted map/flt/fld closure-bind off the tree-bridge to
+-- native OP_CALL_DYN with argc=2 (map/flt) and argc=3 (fld). srt 3-arg
+-- closure-bind still bridges pending PR B's finalizer-opcode extension.
 -- run: main
 -- out: [c, a, b]
 -- run: prices-demo
 -- out: [10, 20, 10]
+-- run: above-demo
+-- out: [3, 4, 5]
+-- run: weighted-demo
+-- out: 30

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -677,12 +677,11 @@ pub(crate) fn is_tree_bridge_eligible(b: crate::builtins::Builtin, argc: usize) 
         // natively via OP_CALL_DYN + OP_ISERR short-circuit + OP_WRAPOK so
         // closure callbacks dispatch without a tree re-entry. See the
         // matching arm in the compiler.
-        // Closure-bind ctx variants. The fn receives an extra ctx arg the
-        // native emitters don't shape today — bridge keeps semantics aligned
-        // with the tree interpreter and adds VM/Cranelift coverage in PR 3c.
-        (Builtin::Map, 3) => true,
-        (Builtin::Flt, 3) => true,
-        (Builtin::Fld, 4) => true,
+        // Closure-bind ctx variants. PR A of ILO-45 (2026-05-22) lifted
+        // map/flt/fld off the bridge to native VM dispatch via 2- and 3-arg
+        // OP_CALL_DYN — Cranelift inherits via the existing OP_CALL_DYN
+        // codegen. srt 3 and rsrt 3 still bridge pending a finalizer-opcode
+        // extension (PR B).
         (Builtin::Srt, 3) => true,
         // rsrt fn ctx xs — closure-bind descending sort. Same bridge
         // contract as srt 3-arg.
@@ -4788,6 +4787,69 @@ impl RegCompiler {
                             self.next_reg = acc_reg + 1;
                             return acc_reg;
                         }
+                        // map fn ctx xs → closure-bind variant. Per-iter call is
+                        // 2-arg: fn(item, ctx). Reg window after res: arg0=item,
+                        // arg1=ctx, argc=2. OP_CALL_DYN's closure path auto-appends
+                        // any trailing captures after these two user args (see
+                        // src/vm/mod.rs:9785). Lifted off the tree-bridge in PR A
+                        // of ILO-45 — matches runtime/mod.rs:5737 call_args order.
+                        (Builtin::Map, 3) => {
+                            let fn_reg = self.compile_expr(&args[0]);
+                            let ctx_reg = self.compile_expr(&args[1]);
+                            let xs_reg = self.compile_expr(&args[2]);
+
+                            let acc_reg = self.alloc_reg();
+                            self.emit_abx(OP_LISTNEW, acc_reg, 0);
+
+                            let idx_reg = self.alloc_reg();
+                            let zero_ki = self.current.add_const(Value::Number(0.0));
+                            self.emit_abx(OP_LOADK, idx_reg, zero_ki);
+                            self.reg_is_num[idx_reg as usize] = true;
+
+                            let item_reg = self.alloc_reg();
+                            let nil_ki = self.current.add_const(Value::Nil);
+                            self.emit_abx(OP_LOADK, item_reg, nil_ki);
+
+                            // OP_CALL_DYN reads R[A+1..=A+argc]; argc=2 needs three
+                            // contiguous regs: res, arg0 (item), arg1 (ctx).
+                            let res_reg = self.alloc_reg();
+                            self.emit_abx(OP_LOADK, res_reg, nil_ki);
+                            let arg0_reg = self.alloc_reg();
+                            assert!(
+                                arg0_reg == res_reg + 1,
+                                "map ctx HOF: arg0 reg must follow result reg contiguously"
+                            );
+                            self.emit_abx(OP_LOADK, arg0_reg, nil_ki);
+                            let arg1_reg = self.alloc_reg();
+                            assert!(
+                                arg1_reg == arg0_reg + 1,
+                                "map ctx HOF: arg1 reg must follow arg0 reg contiguously"
+                            );
+                            self.emit_abx(OP_LOADK, arg1_reg, nil_ki);
+
+                            let _loop_top = self.current.code.len();
+                            self.emit_abc(OP_FOREACHPREP, item_reg, xs_reg, idx_reg);
+                            let exit_jump_a = self.emit_jmp_placeholder();
+
+                            let body_top = self.current.code.len();
+                            self.emit_abc(OP_MOVE, arg0_reg, item_reg, 0);
+                            self.emit_abc(OP_MOVE, arg1_reg, ctx_reg, 0);
+                            self.emit_abc(OP_CALL_DYN, res_reg, fn_reg, 2);
+                            self.emit_abc(OP_LISTAPPEND, acc_reg, acc_reg, res_reg);
+
+                            self.emit_abc(OP_FOREACHNEXT, item_reg, xs_reg, idx_reg);
+                            let exit_jump_b = self.emit_jmp_placeholder();
+                            self.emit_jump_to(body_top);
+
+                            self.current.patch_jump(exit_jump_a);
+                            self.current.patch_jump(exit_jump_b);
+
+                            self.current_all_regs_numeric = false;
+                            self.reg_is_num[acc_reg as usize] = false;
+
+                            self.next_reg = acc_reg + 1;
+                            return acc_reg;
+                        }
                         // flt fn xs → native HOF loop using OP_CALL_DYN.
                         // Same shape as `map` but:
                         //   - the call result drives a bool typecheck (OP_ISBOOL)
@@ -4931,6 +4993,82 @@ impl RegCompiler {
                             self.next_reg = acc_reg + 1;
                             return acc_reg;
                         }
+                        // flt fn ctx xs → closure-bind variant. Per-iter call is
+                        // 2-arg: fn(item, ctx) → bool. Same bool-check + conditional
+                        // append as flt 2. Lifted off the tree-bridge in PR A of
+                        // ILO-45.
+                        (Builtin::Flt, 3) => {
+                            let fn_reg = self.compile_expr(&args[0]);
+                            let ctx_reg = self.compile_expr(&args[1]);
+                            let xs_reg = self.compile_expr(&args[2]);
+
+                            let acc_reg = self.alloc_reg();
+                            self.emit_abx(OP_LISTNEW, acc_reg, 0);
+
+                            let idx_reg = self.alloc_reg();
+                            let zero_ki = self.current.add_const(Value::Number(0.0));
+                            self.emit_abx(OP_LOADK, idx_reg, zero_ki);
+                            self.reg_is_num[idx_reg as usize] = true;
+
+                            let item_reg = self.alloc_reg();
+                            let nil_ki = self.current.add_const(Value::Nil);
+                            self.emit_abx(OP_LOADK, item_reg, nil_ki);
+
+                            let res_reg = self.alloc_reg();
+                            self.emit_abx(OP_LOADK, res_reg, nil_ki);
+                            let arg0_reg = self.alloc_reg();
+                            assert!(
+                                arg0_reg == res_reg + 1,
+                                "flt ctx HOF: arg0 reg must follow result reg contiguously"
+                            );
+                            self.emit_abx(OP_LOADK, arg0_reg, nil_ki);
+                            let arg1_reg = self.alloc_reg();
+                            assert!(
+                                arg1_reg == arg0_reg + 1,
+                                "flt ctx HOF: arg1 reg must follow arg0 reg contiguously"
+                            );
+                            self.emit_abx(OP_LOADK, arg1_reg, nil_ki);
+
+                            // Scratch for the bool typecheck.
+                            let isb_reg = self.alloc_reg();
+                            self.emit_abx(OP_LOADK, isb_reg, nil_ki);
+
+                            let _loop_top = self.current.code.len();
+                            self.emit_abc(OP_FOREACHPREP, item_reg, xs_reg, idx_reg);
+                            let exit_jump_a = self.emit_jmp_placeholder();
+
+                            let body_top = self.current.code.len();
+                            self.emit_abc(OP_MOVE, arg0_reg, item_reg, 0);
+                            self.emit_abc(OP_MOVE, arg1_reg, ctx_reg, 0);
+                            self.emit_abc(OP_CALL_DYN, res_reg, fn_reg, 2);
+
+                            self.emit_abc(OP_ISBOOL, isb_reg, res_reg, 0);
+                            let typeok_jump = self.emit_jmpt(isb_reg);
+                            let err_text_ki = self.current.add_const(Value::Text(Arc::new(
+                                "flt: predicate must return bool".to_string(),
+                            )));
+                            self.emit_abx(OP_LOADK, arg0_reg, err_text_ki);
+                            self.emit_abc(OP_WRAPERR, arg0_reg, arg0_reg, 0);
+                            self.emit_abc(OP_PANIC_UNWRAP, 0, arg0_reg, 0);
+                            self.current.patch_jump(typeok_jump);
+
+                            let skip_append_jump = self.emit_jmpf(res_reg);
+                            self.emit_abc(OP_LISTAPPEND, acc_reg, acc_reg, item_reg);
+                            self.current.patch_jump(skip_append_jump);
+
+                            self.emit_abc(OP_FOREACHNEXT, item_reg, xs_reg, idx_reg);
+                            let exit_jump_b = self.emit_jmp_placeholder();
+                            self.emit_jump_to(body_top);
+
+                            self.current.patch_jump(exit_jump_a);
+                            self.current.patch_jump(exit_jump_b);
+
+                            self.current_all_regs_numeric = false;
+                            self.reg_is_num[acc_reg as usize] = false;
+
+                            self.next_reg = acc_reg + 1;
+                            return acc_reg;
+                        }
                         // fld fn xs init → native HOF loop using OP_CALL_DYN.
                         // The accumulator carries the running value across
                         // iterations. Per-iter call is 2-arg: fn(acc, item).
@@ -4983,6 +5121,76 @@ impl RegCompiler {
                             self.emit_abc(OP_MOVE, arg1_reg, item_reg, 0);
                             self.emit_abc(OP_CALL_DYN, res_reg, fn_reg, 2);
                             // acc = res (refresh the accumulator)
+                            self.emit_abc(OP_MOVE, acc_reg, res_reg, 0);
+
+                            self.emit_abc(OP_FOREACHNEXT, item_reg, xs_reg, idx_reg);
+                            let exit_jump_b = self.emit_jmp_placeholder();
+                            self.emit_jump_to(body_top);
+
+                            self.current.patch_jump(exit_jump_a);
+                            self.current.patch_jump(exit_jump_b);
+
+                            self.current_all_regs_numeric = false;
+                            self.reg_is_num[acc_reg as usize] = false;
+
+                            self.next_reg = acc_reg + 1;
+                            return acc_reg;
+                        }
+                        // fld fn ctx xs init → closure-bind variant. Per-iter call
+                        // is 3-arg: fn(acc, item, ctx). Layout: res, arg0=acc,
+                        // arg1=item, arg2=ctx, argc=3. Lifted off the tree-bridge
+                        // in PR A of ILO-45.
+                        (Builtin::Fld, 4) => {
+                            let fn_reg = self.compile_expr(&args[0]);
+                            let ctx_reg = self.compile_expr(&args[1]);
+                            let xs_reg = self.compile_expr(&args[2]);
+                            let init_reg = self.compile_expr(&args[3]);
+
+                            let acc_reg = self.alloc_reg();
+                            self.emit_abc(OP_MOVE, acc_reg, init_reg, 0);
+                            self.reg_is_num[acc_reg as usize] = false;
+
+                            let idx_reg = self.alloc_reg();
+                            let zero_ki = self.current.add_const(Value::Number(0.0));
+                            self.emit_abx(OP_LOADK, idx_reg, zero_ki);
+                            self.reg_is_num[idx_reg as usize] = true;
+
+                            let item_reg = self.alloc_reg();
+                            let nil_ki = self.current.add_const(Value::Nil);
+                            self.emit_abx(OP_LOADK, item_reg, nil_ki);
+
+                            // OP_CALL_DYN reads R[A+1..=A+argc]; argc=3 needs four
+                            // contiguous regs: res, arg0 (acc), arg1 (item), arg2 (ctx).
+                            let res_reg = self.alloc_reg();
+                            self.emit_abx(OP_LOADK, res_reg, nil_ki);
+                            let arg0_reg = self.alloc_reg();
+                            assert!(
+                                arg0_reg == res_reg + 1,
+                                "fld ctx HOF: arg0 reg must follow result reg contiguously"
+                            );
+                            self.emit_abx(OP_LOADK, arg0_reg, nil_ki);
+                            let arg1_reg = self.alloc_reg();
+                            assert!(
+                                arg1_reg == arg0_reg + 1,
+                                "fld ctx HOF: arg1 reg must follow arg0 reg contiguously"
+                            );
+                            self.emit_abx(OP_LOADK, arg1_reg, nil_ki);
+                            let arg2_reg = self.alloc_reg();
+                            assert!(
+                                arg2_reg == arg1_reg + 1,
+                                "fld ctx HOF: arg2 reg must follow arg1 reg contiguously"
+                            );
+                            self.emit_abx(OP_LOADK, arg2_reg, nil_ki);
+
+                            let _loop_top = self.current.code.len();
+                            self.emit_abc(OP_FOREACHPREP, item_reg, xs_reg, idx_reg);
+                            let exit_jump_a = self.emit_jmp_placeholder();
+
+                            let body_top = self.current.code.len();
+                            self.emit_abc(OP_MOVE, arg0_reg, acc_reg, 0);
+                            self.emit_abc(OP_MOVE, arg1_reg, item_reg, 0);
+                            self.emit_abc(OP_MOVE, arg2_reg, ctx_reg, 0);
+                            self.emit_abc(OP_CALL_DYN, res_reg, fn_reg, 3);
                             self.emit_abc(OP_MOVE, acc_reg, res_reg, 0);
 
                             self.emit_abc(OP_FOREACHNEXT, item_reg, xs_reg, idx_reg);


### PR DESCRIPTION
## Summary

PR A of ILO-45 — first slice of the actual tree-walker eval-loop deletion. Lifts `map fn ctx xs` / `flt fn ctx xs` / `fld fn ctx xs init` from tree-bridge dispatch to native VM dispatch via `OP_CALL_DYN`. Cranelift inherits via the existing `jit_call_dyn` helper.

The bridge for these three HOFs called `eval_body` (the tree-walker's expression evaluator) per-element to run the user's closure-bind callback. After this PR they dispatch natively. Three down, five HOFs (`srt 3`, `rsrt 2`, `rsrt 3`, `ct 2`, `ct 3`) plus the non-HOF bridge entries to go before the eval loop can actually be deleted.

## Why now

PR #613 shipped the user-visible promise (no `Engine::Tree`, no `--run-tree`, runtime renamed) but kept `eval_body` alive because the bridge for closure-bind HOFs called into it. This PR starts unwinding that dependency.

ILO-234's "bridge is the right abstraction" framing held for non-HOF builtins (regex / fmt / fs / crypto / calendar — cheap round-trip, no eval involvement). For HOFs the round-trip goes through `call_function` → `eval_body`, which is the load-bearing path that keeps the tree-walker alive. Lifting these natively is the only way to actually delete it.

## What's in the diff

Single commit, two files:

- `src/vm/mod.rs`
  - Three new arms in `compile_call`: `(Builtin::Map, 3)`, `(Builtin::Flt, 3)`, `(Builtin::Fld, 4)`. Each emits `OP_FOREACHPREP` / `OP_CALL_DYN` / `OP_LISTAPPEND` (or fld's accumulator refresh) in the same shape as the existing 2-arg arms. Reg layout: res + 2 or 3 contiguous arg slots. flt 3 keeps the bool typecheck + WRAPERR/PANIC_UNWRAP error path from flt 2.
  - `is_tree_bridge_eligible`: dropped the three entries; `Srt, 3` and `Rsrt, 3` retained pending PR B.
- `examples/closure-bind.@`
  - Lifted `engine-skip: jit` directive (closure-bind HOFs now work on JIT)
  - Added `above-demo` (flt 3) and `weighted-demo` (fld 4) with assertable output

Cranelift inherits via the existing OP_CALL_DYN codegen — no Cranelift changes needed.

## Test plan

- [x] `cargo test --release --features cranelift` — full suite green, 3348+ unit tests pass, no regressions
- [x] `examples/closure-bind.@` runs identically across default / `--vm` / `--jit` for all four demo functions
- [x] `cargo test --release --features cranelift --test examples_engines` passes
- [x] rust-review subagent run on the diff — no blockers found

## Follow-ups

- **PR B**: `srt 3` / `rsrt 2` / `rsrt 3` — needs `OP_SRT_BY_KEY` desc-flag extension or new `OP_RSRT_BY_KEY`
- **PR C**: `ct 2` / `ct 3` — needs finalizer or inline counter loop
- **PR D**: audit non-HOF bridge entries (regex/fmt/fs/crypto/calendar/etc) for transitive `eval_body` reachability and lift any that need it
- **PR E**: actual deletion of `eval_body`/`eval_stmt`/`eval_expr`/`Env`/trampoline/`ACTIVE_AST_PROGRAM` (headline LoC win)