### PR TITLE
feat: generics multiple-bound conjunctions (ILO-386)

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -127,15 +127,19 @@ pub struct Param {
 pub enum Decl {
     /// `name<a:Comparable b> params>return;body`
     /// `type_params` holds bounded generic type-variable declarations.
-    /// Syntax: `<letter>` or `<letter:Bound>`, space-separated inside `<...>`.
-    /// When absent the vec is empty and existing `a`/`b`/etc. type-variable
-    /// behaviour (treat as Unknown / accept any type) is preserved.
+    /// Syntax: `<letter>` or `<letter:Bound1+Bound2>`, space-separated inside
+    /// `<...>`.  Multiple bounds are joined with `+` (conjunction): the type
+    /// variable must satisfy ALL listed bounds.  When absent the vec is empty
+    /// and existing `a`/`b`/etc. type-variable behaviour (treat as Unknown /
+    /// accept any type) is preserved.
     Function {
         name: String,
-        /// Generic type-variable declarations: `<a:Comparable b:Numeric c>`.
-        /// Empty means no explicit generic params (legacy behaviour).
+        /// Generic type-variable declarations: `<a:Comparable b:Numeric+Comparable c>`.
+        /// Each entry is `(var_name, bounds)` where `bounds` is a conjunction
+        /// (all must be satisfied).  Empty bounds list means `Any`.
+        /// Empty outer vec means no explicit generic params (legacy behaviour).
         #[serde(skip)]
-        type_params: Vec<(String, Bound)>,
+        type_params: Vec<(String, Vec<Bound>)>,
         params: Vec<Param>,
         return_type: Type,
         body: Vec<Spanned<Stmt>>,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1334,15 +1334,17 @@ impl Parser {
 
     /// Parse optional generic type-parameter block: `<a:Comparable b:Numeric c>`.
     ///
-    /// Syntax: `<` ( letter ( `:` bound )? )+ `>` where `letter` is a single
-    /// lowercase ASCII letter (the type-variable name) and `bound` is one of
-    /// `Comparable`, `Numeric`, `Text`, or `Any`.
+    /// Syntax: `<` ( letter ( `:` bound ( `+` bound )* )? )+ `>` where
+    /// `letter` is a single lowercase ASCII letter (the type-variable name)
+    /// and `bound` is one of `comparable`, `numeric`, `text`, or `any`.
+    /// Multiple bounds joined with `+` form a conjunction: the type variable
+    /// must satisfy ALL of them.
     ///
     /// Returns an empty vec if the next token is not `<`.
-    /// Emits `ILO-P022` for malformed type-param blocks and returns the empty vec
-    /// on error (the declaration continues; the type checker will treat all vars
-    /// as `Any`-bounded).
-    fn parse_type_params(&mut self) -> Result<Vec<(String, crate::ast::Bound)>> {
+    /// Emits `ILO-P022` for malformed type-param blocks and returns the empty
+    /// vec on error (the declaration continues; the type checker will treat all
+    /// vars as `Any`-bounded).
+    fn parse_type_params(&mut self) -> Result<Vec<(String, Vec<crate::ast::Bound>)>> {
         use crate::ast::Bound;
         if self.peek() != Some(&Token::Less) {
             return Ok(vec![]);
@@ -1359,38 +1361,50 @@ impl Parser {
                 Some(Token::Ident(ref name)) if name.len() == 1 && name.chars().next().map_or(false, |c| c.is_lowercase()) => {
                     let var_name = name.clone();
                     self.advance();
-                    let bound = if self.peek() == Some(&Token::Colon) {
+                    let bounds = if self.peek() == Some(&Token::Colon) {
                         self.advance(); // consume `:`
-                        match self.peek().cloned() {
-                            Some(Token::Ident(ref b)) => {
-                                let bound = match b.as_str() {
-                                    "comparable" => Bound::Comparable,
-                                    "numeric" => Bound::Numeric,
-                                    "text" => Bound::Text,
-                                    "any" => Bound::Any,
-                                    other => {
-                                        return Err(self.error_hint(
-                                            "ILO-P022",
-                                            format!("unknown bound '{other}' — expected comparable, numeric, text, or any"),
-                                            "write `<a:comparable>` or `<a:numeric>` etc.".to_string(),
-                                        ));
+                        // Parse first bound
+                        let mut bounds = Vec::new();
+                        loop {
+                            match self.peek().cloned() {
+                                Some(Token::Ident(ref b)) => {
+                                    let bound = match b.as_str() {
+                                        "comparable" => Bound::Comparable,
+                                        "numeric" => Bound::Numeric,
+                                        "text" => Bound::Text,
+                                        "any" => Bound::Any,
+                                        other => {
+                                            return Err(self.error_hint(
+                                                "ILO-P022",
+                                                format!("unknown bound '{other}' — expected comparable, numeric, text, or any"),
+                                                "write `<a:comparable>` or `<a:numeric+comparable>` etc.".to_string(),
+                                            ));
+                                        }
+                                    };
+                                    self.advance();
+                                    bounds.push(bound);
+                                    // Check for `+` to continue conjunction
+                                    if self.peek() == Some(&Token::Plus) {
+                                        self.advance(); // consume `+`
+                                        // Loop to parse next bound
+                                    } else {
+                                        break;
                                     }
-                                };
-                                self.advance();
-                                bound
-                            }
-                            _ => {
-                                return Err(self.error_hint(
-                                    "ILO-P022",
-                                    "expected bound name after ':'".to_string(),
-                                    "valid bounds: comparable, numeric, text, any".to_string(),
-                                ));
+                                }
+                                _ => {
+                                    return Err(self.error_hint(
+                                        "ILO-P022",
+                                        "expected bound name after ':' or '+'".to_string(),
+                                        "valid bounds: comparable, numeric, text, any".to_string(),
+                                    ));
+                                }
                             }
                         }
+                        bounds
                     } else {
-                        Bound::Any
+                        vec![Bound::Any]
                     };
-                    params.push((var_name, bound));
+                    params.push((var_name, bounds));
                 }
                 Some(Token::Greater) => {
                     // handled by loop condition; shouldn't reach here
@@ -1401,7 +1415,7 @@ impl Parser {
                     return Err(self.error_hint(
                         "ILO-P022",
                         "expected single-letter type variable in generic param list".to_string(),
-                        "write `<a>` or `<a:Comparable>` — type variables must be single lowercase letters".to_string(),
+                        "write `<a>` or `<a:comparable>` or `<a:numeric+comparable>` — type variables must be single lowercase letters".to_string(),
                     ));
                 }
             }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -87,7 +87,7 @@ struct FuncSig {
     /// `Decl::Function::type_params`. Empty for functions with no generic
     /// type param block (legacy behaviour: type vars remain `Ty::Unknown`,
     /// compatible with anything).
-    type_bounds: std::collections::HashMap<String, crate::ast::Bound>,
+    type_bounds: std::collections::HashMap<String, Vec<crate::ast::Bound>>,
 }
 
 #[derive(Clone)]
@@ -4058,7 +4058,7 @@ impl VerifyContext {
                         .collect();
                     let ret = convert_type_with_aliases(return_type, &self.aliases);
                     self.validate_named_types_in_sig(name, &converted_params, &ret);
-                    let type_bounds: std::collections::HashMap<String, crate::ast::Bound> =
+                    let type_bounds: std::collections::HashMap<String, Vec<crate::ast::Bound>> =
                         type_params.iter().cloned().collect();
                     self.functions.insert(
                         name.clone(),
@@ -5166,40 +5166,42 @@ impl VerifyContext {
                                     && letter.chars().next().map_or(false, |c| c.is_lowercase())
                                     && !matches!(letter.as_str(), "n" | "t" | "b")
                                 {
-                                    // Check bound satisfaction first
-                                    if let Some(bound) = type_bounds.get(letter) {
-                                        let satisfies = match bound {
-                                            crate::ast::Bound::Any => true,
-                                            crate::ast::Bound::Comparable => matches!(
-                                                arg_ty,
-                                                Ty::Number | Ty::Text | Ty::Bool | Ty::Unknown
-                                            ),
-                                            crate::ast::Bound::Numeric => {
-                                                matches!(arg_ty, Ty::Number | Ty::Unknown)
-                                            }
-                                            crate::ast::Bound::Text => {
-                                                matches!(arg_ty, Ty::Text | Ty::Unknown)
-                                            }
-                                        };
-                                        if !satisfies {
-                                            self.err(
-                                                "ILO-T044",
-                                                func,
-                                                format!(
-                                                    "type argument for generic '{letter}' in '{}' must satisfy bound {bound}, got {arg_ty}",
-                                                    callee
+                                    // Check bound satisfaction for all bounds in the conjunction
+                                    if let Some(bounds) = type_bounds.get(letter) {
+                                        for bound in bounds {
+                                            let satisfies = match bound {
+                                                crate::ast::Bound::Any => true,
+                                                crate::ast::Bound::Comparable => matches!(
+                                                    arg_ty,
+                                                    Ty::Number | Ty::Text | Ty::Bool | Ty::Unknown
                                                 ),
-                                                Some(format!(
-                                                    "bound {bound} allows: {}",
-                                                    match bound {
-                                                        crate::ast::Bound::Comparable => "n, t, b",
-                                                        crate::ast::Bound::Numeric => "n",
-                                                        crate::ast::Bound::Text => "t",
-                                                        crate::ast::Bound::Any => "any type",
-                                                    }
-                                                )),
-                                                Some(span),
-                                            );
+                                                crate::ast::Bound::Numeric => {
+                                                    matches!(arg_ty, Ty::Number | Ty::Unknown)
+                                                }
+                                                crate::ast::Bound::Text => {
+                                                    matches!(arg_ty, Ty::Text | Ty::Unknown)
+                                                }
+                                            };
+                                            if !satisfies {
+                                                self.err(
+                                                    "ILO-T044",
+                                                    func,
+                                                    format!(
+                                                        "type argument for generic '{letter}' in '{}' must satisfy bound {bound}, got {arg_ty}",
+                                                        callee
+                                                    ),
+                                                    Some(format!(
+                                                        "bound {bound} allows: {}",
+                                                        match bound {
+                                                            crate::ast::Bound::Comparable => "n, t, b",
+                                                            crate::ast::Bound::Numeric => "n",
+                                                            crate::ast::Bound::Text => "t",
+                                                            crate::ast::Bound::Any => "any type",
+                                                        }
+                                                    )),
+                                                    Some(span),
+                                                );
+                                            }
                                         }
                                     }
                                     // Check cross-call-site consistency

--- a/tests/regression_generics_multibound.rs
+++ b/tests/regression_generics_multibound.rs
@@ -1,0 +1,131 @@
+// Regression tests for multiple-bound conjunctions on generic type variables
+// (ILO-386).
+//
+// Syntax: `<a:numeric+comparable>` — the type variable `a` must satisfy BOTH
+// `numeric` AND `comparable`. This is an intersection of bounds, not a union.
+//
+// This extends ILO-61 (single-bound generics) and ILO-385 (generic return
+// types).
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+/// Run inline snippet with entry-point, assert success, return stdout.
+fn run_ok(src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, entry])
+        .output()
+        .expect("failed to spawn ilo");
+    assert!(
+        out.status.success(),
+        "expected success for snippet {src:?} entry={entry}\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Run inline snippet and assert failure with specific error code in stderr.
+fn assert_error(src: &str, expected_code: &str) {
+    // First ident before `<` or space is the entry function name.
+    let entry = src
+        .find(|c: char| !c.is_ascii_alphabetic() && c != '-')
+        .map(|i| &src[..i])
+        .unwrap_or("f");
+    // Collect entry from the `main` function if present.
+    let entry = if src.contains("main>") { "main" } else { entry };
+    let out = ilo()
+        .args([src, entry])
+        .output()
+        .expect("failed to spawn ilo");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "expected failure for snippet {src:?} (code {expected_code}), but succeeded"
+    );
+    assert!(
+        stderr.contains(expected_code),
+        "expected {expected_code} in stderr for snippet {src:?}\nstderr was:\n{stderr}"
+    );
+}
+
+// ---- Acceptance: numeric+comparable accepts `n` (satisfies both) ----
+
+#[test]
+fn multibound_call_with_number() {
+    // `n` satisfies both `numeric` and `comparable`.
+    let src = "double<a:numeric+comparable> x:a>a;+ x x\nmain>n;double 7";
+    assert_eq!(run_ok(src, "main"), "14");
+}
+
+#[test]
+fn multibound_identity_numeric_comparable() {
+    let src = "f<a:numeric+comparable> x:a>a;x\nmain>n;f 42";
+    assert_eq!(run_ok(src, "main"), "42");
+}
+
+// ---- Rejection: numeric+comparable rejects `t` (fails numeric) ----
+
+#[test]
+fn multibound_numeric_comparable_rejects_t() {
+    // `t` satisfies `comparable` but NOT `numeric` — should fail ILO-T044.
+    let src = "f<a:numeric+comparable> x:a>a;x\nmain>t;f \"hello\"";
+    assert_error(src, "ILO-T044");
+}
+
+// ---- Rejection: numeric+text rejects `b` (fails both numeric and text) ----
+
+#[test]
+fn multibound_numeric_text_rejects_b() {
+    // `b` (bool) satisfies neither numeric nor text.
+    let src = "f<a:numeric+text> x:a>a;x\nmain>b;f true";
+    assert_error(src, "ILO-T044");
+}
+
+// ---- Three-bound conjunction: numeric+comparable+text (impossible to satisfy) ----
+
+#[test]
+fn multibound_three_way_impossible_with_n() {
+    // `n` satisfies numeric and comparable but NOT text.
+    let src = "f<a:numeric+comparable+text> x:a>a;x\nmain>n;f 1";
+    assert_error(src, "ILO-T044");
+}
+
+#[test]
+fn multibound_three_way_impossible_with_t() {
+    // `t` satisfies comparable and text but NOT numeric.
+    let src = "f<a:numeric+comparable+text> x:a>a;x\nmain>t;f \"hi\"";
+    assert_error(src, "ILO-T044");
+}
+
+// ---- Parsing: single bound still works (no regression) ----
+
+#[test]
+fn single_bound_no_regression() {
+    let src = "inc<a:numeric> x:a>a;+ x 1\nmain>n;inc 5";
+    assert_eq!(run_ok(src, "main"), "6");
+}
+
+// ---- Parsing: unbounded type variable still works ----
+
+#[test]
+fn unbound_type_var_no_regression() {
+    let src = "ident<a> x:a>a;x\nmain>n;ident 99";
+    assert_eq!(run_ok(src, "main"), "99");
+}
+
+// ---- Comparable+numeric = same as numeric+comparable (order should not matter) ----
+
+#[test]
+fn multibound_order_comparable_then_numeric() {
+    let src = "f<a:comparable+numeric> x:a>a;x\nmain>n;f 5";
+    assert_eq!(run_ok(src, "main"), "5");
+}
+
+#[test]
+fn multibound_order_comparable_then_numeric_rejects_t() {
+    let src = "f<a:comparable+numeric> x:a>a;x\nmain>t;f \"x\"";
+    assert_error(src, "ILO-T044");
+}


### PR DESCRIPTION
## Summary

- Extends bounded generics (ILO-61, #620) to support **conjunctions of bounds** with `+` syntax: `<a:numeric+comparable>` means `a` must satisfy ALL listed bounds (intersection, not union).
- Builds on ILO-385 (#628) generic return-type substitution.

## Changes

**`src/ast/mod.rs`**: `type_params` field changed from `Vec<(String, Bound)>` to `Vec<(String, Vec<Bound>)>` — each type variable carries a conjunction of bounds.

**`src/parser/mod.rs`**: After consuming the first bound name, loops consuming `+` + another bound ident to build the conjunction. No tokenizer changes needed — `Token::Plus` already existed.

**`src/verify.rs`**: `type_bounds` map now holds `Vec<Bound>`; call-site bound checker iterates all bounds in the conjunction and emits `ILO-T044` for each unsatisfied one.

**`tests/regression_generics_multibound.rs`**: 10 regression tests covering:
- Acceptance: `n` satisfies `numeric+comparable`
- Rejection: `t` fails `numeric` in `numeric+comparable`
- Rejection: `b` fails both bounds in `numeric+text`
- Three-bound impossible conjunctions (`numeric+comparable+text`)
- Order independence (`comparable+numeric` behaves same as `numeric+comparable`)
- Regressions: single-bound and unbounded type vars still work

## Test plan

- [x] `cargo test --test regression_generics_multibound` — 10/10 pass
- [x] `cargo test --lib` — 3342/3342 pass
- [ ] Full integration test suite

Closes ILO-386

🤖 Generated with [Claude Code](https://claude.com/claude-code)