### PR TITLE
feat(httpd): wire --allow-net cap check (ILO-381)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -272,6 +272,11 @@ pub struct HttpdArgs {
 
     /// Name of the handler function (default: `handler`).
     pub func: Option<String>,
+
+    /// Grant network access (required to bind a port).
+    /// Comma-separated list of hosts, `*` for all, or omit to deny.
+    #[arg(long)]
+    pub allow_net: Option<String>,
 }
 
 // ── Tools ──────────────────────────────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -930,16 +930,22 @@ fn collect_mcp_tool_decls(path: Option<&str>) -> Result<Vec<ast::Decl>, String> 
 // One thread is spawned per accepted connection (minimal thread-per-request
 // pool). No async runtime is required — the ilo interpreter is synchronous.
 //
-// TODO(ILO-59): add --allow-net cap check once the cap-flags PR lands.
+// Cap check is performed inside `httpd_cmd` before binding the socket.
 
 /// Request bodies larger than this byte threshold are presented to the handler
 /// as a `Value::List` of text lines (`L t`) rather than a single `Value::Text`.
 /// Handlers iterate with `@line req.body`; small bodies remain a plain `t`.
 const LAZY_BODY_THRESHOLD: usize = 65_536; // 64 KiB
 
-fn httpd_cmd(port: u16, handler_file: &str, func_name: &str) -> i32 {
+fn httpd_cmd(port: u16, handler_file: &str, func_name: &str, caps: &Caps) -> i32 {
     use std::net::TcpListener;
     use std::sync::Arc;
+
+    // ── Capability check — must have --allow-net to bind a port ──────────────
+    if let Err(_) = caps.check_net("0.0.0.0") {
+        eprintln!("error: ilo httpd needs --allow-net to listen on a port");
+        return 1;
+    }
 
     // ── Load and compile the handler program once ─────────────────────────────
     let source = match std::fs::read_to_string(handler_file) {
@@ -3144,7 +3150,8 @@ fn dispatch_cli(cli: cli::Cli, bare_has_bin: bool) -> i32 {
         }
         Some(cli::Cmd::Httpd(h)) => {
             let func = h.func.as_deref().unwrap_or("handler");
-            httpd_cmd(h.port, &h.handler, func)
+            let caps = build_httpd_caps(&h);
+            httpd_cmd(h.port, &h.handler, func, &caps)
         }
         Some(cli::Cmd::Test(t)) => cli::test_runner::run(t),
         Some(cli::Cmd::Version) => version_cmd(cli.global.explicit_json()),
@@ -3773,6 +3780,30 @@ fn build_caps(r: &cli::RunArgs) -> Arc<Caps> {
             .map(Caps::parse_allow)
             .unwrap_or(Policy::All),
     })
+}
+
+/// Build a `Caps` from the `--allow-*` flags on an `HttpdArgs`.
+///
+/// `ilo httpd` only exposes `--allow-net`; all other capability dimensions
+/// default to `Policy::All` (unrestricted) since httpd needs fs access to
+/// read its handler file.  If no `--allow-*` flag is supplied the policy is
+/// `Caps::Restricted` with an empty net list, which blocks all network access
+/// and will cause `check_net` to return an error.
+fn build_httpd_caps(h: &cli::HttpdArgs) -> Caps {
+    match &h.allow_net {
+        Some(val) => Caps::Restricted {
+            net: Caps::parse_allow(val),
+            read: Policy::All,
+            write: Policy::All,
+            run: Policy::All,
+        },
+        None => Caps::Restricted {
+            net: Policy::List(vec![]),
+            read: Policy::All,
+            write: Policy::All,
+            run: Policy::All,
+        },
+    }
 }
 
 /// Dispatch the `run` subcommand via parsed RunArgs.  Returns exit code.

--- a/tests/capability_flags.rs
+++ b/tests/capability_flags.rs
@@ -7,6 +7,8 @@
 use ilo::caps::{Caps, Policy};
 use ilo::interpreter::{self, Value};
 use ilo::{lexer, parser, vm};
+use std::io::Write;
+use std::process::Command;
 use std::sync::Arc;
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -335,4 +337,87 @@ fn one_flag_restricts_only_that_dimension() {
         "write should be unrestricted"
     );
     assert!(caps.check_run("rm").is_ok(), "run should be unrestricted");
+}
+
+// ── httpd --allow-net cap check ───────────────────────────────────────────────
+
+fn ilo_bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+/// `ilo httpd` without `--allow-net` must exit non-zero and print the
+/// expected error message.  We use a dummy handler file (a minimal ilo
+/// function) so the CLI gets past file-not-found before hitting the cap check.
+#[test]
+fn httpd_refuses_to_start_without_allow_net() {
+    // Write a minimal handler file that would be valid if the cap check passed.
+    let mut handler = tempfile::NamedTempFile::new().expect("tmpfile");
+    handler
+        .write_all(b"fn handler req:R>R; req\n")
+        .expect("write handler");
+
+    let out = ilo_bin()
+        .args(["httpd", "--port", "19876", handler.path().to_str().unwrap()])
+        .output()
+        .expect("failed to run ilo");
+
+    assert!(
+        !out.status.success(),
+        "ilo httpd should exit non-zero without --allow-net"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--allow-net"),
+        "stderr should mention --allow-net, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("ilo httpd needs --allow-net to listen on a port"),
+        "stderr should contain the full error message, got: {stderr}"
+    );
+}
+
+/// `ilo httpd --allow-net *` should pass the cap check.  We verify it
+/// proceeds past the error stage (it will fail later trying to parse the
+/// handler, but the cap error must NOT appear).
+#[test]
+fn httpd_passes_cap_check_with_allow_net_star() {
+    // Write a minimal handler file.
+    let mut handler = tempfile::NamedTempFile::new().expect("tmpfile");
+    handler
+        .write_all(b"fn handler req:R>R; req\n")
+        .expect("write handler");
+
+    // We give it an unparseable port so the process exits quickly,
+    // but we just need to confirm no cap error in stderr.
+    // Actually use a real port but kill immediately by checking stderr only.
+    // Spawn and immediately collect — the server will block on accept;
+    // use a very short timeout approach: just check it doesn't print cap error.
+    // We check that with --allow-net=* the cap error message is absent.
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_ilo"))
+        .args([
+            "httpd",
+            "--allow-net",
+            "*",
+            "--port",
+            "19877",
+            handler.path().to_str().unwrap(),
+        ])
+        // Run with a timeout by spawning and killing immediately
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn ilo httpd");
+
+    // Give it a moment to start then kill.
+    std::thread::sleep(std::time::Duration::from_millis(200));
+    // The process is a server loop; kill it.
+    let mut child = out;
+    let _ = child.kill();
+    let result = child.wait_with_output().expect("wait");
+
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(
+        !stderr.contains("ilo httpd needs --allow-net"),
+        "cap error must not appear when --allow-net=* is passed, stderr: {stderr}"
+    );
 }


### PR DESCRIPTION
## Summary

- Adds `--allow-net` flag to `HttpdArgs` (mirrors the `RunArgs` pattern from ILO-59)
- `httpd_cmd` now calls `caps.check_net("0.0.0.0")` before binding the TCP socket; exits 1 with `"ilo httpd needs --allow-net to listen on a port"` if the check fails
- New `build_httpd_caps()` helper: no `--allow-net` flag → `Caps::Restricted { net: Policy::List([]) }` (deny all); `--allow-net=*` → `Policy::All`; specific hosts are passed through `Caps::parse_allow`
- Resolves the `TODO(ILO-59)` comment left in the httpd block comment

Builds on:
- ILO-46 (#617) — `httpd_cmd` implementation
- ILO-59 (#606) — `src/caps.rs` + `Caps::check_net`

## Test plan

- [x] `httpd_refuses_to_start_without_allow_net` — verifies exit non-zero + error message when `--allow-net` is omitted
- [x] `httpd_passes_cap_check_with_allow_net_star` — verifies cap error absent when `--allow-net *` is supplied
- [x] All existing httpd unit tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)