### PR TITLE
feat(ILO-401): VM/JIT codegen for Value::Variant (sum types)

### DIFF
--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -7290,4 +7290,43 @@ f a:t b:t>t;join a b"#,
     // every time `cargo test --release --features cranelift` runs inside an
     // isolated worktree (the AOT tests link successfully iff the lookup
     // honours `.cargo/config.toml`).
+
+    // ── ILO-401: Cranelift codegen for sum-type bytecode ─────────────────────
+
+    /// Cranelift must accept bytecode produced from a sum-type program.
+    /// The VM compiler emits only standard opcodes (OP_RECNEW, OP_RECFLD,
+    /// OP_EQ, OP_LOADK) for variants; this test confirms those opcodes flow
+    /// through the full Cranelift IR-generation path without a bailout.
+    #[test]
+    fn codegen_sum_type_variants_emit_object() {
+        // sum type with payload variants (circle, square) and a no-payload variant (point)
+        let bytes = compile_to_object_bytes(
+            "type shape = circle(n) | square(n) | point\n\
+             area s:shape>n;?s{circle(r):*3.14159 *r r;square(side):*side side;point:0}\n\
+             main>n;+area(circle 5) area(square 3)",
+        );
+        assert!(
+            bytes.is_ok(),
+            "Cranelift sum-type codegen failed: {:?}",
+            bytes.err()
+        );
+        let obj = bytes.unwrap();
+        assert!(!obj.is_empty(), "object file must not be empty");
+    }
+
+    /// Cranelift must accept sum-type programs with zero-payload variants used
+    /// as bare values (not called with arguments).
+    #[test]
+    fn codegen_sum_type_zero_payload_variant_emit_object() {
+        let bytes = compile_to_object_bytes(
+            "type color = red | green | blue\n\
+             pick c:color>t;?c{red:\"r\";green:\"g\";blue:\"b\"}\n\
+             main>t;pick red",
+        );
+        assert!(
+            bytes.is_ok(),
+            "Cranelift zero-payload variant codegen failed: {:?}",
+            bytes.err()
+        );
+    }
 }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -1756,6 +1756,13 @@ struct RegCompiler {
     /// covers the rebind shape; this flag covers the tail-position
     /// `mset m k v` shape inside helper fns reached via OP_CALL_OWN1.
     in_tail_position: bool,
+    /// Sum-type variant constructors: maps variant name → (type_id, tag_index, has_payload).
+    /// Registered during compile_program when a Decl::SumType is encountered.
+    /// type_id is the record type registered as `__variant_<typename>` with
+    /// fields ["tag", "payload"]. tag_index is the 0-based ordinal of the
+    /// variant within the sum type declaration.  has_payload is true when the
+    /// variant was declared with a payload argument (e.g. `circle(n)`).
+    variant_map: HashMap<String, (u16, usize, bool)>,
 }
 
 impl RegCompiler {
@@ -1779,6 +1786,7 @@ impl RegCompiler {
             current_fn_name: String::new(),
             current_fn_span: crate::ast::Span::UNKNOWN,
             in_tail_position: false,
+            variant_map: HashMap::new(),
         }
     }
 
@@ -2115,15 +2123,11 @@ impl RegCompiler {
     }
 
     fn compile_program(mut self, program: &Program) -> Result<CompiledProgram, CompileError> {
-        // Sum types with payloads are not yet natively supported by the VM.
-        // Return a compile error so the caller can fall back to the tree interpreter.
-        for decl in &program.declarations {
-            if let Decl::SumType { name, .. } = decl {
-                return Err(CompileError::SumTypeNotSupported { name: name.clone() });
-            }
-        }
-
-        // Build type registry from TypeDefs
+        // Build type registry from TypeDefs and SumTypes.
+        // SumTypes are represented as 2-field heap records with type name
+        // `__variant_<typename>`, fields ["tag", "payload"].  The `tag` slot
+        // holds the variant's 0-based ordinal as a Number; `payload` holds the
+        // constructor argument (or Nil for payload-less variants).
         for decl in &program.declarations {
             if let Decl::TypeDef { name, fields, .. } = decl {
                 let field_names: Vec<String> = fields.iter().map(|p| p.name.clone()).collect();
@@ -2135,6 +2139,25 @@ impl RegCompiler {
                 }
                 self.type_registry
                     .register(name.clone(), field_names, num_fields);
+            }
+        }
+
+        // Register sum-type variant record types and build variant_map.
+        for decl in &program.declarations {
+            if let Decl::SumType { name, variants, .. } = decl {
+                // Shared record type for all variants of this sum type.
+                // Fields: [0] = "tag" (numeric ordinal), [1] = "payload".
+                // Bit 0 of num_fields is set because field 0 ("tag") is always Number.
+                let type_name = format!("__variant_{}", name);
+                let type_id = self.type_registry.register(
+                    type_name,
+                    vec!["tag".to_string(), "payload".to_string()],
+                    0b01, // field 0 ("tag") is numeric
+                );
+                for (idx, v) in variants.iter().enumerate() {
+                    self.variant_map
+                        .insert(v.name.clone(), (type_id, idx, v.payload.is_some()));
+                }
             }
         }
 
@@ -2265,6 +2288,61 @@ impl RegCompiler {
             is_tool,
             ast: None,
         })
+    }
+
+    /// Emit a 2-field variant record: { tag: <tag_idx as Number>, payload: <payload_reg or Nil> }.
+    /// Returns the result register holding the new record.
+    fn emit_variant_record(
+        &mut self,
+        type_id: u16,
+        tag_idx: usize,
+        payload_reg: Option<u8>,
+    ) -> u8 {
+        // Allocate tag constant
+        let tag_val = Value::Number(tag_idx as f64);
+        let tag_ki = self.current.add_const(tag_val);
+        let tag_reg = self.alloc_reg();
+        self.emit_abx(OP_LOADK, tag_reg, tag_ki);
+        self.reg_is_num[tag_reg as usize] = true;
+
+        let payload_r = match payload_reg {
+            Some(r) => r,
+            None => {
+                let nil_ki = self.current.add_const(Value::Nil);
+                let nil_reg = self.alloc_reg();
+                self.emit_abx(OP_LOADK, nil_reg, nil_ki);
+                nil_reg
+            }
+        };
+
+        // OP_RECNEW: result in `a`, fields starting at `fields_base`.
+        // Layout: fields_base+0 = tag, fields_base+1 = payload.
+        // bx encodes (type_id << 8) | n_fields.
+        let a = self.alloc_reg();
+        let fields_base = self.next_reg;
+        // Ensure tag_reg and payload_r are in consecutive slots at fields_base.
+        if tag_reg != fields_base {
+            self.emit_abc(OP_MOVE, fields_base, tag_reg, 0);
+        }
+        self.next_reg = fields_base + 1;
+        if self.next_reg > self.max_reg {
+            self.max_reg = self.next_reg;
+        }
+        if payload_r != fields_base + 1 {
+            let _ = self.alloc_reg(); // reserve fields_base+1
+            self.emit_abc(OP_MOVE, fields_base + 1, payload_r, 0);
+        } else {
+            self.next_reg = fields_base + 2;
+            if self.next_reg > self.max_reg {
+                self.max_reg = self.next_reg;
+            }
+        }
+        let bx = (type_id << 8) | 2u16;
+        self.emit_abx(OP_RECNEW, a, bx);
+        self.reg_record_type[a as usize] = type_id;
+        // Reclaim scratch registers; only `a` stays live.
+        self.next_reg = a + 1;
+        a
     }
 
     fn compile_body(&mut self, stmts: &[crate::ast::Spanned<Stmt>]) -> Option<u8> {
@@ -3081,15 +3159,61 @@ impl RegCompiler {
                     end_jumps.push(self.emit_jmp_placeholder());
                     self.current.patch_jump(skip);
                 }
-                Pattern::Variant { .. } => {
-                    // Sum type variant patterns are not yet natively compiled
-                    // by the VM. The compile_program guard at the top of
-                    // compile_program returns SumTypeNotSupported before we
-                    // reach this point; this arm is a safety net.
-                    self.first_error
-                        .get_or_insert(CompileError::SumTypeNotSupported {
-                            name: "<variant>".to_string(),
-                        });
+                Pattern::Variant { tag, binding } => {
+                    // Sum-type variant pattern: check sub_reg.tag == expected_idx,
+                    // optionally bind sub_reg.payload.
+                    //
+                    // Emitted sequence:
+                    //   tag_reg  = OP_RECFLD sub_reg, 0    ; extract tag field
+                    //   cmp_reg  = OP_LOADK  <tag_idx>
+                    //   eq_reg   = OP_EQ     tag_reg, cmp_reg
+                    //              OP_JMPF  eq_reg, <skip>
+                    //   [bind_reg = OP_RECFLD sub_reg, 1]   ; if binding present
+                    //   <body>
+                    //   OP_JMP <end>          ; added to end_jumps
+                    // skip:
+                    if let Some(&(type_id, tag_idx, _)) = self.variant_map.get(tag) {
+                        // Extract the tag field (index 0).
+                        let tag_reg = self.alloc_reg();
+                        self.emit_abc(OP_RECFLD, tag_reg, sub_reg, 0);
+                        self.reg_is_num[tag_reg as usize] = true;
+
+                        // Load the expected tag index as a constant.
+                        let cmp_ki = self.current.add_const(Value::Number(tag_idx as f64));
+                        let cmp_reg = self.alloc_reg();
+                        self.emit_abx(OP_LOADK, cmp_reg, cmp_ki);
+                        self.reg_is_num[cmp_reg as usize] = true;
+
+                        // Compare and branch if not equal.
+                        let eq_reg = self.alloc_reg();
+                        self.emit_abc(OP_EQ, eq_reg, tag_reg, cmp_reg);
+                        let skip = self.emit_jmpf(eq_reg);
+
+                        // Optionally bind payload (field index 1).
+                        if let Some(bind_name) = binding {
+                            let bind_reg = self.alloc_reg();
+                            self.emit_abc(OP_RECFLD, bind_reg, sub_reg, 1);
+                            self.reg_record_type[bind_reg as usize] = u16::MAX;
+                            self.add_local(bind_name, bind_reg);
+                        }
+
+                        let body_result = self.compile_body(&arm.body);
+                        if let Some(br) = body_result
+                            && br != result_reg
+                        {
+                            self.emit_abc(OP_MOVE, result_reg, br, 0);
+                        }
+                        end_jumps.push(self.emit_jmp_placeholder());
+                        self.current.patch_jump(skip);
+                        let _ = type_id; // type_id used for future type-tracking
+                    } else {
+                        // Unknown variant tag — variant_map was not populated
+                        // (e.g. the variant is from a type defined elsewhere).
+                        self.first_error
+                            .get_or_insert(CompileError::UndefinedVariable {
+                                name: tag.clone(),
+                            });
+                    }
                 }
             }
 
@@ -3617,6 +3741,23 @@ impl RegCompiler {
             Expr::Ref(name) => {
                 if let Some(reg) = self.resolve_local(name) {
                     reg // FREE — no instruction needed!
+                } else if let Some(&(type_id, tag_idx, has_payload)) =
+                    self.variant_map.get(name)
+                {
+                    if !has_payload {
+                        // 0-payload variant used as a bare value: emit the 2-field
+                        // record (tag=tag_idx, payload=Nil) directly.
+                        self.emit_variant_record(type_id, tag_idx, None)
+                    } else {
+                        // Payload variant used as a bare reference (first-class
+                        // constructor value). This is uncommon; fall through to the
+                        // UndefinedVariable error path so callers get a clear message
+                        // rather than silent wrong behaviour.
+                        self.first_error.get_or_insert(CompileError::UndefinedVariable {
+                            name: name.clone(),
+                        });
+                        0
+                    }
                 } else if let Some(idx) = self.func_names.iter().position(|n| n == name) {
                     // User function used as a value (passed to a HOF, stored,
                     // etc.). Encode as a FnRef NanVal via OP_LOADFN. Bx high
@@ -5472,6 +5613,29 @@ impl RegCompiler {
                     }
 
                     return a;
+                }
+
+                // ── Sum-type variant constructor ──────────────────────────────
+                // Intercept calls like `circle 5` or `point` where `circle`/`point`
+                // are variant names registered in variant_map.  Emit inline record
+                // construction (OP_RECNEW) rather than a function call.
+                if let Some(&(type_id, tag_idx, has_payload)) =
+                    self.variant_map.get(function)
+                {
+                    let payload_reg = if has_payload {
+                        if args.len() == 1 {
+                            Some(self.compile_expr(&args[0]))
+                        } else {
+                            self.first_error
+                                .get_or_insert(CompileError::UndefinedFunction {
+                                    name: function.clone(),
+                                });
+                            return 0;
+                        }
+                    } else {
+                        None
+                    };
+                    return self.emit_variant_record(type_id, tag_idx, payload_reg);
                 }
 
                 // Compiling args of this call: each arg is NOT in tail
@@ -35931,6 +36095,69 @@ main>n
             other => panic!("expected VmError::Arity, got {other:?}"),
         }
     }
+
+    // ── ILO-401: Sum-type VM/JIT codegen ─────────────────────────────────────
+
+    /// VM can construct a payload-less variant and pattern-match on it.
+    #[test]
+    fn sum_type_vm_zero_payload_variant() {
+        let v = vm_run_main_for_test(
+            "type color = red | green | blue\n\
+             pick c:color>t;?c{red:\"r\";green:\"g\";blue:\"b\"}\n\
+             main>t;pick red",
+        );
+        assert_eq!(v, Value::Text(std::sync::Arc::new("r".to_string())));
+    }
+
+    /// VM can construct a payload-carrying variant and extract the payload in a match.
+    #[test]
+    fn sum_type_vm_payload_variant_match() {
+        // circle area = 3.14159 * 25 = 78.53975; square area = 9; sum = 87.53975
+        let v = vm_run_main_for_test(
+            "type shape = circle(n) | square(n) | point\n\
+             area s:shape>n;?s{circle(r):*3.14159 *r r;square(side):*side side;point:0}\n\
+             main>n;+area(circle 5) area(square 3)",
+        );
+        match v {
+            Value::Number(n) => {
+                assert!((n - 87.53975_f64).abs() < 1e-4, "expected ~87.53975, got {n}");
+            }
+            _ => panic!("expected Number, got {v:?}"),
+        }
+    }
+
+    /// Regression: same program runs identically under tree interpreter and VM.
+    #[test]
+    fn sum_type_vm_matches_interpreter() {
+        let src = "type shape = circle(n) | square(n) | point\n\
+             area s:shape>n;?s{circle(r):*3.14159 *r r;square(side):*side side;point:0}\n\
+             main>n;+area(circle 5) area(square 3)";
+        let prog = parse_program(src);
+        let compiled = compile(&prog).unwrap();
+        let vm_result = run(&compiled, Some("main"), vec![]).unwrap();
+        let interp_result = crate::interpreter::run(&prog, Some("main"), vec![]).unwrap();
+        assert_eq!(
+            vm_result, interp_result,
+            "VM and tree interpreter disagree on sum-type result"
+        );
+    }
+
+    /// VM compile step must not return ILO-E803 (SumTypeNotSupported).
+    #[test]
+    fn sum_type_vm_no_e803_bailout() {
+        let src = "type shape = circle(n) | square(n) | point\n\
+             area s:shape>n;?s{circle(r):*3.14159 *r r;square(side):*side side;point:0}\n\
+             main>n;+area(circle 5) area(square 3)";
+        let prog = parse_program(src);
+        let compiled = compile(&prog).expect("sum-type program must compile without ILO-E803");
+        let val = run(&compiled, Some("main"), vec![]).unwrap();
+        match val {
+            Value::Number(n) => {
+                assert!((n - 87.53975_f64).abs() < 1e-4, "expected ~87.53975, got {n}");
+            }
+            _ => panic!("expected Number, got {val:?}"),
+        }
+    }
 }
 
 #[cfg(all(test, feature = "cranelift"))]
@@ -36088,4 +36315,5 @@ mod aot_publish_tests {
             _ => panic!("expected list, got {v:?}"),
         }
     }
+
 }


### PR DESCRIPTION
## Summary

- Removes the `ILO-E803 SumTypeNotSupported` bailout that forced all sum-type programs to fall back to the tree interpreter
- Implements variant construction and pattern-matching in the bytecode VM using standard record opcodes (`OP_RECNEW`, `OP_RECFLD`, `OP_EQ`, `OP_LOADK`)
- Cranelift AOT/JIT works without any changes — it already handles all emitted opcodes

## Codegen strategy

Each variant is stored as a 2-field heap record of type `__variant_<typename>`:
- Field 0: `tag` — numeric ordinal (0-based) of the variant within the sum type
- Field 1: `payload` — constructor argument for payload variants, or `Nil`

**Construction** (`circle 5` → payload variant, `point` → no-payload variant):
- `emit_variant_record(type_id, tag_idx, payload_reg)` emits `OP_LOADK` (tag constant) + `OP_RECNEW`
- Intercepted in `Expr::Call` (before user-function lookup) and `Expr::Ref`

**Pattern matching** (`?s{circle(r):...}`):
- `Pattern::Variant` emits `OP_RECFLD sub_reg, 0` → `OP_EQ` → `OP_JMPF`, then optionally `OP_RECFLD sub_reg, 1` to bind payload

## Test plan

- [x] `examples/sum-types.ilo` produces correct output under `--vm` and `--jit`
- [x] `vm::tests::sum_type_vm_zero_payload_variant` — no-payload variant constructs and matches
- [x] `vm::tests::sum_type_vm_payload_variant_match` — payload variant carries value through match
- [x] `vm::tests::sum_type_vm_matches_interpreter` — VM result equals tree interpreter result
- [x] `vm::tests::sum_type_vm_no_e803_bailout` — compile no longer returns ILO-E803
- [x] `compile_cranelift::tests::codegen_sum_type_variants_emit_object` — Cranelift accepts bytecode
- [x] `compile_cranelift::tests::codegen_sum_type_zero_payload_variant_emit_object` — zero-payload variant codegen

🤖 Generated with [Claude Code](https://claude.com/claude-code)