### PR TITLE
feat(ILO-377): stepped range loops via `by` clause

### DIFF
--- a/examples/inline-lambda-capture.ilo
+++ b/examples/inline-lambda-capture.ilo
@@ -18,7 +18,7 @@ above xs:L n thr:n>L n;flt (x:n>b;>x thr) xs
 near xs:L n target:n>L n;srt (x:n>n;abs -x target) xs
 
 -- Bump every element by a captured amount.
-bump xs:L n by:n>L n;map (x:n>n;+x by) xs
+bump xs:L n amt:n>L n;map (x:n>n;+x amt) xs
 
 -- Two captures: filter to values between lo and hi (inclusive).
 between xs:L n lo:n hi:n>L n;flt (x:n>b;&(>=x lo) <=x hi) xs

--- a/examples/range-step.ilo
+++ b/examples/range-step.ilo
@@ -1,0 +1,19 @@
+-- Stepped range iteration: `@i start..end by step{body}`
+-- Iterates i = start, start+step, start+2*step, ... while i < end.
+-- v1: positive integer steps only.
+
+-- Collect even indices 0..10 by 2 → [0,2,4,6,8]
+evens >L n;out=[];@i 0..10 by 2{out=+=out i};out
+
+-- Collect multiples of 3 up to n
+by3 n:n>L n;out=[];@i 0..n by 3{out=+=out i};out
+
+-- Sum every other element
+sum-step xs:L n step:n>n;s=0;n=len xs;@i 0..n by step{s=+s at xs i};s
+
+-- run: evens
+-- out: [0, 2, 4, 6, 8]
+-- run: by3 12
+-- out: [0, 3, 6, 9]
+-- run: sum-step [10,20,30,40,50] 2
+-- out: 90

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -187,11 +187,13 @@ pub enum Stmt {
         body: Vec<Spanned<Stmt>>,
     },
 
-    /// `@binding start..end{body}` — range iteration
+    /// `@binding start..end{body}` or `@binding start..end by step{body}` — range iteration
     ForRange {
         binding: String,
         start: Expr,
         end: Expr,
+        /// Optional step size (`by <expr>`). `None` means step of 1.
+        step: Option<Expr>,
         body: Vec<Spanned<Stmt>>,
     },
 
@@ -593,10 +595,13 @@ fn resolve_aliases_stmt(stmt: &mut Stmt) {
             }
         }
         Stmt::ForRange {
-            start, end, body, ..
+            start, end, step, body, ..
         } => {
             resolve_aliases_expr(start);
             resolve_aliases_expr(end);
+            if let Some(s) = step {
+                resolve_aliases_expr(s);
+            }
             for s in body {
                 resolve_aliases_stmt(&mut s.node);
             }
@@ -794,10 +799,14 @@ fn desugar_stmt(stmt: &mut Stmt, scope: &mut Vec<String>, rf: &std::collections:
             binding,
             start,
             end,
+            step,
             body,
         } => {
             desugar_expr(start, scope, rf);
             desugar_expr(end, scope, rf);
+            if let Some(st) = step {
+                desugar_expr(st, scope, rf);
+            }
             let depth = scope.len();
             scope.push(binding.clone());
             for s in body {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -595,7 +595,11 @@ fn resolve_aliases_stmt(stmt: &mut Stmt) {
             }
         }
         Stmt::ForRange {
-            start, end, step, body, ..
+            start,
+            end,
+            step,
+            body,
+            ..
         } => {
             resolve_aliases_expr(start);
             resolve_aliases_expr(end);

--- a/src/codegen/fmt.rs
+++ b/src/codegen/fmt.rs
@@ -316,13 +316,20 @@ fn fmt_stmt_dense(stmt: &Stmt) -> String {
             binding,
             start,
             end,
+            step,
             body,
         } => {
+            let step_part = if let Some(st) = step {
+                format!(" by {}", fmt_expr(st, FmtMode::Dense))
+            } else {
+                String::new()
+            };
             format!(
-                "@{} {}..{}{{{}}}",
+                "@{} {}..{}{}{{{}}}",
                 binding,
                 fmt_expr(start, FmtMode::Dense),
                 fmt_expr(end, FmtMode::Dense),
+                step_part,
                 fmt_body_dense(body)
             )
         }
@@ -438,6 +445,7 @@ fn fmt_stmt_expanded(out: &mut String, stmt: &Stmt, indent_level: usize) {
             binding,
             start,
             end,
+            step,
             body,
         } => {
             out.push_str(&ind);
@@ -448,6 +456,10 @@ fn fmt_stmt_expanded(out: &mut String, stmt: &Stmt, indent_level: usize) {
             out.push_str(&fmt_expr(start, FmtMode::Expanded));
             out.push_str("..");
             out.push_str(&fmt_expr(end, FmtMode::Expanded));
+            if let Some(st) = step {
+                out.push_str(" by ");
+                out.push_str(&fmt_expr(st, FmtMode::Expanded));
+            }
             out.push_str(" {\n");
             fmt_body_expanded(out, body, indent_level + 1);
             out.push_str(&ind);

--- a/src/codegen/python.rs
+++ b/src/codegen/python.rs
@@ -344,17 +344,29 @@ fn emit_stmt(out: &mut String, stmt: &Stmt, level: usize, implicit_return: bool)
             binding,
             start,
             end,
+            step,
             body,
         } => {
             let s = emit_expr(out, level, start);
             let e = emit_expr(out, level, end);
             indent(out, level);
-            out.push_str(&format!(
-                "for {} in range(int({}), int({})):\n",
-                py_name(binding),
-                s,
-                e
-            ));
+            if let Some(step_expr) = step {
+                let st = emit_expr(out, level, step_expr);
+                out.push_str(&format!(
+                    "for {} in range(int({}), int({}), int({})):\n",
+                    py_name(binding),
+                    s,
+                    e,
+                    st
+                ));
+            } else {
+                out.push_str(&format!(
+                    "for {} in range(int({}), int({})):\n",
+                    py_name(binding),
+                    s,
+                    e
+                ));
+            }
             emit_body(out, body, level + 1, false);
         }
         Stmt::While { condition, body } => {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -190,10 +190,13 @@ fn collect_stmts(
                 collect_stmts(body, calls, types);
             }
             Stmt::ForRange {
-                start, end, body, ..
+                start, end, step, body, ..
             } => {
                 collect_calls(start, calls, types);
                 collect_calls(end, calls, types);
+                if let Some(st) = step {
+                    collect_calls(st, calls, types);
+                }
                 collect_stmts(body, calls, types);
             }
             Stmt::While { condition, body } => {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -190,7 +190,11 @@ fn collect_stmts(
                 collect_stmts(body, calls, types);
             }
             Stmt::ForRange {
-                start, end, step, body, ..
+                start,
+                end,
+                step,
+                body,
+                ..
             } => {
                 collect_calls(start, calls, types);
                 collect_calls(end, calls, types);

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -8321,6 +8321,7 @@ fn eval_stmt(env: &mut Env, stmt: &Stmt, is_tail: bool) -> Result<Option<BodyRes
             binding,
             start,
             end,
+            step,
             body,
         } => {
             let start_val = eval_expr(env, start)?;
@@ -8338,8 +8339,17 @@ fn eval_stmt(env: &mut Env, stmt: &Stmt, is_tail: bool) -> Result<Option<BodyRes
                 Value::Number(n) => n as i64,
                 _ => return Err(RuntimeError::new("ILO-R007", "range end must be a number")),
             };
+            let st: i64 = if let Some(step_expr) = step {
+                match eval_expr(env, step_expr)? {
+                    Value::Number(n) => n as i64,
+                    _ => return Err(RuntimeError::new("ILO-R007", "range step must be a number")),
+                }
+            } else {
+                1
+            };
             let mut last = Value::Nil;
-            for i in s..e {
+            let mut i = s;
+            while i < e {
                 env.push_scope();
                 env.define(binding, Value::Number(i as f64));
                 // Range body is not in tail position; see ForEach above.
@@ -8353,12 +8363,16 @@ fn eval_stmt(env: &mut Env, stmt: &Stmt, is_tail: bool) -> Result<Option<BodyRes
                         last = v;
                         break;
                     }
-                    BodyResult::Continue => continue,
+                    BodyResult::Continue => {
+                        i += st;
+                        continue;
+                    }
                     BodyResult::TailCall { .. } => {
                         unreachable!("TailCall escaping non-tail range body");
                     }
                     BodyResult::Value(v) => last = v,
                 }
+                i += st;
             }
             Ok(Some(BodyResult::Value(last)))
         }

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -32,6 +32,10 @@ pub enum Token {
     #[token("S")]
     SumType,
 
+    // Step keyword for range loops: `@i 0..n by 2{...}`
+    #[token("by")]
+    By,
+
     // Reserved keywords from other languages — not valid in ilo, emit friendly errors
     #[token("if")]
     KwIf,
@@ -193,6 +197,9 @@ impl Token {
     /// `TokenKind` variant name (`Greater`, `PipeOp`, `LBrace` ...).
     pub fn user_facing_name(&self) -> String {
         match self {
+            // Step keyword
+            Token::By => "`by`".into(),
+
             // Keywords
             Token::Type => "`type`".into(),
             Token::Tool => "`tool`".into(),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2257,11 +2257,19 @@ impl Parser {
         if self.peek() == Some(&Token::DotDot) {
             self.advance(); // consume ..
             let end_expr = self.parse_expr_inner()?;
+            // Optional `by <step>` clause: `@i 0..n by 2{...}`
+            let step_expr = if self.peek() == Some(&Token::By) {
+                self.advance(); // consume `by`
+                Some(self.parse_expr_inner()?)
+            } else {
+                None
+            };
             let body = self.parse_brace_body()?;
             return Ok(Stmt::ForRange {
                 binding,
                 start: start_expr,
                 end: end_expr,
+                step: step_expr,
                 body,
             });
         }
@@ -4493,10 +4501,14 @@ For variable-position list indexing bind the head first: \
                 binding,
                 start,
                 end,
+                step,
                 body,
             } => {
                 self.collect_free_in_expr(start, params, local, free);
                 self.collect_free_in_expr(end, params, local, free);
+                if let Some(st) = step {
+                    self.collect_free_in_expr(st, params, local, free);
+                }
                 let depth = local.len();
                 local.push(binding.clone());
                 for s in body {

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -4563,6 +4563,7 @@ impl VerifyContext {
                 binding,
                 start,
                 end,
+                step,
                 body,
             } => {
                 let start_ty = self.infer_expr(func, scope, start, span);
@@ -4584,6 +4585,30 @@ impl VerifyContext {
                         None,
                         Some(span),
                     );
+                }
+                if let Some(step_expr) = step {
+                    let step_ty = self.infer_expr(func, scope, step_expr, span);
+                    if !compatible(&step_ty, &Ty::Number) {
+                        self.err(
+                            "ILO-T014",
+                            func,
+                            format!("range step must be n, got {step_ty}"),
+                            None,
+                            Some(span),
+                        );
+                    }
+                    // Reject literal zero or negative steps
+                    if let Expr::Literal(Literal::Number(n)) = step_expr {
+                        if *n <= 0.0 {
+                            self.err(
+                                "ILO-V001",
+                                func,
+                                format!("range step must be positive, got {n} — use a positive integer step (e.g. `by 2`)"),
+                                None,
+                                Some(span),
+                            );
+                        }
+                    }
                 }
                 scope.push(HashMap::new());
                 scope_insert(scope, binding.clone(), Ty::Number);

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -2781,11 +2781,22 @@ impl RegCompiler {
                 binding,
                 start,
                 end,
+                step,
                 body,
             } => {
                 // Evaluate start and end once
                 let start_reg = self.compile_expr(start);
                 let end_reg = self.compile_expr(end);
+
+                // Evaluate step (or use constant 1)
+                let step_reg = if let Some(step_expr) = step {
+                    self.compile_expr(step_expr)
+                } else {
+                    let one_ki = self.current.add_const(Value::Number(1.0));
+                    let r = self.alloc_reg();
+                    self.emit_abx(OP_LOADK, r, one_ki);
+                    r
+                };
 
                 let last_reg = self.alloc_reg();
                 let nil_ki = self.current.add_const(Value::Nil);
@@ -2796,8 +2807,6 @@ impl RegCompiler {
                 let counter_reg = self.alloc_reg();
                 self.emit_abc(OP_MOVE, counter_reg, start_reg, 0);
                 self.add_local(binding, counter_reg);
-
-                let one_ki = self.current.add_const(Value::Number(1.0));
 
                 // Loop top: check counter < end
                 let loop_top = self.current.code.len();
@@ -2835,14 +2844,8 @@ impl RegCompiler {
                     }
                 }
 
-                // counter += 1 (use ADDK_N when counter is known numeric)
-                if self.reg_is_num[counter_reg as usize] && one_ki <= 255 {
-                    self.emit_abc(OP_ADDK_N, counter_reg, counter_reg, one_ki as u8);
-                } else {
-                    let one_reg = self.alloc_reg();
-                    self.emit_abx(OP_LOADK, one_reg, one_ki);
-                    self.emit_abc(OP_ADD, counter_reg, counter_reg, one_reg);
-                }
+                // counter += step
+                self.emit_abc(OP_ADD, counter_reg, counter_reg, step_reg);
 
                 // Jump back to loop top
                 self.emit_jump_to(loop_top);


### PR DESCRIPTION
## Summary

Implements ILO-377: extends `@i start..end{body}` with an optional `by <step>` clause for stepped range iteration.

**Syntax chosen:** `@i 0..n by 2{body}` — the `by` keyword is terse, English-readable, and doesn't collide with the prefix-binop rule because `by` is now a hard lexer token (`Token::By`) that halts greedy call-argument parsing.

- `@i 0..10 by 2{...}` → indices 0, 2, 4, 6, 8
- `@j 0..n by step{...}` → dynamic step from variable
- `@k 0..len xs by 3{...}` → call-form end bound still works

## Changes

- **Lexer:** `by` → `Token::By` (stops greedy call-arg consumption at the range-end boundary)
- **Parser:** `parse_foreach` checks for `Token::By` after end expression and parses step
- **AST:** `ForRange` gains `step: Option<Expr>` field
- **Interpreter (tree):** uses step in while loop; `cnt` advances by step
- **VM (bytecode):** step_reg evaluated once; replaces hard-coded +1
- **Verifier:** type-checks step; rejects literal zero/negative steps with ILO-V001 hint
- **Codegen (fmt, python):** `by step` rendered; Python uses `range(s, e, step)`
- **graph.rs:** walks step expr for call-dependency tracking
- **`examples/range-step.ilo`:** three `-- run:` / `-- out:` cases for `tests/examples_engines`
- **`examples/inline-lambda-capture.ilo`:** rename `by` param → `amt` (now reserved keyword)

## Test plan

- [x] `cargo test --lib` — 3330 passed
- [x] `cargo test --test examples` — all example engine tests pass including new `range-step.ilo`
- [x] `cargo test --tests` — all integration tests pass
- [x] Manual: `evens` → `[0, 2, 4, 6, 8]`, `by3 12` → `[0, 3, 6, 9]`, `sum-step` → `90`
- [x] Pre-existing doctest failure (`src/verify.rs:361`) is unrelated and present on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)