### PR TITLE
feat(ILO-400): lazy / on-demand module loading

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -151,6 +151,12 @@ impl UsePredicate {
             "native" => Some(Self::Native),
             "test" => Some(Self::Test),
             _ => None,
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "wasm"   => Some(Self::Wasm),
+            "native" => Some(Self::Native),
+            "test"   => Some(Self::Test),
+            _        => None,
         }
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -151,12 +151,6 @@ impl UsePredicate {
             "native" => Some(Self::Native),
             "test" => Some(Self::Test),
             _ => None,
-    pub fn from_str(s: &str) -> Option<Self> {
-        match s {
-            "wasm"   => Some(Self::Wasm),
-            "native" => Some(Self::Native),
-            "test"   => Some(Self::Test),
-            _        => None,
         }
     }
 }
@@ -221,6 +215,10 @@ pub enum Decl {
     /// `use re:"path/to/file.ilo" [name1 name2]` — import AND re-export the named
     ///   declarations: they become part of this module's public surface.
     /// Resolved before verification; replaced by the imported declarations in
+    /// `use lazy:"./big-module"` — lazy (on-demand) import: the module is only
+    ///   loaded if at least one `<stem>-*` symbol from it is referenced in the
+    ///   program. Symbols are prefixed with the path stem (e.g. `big-module-fn`).
+    ///   Resolved before verification; replaced by the imported declarations in
     /// the merged program. Stripped by the verifier/codegen as a safety net.
     Use {
         path: String,
@@ -239,6 +237,12 @@ pub enum Decl {
         /// of this module's public surface (visible to consumers of this module).
         /// Without this flag, imported names are internal to this module only.
         reexport: bool,
+        /// Lazy (on-demand) import: `use lazy:"./path"`.
+        /// When `true`, the module is only loaded if a `<stem>-*` symbol is
+        /// referenced elsewhere in the program. The alias is derived from the
+        /// path stem (last component without extension).
+        #[serde(default)]
+        lazy: bool,
         #[serde(skip)]
         span: Span,
     },

--- a/src/codegen/explain.rs
+++ b/src/codegen/explain.rs
@@ -570,6 +570,7 @@ mod tests {
             predicate: None,
             alt_path: None,
             reexport: false,
+            lazy: false,
             span: Span::UNKNOWN,
         });
         prog.declarations.push(Decl::Error {

--- a/src/codegen/fmt.rs
+++ b/src/codegen/fmt.rs
@@ -1341,6 +1341,7 @@ mod tests {
             predicate: None,
             alt_path: None,
             reexport: false,
+            lazy: false,
             span: Span::UNKNOWN,
         };
         let s = format_decl(&use_decl, FmtMode::Dense);

--- a/src/codegen/python.rs
+++ b/src/codegen/python.rs
@@ -2334,6 +2334,7 @@ mod tests {
             predicate: None,
             alt_path: None,
             reexport: false,
+            lazy: false,
             span: Span::UNKNOWN,
         });
         let py = emit(&prog);

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -15194,6 +15194,7 @@ mod tests {
                 predicate: None,
                 alt_path: None,
                 reexport: false,
+                lazy: false,
                 span: Span { start: 0, end: 0 },
             },
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -2685,6 +2685,13 @@ fn apply_only_filter(
                 .unwrap_or(false)
         })
         .collect()
+        match (self, pred) {
+            (BuildTarget::Wasm,   ast::UsePredicate::Wasm)   => true,
+            (BuildTarget::Native, ast::UsePredicate::Native) => true,
+            (BuildTarget::Test,   ast::UsePredicate::Test)   => true,
+            _ => false,
+        }
+    }
 }
 
 /// Resolve all `Decl::Use` nodes in `decls` recursively, returning a flat
@@ -2745,6 +2752,7 @@ fn resolve_imports_inner(
             span,
         } = decl
         {
+        if let ast::Decl::Use { path, only, alias, predicate, alt_path, span } = decl {
             // For conditional imports, select the right branch now.
             let path = if let Some(pred) = predicate {
                 if build_target.eval(pred) {
@@ -7374,6 +7382,7 @@ mod tests {
             &mut diags,
             BuildTarget::default(),
         );
+        let result = resolve_imports(vec![use_decl], None, &mut visited, &mut diags, BuildTarget::default());
         assert!(result.is_empty());
         assert!(diags.iter().any(|d| d.code == Some("ILO-P017")));
         assert!(diags[0].message.contains("inline code"));
@@ -7426,6 +7435,7 @@ mod tests {
             &mut diags,
             BuildTarget::default(),
         );
+        let result = resolve_imports(vec![func_decl], None, &mut visited, &mut diags, BuildTarget::default());
         assert_eq!(result.len(), 1);
         assert!(diags.is_empty());
     }
@@ -7706,6 +7716,7 @@ mod tests {
     #[test]
     fn resolve_imports_conditional_wasm_true_branch() {
         // `use ?wasm "wasm.ilo" : "native.ilo"` with BuildTarget::Wasm → loads wasm.ilo
+        use std::io::Write;
         let wasm_path = "/tmp/ilo_cond_wasm_ILO399.ilo";
         let native_path = "/tmp/ilo_cond_native_ILO399.ilo";
         std::fs::write(wasm_path, "wasm-fn>n;42").unwrap();
@@ -7740,6 +7751,8 @@ mod tests {
             !names.contains(&"native-fn"),
             "native-fn should not be imported"
         );
+        assert!(names.contains(&"wasm-fn"), "expected wasm-fn, got: {names:?}");
+        assert!(!names.contains(&"native-fn"), "native-fn should not be imported");
 
         std::fs::remove_file(wasm_path).ok();
         std::fs::remove_file(native_path).ok();
@@ -7837,6 +7850,8 @@ mod tests {
             !names.contains(&"wasm-fn"),
             "wasm-fn should not be imported"
         );
+        assert!(names.contains(&"native-fn"), "expected native-fn, got: {names:?}");
+        assert!(!names.contains(&"wasm-fn"), "wasm-fn should not be imported");
 
         std::fs::remove_file(wasm_path).ok();
         std::fs::remove_file(native_path).ok();
@@ -7925,6 +7940,7 @@ mod tests {
             names.contains(&"stub-fn"),
             "expected stub-fn, got: {names:?}"
         );
+        assert!(names.contains(&"stub-fn"), "expected stub-fn, got: {names:?}");
 
         std::fs::remove_file(stub_path).ok();
         std::fs::remove_file(real_path).ok();
@@ -9024,6 +9040,7 @@ mod tests {
             &mut diagnostics,
             BuildTarget::default(),
         );
+        let result = resolve_imports(decls, None, &mut visited, &mut diagnostics, BuildTarget::default());
         assert!(result.is_empty(), "should return no decls");
         assert!(!diagnostics.is_empty(), "should emit error");
         assert!(diagnostics[0].message.contains("file path context"));
@@ -9043,6 +9060,7 @@ mod tests {
             &mut diagnostics,
             BuildTarget::default(),
         );
+        let result = resolve_imports(decls, Some(dir), &mut visited, &mut diagnostics, BuildTarget::default());
         assert!(result.is_empty());
         assert!(!diagnostics.is_empty());
         assert!(diagnostics[0].message.contains("nonexistent_file_xyz.ilo"));
@@ -9067,6 +9085,7 @@ mod tests {
             &mut diagnostics,
             BuildTarget::default(),
         );
+        let result = resolve_imports(decls, Some(dir), &mut visited, &mut diagnostics, BuildTarget::default());
         assert!(result.is_empty());
         assert!(!diagnostics.is_empty());
         assert!(diagnostics[0].message.contains("circular"));
@@ -9089,6 +9108,7 @@ mod tests {
             &mut diagnostics,
             BuildTarget::default(),
         );
+        let _result = resolve_imports(decls, Some(dir), &mut visited, &mut diagnostics, BuildTarget::default());
         assert!(!diagnostics.is_empty(), "should emit lex error diagnostic");
         std::fs::remove_file(path).ok();
     }
@@ -9117,6 +9137,7 @@ mod tests {
             &mut diagnostics,
             BuildTarget::default(),
         );
+        resolve_imports(decls, Some(dir), &mut visited, &mut diagnostics, BuildTarget::default());
         assert!(!diagnostics.is_empty());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2685,13 +2685,6 @@ fn apply_only_filter(
                 .unwrap_or(false)
         })
         .collect()
-        match (self, pred) {
-            (BuildTarget::Wasm,   ast::UsePredicate::Wasm)   => true,
-            (BuildTarget::Native, ast::UsePredicate::Native) => true,
-            (BuildTarget::Test,   ast::UsePredicate::Test)   => true,
-            _ => false,
-        }
-    }
 }
 
 /// Resolve all `Decl::Use` nodes in `decls` recursively, returning a flat
@@ -2705,6 +2698,11 @@ fn apply_only_filter(
 ///
 /// Privacy rule: declarations whose name starts with `_` are module-private and
 /// are never exported. They are stripped during import regardless of `only` or `alias`.
+///
+/// Lazy imports (`use lazy:"./path"`) are deferred: the module file is only
+/// opened if at least one `<stem>-*` symbol is referenced in the non-lazy
+/// declarations. This lets large optional modules be listed without paying
+/// any parse/IO cost when unused.
 fn resolve_imports(
     decls: Vec<ast::Decl>,
     base_dir: Option<&std::path::Path>,
@@ -2712,7 +2710,54 @@ fn resolve_imports(
     diagnostics: &mut Vec<Diagnostic>,
     build_target: BuildTarget,
 ) -> Vec<ast::Decl> {
-    resolve_imports_inner(decls, base_dir, visited, diagnostics, build_target, false).0
+    // Separate lazy Use nodes from everything else for a two-pass approach.
+    let mut eager_decls: Vec<ast::Decl> = Vec::new();
+    let mut lazy_pending: Vec<ast::Decl> = Vec::new();
+    for decl in decls {
+        if matches!(&decl, ast::Decl::Use { lazy: true, .. }) {
+            lazy_pending.push(decl);
+        } else {
+            eager_decls.push(decl);
+        }
+    }
+
+    // Pass 1: resolve all eager (non-lazy) declarations.
+    let mut result = resolve_imports_inner(
+        eager_decls,
+        base_dir,
+        visited,
+        diagnostics,
+        build_target,
+        false,
+    )
+    .0;
+
+    // Pass 2: for each lazy pending import, check if any `<alias>-*` symbol
+    // is referenced in the already-resolved declarations. Only load if so.
+    for decl in lazy_pending {
+        if let ast::Decl::Use { ref alias, .. } = decl {
+            let prefix = format!("{}-", alias.as_deref().unwrap_or(""));
+            if decls_reference_prefix(&result, &prefix) {
+                // Symbol is used — load the module via the eager path.
+                let loaded = resolve_imports_inner(
+                    vec![decl],
+                    base_dir,
+                    visited,
+                    diagnostics,
+                    build_target,
+                    false,
+                )
+                .0;
+                // Prepend so lazy module decls precede the importer's own decls.
+                let mut combined = loaded;
+                combined.extend(result);
+                result = combined;
+            }
+            // else: no reference to this module — skip loading entirely.
+        }
+    }
+
+    result
 }
 
 /// Resolves imports and returns `(all_decls, exported_names)`.
@@ -2749,10 +2794,10 @@ fn resolve_imports_inner(
             predicate,
             alt_path,
             reexport,
+            lazy: _,
             span,
         } = decl
         {
-        if let ast::Decl::Use { path, only, alias, predicate, alt_path, span } = decl {
             // For conditional imports, select the right branch now.
             let path = if let Some(pred) = predicate {
                 if build_target.eval(pred) {
@@ -2792,6 +2837,7 @@ fn resolve_imports_inner(
                             predicate: None,
                             alt_path: None,
                             reexport: false,
+                            lazy: false,
                             span,
                         };
                         let mut sub = resolve_imports(
@@ -3062,6 +3108,126 @@ fn resolve_imports_inner(
     }
 
     (result, exported_names.into_iter().collect())
+}
+
+/// Return `true` if any `Expr::Call` or `Expr::Ref` in `decls` has a name
+/// that starts with `prefix`. Used by the lazy-import gate to decide whether
+/// a deferred module is actually needed.
+fn decls_reference_prefix(decls: &[ast::Decl], prefix: &str) -> bool {
+    fn expr_refs(expr: &ast::Expr, prefix: &str) -> bool {
+        match expr {
+            ast::Expr::Call { function, args, .. } => {
+                if function.starts_with(prefix) {
+                    return true;
+                }
+                args.iter().any(|a| expr_refs(a, prefix))
+            }
+            ast::Expr::Ref(name) => name.starts_with(prefix),
+            ast::Expr::BinOp { left, right, .. } => {
+                expr_refs(left, prefix) || expr_refs(right, prefix)
+            }
+            ast::Expr::UnaryOp { operand, .. } => expr_refs(operand, prefix),
+            ast::Expr::Ok(inner) | ast::Expr::Err(inner) => expr_refs(inner, prefix),
+            ast::Expr::List(items) => items.iter().any(|e| expr_refs(e, prefix)),
+            ast::Expr::Record { fields, .. } => fields.iter().any(|(_, e)| expr_refs(e, prefix)),
+            ast::Expr::Field { object, .. } => expr_refs(object, prefix),
+            ast::Expr::Index { object, .. } => expr_refs(object, prefix),
+            ast::Expr::Match { subject, arms } => {
+                subject
+                    .as_deref()
+                    .map(|s| expr_refs(s, prefix))
+                    .unwrap_or(false)
+                    || arms
+                        .iter()
+                        .any(|arm| arm.body.iter().any(|s| stmt_refs(&s.node, prefix)))
+            }
+            ast::Expr::NilCoalesce { value, default } => {
+                expr_refs(value, prefix) || expr_refs(default, prefix)
+            }
+            ast::Expr::With { object, updates } => {
+                expr_refs(object, prefix) || updates.iter().any(|(_, e)| expr_refs(e, prefix))
+            }
+            ast::Expr::Ternary {
+                condition,
+                then_expr,
+                else_expr,
+            } => {
+                expr_refs(condition, prefix)
+                    || expr_refs(then_expr, prefix)
+                    || expr_refs(else_expr, prefix)
+            }
+            ast::Expr::MakeClosure { captures, .. } => {
+                captures.iter().any(|e| expr_refs(e, prefix))
+            }
+            ast::Expr::AnonRecord { fields, .. } => {
+                fields.iter().any(|(_, e)| expr_refs(e, prefix))
+            }
+            ast::Expr::Literal(_) | ast::Expr::Todo(_) | ast::Expr::Panic(_) => false,
+        }
+    }
+
+    fn stmt_refs(stmt: &ast::Stmt, prefix: &str) -> bool {
+        match stmt {
+            ast::Stmt::Let { value, .. } | ast::Stmt::Destructure { value, .. } => {
+                expr_refs(value, prefix)
+            }
+            ast::Stmt::Expr(e) | ast::Stmt::Return(e) => expr_refs(e, prefix),
+            ast::Stmt::Break(Some(e)) => expr_refs(e, prefix),
+            ast::Stmt::Break(None) | ast::Stmt::Continue => false,
+            ast::Stmt::Guard {
+                condition,
+                body,
+                else_body,
+                ..
+            } => {
+                expr_refs(condition, prefix)
+                    || body.iter().any(|s| stmt_refs(&s.node, prefix))
+                    || else_body
+                        .as_deref()
+                        .map(|b| b.iter().any(|s| stmt_refs(&s.node, prefix)))
+                        .unwrap_or(false)
+            }
+            ast::Stmt::Match { subject, arms } => {
+                subject
+                    .as_ref()
+                    .map(|s| expr_refs(s, prefix))
+                    .unwrap_or(false)
+                    || arms
+                        .iter()
+                        .any(|arm| arm.body.iter().any(|s| stmt_refs(&s.node, prefix)))
+            }
+            ast::Stmt::ForEach {
+                collection, body, ..
+            } => expr_refs(collection, prefix) || body.iter().any(|s| stmt_refs(&s.node, prefix)),
+            ast::Stmt::ForRange {
+                start, end, body, ..
+            } => {
+                expr_refs(start, prefix)
+                    || expr_refs(end, prefix)
+                    || body.iter().any(|s| stmt_refs(&s.node, prefix))
+            }
+            ast::Stmt::While { condition, body } => {
+                expr_refs(condition, prefix) || body.iter().any(|s| stmt_refs(&s.node, prefix))
+            }
+            ast::Stmt::Defer { expr, .. } => expr_refs(expr, prefix),
+        }
+    }
+
+    for decl in decls {
+        let referenced = match decl {
+            ast::Decl::Function { body, .. } => body.iter().any(|s| stmt_refs(&s.node, prefix)),
+            ast::Decl::Tool { .. }
+            | ast::Decl::TypeDef { .. }
+            | ast::Decl::SumType { .. }
+            | ast::Decl::Alias { .. }
+            | ast::Decl::Use { .. }
+            | ast::Decl::Error { .. } => false,
+        };
+        if referenced {
+            return true;
+        }
+    }
+    false
 }
 
 /// Rename all named declarations in `decls` by prepending `alias-` to their name.
@@ -7035,6 +7201,7 @@ mod tests {
             predicate: None,
             alt_path: None,
             reexport: false,
+            lazy: false,
             span: ast::Span { start: 0, end: 0 },
         };
         assert_eq!(decl_name(&d), None);
@@ -7076,6 +7243,7 @@ mod tests {
             predicate: None,
             alt_path: None,
             reexport: false,
+            lazy: false,
             span: ast::Span { start: 0, end: 0 },
         };
         let mut diags = Vec::new();
@@ -7114,6 +7282,7 @@ mod tests {
             predicate: None,
             alt_path: None,
             reexport: false,
+            lazy: false,
             span: ast::Span { start: 0, end: 0 },
         };
         let mut diags = Vec::new();
@@ -7371,6 +7540,7 @@ mod tests {
             predicate: None,
             alt_path: None,
             reexport: false,
+            lazy: false,
             span: ast::Span { start: 0, end: 20 },
         };
         let mut visited = std::collections::HashSet::new();
@@ -7382,7 +7552,6 @@ mod tests {
             &mut diags,
             BuildTarget::default(),
         );
-        let result = resolve_imports(vec![use_decl], None, &mut visited, &mut diags, BuildTarget::default());
         assert!(result.is_empty());
         assert!(diags.iter().any(|d| d.code == Some("ILO-P017")));
         assert!(diags[0].message.contains("inline code"));
@@ -7397,6 +7566,7 @@ mod tests {
             predicate: None,
             alt_path: None,
             reexport: false,
+            lazy: false,
             span: ast::Span { start: 0, end: 30 },
         };
         let mut visited = std::collections::HashSet::new();
@@ -7435,7 +7605,6 @@ mod tests {
             &mut diags,
             BuildTarget::default(),
         );
-        let result = resolve_imports(vec![func_decl], None, &mut visited, &mut diags, BuildTarget::default());
         assert_eq!(result.len(), 1);
         assert!(diags.is_empty());
     }
@@ -7524,6 +7693,7 @@ mod tests {
             predicate: None,
             alt_path: None,
             reexport: false,
+            lazy: false,
             span: ast::Span { start: 0, end: 0 },
         }];
         let mut visited = std::collections::HashSet::new();
@@ -7564,6 +7734,7 @@ mod tests {
             predicate: None,
             alt_path: None,
             reexport: false,
+            lazy: false,
             span: ast::Span { start: 0, end: 0 },
         }];
         let mut visited = std::collections::HashSet::new();
@@ -7603,6 +7774,7 @@ mod tests {
             predicate: None,
             alt_path: None,
             reexport: false,
+            lazy: false,
             span: ast::Span { start: 0, end: 0 },
         };
         let mut diags = Vec::new();
@@ -7643,6 +7815,7 @@ mod tests {
             predicate: None,
             alt_path: None,
             reexport: false,
+            lazy: false,
             span: ast::Span { start: 0, end: 0 },
         };
         let mut diags = Vec::new();
@@ -7686,6 +7859,7 @@ mod tests {
             predicate: None,
             alt_path: None,
             reexport: false,
+            lazy: false,
             span: ast::Span { start: 0, end: 0 },
         };
         let mut diags = Vec::new();
@@ -7729,6 +7903,7 @@ mod tests {
             predicate: Some(ast::UsePredicate::Wasm),
             alt_path: Some("ilo_cond_native_ILO399.ilo".into()),
             reexport: false,
+            lazy: false,
             span: ast::Span::UNKNOWN,
         };
         let mut diags = Vec::new();
@@ -7751,8 +7926,6 @@ mod tests {
             !names.contains(&"native-fn"),
             "native-fn should not be imported"
         );
-        assert!(names.contains(&"wasm-fn"), "expected wasm-fn, got: {names:?}");
-        assert!(!names.contains(&"native-fn"), "native-fn should not be imported");
 
         std::fs::remove_file(wasm_path).ok();
         std::fs::remove_file(native_path).ok();
@@ -7786,6 +7959,7 @@ mod tests {
             predicate: None,
             alt_path: None,
             reexport: false,
+            lazy: false,
             span: ast::Span { start: 0, end: 0 },
         };
         let mut diags = Vec::new();
@@ -7828,6 +8002,7 @@ mod tests {
             predicate: Some(ast::UsePredicate::Wasm),
             alt_path: Some("ilo_cond2_native_ILO399.ilo".into()),
             reexport: false,
+            lazy: false,
             span: ast::Span::UNKNOWN,
         };
         let mut diags = Vec::new();
@@ -7850,8 +8025,6 @@ mod tests {
             !names.contains(&"wasm-fn"),
             "wasm-fn should not be imported"
         );
-        assert!(names.contains(&"native-fn"), "expected native-fn, got: {names:?}");
-        assert!(!names.contains(&"wasm-fn"), "wasm-fn should not be imported");
 
         std::fs::remove_file(wasm_path).ok();
         std::fs::remove_file(native_path).ok();
@@ -7880,6 +8053,7 @@ mod tests {
             predicate: None,
             alt_path: None,
             reexport: false,
+            lazy: false,
             span: ast::Span { start: 0, end: 0 },
         };
         let mut diags = Vec::new();
@@ -7922,6 +8096,7 @@ mod tests {
             predicate: Some(ast::UsePredicate::Test),
             alt_path: Some("ilo_cond_real_ILO399.ilo".into()),
             reexport: false,
+            lazy: false,
             span: ast::Span::UNKNOWN,
         };
         let mut diags = Vec::new();
@@ -7940,10 +8115,124 @@ mod tests {
             names.contains(&"stub-fn"),
             "expected stub-fn, got: {names:?}"
         );
-        assert!(names.contains(&"stub-fn"), "expected stub-fn, got: {names:?}");
 
         std::fs::remove_file(stub_path).ok();
         std::fs::remove_file(real_path).ok();
+    }
+
+    // ── resolve_imports: lazy loading (ILO-400) ───────────────────────────────
+
+    #[test]
+    fn resolve_imports_lazy_not_loaded_when_unreferenced() {
+        // A `use lazy:"./big-mod.ilo"` where no `big-mod-*` symbol appears in the
+        // program body → the file must never be opened (module skipped).
+        use std::io::Write;
+        // Use a path that does NOT exist so any file-open attempt causes an error.
+        let lib_path = "/tmp/ilo_lazy_SHOULD_NOT_OPEN_ILO400.ilo";
+        // Remove to ensure it doesn't exist
+        std::fs::remove_file(lib_path).ok();
+
+        // Importer has a function that does NOT reference big-mod-* symbols.
+        let caller = ast::Decl::Function {
+            name: "main".into(),
+            type_params: vec![],
+            params: vec![],
+            return_type: ast::Type::Number,
+            body: vec![ast::Spanned::unknown(ast::Stmt::Return(
+                ast::Expr::Literal(ast::Literal::Number(42.0)),
+            ))],
+            span: ast::Span::UNKNOWN,
+        };
+
+        let lazy_use = ast::Decl::Use {
+            path: "ilo_lazy_SHOULD_NOT_OPEN_ILO400.ilo".into(),
+            only: None,
+            alias: Some("ilo-lazy-SHOULD-NOT-OPEN-ILO400".into()),
+            predicate: None,
+            alt_path: None,
+            reexport: false,
+            lazy: true,
+            span: ast::Span::UNKNOWN,
+        };
+
+        let mut diags = Vec::new();
+        let mut visited = std::collections::HashSet::new();
+        let result = resolve_imports(
+            vec![lazy_use, caller],
+            Some(std::path::Path::new("/tmp")),
+            &mut visited,
+            &mut diags,
+            BuildTarget::default(),
+        );
+
+        // No diagnostics: the file was never opened (missing file → no error).
+        assert!(
+            diags.is_empty(),
+            "lazy module must not be opened when unreferenced, got diags: {diags:?}"
+        );
+        // Only `main` should appear.
+        let names: Vec<_> = result.iter().filter_map(|d| decl_name(d)).collect();
+        assert_eq!(names, vec!["main"], "expected only main, got: {names:?}");
+    }
+
+    #[test]
+    fn resolve_imports_lazy_loaded_when_referenced() {
+        // A `use lazy:"./mod.ilo"` where a `mod-*` symbol IS referenced →
+        // the module is loaded and its declarations appear in the result.
+        use std::io::Write;
+        let lib_path = "/tmp/ilo_lazy_load_ILO400.ilo";
+        let mut f = std::fs::File::create(lib_path).unwrap();
+        writeln!(f, "mod-helper>n;99").unwrap();
+        drop(f);
+
+        // Caller references `mod-helper` (a `mod-` prefixed symbol).
+        let caller = ast::Decl::Function {
+            name: "main".into(),
+            type_params: vec![],
+            params: vec![],
+            return_type: ast::Type::Number,
+            body: vec![ast::Spanned::unknown(ast::Stmt::Return(ast::Expr::Call {
+                function: "mod-helper".into(),
+                args: vec![],
+                unwrap: ast::UnwrapMode::None,
+            }))],
+            span: ast::Span::UNKNOWN,
+        };
+
+        let lazy_use = ast::Decl::Use {
+            path: "ilo_lazy_load_ILO400.ilo".into(),
+            only: None,
+            alias: Some("mod".into()),
+            predicate: None,
+            alt_path: None,
+            reexport: false,
+            lazy: true,
+            span: ast::Span::UNKNOWN,
+        };
+
+        let mut diags = Vec::new();
+        let mut visited = std::collections::HashSet::new();
+        let result = resolve_imports(
+            vec![lazy_use, caller],
+            Some(std::path::Path::new("/tmp")),
+            &mut visited,
+            &mut diags,
+            BuildTarget::default(),
+        );
+
+        assert!(diags.is_empty(), "no errors expected: {diags:?}");
+        let names: Vec<_> = result.iter().filter_map(|d| decl_name(d)).collect();
+        // The loaded module function is prefixed with `mod-`
+        assert!(
+            names.iter().any(|n| n.starts_with("mod-")),
+            "expected mod-* symbol from loaded lazy module, got: {names:?}"
+        );
+        assert!(
+            names.contains(&"main"),
+            "main must also be present: {names:?}"
+        );
+
+        std::fs::remove_file(lib_path).ok();
     }
 
     #[test]
@@ -9023,6 +9312,7 @@ mod tests {
             predicate: None,
             alt_path: None,
             reexport: false,
+            lazy: false,
             span: ast::Span::UNKNOWN,
         }
     }
@@ -9040,7 +9330,6 @@ mod tests {
             &mut diagnostics,
             BuildTarget::default(),
         );
-        let result = resolve_imports(decls, None, &mut visited, &mut diagnostics, BuildTarget::default());
         assert!(result.is_empty(), "should return no decls");
         assert!(!diagnostics.is_empty(), "should emit error");
         assert!(diagnostics[0].message.contains("file path context"));
@@ -9060,7 +9349,6 @@ mod tests {
             &mut diagnostics,
             BuildTarget::default(),
         );
-        let result = resolve_imports(decls, Some(dir), &mut visited, &mut diagnostics, BuildTarget::default());
         assert!(result.is_empty());
         assert!(!diagnostics.is_empty());
         assert!(diagnostics[0].message.contains("nonexistent_file_xyz.ilo"));
@@ -9085,7 +9373,6 @@ mod tests {
             &mut diagnostics,
             BuildTarget::default(),
         );
-        let result = resolve_imports(decls, Some(dir), &mut visited, &mut diagnostics, BuildTarget::default());
         assert!(result.is_empty());
         assert!(!diagnostics.is_empty());
         assert!(diagnostics[0].message.contains("circular"));
@@ -9108,7 +9395,6 @@ mod tests {
             &mut diagnostics,
             BuildTarget::default(),
         );
-        let _result = resolve_imports(decls, Some(dir), &mut visited, &mut diagnostics, BuildTarget::default());
         assert!(!diagnostics.is_empty(), "should emit lex error diagnostic");
         std::fs::remove_file(path).ok();
     }
@@ -9137,7 +9423,6 @@ mod tests {
             &mut diagnostics,
             BuildTarget::default(),
         );
-        resolve_imports(decls, Some(dir), &mut visited, &mut diagnostics, BuildTarget::default());
         assert!(!diagnostics.is_empty());
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -883,7 +883,6 @@ statement boundary; bind the chain to a local first. For example, split \
                         "ILO-P016",
                         "expected a predicate name (wasm/native/test) after `use ?`, got EOF"
                             .into(),
-                        "expected a predicate name (wasm/native/test) after `use ?`, got EOF".into(),
                     ));
                 }
             };
@@ -904,7 +903,6 @@ statement boundary; bind the chain to a local first. For example, split \
                     self.advance();
                     p
                 }
-                Some(Token::Text(p)) => { self.advance(); p }
                 Some(tok) => {
                     return Err(self.error(
                         "ILO-P016",
@@ -926,7 +924,6 @@ statement boundary; bind the chain to a local first. For example, split \
                 Some(Token::Colon) => {
                     self.advance();
                 }
-                Some(Token::Colon) => { self.advance(); }
                 Some(tok) => {
                     return Err(self.error(
                         "ILO-P016",
@@ -942,7 +939,6 @@ statement boundary; bind the chain to a local first. For example, split \
                         format!(
                             "expected `:` after true-branch path in `use ?{pred_name}`, got EOF"
                         ),
-                        format!("expected `:` after true-branch path in `use ?{pred_name}`, got EOF"),
                     ));
                 }
             };
@@ -952,7 +948,6 @@ statement boundary; bind the chain to a local first. For example, split \
                     self.advance();
                     p
                 }
-                Some(Token::Text(p)) => { self.advance(); p }
                 Some(tok) => {
                     return Err(self.error(
                         "ILO-P016",
@@ -977,6 +972,7 @@ statement boundary; bind the chain to a local first. For example, split \
                 predicate: Some(predicate),
                 alt_path: Some(false_path),
                 reexport: false,
+                lazy: false,
                 span: start.merge(end),
             });
         }
@@ -989,10 +985,6 @@ statement boundary; bind the chain to a local first. For example, split \
         // Detected by whether the next token is a string literal or an ident followed by `:`.
         // The special ident `re` triggers the re-export form; any other ident triggers the alias form.
         let (alias, path, reexport) = match self.peek().cloned() {
-        // Detect named-module form: `use alias:"path"` — ident immediately
-        // followed by `:` then a string literal.
-        // Distinguished from the plain form `use "path"` by the leading ident.
-        let (alias, path) = match self.peek().cloned() {
             Some(Token::Text(p)) => {
                 // Plain form: `use "path"`
                 self.advance();
@@ -1069,6 +1061,24 @@ statement boundary; bind the chain to a local first. For example, split \
 
         // Optional `[name1 name2 ...]` scoped import list.
         // Incompatible with alias form; required for re-export form.
+        // Detect lazy import: `use lazy:"./path"` — `lazy` is a reserved
+        // modifier, not a real alias. The effective alias is derived from the
+        // path stem (last path component without extension), e.g.
+        // `use lazy:"./big-module"` → alias `big-module`, lazy = true.
+        let (alias, lazy) = match alias {
+            Some(ref a) if a == "lazy" => {
+                // Derive alias from the path stem.
+                let stem = std::path::Path::new(&path)
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or(&path)
+                    .to_string();
+                (Some(stem), true)
+            }
+            other => (other, false),
+        };
+
+        // Optional `[name1 name2 ...]` scoped import list (incompatible with alias form)
         let only = if self.peek() == Some(&Token::LBracket) {
             if alias.is_some() {
                 return Err(self.error(
@@ -1116,6 +1126,7 @@ statement boundary; bind the chain to a local first. For example, split \
             predicate: None,
             alt_path: None,
             reexport,
+            lazy,
             span: start.merge(end),
         })
     }
@@ -9577,7 +9588,6 @@ mod tests {
             alias,
             ..
         } = &prog.declarations[0]
-        let Decl::Use { path, alt_path, predicate, only, alias, .. } = &prog.declarations[0]
         else {
             panic!("expected Use, got {:?}", prog.declarations)
         };
@@ -9598,7 +9608,6 @@ mod tests {
             ..
         } = &prog.declarations[0]
         else {
-        let Decl::Use { predicate, path, alt_path, .. } = &prog.declarations[0] else {
             panic!("expected Use")
         };
         assert_eq!(*predicate, Some(UsePredicate::Native));
@@ -9622,7 +9631,6 @@ mod tests {
             errors
                 .iter()
                 .any(|e| e.code == "ILO-P016" && e.message.contains("unknown")),
-            errors.iter().any(|e| e.code == "ILO-P016" && e.message.contains("unknown")),
             "expected ILO-P016 unknown predicate, got: {errors:?}"
         );
     }
@@ -9643,6 +9651,45 @@ mod tests {
             errors.iter().any(|e| e.code == "ILO-P016"),
             "expected ILO-P016 for missing colon: {errors:?}"
         );
+    }
+
+    // --- lazy use (ILO-400) ---
+
+    #[test]
+    fn parse_use_lazy_sets_lazy_flag_and_stem_alias() {
+        // `use lazy:"./big-module.ilo"` → lazy=true, alias="big-module"
+        let prog = parse_str(r#"use lazy:"./big-module.ilo""#);
+        let Decl::Use {
+            path, alias, lazy, ..
+        } = &prog.declarations[0]
+        else {
+            panic!("expected Use, got {:?}", prog.declarations)
+        };
+        assert_eq!(path, "./big-module.ilo");
+        assert_eq!(alias.as_deref(), Some("big-module"));
+        assert!(*lazy, "lazy flag must be true");
+    }
+
+    #[test]
+    fn parse_use_lazy_no_extension() {
+        // Path without extension: stem is the whole basename
+        let prog = parse_str(r#"use lazy:"./utils""#);
+        let Decl::Use { alias, lazy, .. } = &prog.declarations[0] else {
+            panic!("expected Use")
+        };
+        assert_eq!(alias.as_deref(), Some("utils"));
+        assert!(*lazy, "lazy flag must be true");
+    }
+
+    #[test]
+    fn parse_use_non_lazy_alias_unchanged() {
+        // Non-lazy alias: `use m:"lib.ilo"` should leave lazy=false
+        let prog = parse_str(r#"use m:"lib.ilo""#);
+        let Decl::Use { alias, lazy, .. } = &prog.declarations[0] else {
+            panic!("expected Use")
+        };
+        assert_eq!(alias.as_deref(), Some("m"));
+        assert!(!lazy, "lazy must be false for non-lazy import");
     }
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -883,6 +883,7 @@ statement boundary; bind the chain to a local first. For example, split \
                         "ILO-P016",
                         "expected a predicate name (wasm/native/test) after `use ?`, got EOF"
                             .into(),
+                        "expected a predicate name (wasm/native/test) after `use ?`, got EOF".into(),
                     ));
                 }
             };
@@ -903,6 +904,7 @@ statement boundary; bind the chain to a local first. For example, split \
                     self.advance();
                     p
                 }
+                Some(Token::Text(p)) => { self.advance(); p }
                 Some(tok) => {
                     return Err(self.error(
                         "ILO-P016",
@@ -924,6 +926,7 @@ statement boundary; bind the chain to a local first. For example, split \
                 Some(Token::Colon) => {
                     self.advance();
                 }
+                Some(Token::Colon) => { self.advance(); }
                 Some(tok) => {
                     return Err(self.error(
                         "ILO-P016",
@@ -939,6 +942,7 @@ statement boundary; bind the chain to a local first. For example, split \
                         format!(
                             "expected `:` after true-branch path in `use ?{pred_name}`, got EOF"
                         ),
+                        format!("expected `:` after true-branch path in `use ?{pred_name}`, got EOF"),
                     ));
                 }
             };
@@ -948,6 +952,7 @@ statement boundary; bind the chain to a local first. For example, split \
                     self.advance();
                     p
                 }
+                Some(Token::Text(p)) => { self.advance(); p }
                 Some(tok) => {
                     return Err(self.error(
                         "ILO-P016",
@@ -984,6 +989,10 @@ statement boundary; bind the chain to a local first. For example, split \
         // Detected by whether the next token is a string literal or an ident followed by `:`.
         // The special ident `re` triggers the re-export form; any other ident triggers the alias form.
         let (alias, path, reexport) = match self.peek().cloned() {
+        // Detect named-module form: `use alias:"path"` — ident immediately
+        // followed by `:` then a string literal.
+        // Distinguished from the plain form `use "path"` by the leading ident.
+        let (alias, path) = match self.peek().cloned() {
             Some(Token::Text(p)) => {
                 // Plain form: `use "path"`
                 self.advance();
@@ -9568,6 +9577,7 @@ mod tests {
             alias,
             ..
         } = &prog.declarations[0]
+        let Decl::Use { path, alt_path, predicate, only, alias, .. } = &prog.declarations[0]
         else {
             panic!("expected Use, got {:?}", prog.declarations)
         };
@@ -9588,6 +9598,7 @@ mod tests {
             ..
         } = &prog.declarations[0]
         else {
+        let Decl::Use { predicate, path, alt_path, .. } = &prog.declarations[0] else {
             panic!("expected Use")
         };
         assert_eq!(*predicate, Some(UsePredicate::Native));
@@ -9611,6 +9622,7 @@ mod tests {
             errors
                 .iter()
                 .any(|e| e.code == "ILO-P016" && e.message.contains("unknown")),
+            errors.iter().any(|e| e.code == "ILO-P016" && e.message.contains("unknown")),
             "expected ILO-P016 unknown predicate, got: {errors:?}"
         );
     }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -10275,6 +10275,7 @@ mod tests {
             predicate: None,
             alt_path: None,
             reexport: false,
+            lazy: false,
             span: Span::UNKNOWN,
         });
         let result = verify(&program);

--- a/tests/regression_lazy_module_loading.rs
+++ b/tests/regression_lazy_module_loading.rs
@@ -1,0 +1,89 @@
+// Regression tests for lazy / on-demand module loading (ILO-400).
+//
+// `use lazy:"./path"` defers module resolution until at least one
+// `<stem>-*` symbol from the module is referenced in the program.
+// If no symbol is referenced the file is never opened.
+//
+// Contracts locked in here:
+// 1. A lazy import where no `<stem>-*` symbol is referenced → module
+//    never opened; missing file causes no error.
+// 2. A lazy import where a `<stem>-*` symbol IS referenced → module
+//    is loaded and its declarations are available at runtime.
+
+use std::io::Write;
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+// Write `content` to `path`, returning the path.
+fn write_tmp(path: &str, content: &str) -> String {
+    let mut f = std::fs::File::create(path).expect("create tmp file");
+    write!(f, "{}", content).expect("write tmp file");
+    path.to_string()
+}
+
+// ── 1. Lazy import not opened when unreferenced ───────────────────────────
+
+#[test]
+fn lazy_import_not_opened_when_unreferenced() {
+    // The big-module file does NOT exist. The importer never calls big-module-*.
+    // Resolution must succeed with no errors.
+    let importer_path = write_tmp(
+        "/tmp/ilo_lazy_importer_ILO400.ilo",
+        // Uses lazy but calls nothing from big-module
+        r#"use lazy:"./ilo_lazy_BIG_MODULE_NONEXISTENT_ILO400.ilo"
+main>n;42"#,
+    );
+
+    let out = ilo()
+        .args([&importer_path, "--vm", "main"])
+        .output()
+        .expect("failed to run ilo");
+
+    let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+
+    assert!(
+        out.status.success(),
+        "lazy import of missing module must succeed when unreferenced; stderr={stderr}"
+    );
+    assert_eq!(stdout, "42", "expected 42, got: {stdout}");
+
+    std::fs::remove_file(&importer_path).ok();
+}
+
+// ── 2. Lazy import loaded when referenced ────────────────────────────────
+
+#[test]
+fn lazy_import_loaded_when_referenced() {
+    // The module file is named `bigmod.ilo` → stem is `bigmod`.
+    // The importer calls `bigmod-answer` (stem-prefixed symbol).
+    // The module declares `answer>n;99`; after lazy load it becomes `bigmod-answer`.
+    let module_path = write_tmp("/tmp/bigmod.ilo", "answer>n;99");
+    let importer_path = write_tmp(
+        "/tmp/ilo_lazy_caller_ILO400.ilo",
+        "use lazy:\"./bigmod.ilo\"\nmain>n;bigmod-answer()",
+    );
+
+    let out = ilo()
+        .args([&importer_path, "--vm", "main"])
+        .output()
+        .expect("failed to run ilo");
+
+    let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+
+    assert!(
+        out.status.success(),
+        "lazy import must be loaded when referenced; stderr={stderr}"
+    );
+    assert_eq!(
+        stdout, "99",
+        "expected 99 from bigmod-answer, got: {stdout}"
+    );
+
+    std::fs::remove_file(&module_path).ok();
+    std::fs::remove_file(&importer_path).ok();
+}


### PR DESCRIPTION
## Summary

- Adds `use lazy:"./big-module"` syntax — modules are only resolved when at least one `<stem>-*` symbol is referenced in the program; unreferenced lazy imports are never opened (zero IO cost)
- AST: `Decl::Use` gains `lazy: bool` field with `#[serde(default)]` for backward compatibility
- Parser: `lazy` is a reserved modifier alias; effective alias is derived from path stem (`./big-module.ilo` → alias `big-module`, symbols `big-module-foo`)
- Resolver: two-pass approach — eager imports first, then lazy imports gate-checked via `decls_reference_prefix` AST walker; lazy modules prepended when loaded

## Test plan

- [ ] Parser unit tests: `use lazy:"./path"` sets `lazy=true` and derives stem alias; non-lazy aliases unchanged
- [ ] Resolver unit tests: unreferenced lazy import → file never opened (missing file = no error); referenced lazy import → module loaded and symbols available
- [ ] Integration tests (`tests/regression_lazy_module_loading.rs`): end-to-end — unreferenced missing file succeeds, referenced module loaded and callable
- [ ] All 3345 lib tests green
- [ ] `cargo test --test regression_lazy_module_loading` green

Closes ILO-400. Extends ILO-60 (#627).

🤖 Generated with [Claude Code](https://claude.com/claude-code)