### PR TITLE
chore: tighten modular-skill token caps to measured baseline + headroom (ILO-382)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,9 +32,9 @@ jobs:
     - name: Install tiktoken
       run: pip install tiktoken
     - name: Enforce modular-skill token budget (cl100k_base)
-      # Each ilo-*.md skill must be ≤ 1,000 tokens, with one exception:
-      # ilo-language (the foundational module) is capped at ≤ 1,500.
-      # Aggregate across all modules ≤ 8,500. The in-binary
+      # Aggressive per-module caps set in ILO-382 (measured baseline + ~50-token
+      # headroom). See scripts/check-skill-tokens.py for per-module overrides.
+      # Aggregate across all modules ≤ 12,500. The in-binary
       # tests/skill_modular.rs enforces a byte proxy for the same limit,
       # but this step is the canonical check using the same tokeniser
       # an agent host uses to size the context window.

--- a/scripts/check-skill-tokens.py
+++ b/scripts/check-skill-tokens.py
@@ -3,16 +3,17 @@
 Enforce the modular-skill token budget.
 
 Each `skills/ilo/ilo-*.md` module must encode to <= 1,000 tokens under
-`cl100k_base`, with one exception: `ilo-language` is the foundational
-module every agent loads first, so it carries a higher 1,500-token cap
-to accommodate core syntax that doesn't split cleanly. The aggregate
-across all modules must be <= 8,500.
+`cl100k_base`. Modules that are currently above this baseline carry an
+explicit per-module override in `PER_MODULE_OVERRIDES`; those overrides are
+set to measured size + ~50-token headroom (aggressive cap, ILO-382). Growth
+past an override requires an editorial trim or a module split — not a bump.
+The aggregate across all modules must be <= 12,500.
 
 The budget exists because the whole point of splitting the monolithic
 ~16,000-token compact spec into modules was to let agents load only the
 slices their current task needs (typical: 1-2 modules ~ 2,000 tokens). If
-a category module drifts past 1,000 tokens, the per-task economics regress,
-so the guard is a CI gate, not advisory.
+a category module drifts, the per-task economics regress, so the guard is
+a CI gate, not advisory.
 
 `ilo-builtins` was split into four category files (core, math, io, text)
 to give headroom as the language grows (PR: skill-split-by-category).
@@ -43,23 +44,24 @@ SKILL_NAMES = [
 ]
 
 PER_MODULE_LIMIT = 1000
-# Per-module overrides for the densest modules. Caps track measured size
-# with light headroom; the aggregate budget (TOTAL_LIMIT) is the real
-# token-economics gate, since agents load 1-2 modules per task.
-# `ilo-language` is the foundational module every agent loads first.
-# `ilo-builtins-io` covers HTTP, JSON, env, time, process - dogfooding
-# hits it on every other doc PR. `ilo-builtins-math` carries the full
-# numerics surface (stats, distance, regression, FFT, bisect). `ilo-agent`
-# documents the agent-protocol RPC, which has grown with each verb.
+# Per-module overrides: actual measured size + ~50-token headroom.
+# These are aggressive caps picked empirically from the current corpus
+# (ILO-382). Any growth past these limits requires an editorial trim
+# or a module split — not a cap bump.
+#
+# Measured baseline (cl100k_base, 2026-05-22):
+#   ilo-language:       1654  ilo-builtins-core:  1071
+#   ilo-builtins-math:  1409  ilo-builtins-io:    1947
+#   ilo-builtins-text:  1140  ilo-agent:          1219
 PER_MODULE_OVERRIDES = {
     "ilo-language": 1700,
-    "ilo-builtins-core": 1200,
-    "ilo-builtins-math": 1500,
+    "ilo-builtins-core": 1125,
+    "ilo-builtins-math": 1460,
     "ilo-builtins-io": 2000,
-    "ilo-builtins-text": 1200,
-    "ilo-agent": 1300,
+    "ilo-builtins-text": 1190,
+    "ilo-agent": 1270,
 }
-TOTAL_LIMIT = 15000
+TOTAL_LIMIT = 12500
 
 
 def main() -> int:

--- a/tests/skill_modular.rs
+++ b/tests/skill_modular.rs
@@ -42,20 +42,20 @@ const SKILL_NAMES: &[&str] = &[
     "ilo-edit-loop",
 ];
 
-/// Conservative byte budget per module. cl100k_base averages ~3.4 bytes/token
-/// on dense reference-style markdown like ours, so 4_000 bytes ≈ 1,180 tokens
-/// in the worst case. The Python tiktoken job in CI enforces the precise
-/// per-module cap (1,000 tokens for category modules, 1,500 for the
-/// foundational `ilo-language`); this in-binary check is a defence-in-depth
-/// tripwire that catches drift even when CI is bypassed.
-const BYTE_BUDGET_PER_MODULE: usize = 7_000;
+/// Aggressive byte budget per module (ILO-382). cl100k_base averages ~3.4
+/// bytes/token on dense reference-style markdown like ours, so 6_500 bytes ≈
+/// ~1,900 tokens in the worst case. The Python tiktoken job in CI enforces the
+/// precise per-module caps (see `scripts/check-skill-tokens.py`); this in-binary
+/// check is a defence-in-depth tripwire that catches drift even when CI is
+/// bypassed. Set to actual largest module (ilo-builtins-io, ~6,230 bytes) plus
+/// ~270 bytes headroom.
+const BYTE_BUDGET_PER_MODULE: usize = 6_500;
 
-/// Total bytes across all twelve. ~31,200 bytes ≈ 9,000 tokens at ~3.4 bytes
-/// per cl100k_base token on our content; the tighter tiktoken job in CI
-/// enforces the actual 8,500-token cap. Leaving the byte tripwire a few
-/// hundred tokens of slack avoids spurious failures when a single-character
-/// edit lands locally without re-running the Python counter.
-const BYTE_BUDGET_TOTAL: usize = 52_000;
+/// Total bytes across all twelve (ILO-382 aggressive cap). Measured baseline
+/// is ~38,082 bytes; the tighter tiktoken job in CI enforces the 12,500-token
+/// aggregate cap. Leaving ~10% byte slack here avoids spurious failures when a
+/// small edit lands locally without re-running the Python counter.
+const BYTE_BUDGET_TOTAL: usize = 42_000;
 
 fn read_skill(name: &str) -> String {
     let p = repo_root().join("skills/ilo").join(format!("{name}.md"));
@@ -138,8 +138,8 @@ fn per_module_byte_budget_respected() {
         assert!(
             len <= BYTE_BUDGET_PER_MODULE,
             "{n}.md is {len} bytes, over the per-module budget of {BYTE_BUDGET_PER_MODULE}. \
-             Trim or split. The hard per-module token cap (1,000 for category modules, \
-             1,500 for ilo-language) is enforced by the tiktoken CI job."
+             Trim or split. Hard per-module token caps are enforced by the tiktoken CI job \
+             (see scripts/check-skill-tokens.py — aggressive caps set in ILO-382)."
         );
     }
 }
@@ -150,7 +150,7 @@ fn total_byte_budget_respected() {
     assert!(
         total <= BYTE_BUDGET_TOTAL,
         "total skills size is {total} bytes, over the aggregate budget of {BYTE_BUDGET_TOTAL}. \
-         The hard 8,500-token cap is enforced by the tiktoken CI job."
+         The hard 12,500-token aggregate cap is enforced by the tiktoken CI job."
     );
 }
 


### PR DESCRIPTION
## Summary

- Sets per-module token caps to actual measured size + ~50-token headroom (aggressive caps per ILO-382)
- Reduces aggregate token limit from 15,000 → 12,500
- Tightens byte tripwires in `tests/skill_modular.rs` from 7,000/52,000 → 6,500/42,000 to match current actual usage

## Cap changes

| Module | Old cap | New cap | Measured |
|--------|---------|---------|---------|
| ilo-language | 1700 | 1700 | 1654 |
| ilo-builtins-core | 1200 | 1125 | 1071 |
| ilo-builtins-math | 1500 | 1460 | 1409 |
| ilo-builtins-io | 2000 | 2000 | 1947 |
| ilo-builtins-text | 1200 | 1190 | 1140 |
| ilo-agent | 1300 | 1270 | 1219 |
| TOTAL | 15000 | 12500 | 11676 |

Growth past any cap now requires an editorial trim or module split — not a cap bump. This makes the guardrail meaningful rather than a loose advisory.

## Test plan

- [x] `python3 scripts/check-skill-tokens.py` passes
- [x] `cargo test --test skill_modular` passes (7/7)
- [ ] CI tiktoken job green

Closes ILO-382

🤖 Generated with [Claude Code](https://claude.com/claude-code)