### PR TITLE
feat(ILO-403): recursive sum types — nil variant, self-referential payloads

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -595,6 +595,12 @@ impl Env {
         if Builtin::is_builtin(name) {
             return Ok(Value::FnRef(name.to_string()));
         }
+        // `nil` is emitted as Expr::Ref("nil") by the parser (so that sum-type
+        // variants named `nil` resolve correctly).  When no `nil` variant is
+        // registered, fall back to the built-in nil value.
+        if name == "nil" {
+            return Ok(Value::Nil);
+        }
         Err(RuntimeError::new(
             "ILO-R001",
             format!("undefined variable: {}", name),
@@ -9808,6 +9814,12 @@ fn match_pattern(pattern: &Pattern, value: &Value) -> Option<Vec<(String, Value)
             }
         }
         Pattern::Variant { tag, binding } => {
+            // `nil:` in a match arm is emitted as Pattern::Variant { tag: "nil" }
+            // so that it can match both the built-in nil value (Optional/nil) and
+            // a sum-type variant named `nil`.
+            if tag == "nil" && matches!(value, Value::Nil) {
+                return Some(vec![]);
+            }
             if let Value::Variant {
                 tag: vtag, payload, ..
             } = value

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1146,13 +1146,22 @@ statement boundary; bind the chain to a local first. For example, split \
     fn parse_sum_type_body(&mut self, name: String, start: Span) -> Result<Decl> {
         let mut variants = Vec::new();
         loop {
-            // Each variant: `ident` optionally followed by `(type)`
-            let vname = self.expect_ident().map_err(|_| {
-                self.error(
-                    "ILO-P010",
-                    "expected variant name in sum type declaration".into(),
-                )
-            })?;
+            // Each variant: `ident` optionally followed by `(type)`.
+            // `nil` is a keyword in expressions but is a perfectly valid variant
+            // name in a sum type declaration (e.g. `type list = nil | cons(n)`),
+            // so we accept Token::Nil here in addition to plain identifiers.
+            let vname = match self.peek().cloned() {
+                Some(Token::Nil) => {
+                    self.advance();
+                    "nil".to_string()
+                }
+                _ => self.expect_ident().map_err(|_| {
+                    self.error(
+                        "ILO-P010",
+                        "expected variant name in sum type declaration".into(),
+                    )
+                })?,
+            };
             let payload = if self.peek() == Some(&Token::LParen) {
                 self.advance(); // consume `(`
                 let ty = self.parse_type()?;
@@ -2993,7 +3002,16 @@ statement boundary; bind the chain to a local first. For example, split \
             }
             Some(Token::Nil) => {
                 self.advance();
-                Ok(Pattern::Literal(Literal::Nil))
+                // `nil:` in a match arm can mean either:
+                //  - the built-in nil literal (Optional/nil check)
+                //  - a sum-type variant named `nil` (e.g. `type list = nil | cons(n)`)
+                // We emit Pattern::Variant so the same arm covers both cases.
+                // The interpreter and VM both handle this: matching Value::Nil
+                // as well as Value::Variant { tag: "nil" }.
+                Ok(Pattern::Variant {
+                    tag: "nil".to_string(),
+                    binding: None,
+                })
             }
             Some(Token::Ident(name)) if matches!(name.as_str(), "n" | "t" | "b" | "l") => {
                 let ty = match name.as_str() {
@@ -5056,7 +5074,12 @@ results first: `r={first_op}a b;…r` keeps each step explicit."
             }
             Some(Token::Nil) => {
                 self.advance();
-                Ok(Expr::Literal(Literal::Nil))
+                // Emit as Expr::Ref("nil") so that, when a sum-type variant
+                // named `nil` is in scope, it resolves to the variant
+                // constructor (returning the sum type).  The verifier and
+                // interpreter both fall back to the ordinary nil value when no
+                // such variant is registered.
+                Ok(Expr::Ref("nil".to_string()))
             }
             Some(Token::Underscore) => {
                 // `_ident` (no whitespace between `_` and the following ident) →
@@ -10916,7 +10939,10 @@ mod tests {
 
     #[test]
     fn parse_match_nil_literal_pattern() {
-        // `?x{nil:0;_:1}` — nil token as a match pattern (Pattern::Literal(Literal::Nil))
+        // `?x{nil:0;_:1}` — nil token as a match pattern.
+        // Since ILO-403, `nil:` in a match arm is emitted as
+        // Pattern::Variant { tag: "nil" } so it covers both built-in nil
+        // values (Optional) and sum-type variants named `nil`.
         let prog = parse_str("f x:n>n;?x{nil:0;_:1}");
         let Decl::Function { body, .. } = &prog.declarations[0] else {
             panic!("expected function")
@@ -10924,7 +10950,10 @@ mod tests {
         let Stmt::Match { arms, .. } = &body[0].node else {
             panic!("expected match")
         };
-        assert!(matches!(&arms[0].pattern, Pattern::Literal(Literal::Nil)));
+        assert!(matches!(
+            &arms[0].pattern,
+            Pattern::Variant { tag, binding: None } if tag == "nil"
+        ));
     }
 
     // ── Coverage: L975 — parse_expr_or_guard: guard with else body ─────────────
@@ -11105,14 +11134,17 @@ mod tests {
 
     #[test]
     fn parse_nil_literal_operand() {
-        // `nil` as an expression operand — exercises Token::Nil in parse_operand
+        // `nil` as an expression operand.
+        // Since ILO-403, Token::Nil produces Expr::Ref("nil") so that sum-type
+        // variants named `nil` resolve correctly via the variant_constructors map.
+        // When no `nil` variant is in scope the interpreter/VM fall back to nil.
         let prog = parse_str("f>_;nil");
         let Decl::Function { body, .. } = &prog.declarations[0] else {
             panic!("expected function")
         };
         assert!(matches!(
             &body[0].node,
-            Stmt::Expr(Expr::Literal(Literal::Nil))
+            Stmt::Expr(Expr::Ref(name)) if name == "nil"
         ));
     }
 
@@ -11330,6 +11362,8 @@ mod tests {
     // Nil literal in match pattern
     #[test]
     fn cov_nil_literal_pattern() {
+        // Since ILO-403, `nil:` in a match arm is Pattern::Variant { tag: "nil" }
+        // (covers both built-in nil and sum-type variants named `nil`).
         let prog = parse_str(r#"f x:n>n;?x{nil:0;_:1}"#);
         let Decl::Function { body, .. } = &prog.declarations[0] else {
             panic!("expected function")
@@ -11337,7 +11371,10 @@ mod tests {
         let Stmt::Match { arms, .. } = &body[0].node else {
             panic!("expected match")
         };
-        assert!(matches!(&arms[0].pattern, Pattern::Literal(Literal::Nil)));
+        assert!(matches!(
+            &arms[0].pattern,
+            Pattern::Variant { tag, binding: None } if tag == "nil"
+        ));
     }
 
     // parse_let single-brace desugar: v=cond{body} → Guard { condition, body: [Let{name,...}] }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -5146,6 +5146,13 @@ impl VerifyContext {
                         );
                     }
                     Ty::Unknown
+                } else if name == "nil" {
+                    // `nil` as a bare expression: the parser emits Expr::Ref("nil")
+                    // for Token::Nil so that sum-type variants named `nil` resolve
+                    // correctly (see the variant_constructors branch above).  When
+                    // no `nil` variant is in scope, treat it as the built-in nil
+                    // value (Ty::Nil) for backward compatibility with Optional usage.
+                    Ty::Nil
                 } else {
                     let mut candidates: Vec<String> = scope
                         .iter()

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -3493,6 +3493,27 @@ impl RegCompiler {
                         end_jumps.push(self.emit_jmp_placeholder());
                         self.current.patch_jump(skip);
                         let _ = type_id; // type_id used for future type-tracking
+                    } else if tag == "nil" {
+                        // `nil:` was emitted as Pattern::Variant { tag: "nil" } by the
+                        // parser (to also cover sum-type variants named `nil`).  When
+                        // the variant_map has no `nil` entry the subject is a plain
+                        // Optional/nil value, so fall back to a nil-literal equality
+                        // check — same code path as the old Pattern::Literal(Nil) arm.
+                        let nil_ki = self.current.add_const(Value::Nil);
+                        let nil_reg = self.alloc_reg();
+                        self.emit_abx(OP_LOADK, nil_reg, nil_ki);
+                        let eq_reg = self.alloc_reg();
+                        self.emit_abc(OP_EQ, eq_reg, sub_reg, nil_reg);
+                        let skip = self.emit_jmpf(eq_reg);
+
+                        let body_result = self.compile_body(&arm.body);
+                        if let Some(br) = body_result
+                            && br != result_reg
+                        {
+                            self.emit_abc(OP_MOVE, result_reg, br, 0);
+                        }
+                        end_jumps.push(self.emit_jmp_placeholder());
+                        self.current.patch_jump(skip);
                     } else {
                         // Unknown variant tag — variant_map was not populated
                         // (e.g. the variant is from a type defined elsewhere).
@@ -4127,6 +4148,15 @@ impl RegCompiler {
                     let ra = self.alloc_reg();
                     let bx = 0x8000u16 | (b.tag() as u16);
                     self.emit_abx(OP_LOADFN, ra, bx);
+                    ra
+                } else if name == "nil" {
+                    // `nil` is emitted as Expr::Ref("nil") by the parser so that
+                    // sum-type variants named `nil` resolve via variant_map above.
+                    // When no such variant is registered, fall back to loading the
+                    // built-in nil constant (backward-compatible Optional / nil usage).
+                    let ra = self.alloc_reg();
+                    let ki = self.current.add_const(Value::Nil);
+                    self.emit_abx(OP_LOADK, ra, ki);
                     ra
                 } else {
                     self.first_error

--- a/tests/engine-matrix/50-recursive-sum-type.ilo
+++ b/tests/engine-matrix/50-recursive-sum-type.ilo
@@ -1,0 +1,10 @@
+-- feature: recursive sum types (ILO-403) — linked list via nil | cons(cell)
+-- expected: 15
+type nlist = nil | cons(cell)
+type cell { hd:n; tl:nlist }
+
+lsum xs:nlist>n;?xs{nil:0;cons(c):+c.hd(lsum c.tl)}
+
+main>n
+  l=cons (cell hd:1 tl:(cons (cell hd:2 tl:(cons (cell hd:3 tl:(cons (cell hd:4 tl:(cons (cell hd:5 tl:nil)))))))))
+  lsum l

--- a/tests/regression_recursive_sum_types.rs
+++ b/tests/regression_recursive_sum_types.rs
@@ -1,0 +1,89 @@
+// ILO-403: recursive sum types (linked list)
+//
+// Pins the behaviour of `type list = nil | cons(cell)` patterns where a
+// sum-type variant payload references the enclosing sum type, forming a
+// classic heap-chained linked list.  Covers:
+//   - `nil` as a variant name (was rejected by the parser as a reserved word)
+//   - `nil` in expression position resolves to the variant constructor when
+//     a `nil` variant is in scope, or to the built-in nil value otherwise
+//   - `nil:` in a match arm covers both nil literal and `nil` variant tag
+//   - Self-referential payloads via a record cons-cell type
+//   - 5-element list construction and recursive walk (sum, length)
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_file(path: &str) -> String {
+    let out = ilo()
+        .args(["run", path])
+        .output()
+        .expect("spawn ilo");
+    assert!(
+        out.status.success(),
+        "ilo failed for {path}:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn run_src(src: &str) -> String {
+    let tmp = tempfile(src);
+    run_file(&tmp)
+}
+
+fn tempfile(src: &str) -> String {
+    use std::io::Write;
+    let path = format!(
+        "/tmp/ilo-ilo403-test-{}.ilo",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .subsec_nanos()
+    );
+    let mut f = std::fs::File::create(&path).expect("create temp file");
+    f.write_all(src.as_bytes()).expect("write temp file");
+    path
+}
+
+// ── Core: 5-element list via engine-matrix file ──────────────────────────
+
+#[test]
+fn five_element_list_sum() {
+    let result = run_file("tests/engine-matrix/50-recursive-sum-type.ilo");
+    assert_eq!(result, "15", "sum of 1..5 list should be 15");
+}
+
+// ── nil as variant name and in expressions ───────────────────────────────
+
+#[test]
+fn nil_variant_name_and_expression() {
+    // `nil` can be used as a 0-arg variant constructor.
+    // `nil:` in a match arm covers both the built-in nil and the variant.
+    let result = run_src(
+        "type nlist = nil | cons(n)\nllen xs:nlist>n;?xs{nil:0;cons(h):+1 0}\nmain>n;a=cons 3;b=nil;+llen(a) llen(b)\n",
+    );
+    assert_eq!(result, "1");
+}
+
+// ── nil backward compat: nil literal still works outside sum type scope ──
+
+#[test]
+fn nil_literal_backward_compat() {
+    let result = run_src("main>n\n  x=nil\n  5\n");
+    assert_eq!(result, "5");
+}
+
+// ── Self-referential recursive type ──────────────────────────────────────
+
+#[test]
+fn recursive_sum_type_length_and_sum() {
+    let result = run_src(
+        "type nlist = nil | cons(cell)\ntype cell { hd:n; tl:nlist }\nllen xs:nlist>n;?xs{nil:0;cons(c):+1(llen c.tl)}\nlsum xs:nlist>n;?xs{nil:0;cons(c):+c.hd(lsum c.tl)}\nmain>n;l=cons (cell hd:10 tl:(cons (cell hd:20 tl:(cons (cell hd:30 tl:nil)))));+llen(l) lsum(l)\n",
+    );
+    // length=3, sum=60, total=63
+    assert_eq!(result, "63");
+}


### PR DESCRIPTION
## Summary

- **Parser**: accept `nil` as a variant name in `type Name = nil | ...` declarations (was rejected as a reserved keyword); emit `Expr::Ref("nil")` so a registered `nil` variant constructor resolves correctly; emit `Pattern::Variant { tag: "nil" }` for `nil:` match arms to cover both Optional-nil and sum-type-nil
- **Interpreter / Verifier / VM**: fall back gracefully to the built-in nil value when no `nil` variant is in scope — full backward compatibility
- **Tests**: engine-matrix `50-recursive-sum-type.ilo` (5-element list, sum=15) + `regression_recursive_sum_types.rs` (nil variant, recursive list, backward compat)

Example that now works end-to-end:

```
type nlist = nil | cons(cell)
type cell { hd:n; tl:nlist }

lsum xs:nlist>n;?xs{nil:0;cons(c):+c.hd(lsum c.tl)}

main>n
  l=cons (cell hd:1 tl:(cons (cell hd:2 tl:(cons (cell hd:3 tl:nil)))))
  lsum l  -- returns 6
```

## Test plan

- [x] `cargo test` — 3340 pass, 0 fail
- [x] `regression_recursive_sum_types` — 4 tests pass (nil variant, backward compat, recursive list length+sum, 5-element matrix test)
- [x] engine-matrix test 50 (`lsum` of 1..5 = 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)