### PR TITLE
Widen str to accept text input (identity passthrough)

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -10897,11 +10897,7 @@ mod tests {
     #[test]
     fn err_str_wrong_type() {
         // str now accepts text (identity) and number; bool triggers the error
-        let err = run_str_err(
-            r#"f x:_ >t;str x"#,
-            Some("f"),
-            vec![Value::Bool(true)],
-        );
+        let err = run_str_err(r#"f x:_ >t;str x"#, Some("f"), vec![Value::Bool(true)]);
         assert!(err.contains("str requires"));
     }
 

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -3381,10 +3381,7 @@ fn wr_run(env: &mut Env, args: Vec<Value>) -> Result<Value> {
                     other => {
                         return Err(RuntimeError::new(
                             "ILO-R009",
-                            format!(
-                                "wr: data for {fmt} must be a list of rows, got {:?}",
-                                other
-                            ),
+                            format!("wr: data for {fmt} must be a list of rows, got {:?}", other),
                         ));
                     }
                 };
@@ -3515,7 +3512,13 @@ fn fmt_run(args: &[Value]) -> Result<Value> {
 
 /// `#[inline(never)]` — flt fn [ctx] xs > L a
 #[inline(never)]
-fn flt_run(env: &mut Env, fn_name: &str, captures: Vec<Value>, ctx: Option<Value>, items: Arc<Vec<Value>>) -> Result<Value> {
+fn flt_run(
+    env: &mut Env,
+    fn_name: &str,
+    captures: Vec<Value>,
+    ctx: Option<Value>,
+    items: Arc<Vec<Value>>,
+) -> Result<Value> {
     let mut keep: Vec<bool> = Vec::with_capacity(items.len());
     for item in items.iter() {
         let mut call_args = match &ctx {
@@ -3557,7 +3560,12 @@ fn flt_run(env: &mut Env, fn_name: &str, captures: Vec<Value>, ctx: Option<Value
 
 /// `#[inline(never)]` — grp fn xs > M t (L a)
 #[inline(never)]
-fn grp_run(env: &mut Env, fn_name: &str, captures: Vec<Value>, items: Arc<Vec<Value>>) -> Result<Value> {
+fn grp_run(
+    env: &mut Env,
+    fn_name: &str,
+    captures: Vec<Value>,
+    items: Arc<Vec<Value>>,
+) -> Result<Value> {
     let mut groups: std::collections::HashMap<MapKey, Vec<Value>> =
         std::collections::HashMap::new();
     for item in items.iter() {
@@ -3597,7 +3605,12 @@ fn grp_run(env: &mut Env, fn_name: &str, captures: Vec<Value>, items: Arc<Vec<Va
 
 /// `#[inline(never)]` — uniqby fn xs > L a
 #[inline(never)]
-fn uniqby_run(env: &mut Env, fn_name: &str, captures: Vec<Value>, items: Arc<Vec<Value>>) -> Result<Value> {
+fn uniqby_run(
+    env: &mut Env,
+    fn_name: &str,
+    captures: Vec<Value>,
+    items: Arc<Vec<Value>>,
+) -> Result<Value> {
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut out: Vec<Value> = Vec::new();
     for item in items.iter() {
@@ -3812,9 +3825,7 @@ fn del_hed_opt_run(env: &mut Env, builtin: Option<Builtin>, args: Vec<Value>) ->
         }
         match req.send() {
             Ok(resp) => match resp.as_str() {
-                Ok(body) => {
-                    Ok(Value::Ok(Box::new(Value::Text(Arc::new(body.to_string())))))
-                }
+                Ok(body) => Ok(Value::Ok(Box::new(Value::Text(Arc::new(body.to_string()))))),
                 Err(e) => Ok(Value::Err(Box::new(Value::Text(Arc::new(format!(
                     "response is not valid UTF-8: {e}"
                 )))))),
@@ -4398,9 +4409,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
     }
     if builtin == Some(Builtin::Clamp) && args.len() == 3 {
         return match (&args[0], &args[1], &args[2]) {
-            (Value::Number(x), Value::Number(lo), Value::Number(hi)) => {
-                Ok(clamp_run(*x, *lo, *hi))
-            }
+            (Value::Number(x), Value::Number(lo), Value::Number(hi)) => Ok(clamp_run(*x, *lo, *hi)),
             _ => Err(RuntimeError::new(
                 "ILO-R009",
                 "clamp requires three numbers".to_string(),
@@ -4410,13 +4419,19 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
     if builtin == Some(Builtin::Min) && args.len() == 2 {
         return match (&args[0], &args[1]) {
             (Value::Number(a), Value::Number(b)) => Ok(Value::Number(a.min(*b))),
-            _ => Err(RuntimeError::new("ILO-R009", "min requires two numbers".to_string())),
+            _ => Err(RuntimeError::new(
+                "ILO-R009",
+                "min requires two numbers".to_string(),
+            )),
         };
     }
     if builtin == Some(Builtin::Max) && args.len() == 2 {
         return match (&args[0], &args[1]) {
             (Value::Number(a), Value::Number(b)) => Ok(Value::Number(a.max(*b))),
-            _ => Err(RuntimeError::new("ILO-R009", "max requires two numbers".to_string())),
+            _ => Err(RuntimeError::new(
+                "ILO-R009",
+                "max requires two numbers".to_string(),
+            )),
         };
     }
     if builtin == Some(Builtin::Argmax) && args.len() == 1 {
@@ -7624,21 +7639,36 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
     if builtin == Some(Builtin::Rsum) && args.len() == 2 {
         let n_f = match &args[0] {
             Value::Number(n) => *n,
-            other => return Err(RuntimeError::new("ILO-R009", format!("rsum: first arg n must be a number, got {:?}", other))),
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!("rsum: first arg n must be a number, got {:?}", other),
+                ));
+            }
         };
         return rolling_window_run("rsum", Builtin::Rsum, n_f, &args[1]);
     }
     if builtin == Some(Builtin::Ravg) && args.len() == 2 {
         let n_f = match &args[0] {
             Value::Number(n) => *n,
-            other => return Err(RuntimeError::new("ILO-R009", format!("ravg: first arg n must be a number, got {:?}", other))),
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!("ravg: first arg n must be a number, got {:?}", other),
+                ));
+            }
         };
         return rolling_window_run("ravg", Builtin::Ravg, n_f, &args[1]);
     }
     if builtin == Some(Builtin::Rmin) && args.len() == 2 {
         let n_f = match &args[0] {
             Value::Number(n) => *n,
-            other => return Err(RuntimeError::new("ILO-R009", format!("rmin: first arg n must be a number, got {:?}", other))),
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!("rmin: first arg n must be a number, got {:?}", other),
+                ));
+            }
         };
         return rolling_window_run("rmin", Builtin::Rmin, n_f, &args[1]);
     }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -4303,9 +4303,10 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 };
                 Ok(Value::Text(Arc::new(s)))
             }
+            Value::Text(_) => Ok(args[0].clone()),
             other => Err(RuntimeError::new(
                 "ILO-R009",
-                format!("str requires a number, got {:?}", other),
+                format!("str requires a number or text, got {:?}", other),
             )),
         };
     }
@@ -10895,12 +10896,13 @@ mod tests {
 
     #[test]
     fn err_str_wrong_type() {
+        // str now accepts text (identity) and number; bool triggers the error
         let err = run_str_err(
-            r#"f x:t>t;str x"#,
+            r#"f x:_ >t;str x"#,
             Some("f"),
-            vec![Value::Text(Arc::new("hi".to_string()))],
+            vec![Value::Bool(true)],
         );
-        assert!(err.contains("str requires a number"));
+        assert!(err.contains("str requires"));
     }
 
     #[test]

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -501,7 +501,7 @@ const BUILTINS: &[(&str, &[&str], &str)] = &[
     // (name, param_types, return_type_desc)
     // We use special strings to describe signatures
     ("len", &["list_or_text"], "n"),
-    ("str", &["n"], "t"),
+    ("str", &["t_or_n"], "t"),
     ("num", &["t_or_n"], "R n t"),
     ("abs", &["n"], "n"),
     ("flr", &["n"], "n"),
@@ -852,8 +852,8 @@ fn builtin_as_fn_ty(name: &str) -> Option<Ty> {
         "chr" => Ty::Fn(vec![n.clone()], Box::new(t.clone())),
         // 1-arg t -> L t (split into single-char strings, one per Unicode scalar)
         "chars" => Ty::Fn(vec![t.clone()], Box::new(Ty::List(Box::new(t.clone())))),
-        // 1-arg n->t and t->R n t
-        "str" => Ty::Fn(vec![n], Box::new(t)),
+        // 1-arg (n|t)->t  — identity for text, number→text conversion for numbers
+        "str" => Ty::Fn(vec![Ty::Unknown], Box::new(t)),
         "num" => Ty::Fn(
             vec![t.clone()],
             Box::new(Ty::Result(Box::new(Ty::Number), Box::new(t))),
@@ -894,11 +894,12 @@ fn builtin_check_args(
         "str" => {
             if let Some(arg) = arg_types.first()
                 && !compatible(arg, &Ty::Number)
+                && !compatible(arg, &Ty::Text)
             {
                 errors.push(VerifyError {
                     code: "ILO-T013",
                     function: func_ctx.to_string(),
-                    message: format!("'str' expects n, got {arg}"),
+                    message: format!("'str' expects n or t, got {arg}"),
                     hint: None,
                     span,
                     is_warning: false,
@@ -6741,14 +6742,24 @@ mod tests {
     // ---- builtin_check_args type errors ----
 
     #[test]
-    fn builtin_str_wrong_type() {
+    fn builtin_str_text_passthrough() {
+        // str is now polymorphic — text input is accepted without error
         let result = parse_and_verify("f x:t>t;str x");
+        assert!(result.is_ok(), "expected no errors, got: {:?}", result);
+    }
+
+    #[test]
+    fn builtin_str_wrong_type() {
+        // bool is still rejected by str
+        let result = parse_and_verify("f x:b>t;str x");
         assert!(result.is_err());
         let errors = result.unwrap_err();
         assert!(
             errors
                 .iter()
-                .any(|e| e.message.contains("'str' expects n, got t"))
+                .any(|e| e.message.contains("'str' expects n or t, got b")),
+            "unexpected errors: {:?}",
+            errors
         );
     }
 

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -22454,7 +22454,11 @@ mod tests {
     fn vm_str_text_passthrough() {
         // OP_STR on text is identity — returns the same string unchanged
         let source = "f x:t>t;str x";
-        let result = vm_run(source, Some("f"), vec![Value::Text(Arc::new("hello".to_string()))]);
+        let result = vm_run(
+            source,
+            Some("f"),
+            vec![Value::Text(Arc::new("hello".to_string()))],
+        );
         assert_eq!(result, Value::Text(Arc::new("hello".to_string())));
     }
 
@@ -30225,11 +30229,7 @@ mod tests {
     #[test]
     fn vm_err_str_wrong_type() {
         // str now accepts text (identity) and number; bool triggers the error
-        let err = vm_run_err(
-            r#"f x:_ >t;str x"#,
-            Some("f"),
-            vec![Value::Bool(true)],
-        );
+        let err = vm_run_err(r#"f x:_ >t;str x"#, Some("f"), vec![Value::Bool(true)]);
         assert!(
             err.contains("str") || err.contains("number") || err.contains("type"),
             "got: {err}"

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -10679,16 +10679,21 @@ impl<'a> VM<'a> {
                     let a = ((inst >> 16) & 0xFF) as usize + base;
                     let b = ((inst >> 8) & 0xFF) as usize + base;
                     let v = reg!(b);
-                    if !v.is_number() {
-                        vm_err!(VmError::Type("str requires a number"));
-                    }
-                    let n = v.as_number();
-                    let s = if n.fract() == 0.0 && n.abs() < 1e15 {
-                        format!("{}", n as i64)
+                    if v.is_string() {
+                        // identity passthrough — text in, same text out
+                        v.clone_rc();
+                        reg_set!(a, v);
+                    } else if v.is_number() {
+                        let n = v.as_number();
+                        let s = if n.fract() == 0.0 && n.abs() < 1e15 {
+                            format!("{}", n as i64)
+                        } else {
+                            format!("{}", n)
+                        };
+                        reg_set!(a, NanVal::heap_string(s));
                     } else {
-                        format!("{}", n)
-                    };
-                    reg_set!(a, NanVal::heap_string(s));
+                        vm_err!(VmError::Type("str requires a number or text"));
+                    }
                 }
                 OP_NUM => {
                     let a = ((inst >> 16) & 0xFF) as usize + base;
@@ -14745,8 +14750,12 @@ pub(crate) extern "C" fn jit_len(a: u64, span_bits: u64) -> u64 {
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn jit_str(a: u64, span_bits: u64) -> u64 {
     let v = NanVal(a);
+    if v.is_string() {
+        // identity passthrough — text in, same text out
+        return v.0;
+    }
     if !v.is_number() {
-        jit_set_runtime_error_with_span(VmError::Type("str requires a number"), span_bits);
+        jit_set_runtime_error_with_span(VmError::Type("str requires a number or text"), span_bits);
         return TAG_NIL;
     }
     let n = v.as_number();
@@ -22442,14 +22451,18 @@ mod tests {
     }
 
     #[test]
-    fn vm_str_non_number_type_error() {
-        // OP_STR on text → L1903 ("str requires a number")
+    fn vm_str_text_passthrough() {
+        // OP_STR on text is identity — returns the same string unchanged
         let source = "f x:t>t;str x";
-        let err = vm_run_err(
-            source,
-            Some("f"),
-            vec![Value::Text(Arc::new("hi".to_string()))],
-        );
+        let result = vm_run(source, Some("f"), vec![Value::Text(Arc::new("hello".to_string()))]);
+        assert_eq!(result, Value::Text(Arc::new("hello".to_string())));
+    }
+
+    #[test]
+    fn vm_str_non_text_non_number_type_error() {
+        // OP_STR on a non-text, non-number type → runtime error via VM path.
+        // Bypass the verifier by using `_` param type so the VM sees a bool.
+        let err = vm_run_err("f x:_ >t;str x", Some("f"), vec![Value::Bool(true)]);
         assert!(err.contains("str"), "got: {err}");
     }
 
@@ -25933,7 +25946,19 @@ mod tests {
         }
 
         #[test]
-        fn jit_str_non_number_signals_runtime_error() {
+        fn jit_str_text_passthrough() {
+            let input = NanVal::heap_string("hello".to_string());
+            let r = jit_str(input.0, 0);
+            let rv = NanVal(r);
+            assert!(rv.is_string());
+            let HeapObj::Str(s) = (unsafe { rv.as_heap_ref() }) else {
+                panic!("expected Str")
+            };
+            assert_eq!(s.as_str(), "hello");
+        }
+
+        #[test]
+        fn jit_str_non_number_non_text_signals_runtime_error() {
             let _ = jit_take_runtime_error();
             let r = jit_str(TAG_NIL, 0);
             assert!(is_nil(r));
@@ -30199,10 +30224,11 @@ mod tests {
 
     #[test]
     fn vm_err_str_wrong_type() {
+        // str now accepts text (identity) and number; bool triggers the error
         let err = vm_run_err(
-            r#"f x:t>t;str x"#,
+            r#"f x:_ >t;str x"#,
             Some("f"),
-            vec![Value::Text(Arc::new("hi".to_string()))],
+            vec![Value::Bool(true)],
         );
         assert!(
             err.contains("str") || err.contains("number") || err.contains("type"),

--- a/tests/coverage_interpreter.rs
+++ b/tests/coverage_interpreter.rs
@@ -78,7 +78,9 @@ fn abs_wrong_type() {
 
 #[test]
 fn str_wrong_type() {
-    let s = err_stderr("main>t;str \"hi\"", "main", &[]);
+    // str now accepts text (passthrough) and number; use a bool to trigger error.
+    // Bypass the verifier with `_` param type so the runtime sees the bool.
+    let s = err_stderr("main x:_ >t;str x", "main", &["true"]);
     assert!(
         s.contains("ILO-R009")
             || s.contains("ILO-R004")
@@ -87,6 +89,13 @@ fn str_wrong_type() {
             || s.contains("str"),
         "stderr={s}"
     );
+}
+
+#[test]
+fn str_text_passthrough() {
+    // str of text is now identity — should succeed
+    let s = ok_out("main>t;str \"hello\"", "main", &[]);
+    assert_eq!(s.trim(), "hello");
 }
 
 #[test]

--- a/tests/coverage_verify.rs
+++ b/tests/coverage_verify.rs
@@ -48,8 +48,15 @@ fn len_wrong_type() {
 }
 
 #[test]
+fn str_text_passthrough() {
+    // str is now polymorphic: text input is identity, no error
+    assert_ok("main>t;str \"hi\"", "main");
+}
+
+#[test]
 fn str_wrong_type() {
-    assert_err("main>t;str \"hi\"", "ILO-T013", "main");
+    // bool is not accepted by str
+    assert_err("main x:b>t;str x", "ILO-T013", "main");
 }
 
 #[test]

--- a/tests/regression_jit_nil_sweep_batch3.rs
+++ b/tests/regression_jit_nil_sweep_batch3.rs
@@ -239,6 +239,17 @@ fn str_number_cross_engine() {
     check_all("f>t;str 42", "42");
 }
 
+#[test]
+fn str_text_passthrough_cross_engine() {
+    // str of already-text is identity — returns the same string unchanged
+    check_all("f>t;str \"hello\"", "hello");
+}
+
+#[test]
+fn str_text_passthrough_empty_cross_engine() {
+    check_all("f>t;str \"\"", "");
+}
+
 // ── No stale-error leak across successive Cranelift calls ─────────────────
 //
 // PR #254's JitRuntimeErrorGuard clears the TLS error cell on entry/exit.


### PR DESCRIPTION
## Summary

- `str` now accepts text as input and returns it unchanged (identity passthrough), making it polymorphic-identity for already-stringy values
- Number conversion behaviour is unchanged; non-text/non-number still raises a runtime error (`str requires a number or text`)
- All three execution paths updated: tree interpreter (`src/interpreter/mod.rs`), VM bytecode (`OP_STR` in `src/vm/mod.rs`), and JIT helper (`jit_str`). The VM path correctly calls `clone_rc` on the heap string for the passthrough case
- Verifier (`builtin_check_args`) and BUILTINS signature table updated: `str` now accepts `t_or_n`
- `builtin_as_fn_ty` updated to return `Unknown -> t` (polymorphic)

Fixes ILO-375.

## Test plan

- [x] `str_text_passthrough_cross_engine` — `str "hello"` returns `"hello"` across all engines
- [x] `str_text_passthrough_empty_cross_engine` — `str ""` returns `""` 
- [x] `str_number_cross_engine` — existing number conversion still works
- [x] `verify::builtin_str_text_passthrough` — text arg no longer triggers ILO-T013
- [x] `verify::builtin_str_wrong_type` — bool still triggers ILO-T013 with updated message
- [x] `vm_str_text_passthrough` — VM OP_STR returns text unchanged
- [x] `vm_str_non_text_non_number_type_error` — VM errors on non-text/non-number
- [x] `jit_str_text_passthrough` — JIT helper returns text unchanged
- [x] `jit_str_non_number_non_text_signals_runtime_error` — JIT helper errors on nil

🤖 Generated with [Claude Code](https://claude.com/claude-code)