### PR TITLE
feat: block-scope defer/errdefer in loop/if/match arms (ILO-365)

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -8134,6 +8134,26 @@ fn eval_self_rebind_concat(env: &mut Env, rhs_expr: &Expr, prev: Value) -> Resul
     }
 }
 
+/// Run and remove all block-scope defers that were pushed since `saved_len`.
+///
+/// Called at every exit point of a block (normal, break, continue, return).
+/// `is_error` mirrors the function-scope defer semantics: `errdefer` fires
+/// only when true.  Defer errors are silently ignored so a failing defer
+/// doesn't mask the original result.
+fn run_block_defers(env: &mut Env, saved_len: usize, is_error: bool) {
+    // Drain the entries added since we entered the block (LIFO order).
+    let block_defers: Vec<_> = env.defer_stack.drain(saved_len..).rev().collect();
+    for (defer_expr, defer_kind) in block_defers {
+        let should_run = match defer_kind {
+            crate::ast::DeferKind::Always => true,
+            crate::ast::DeferKind::OnError => is_error,
+        };
+        if should_run {
+            let _ = eval_expr(env, &defer_expr);
+        }
+    }
+}
+
 fn eval_stmt(env: &mut Env, stmt: &Stmt, is_tail: bool) -> Result<Option<BodyResult>> {
     match stmt {
         Stmt::Let { name, value } => {
@@ -8226,7 +8246,10 @@ fn eval_stmt(env: &mut Env, stmt: &Stmt, is_tail: bool) -> Result<Option<BodyRes
                 // body, both branches are in tail position.
                 let chosen = if should_run { body } else { else_b };
                 env.push_scope();
+                let defer_mark = env.defer_stack.len();
                 let result = eval_body(env, chosen, is_tail);
+                let is_err = matches!(result, Err(_) | Ok(BodyResult::Return(_)));
+                run_block_defers(env, defer_mark, is_err);
                 env.pop_scope();
                 match result? {
                     BodyResult::Break(v) => Ok(Some(BodyResult::Break(v))),
@@ -8242,7 +8265,10 @@ fn eval_stmt(env: &mut Env, stmt: &Stmt, is_tail: bool) -> Result<Option<BodyRes
                 // relative to the function — the value it produces becomes
                 // the function's return, so a tail call inside trampolines.
                 env.push_scope();
+                let defer_mark = env.defer_stack.len();
                 let result = eval_body(env, body, true);
+                let is_err = matches!(result, Err(_) | Ok(BodyResult::Return(_)));
+                run_block_defers(env, defer_mark, is_err);
                 env.pop_scope();
                 match result? {
                     BodyResult::Break(v) => Ok(Some(BodyResult::Break(v))),
@@ -8266,7 +8292,10 @@ fn eval_stmt(env: &mut Env, stmt: &Stmt, is_tail: bool) -> Result<Option<BodyRes
                 // tail call is the function's tail call. Safe to pass
                 // through.
                 env.push_scope();
+                let defer_mark = env.defer_stack.len();
                 let result = eval_body(env, body, is_tail);
+                let is_err = matches!(result, Err(_) | Ok(BodyResult::Return(_)));
+                run_block_defers(env, defer_mark, is_err);
                 env.pop_scope();
                 match result? {
                     BodyResult::Break(v) => Ok(Some(BodyResult::Break(v))),
@@ -8295,7 +8324,10 @@ fn eval_stmt(env: &mut Env, stmt: &Stmt, is_tail: bool) -> Result<Option<BodyRes
                     // Arm body inherits the match's tail position: a tail
                     // call in the taken arm of a tail-position match
                     // trampolines through.
+                    let defer_mark = env.defer_stack.len();
                     let result = eval_body(env, &arm.body, is_tail);
+                    let is_err = matches!(result, Err(_) | Ok(BodyResult::Return(_)));
+                    run_block_defers(env, defer_mark, is_err);
                     env.pop_scope();
                     match result? {
                         BodyResult::Return(v) => return Ok(Some(BodyResult::Return(v))),
@@ -8326,7 +8358,10 @@ fn eval_stmt(env: &mut Env, stmt: &Stmt, is_tail: bool) -> Result<Option<BodyRes
                         // returns to the loop header after each iteration,
                         // so a "tail call" inside a loop must materialise as
                         // a normal call. Pass `false`.
+                        let defer_mark = env.defer_stack.len();
                         let result = eval_body(env, body, false);
+                        let is_err = matches!(result, Err(_) | Ok(BodyResult::Return(_)));
+                        run_block_defers(env, defer_mark, is_err);
                         env.pop_scope();
                         match result? {
                             BodyResult::Return(v) => {
@@ -8378,7 +8413,10 @@ fn eval_stmt(env: &mut Env, stmt: &Stmt, is_tail: bool) -> Result<Option<BodyRes
                 env.push_scope();
                 env.define(binding, Value::Number(i as f64));
                 // Range body is not in tail position; see ForEach above.
+                let defer_mark = env.defer_stack.len();
                 let result = eval_body(env, body, false);
+                let is_err = matches!(result, Err(_) | Ok(BodyResult::Return(_)));
+                run_block_defers(env, defer_mark, is_err);
                 env.pop_scope();
                 match result? {
                     BodyResult::Return(v) => {
@@ -8405,7 +8443,10 @@ fn eval_stmt(env: &mut Env, stmt: &Stmt, is_tail: bool) -> Result<Option<BodyRes
                     break;
                 }
                 // While body is not in tail position; see ForEach above.
+                let defer_mark = env.defer_stack.len();
                 let result = eval_body(env, body, false);
+                let is_err = matches!(result, Err(_) | Ok(BodyResult::Return(_)));
+                run_block_defers(env, defer_mark, is_err);
                 match result? {
                     BodyResult::Return(v) => {
                         return Ok(Some(BodyResult::Return(v)));

--- a/tests/regression_defer.rs
+++ b/tests/regression_defer.rs
@@ -321,3 +321,65 @@ fn errdefer_reserved_as_identifier_is_parse_error() {
         "expected parse error when using `errdefer` as identifier"
     );
 }
+
+// ── ILO-365: block-scope defer ────────────────────────────────────────────────
+//
+// Note: `defer` takes an *expression* (not a statement), so mutation via
+// `defer =var expr` is unavailable (the parser rejects `defer =` as a
+// potential `defer = 5` assignment to the keyword).  Block-scope firing is
+// therefore verified by two complementary approaches:
+//   1. Return-value tests (run_tree): verify that block-scope defers do not
+//      corrupt the function return value and that no panic occurs.
+//   2. CLI output tests (regression_defer_block_scope.rs): verify the `prnt`
+//      side-effects fire the correct number of times by capturing stdout.
+
+/// A `defer prnt` inside a foreach loop body: return value is not corrupted.
+#[test]
+fn defer_in_foreach_return_value_unaffected() {
+    // Three iterations; defer fires prnt (side-effect only). Return must be 42.
+    let src = "f n:n>n\n  @i [1 2 3]{defer prnt i}\n  n\n";
+    let result = run_tree(src, "f", vec![Value::Number(42.0)]);
+    assert_eq!(result, Value::Number(42.0));
+}
+
+/// A `defer prnt` inside a forrange loop body: return value is not corrupted.
+#[test]
+fn defer_in_forrange_return_value_unaffected() {
+    let src = "f n:n>n\n  @i 0..4{defer prnt i}\n  n\n";
+    let result = run_tree(src, "f", vec![Value::Number(7.0)]);
+    assert_eq!(result, Value::Number(7.0));
+}
+
+/// A `defer prnt` inside an if branch: return value flows through unaffected.
+///
+/// The ternary `=x 1{then_body}{else_body}` form is used so both branches are
+/// testable.  In both cases the function return value is `x`.
+#[test]
+fn defer_in_if_return_value_unaffected() {
+    let src = "f x:n>n\n  =x 1{defer prnt x}{defer prnt x}\n  x\n";
+    let r1 = run_tree(src, "f", vec![Value::Number(1.0)]);
+    let r0 = run_tree(src, "f", vec![Value::Number(0.0)]);
+    assert_eq!(r1, Value::Number(1.0));
+    assert_eq!(r0, Value::Number(0.0));
+}
+
+/// A `defer prnt` inside a match arm: return value flows through unaffected.
+///
+/// Uses the inline match form `? x { pat: body; _: body }`.
+#[test]
+fn defer_in_match_arm_return_value_unaffected() {
+    // ? x { 1: {defer prnt x; x}; _: x }
+    let src = "f x:n>n\n  ? x {1:{defer prnt x;x};_:x}\n  x\n";
+    let r1 = run_tree(src, "f", vec![Value::Number(1.0)]);
+    let r2 = run_tree(src, "f", vec![Value::Number(2.0)]);
+    assert_eq!(r1, Value::Number(1.0));
+    assert_eq!(r2, Value::Number(2.0));
+}
+
+/// A `defer` inside a while body: return value not corrupted.
+#[test]
+fn defer_in_while_return_value_unaffected() {
+    let src = "f n:n>n\n  i=0\n  wh <i 3{i=+i 1;defer prnt i}\n  n\n";
+    let result = run_tree(src, "f", vec![Value::Number(5.0)]);
+    assert_eq!(result, Value::Number(5.0));
+}

--- a/tests/regression_defer_block_scope.rs
+++ b/tests/regression_defer_block_scope.rs
@@ -1,0 +1,238 @@
+//! CLI-level tests for ILO-365: block-scope `defer` / `errdefer`.
+//!
+//! These tests spawn the `ilo` binary and capture stdout so they can verify
+//! that `defer` fires the correct number of times (once per iteration) and
+//! only in the taken branch — behaviour that is impossible to observe through
+//! the `run_tree` return-value API because `defer` only accepts expressions,
+//! not assignment statements.
+//!
+//! Each test runs with `--vm` (the production engine).
+
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn write_src(src: &str, tag: &str) -> std::path::PathBuf {
+    let seq = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let path = std::env::temp_dir().join(format!(
+        "ilo_defer_block_{}_{}_{}.ilo",
+        std::process::id(),
+        seq,
+        tag,
+    ));
+    std::fs::write(&path, src).unwrap();
+    path
+}
+
+fn run_vm(src: &str, fn_name: &str) -> String {
+    let path = write_src(src, fn_name);
+    let out = ilo()
+        .arg(path.to_str().unwrap())
+        .arg("--vm")
+        .arg(fn_name)
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo --vm failed for fn={fn_name} src=`{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+// ── foreach: defer fires once per iteration ──────────────────────────────────
+
+/// `defer prnt i` in a foreach loop body must print once per element.
+/// Three elements → three lines of output (each line is the element value),
+/// plus the function return value auto-printed on the final line.
+#[test]
+fn defer_in_foreach_fires_per_iteration() {
+    // Function iterates over [10 20 30]; each iteration defers `prnt i`.
+    // The defer fires at the end of each iteration (block exit), so output is:
+    //   10
+    //   20
+    //   30
+    //   0        ← function return value (auto-print, last stmt is 0)
+    let src = "f>n;@i [10 20 30]{defer prnt i};0";
+    let out = run_vm(src, "f");
+    let lines: Vec<&str> = out.trim().lines().collect();
+    // The three defer-prints must appear, in order (LIFO within a single-item
+    // stack is still the one item).
+    assert!(
+        lines.contains(&"10") && lines.contains(&"20") && lines.contains(&"30"),
+        "expected 10, 20, 30 in output, got: {:?}",
+        lines
+    );
+    // Count: the defer must fire exactly 3 times (once per iteration), so
+    // there should be exactly 3 occurrences of the element values in output.
+    let defer_lines: Vec<&&str> = lines
+        .iter()
+        .filter(|&&l| l == "10" || l == "20" || l == "30")
+        .collect();
+    assert_eq!(
+        defer_lines.len(),
+        3,
+        "defer must fire exactly once per iteration (3 times), got {} firings in: {:?}",
+        defer_lines.len(),
+        lines
+    );
+}
+
+/// `defer prnt i` in a forrange loop body must fire once per range step.
+#[test]
+fn defer_in_forrange_fires_per_iteration() {
+    // Range 0..3 → iterations i=0, i=1, i=2.  Each iteration defers prnt i.
+    // Expected defer output lines: 0, 1, 2 (one per iteration).
+    let src = "f>n;@i 0..3{defer prnt i};99";
+    let out = run_vm(src, "f");
+    let lines: Vec<&str> = out.trim().lines().collect();
+    // The three deferred prints must appear.
+    assert!(
+        lines.contains(&"0") && lines.contains(&"1") && lines.contains(&"2"),
+        "expected 0, 1, 2 in output, got: {:?}",
+        lines
+    );
+    let defer_count = lines
+        .iter()
+        .filter(|&&l| l == "0" || l == "1" || l == "2")
+        .count();
+    assert_eq!(
+        defer_count, 3,
+        "defer must fire exactly 3 times, got {} in: {:?}",
+        defer_count, lines
+    );
+}
+
+// ── if: defer fires only when branch taken ───────────────────────────────────
+
+/// `defer prnt` inside the taken branch fires; inside the untaken branch it
+/// does not.
+#[test]
+fn defer_in_if_fires_only_when_branch_taken() {
+    // Ternary `=x 1{then}{else}`:
+    //   taken (x=1):   defer prnt "taken"  → stdout has "taken"
+    //   untaken (x=0): else branch has defer prnt "other"
+    let src = "f x:n>n;=x 1{defer prnt \"taken\"}{defer prnt \"other\"};x";
+    let path = write_src(src, "if_taken");
+
+    // When x=1, the if branch fires its defer
+    let out1 = ilo()
+        .arg(path.to_str().unwrap())
+        .arg("--vm")
+        .arg("f")
+        .arg("1")
+        .output()
+        .expect("failed to run");
+    assert!(out1.status.success());
+    let taken_out = String::from_utf8_lossy(&out1.stdout).to_string();
+    assert!(
+        taken_out.contains("taken"),
+        "defer in taken branch must fire, got: {:?}",
+        taken_out
+    );
+    assert!(
+        !taken_out.contains("other"),
+        "defer in untaken branch must NOT fire, got: {:?}",
+        taken_out
+    );
+
+    // When x=0, the else branch fires its defer
+    let out0 = ilo()
+        .arg(path.to_str().unwrap())
+        .arg("--vm")
+        .arg("f")
+        .arg("0")
+        .output()
+        .expect("failed to run");
+    assert!(out0.status.success());
+    let other_out = String::from_utf8_lossy(&out0.stdout).to_string();
+    assert!(
+        other_out.contains("other"),
+        "defer in else branch must fire when x=0, got: {:?}",
+        other_out
+    );
+    assert!(
+        !other_out.contains("taken"),
+        "defer in if branch must NOT fire when x=0, got: {:?}",
+        other_out
+    );
+}
+
+// ── match: defer fires only for matched arm ───────────────────────────────────
+
+/// `defer prnt` in a match arm fires only for the arm whose pattern matches.
+#[test]
+fn defer_in_match_arm_fires_only_for_matched_arm() {
+    // ? x { 1: {defer prnt "arm1"; x}; _: {defer prnt "arm2"; x} }
+    let src = "f x:n>n;? x {1:{defer prnt \"arm1\";x};_:{defer prnt \"arm2\";x}}";
+
+    let path = write_src(src, "match_arm");
+
+    // x=1 → arm1 matches → "arm1" printed, "arm2" not printed
+    let out1 = ilo()
+        .arg(path.to_str().unwrap())
+        .arg("--vm")
+        .arg("f")
+        .arg("1")
+        .output()
+        .expect("failed to run");
+    assert!(out1.status.success());
+    let s1 = String::from_utf8_lossy(&out1.stdout).to_string();
+    assert!(
+        s1.contains("arm1"),
+        "arm1's defer must fire for x=1, got: {:?}",
+        s1
+    );
+    assert!(
+        !s1.contains("arm2"),
+        "arm2's defer must NOT fire for x=1, got: {:?}",
+        s1
+    );
+
+    // x=2 → wildcard arm matches → "arm2" printed, "arm1" not printed
+    let out2 = ilo()
+        .arg(path.to_str().unwrap())
+        .arg("--vm")
+        .arg("f")
+        .arg("2")
+        .output()
+        .expect("failed to run");
+    assert!(out2.status.success());
+    let s2 = String::from_utf8_lossy(&out2.stdout).to_string();
+    assert!(
+        s2.contains("arm2"),
+        "arm2's defer must fire for x=2, got: {:?}",
+        s2
+    );
+    assert!(
+        !s2.contains("arm1"),
+        "arm1's defer must NOT fire for x=2, got: {:?}",
+        s2
+    );
+}
+
+// ── while: defer fires per iteration ─────────────────────────────────────────
+
+/// `defer prnt i` in a while loop body fires once per iteration.
+#[test]
+fn defer_in_while_fires_per_iteration() {
+    // i starts at 0; while i < 3: i = i+1; defer prnt i
+    // defer fires at block exit with i already incremented: 1, 2, 3 → 3 lines
+    let src = "f>n;i=0;wh <i 3{i=+i 1;defer prnt i};99";
+    let out = run_vm(src, "f");
+    let lines: Vec<&str> = out.trim().lines().collect();
+    let defer_count = lines
+        .iter()
+        .filter(|&&l| l == "1" || l == "2" || l == "3")
+        .count();
+    assert_eq!(
+        defer_count, 3,
+        "defer in while must fire 3 times, got {} in: {:?}",
+        defer_count, lines
+    );
+}


### PR DESCRIPTION
## Summary

- Extends function-scope `defer`/`errdefer` (ILO-56, #615) to block scope: a `defer` inside a loop body, if/guard branch, or match arm fires at block exit (LIFO), not at function exit
- Adds `run_block_defers(env, saved_len, is_error)` helper in `src/interpreter/mod.rs` that drains and runs the defer-stack slice pushed since block entry
- Hooks into all four block-introducing evaluation sites: `ForEach`, `ForRange`, `While`, `Stmt::Guard`, and `Stmt::Match`

## Test plan

- [ ] `tests/regression_defer.rs` — 5 new `run_tree` tests verify return values are not corrupted by block-scope defers across foreach, forrange, if/guard, match arm, and while
- [ ] `tests/regression_defer_block_scope.rs` — 5 new CLI tests capture `prnt` stdout to verify: defer fires exactly N times across N iterations (foreach, forrange, while), fires only in the taken if branch, fires only for the matched arm
- [ ] All 28 defer tests pass; the one pre-existing `skill_md::body_is_thin_bootstrap` failure is unrelated

Closes ILO-365.

🤖 Generated with [Claude Code](https://claude.com/claude-code)