### PR TITLE
feat(parser): brace-lambda syntax for fld/map/flt bodies (ILO-404)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -146,12 +146,23 @@ sumsq xs:L n>n;fld (a:n x:n>n;+a *x x) xs 0
 
 Syntax: `(<param>:<type> ...><return-type>;<body>)`. Same shape as a top-level function declaration, wrapped in parens, no name.
 
+**Brace-lambda shorthand** (`{params> stmts}`): bare param names (types inferred as `any`) and no explicit return type. Useful for compact multi-statement bodies in `map`/`flt`/`fld`:
+
+```
+sumsq xs:L n>n;fld {a x>; tmp=*x x; +a tmp} xs 0
+dbl xs:L n>L n;map {x> *x 2} xs
+pos xs:L n>L n;flt {x> >x 0} xs
+```
+
+The `;` after `>` is optional. The body supports the same `;`-chained statement forms as the paren lambda and top-level function bodies (let-bindings, guards, match, loops, `ret`/`brk`/`cnt`). Closure capture also works — any name that isn't a param or body-local is snapshot from the enclosing scope.
+
 **Phase 1 (no captures)** lifts the literal to a synthetic top-level decl and works across every engine (tree, VM, Cranelift JIT, AOT). The body's free variables must all be params, locals defined inside the lambda body, or known top-level fns.
 
 **Phase 2 (closure capture)** lets the body reference variables from the enclosing scope:
 
 ```
-f xs:L n thr:n>L n;flt (x:n>b;>x thr) xs   -- captures `thr`
+f xs:L n thr:n>L n;flt (x:n>b;>x thr) xs   -- captures `thr` (paren form)
+f xs:L n thr:n>L n;flt {x> >x thr} xs       -- captures `thr` (brace form)
 ```
 
 Phase 2 captures run natively on every engine: the tree interpreter, the register VM, the Cranelift JIT, and the Cranelift AOT backend. Each free variable is snapshot by value at the call site (`Expr::MakeClosure`) and appended to the call frame's arg slice on dispatch. The AOT backend additionally embeds the postcard-serialised `CompiledProgram` into the binary's `.rodata` and publishes TLS pointers on startup, so dispatch helpers can re-enter the VM on user-fn callbacks. The ctx-arg form (`srt fn ctx xs`) remains the cross-engine alternative when you want explicit state without forming a closure.

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -3381,10 +3381,7 @@ fn wr_run(env: &mut Env, args: Vec<Value>) -> Result<Value> {
                     other => {
                         return Err(RuntimeError::new(
                             "ILO-R009",
-                            format!(
-                                "wr: data for {fmt} must be a list of rows, got {:?}",
-                                other
-                            ),
+                            format!("wr: data for {fmt} must be a list of rows, got {:?}", other),
                         ));
                     }
                 };
@@ -3515,7 +3512,13 @@ fn fmt_run(args: &[Value]) -> Result<Value> {
 
 /// `#[inline(never)]` — flt fn [ctx] xs > L a
 #[inline(never)]
-fn flt_run(env: &mut Env, fn_name: &str, captures: Vec<Value>, ctx: Option<Value>, items: Arc<Vec<Value>>) -> Result<Value> {
+fn flt_run(
+    env: &mut Env,
+    fn_name: &str,
+    captures: Vec<Value>,
+    ctx: Option<Value>,
+    items: Arc<Vec<Value>>,
+) -> Result<Value> {
     let mut keep: Vec<bool> = Vec::with_capacity(items.len());
     for item in items.iter() {
         let mut call_args = match &ctx {
@@ -3557,7 +3560,12 @@ fn flt_run(env: &mut Env, fn_name: &str, captures: Vec<Value>, ctx: Option<Value
 
 /// `#[inline(never)]` — grp fn xs > M t (L a)
 #[inline(never)]
-fn grp_run(env: &mut Env, fn_name: &str, captures: Vec<Value>, items: Arc<Vec<Value>>) -> Result<Value> {
+fn grp_run(
+    env: &mut Env,
+    fn_name: &str,
+    captures: Vec<Value>,
+    items: Arc<Vec<Value>>,
+) -> Result<Value> {
     let mut groups: std::collections::HashMap<MapKey, Vec<Value>> =
         std::collections::HashMap::new();
     for item in items.iter() {
@@ -3597,7 +3605,12 @@ fn grp_run(env: &mut Env, fn_name: &str, captures: Vec<Value>, items: Arc<Vec<Va
 
 /// `#[inline(never)]` — uniqby fn xs > L a
 #[inline(never)]
-fn uniqby_run(env: &mut Env, fn_name: &str, captures: Vec<Value>, items: Arc<Vec<Value>>) -> Result<Value> {
+fn uniqby_run(
+    env: &mut Env,
+    fn_name: &str,
+    captures: Vec<Value>,
+    items: Arc<Vec<Value>>,
+) -> Result<Value> {
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut out: Vec<Value> = Vec::new();
     for item in items.iter() {
@@ -3812,9 +3825,7 @@ fn del_hed_opt_run(env: &mut Env, builtin: Option<Builtin>, args: Vec<Value>) ->
         }
         match req.send() {
             Ok(resp) => match resp.as_str() {
-                Ok(body) => {
-                    Ok(Value::Ok(Box::new(Value::Text(Arc::new(body.to_string())))))
-                }
+                Ok(body) => Ok(Value::Ok(Box::new(Value::Text(Arc::new(body.to_string()))))),
                 Err(e) => Ok(Value::Err(Box::new(Value::Text(Arc::new(format!(
                     "response is not valid UTF-8: {e}"
                 )))))),
@@ -4397,9 +4408,7 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
     }
     if builtin == Some(Builtin::Clamp) && args.len() == 3 {
         return match (&args[0], &args[1], &args[2]) {
-            (Value::Number(x), Value::Number(lo), Value::Number(hi)) => {
-                Ok(clamp_run(*x, *lo, *hi))
-            }
+            (Value::Number(x), Value::Number(lo), Value::Number(hi)) => Ok(clamp_run(*x, *lo, *hi)),
             _ => Err(RuntimeError::new(
                 "ILO-R009",
                 "clamp requires three numbers".to_string(),
@@ -4409,13 +4418,19 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
     if builtin == Some(Builtin::Min) && args.len() == 2 {
         return match (&args[0], &args[1]) {
             (Value::Number(a), Value::Number(b)) => Ok(Value::Number(a.min(*b))),
-            _ => Err(RuntimeError::new("ILO-R009", "min requires two numbers".to_string())),
+            _ => Err(RuntimeError::new(
+                "ILO-R009",
+                "min requires two numbers".to_string(),
+            )),
         };
     }
     if builtin == Some(Builtin::Max) && args.len() == 2 {
         return match (&args[0], &args[1]) {
             (Value::Number(a), Value::Number(b)) => Ok(Value::Number(a.max(*b))),
-            _ => Err(RuntimeError::new("ILO-R009", "max requires two numbers".to_string())),
+            _ => Err(RuntimeError::new(
+                "ILO-R009",
+                "max requires two numbers".to_string(),
+            )),
         };
     }
     if builtin == Some(Builtin::Argmax) && args.len() == 1 {
@@ -7623,21 +7638,36 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
     if builtin == Some(Builtin::Rsum) && args.len() == 2 {
         let n_f = match &args[0] {
             Value::Number(n) => *n,
-            other => return Err(RuntimeError::new("ILO-R009", format!("rsum: first arg n must be a number, got {:?}", other))),
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!("rsum: first arg n must be a number, got {:?}", other),
+                ));
+            }
         };
         return rolling_window_run("rsum", Builtin::Rsum, n_f, &args[1]);
     }
     if builtin == Some(Builtin::Ravg) && args.len() == 2 {
         let n_f = match &args[0] {
             Value::Number(n) => *n,
-            other => return Err(RuntimeError::new("ILO-R009", format!("ravg: first arg n must be a number, got {:?}", other))),
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!("ravg: first arg n must be a number, got {:?}", other),
+                ));
+            }
         };
         return rolling_window_run("ravg", Builtin::Ravg, n_f, &args[1]);
     }
     if builtin == Some(Builtin::Rmin) && args.len() == 2 {
         let n_f = match &args[0] {
             Value::Number(n) => *n,
-            other => return Err(RuntimeError::new("ILO-R009", format!("rmin: first arg n must be a number, got {:?}", other))),
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!("rmin: first arg n must be a number, got {:?}", other),
+                ));
+            }
         };
         return rolling_window_run("rmin", Builtin::Rmin, n_f, &args[1]);
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4518,6 +4518,10 @@ results first: `r={first_op}a b;…r` keeps each step explicit."
         if self.is_anon_record_literal() {
             return true;
         }
+        // Brace-lambda `{params> stmts}` is also a valid atom start.
+        if self.looks_like_brace_lambda() {
+            return true;
+        }
         matches!(
             self.peek(),
             Some(Token::Ident(_))
@@ -4774,6 +4778,9 @@ results first: `r={first_op}a b;…r` keeps each step explicit."
                 }
                 self.expect(&Token::RBracket)?;
                 Ok(Expr::List(items))
+            }
+            Some(Token::LBrace) if self.looks_like_brace_lambda() => {
+                self.parse_brace_lambda()
             }
             Some(Token::LBrace) if self.is_anon_record_literal() => {
                 self.advance(); // consume `{`
@@ -5092,6 +5099,127 @@ For variable-position list indexing bind the head first: \
                 fn_name: name,
                 captures,
             })
+        }
+    }
+
+    /// Lookahead: does the `{` at the current position start a brace-lambda
+    /// (`{params> stmts}`)? A brace-lambda has a `>` token at brace-depth 1
+    /// before the matching `}`. This distinguishes it from destructure patterns
+    /// `{a;b}=x` (which use `;` before any `>`) and anonymous record literals
+    /// `{field:val}` (handled by `is_anon_record_literal`).
+    fn looks_like_brace_lambda(&self) -> bool {
+        if self.peek() != Some(&Token::LBrace) {
+            return false;
+        }
+        let mut depth = 1usize;
+        let mut i = self.pos + 1;
+        while let Some(tok) = self.token_at(i) {
+            match tok {
+                Token::LParen | Token::LBracket | Token::LBrace => depth += 1,
+                Token::RBrace => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return false;
+                    }
+                }
+                Token::RParen | Token::RBracket => {
+                    if depth > 0 {
+                        depth -= 1;
+                    }
+                }
+                // A `;` at depth 1 before any `>` means destructure, not lambda.
+                Token::Semi if depth == 1 => return false,
+                // A `>` at depth 1 signals brace-lambda params separator.
+                Token::Greater if depth == 1 => return true,
+                _ => {}
+            }
+            i += 1;
+        }
+        false
+    }
+
+    /// Parse `{name... > [;] stmt [; stmt]*}` as a brace-form lambda.
+    ///
+    /// Params are bare identifiers (type defaults to `any`). Return type
+    /// defaults to `any`. Same lifting logic as `parse_inline_lambda`.
+    fn parse_brace_lambda(&mut self) -> Result<Expr> {
+        let start = self.peek_span();
+        self.expect(&Token::LBrace)?;
+
+        // Collect bare param names until `>`.
+        let mut params: Vec<Param> = Vec::new();
+        while self.peek() != Some(&Token::Greater) && self.peek() != Some(&Token::RBrace) {
+            match self.peek() {
+                Some(Token::Ident(_)) => {
+                    let name = self.expect_ident()?;
+                    params.push(Param { name, ty: Type::Any });
+                }
+                _ => {
+                    return Err(self.error_hint(
+                        "ILO-P003",
+                        format!(
+                            "expected param name or `>` in brace-lambda, got {}",
+                            self.peek().map_or("EOF".into(), |t| t.user_facing_name())
+                        ),
+                        "brace-lambda syntax: `{param... > stmts}` — bare param names before `>`".into(),
+                    ));
+                }
+            }
+        }
+        self.expect(&Token::Greater)?;
+        // Optional `;` between `>` and body (e.g. `{a x>; body}`).
+        if self.peek() == Some(&Token::Semi) {
+            self.advance();
+        }
+
+        // Parse body: `;`-separated statements until `}`.
+        let mut body = Vec::new();
+        if self.peek() != Some(&Token::RBrace) {
+            let span_start = self.peek_span();
+            let stmt = self.parse_stmt()?;
+            body.push(Spanned { node: stmt, span: span_start.merge(self.prev_span()) });
+            while self.peek() == Some(&Token::Semi) {
+                self.advance();
+                if self.peek() == Some(&Token::RBrace) {
+                    break;
+                }
+                let span_start = self.peek_span();
+                let stmt = self.parse_stmt()?;
+                body.push(Spanned { node: stmt, span: span_start.merge(self.prev_span()) });
+            }
+        }
+        let end = self.peek_span();
+        self.expect(&Token::RBrace)?;
+
+        // Free-variable analysis and lifting — same as `parse_inline_lambda`.
+        let bound: std::collections::HashSet<String> =
+            params.iter().map(|p| p.name.clone()).collect();
+        let mut free = Vec::new();
+        let mut local: Vec<String> = Vec::new();
+        for stmt in &body {
+            self.collect_free_in_stmt(&stmt.node, &bound, &mut local, &mut free);
+        }
+
+        let fn_name = format!("__lit_{}", self.lambda_counter);
+        self.lambda_counter += 1;
+        let mut lifted_params = params;
+        for cap in &free {
+            lifted_params.push(Param { name: cap.clone(), ty: Type::Any });
+        }
+        self.register_user_fn(&fn_name, &lifted_params);
+        let span = start.merge(end);
+        self.lifted_decls.push(Decl::Function {
+            name: fn_name.clone(),
+            params: lifted_params,
+            return_type: Type::Any,
+            body,
+            span,
+        });
+        if free.is_empty() {
+            Ok(Expr::Ref(fn_name))
+        } else {
+            let captures: Vec<Expr> = free.into_iter().map(Expr::Ref).collect();
+            Ok(Expr::MakeClosure { fn_name, captures })
         }
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4779,9 +4779,7 @@ results first: `r={first_op}a b;…r` keeps each step explicit."
                 self.expect(&Token::RBracket)?;
                 Ok(Expr::List(items))
             }
-            Some(Token::LBrace) if self.looks_like_brace_lambda() => {
-                self.parse_brace_lambda()
-            }
+            Some(Token::LBrace) if self.looks_like_brace_lambda() => self.parse_brace_lambda(),
             Some(Token::LBrace) if self.is_anon_record_literal() => {
                 self.advance(); // consume `{`
                 let expr = self.parse_anon_record_body()?;
@@ -5152,7 +5150,10 @@ For variable-position list indexing bind the head first: \
             match self.peek() {
                 Some(Token::Ident(_)) => {
                     let name = self.expect_ident()?;
-                    params.push(Param { name, ty: Type::Any });
+                    params.push(Param {
+                        name,
+                        ty: Type::Any,
+                    });
                 }
                 _ => {
                     return Err(self.error_hint(
@@ -5161,7 +5162,8 @@ For variable-position list indexing bind the head first: \
                             "expected param name or `>` in brace-lambda, got {}",
                             self.peek().map_or("EOF".into(), |t| t.user_facing_name())
                         ),
-                        "brace-lambda syntax: `{param... > stmts}` — bare param names before `>`".into(),
+                        "brace-lambda syntax: `{param... > stmts}` — bare param names before `>`"
+                            .into(),
                     ));
                 }
             }
@@ -5177,7 +5179,10 @@ For variable-position list indexing bind the head first: \
         if self.peek() != Some(&Token::RBrace) {
             let span_start = self.peek_span();
             let stmt = self.parse_stmt()?;
-            body.push(Spanned { node: stmt, span: span_start.merge(self.prev_span()) });
+            body.push(Spanned {
+                node: stmt,
+                span: span_start.merge(self.prev_span()),
+            });
             while self.peek() == Some(&Token::Semi) {
                 self.advance();
                 if self.peek() == Some(&Token::RBrace) {
@@ -5185,7 +5190,10 @@ For variable-position list indexing bind the head first: \
                 }
                 let span_start = self.peek_span();
                 let stmt = self.parse_stmt()?;
-                body.push(Spanned { node: stmt, span: span_start.merge(self.prev_span()) });
+                body.push(Spanned {
+                    node: stmt,
+                    span: span_start.merge(self.prev_span()),
+                });
             }
         }
         let end = self.peek_span();
@@ -5204,7 +5212,10 @@ For variable-position list indexing bind the head first: \
         self.lambda_counter += 1;
         let mut lifted_params = params;
         for cap in &free {
-            lifted_params.push(Param { name: cap.clone(), ty: Type::Any });
+            lifted_params.push(Param {
+                name: cap.clone(),
+                ty: Type::Any,
+            });
         }
         self.register_user_fn(&fn_name, &lifted_params);
         let span = start.merge(end);

--- a/tests/coverage_parser.rs
+++ b/tests/coverage_parser.rs
@@ -1214,6 +1214,45 @@ fn nested_lambdas_capture() {
     ok("f xs:LLn k:n>LLn;map (ys:Ln>Ln;map (y:n>n;+y k) ys) xs");
 }
 
+// ---------------------------------------------------------------------------
+// Brace-lambda `{params> stmts}` (ILO-404)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn brace_lambda_fld_multi_stmt() {
+    ok("f xs:Ln>n;fld {a x>; tmp=*x 2; +a tmp} xs 0");
+}
+
+#[test]
+fn brace_lambda_fld_single_stmt() {
+    ok("f xs:Ln>n;fld {a x> +a x} xs 0");
+}
+
+#[test]
+fn brace_lambda_map_single_stmt() {
+    ok("f xs:Ln>Ln;map {x> *x 2} xs");
+}
+
+#[test]
+fn brace_lambda_map_multi_stmt() {
+    ok("f xs:Ln>Ln;map {x> y=+x 1; *y 2} xs");
+}
+
+#[test]
+fn brace_lambda_flt_single_stmt() {
+    ok("f xs:Ln>Ln;flt {x> >x 0} xs");
+}
+
+#[test]
+fn brace_lambda_flt_multi_stmt() {
+    ok("f xs:Ln>Ln;flt {x> thresh=0; >x thresh} xs");
+}
+
+#[test]
+fn brace_lambda_closure_capture() {
+    ok("f xs:Ln thr:n>Ln;flt {x> >x thr} xs");
+}
+
 #[test]
 fn pattern_text_arm() {
     ok("f x:t>n;?x{\"a\":1;\"b\":2;_:0}");


### PR DESCRIPTION
## Summary

- Adds `{params> stmts}` brace-lambda form as a compact alternative to `(p:t>r;body)` for HOF call positions (`map`, `flt`, `fld`, etc.)
- Param types default to `any`, return type inferred — no annotation needed
- Supports full `;`-chained multi-statement bodies (let-bindings, guards, match, loops, `ret`/`brk`/`cnt`) identical to paren lambdas
- Closure capture (Phase 2) works: free variables from the enclosing scope are snapshot by value via `Expr::MakeClosure`

Example from ticket:
```
fld {a x>; tmp=*x 2; +a tmp} xs 0   -- multi-stmt fold body
map {x> *x 2} xs                     -- single-stmt map
flt {x> >x thr} xs                   -- closure capture
```

## Implementation

- `looks_like_brace_lambda`: lookahead that fires on `{` with `>` at brace-depth 1 before any `;` (cleanly separates from destructure `{a;b}=x` and anon records `{field:val}`)
- `parse_brace_lambda`: parses bare param names (typed `any`), optional `;` after `>`, then `;`-separated body statements until `}`. Lifts to `__lit_N` synthetic decl, same path as `parse_inline_lambda`.
- `can_start_atom` / `parse_atom_body`: brace-lambda wired into the atom parse path

## Test plan

- [x] 7 new parser regression tests in `coverage_parser.rs`: fld/map/flt single-stmt, multi-stmt, and closure-capture variants
- [x] `cargo test --test coverage_parser` — 254 passed, 0 failed
- [x] Manual: `fld {a x>; tmp=*x 2; +a tmp} [1 2 3] 0` → `12`

🤖 Generated with [Claude Code](https://claude.com/claude-code)