### PR TITLE
Effect sets on function signatures (ILO-361 Phase 3 MVP)

### DIFF
--- a/examples/effect-sets.ilo
+++ b/examples/effect-sets.ilo
@@ -1,0 +1,28 @@
+-- Effect sets (ILO-361): declare which error variants a function may raise.
+-- Syntax: append `^variant|variant` after the return type.
+-- The verifier infers the actual errors from the body and warns on mismatch.
+-- Use `ilo check --show-effects <file>` to see inferred effect sets.
+
+-- No annotation — effect set is unconstrained (existing behaviour unchanged).
+safe-div a:n b:n>R n t
+  =b 0 ^"zero"
+  ~/a b
+
+-- Single declared variant matches the body — no warning.
+parse-positive s:t>R n t ^invalid
+  v=num! s
+  <v 0 ^"invalid"
+  ~v
+
+-- Multiple variants — body raises either on different paths.
+lookup id:n>R n t ^not-found|invalid
+  <id 1 ^"invalid"
+  =id 99 ^"not-found"
+  ~*id 10
+
+-- run: safe-div 10 2
+-- out: 5
+-- run: parse-positive "3"
+-- out: 3
+-- run: parse-positive "-1"
+-- out: nil

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -167,7 +167,7 @@ impl UsePredicate {
 /// Top-level declarations
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Decl {
-    /// `name<a:Comparable b> params>return;body`
+    /// `name<a:Comparable b> params>return ^Variant|Variant;body`
     /// `type_params` holds bounded generic type-variable declarations.
     /// Syntax: `<letter>` or `<letter:Bound>`, space-separated inside `<...>`.
     /// When absent the vec is empty and existing `a`/`b`/etc. type-variable
@@ -180,6 +180,11 @@ pub enum Decl {
         type_params: Vec<(String, Bound)>,
         params: Vec<Param>,
         return_type: Type,
+        /// Optional declared effect set: error variants that may propagate out.
+        /// Written as `^Variant|Variant` after the return type.
+        /// `None` = unannotated (no enforcement); `Some(vec)` = declared set.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        effect_set: Option<Vec<String>>,
         body: Vec<Spanned<Stmt>>,
         #[serde(skip)]
         span: Span,
@@ -1378,6 +1383,7 @@ mod tests {
             name: "f".to_string(),
             params: vec![],
             return_type: Type::Number,
+            effect_set: None,
             body: vec![Spanned::unknown(Stmt::Expr(Expr::Literal(
                 Literal::Number(1.0),
             )))],
@@ -1410,6 +1416,7 @@ mod tests {
                 name: "f".to_string(),
                 params: vec![],
                 return_type: Type::Number,
+                effect_set: None,
                 body: vec![Spanned::unknown(Stmt::While {
                     condition: Expr::Call {
                         function: "length".to_string(),
@@ -1457,6 +1464,7 @@ mod tests {
                 name: "f".to_string(),
                 params: vec![],
                 return_type: Type::Number,
+                effect_set: None,
                 body: vec![Spanned::unknown(Stmt::Return(Expr::Call {
                     function: "length".to_string(),
                     args: vec![Expr::Ref("x".to_string())],
@@ -1486,6 +1494,7 @@ mod tests {
                 name: "f".to_string(),
                 params: vec![],
                 return_type: Type::Number,
+                effect_set: None,
                 body: vec![Spanned::unknown(Stmt::Destructure {
                     bindings: vec!["a".to_string(), "b".to_string()],
                     value: Expr::Call {
@@ -1522,6 +1531,7 @@ mod tests {
                 name: "f".to_string(),
                 params: vec![],
                 return_type: Type::Number,
+                effect_set: None,
                 body: vec![Spanned::unknown(Stmt::Break(Some(Expr::Call {
                     function: "length".to_string(),
                     args: vec![Expr::Ref("x".to_string())],
@@ -1551,6 +1561,7 @@ mod tests {
                 name: "f".to_string(),
                 params: vec![],
                 return_type: Type::Number,
+                effect_set: None,
                 body: vec![
                     Spanned::unknown(Stmt::Break(None)),
                     Spanned::unknown(Stmt::Continue),
@@ -1573,6 +1584,7 @@ mod tests {
                 name: "f".to_string(),
                 params: vec![],
                 return_type: Type::Number,
+                effect_set: None,
                 body: vec![Spanned::unknown(Stmt::Expr(Expr::NilCoalesce {
                     value: Box::new(Expr::Call {
                         function: "length".to_string(),
@@ -1616,6 +1628,7 @@ mod tests {
                 name: "f".to_string(),
                 params: vec![],
                 return_type: Type::Number,
+                effect_set: None,
                 body: vec![Spanned::unknown(Stmt::Expr(Expr::Record {
                     type_name: "point".to_string(),
                     fields: vec![(
@@ -1654,6 +1667,7 @@ mod tests {
                 name: "f".to_string(),
                 params: vec![],
                 return_type: Type::Number,
+                effect_set: None,
                 body: vec![Spanned::unknown(Stmt::Expr(Expr::Match {
                     subject: Some(Box::new(Expr::Call {
                         function: "length".to_string(),
@@ -1703,6 +1717,7 @@ mod tests {
                 name: "f".to_string(),
                 params: vec![],
                 return_type: Type::Number,
+                effect_set: None,
                 body: vec![Spanned::unknown(Stmt::Expr(Expr::With {
                     object: Box::new(Expr::Call {
                         function: "length".to_string(),
@@ -1752,6 +1767,7 @@ mod tests {
                     ty: Type::Number,
                 }],
                 return_type: Type::Number,
+                effect_set: None,
                 body: vec![Spanned::unknown(Stmt::Expr(Expr::Ref("x".to_string())))],
                 span: Span { start: 0, end: 13 },
             }],
@@ -1775,6 +1791,7 @@ mod tests {
                 name: "f".to_string(),
                 params: vec![],
                 return_type: Type::Number,
+                effect_set: None,
                 body: vec![Spanned::unknown(Stmt::Match {
                     subject: None,
                     arms: vec![MatchArm {
@@ -1813,6 +1830,7 @@ mod tests {
                 name: "f".to_string(),
                 params: vec![],
                 return_type: Type::Number,
+                effect_set: None,
                 body: vec![Spanned::unknown(Stmt::Expr(Expr::Match {
                     subject: None,
                     arms: vec![MatchArm {

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -412,6 +412,12 @@ pub struct CheckArgs {
     /// exit-code decision is elevated.
     #[arg(long)]
     pub strict: bool,
+
+    /// Print the inferred effect set (propagated error variants) for every
+    /// Result-returning function after checking. Useful for auditing which
+    /// errors a function may raise and for writing `^variant|...` annotations.
+    #[arg(long)]
+    pub show_effects: bool,
 }
 
 // ── Test ───────────────────────────────────────────────────────────────────────

--- a/src/codegen/python.rs
+++ b/src/codegen/python.rs
@@ -2238,6 +2238,7 @@ mod tests {
                     ty: Type::Text,
                 }],
                 return_type: Type::Number,
+                effect_set: None,
                 body: vec![Spanned::unknown(Stmt::Expr(Expr::Call {
                     function: "num".into(),
                     args: vec![Expr::Ref("s".into())],

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -13395,6 +13395,7 @@ mod tests {
                         ty: Type::Number,
                     }],
                     return_type: Type::Result(Box::new(Type::Number), Box::new(Type::Text)),
+                    effect_set: None,
                     body: inner_body,
                     span: Span::UNKNOWN,
                 },
@@ -13406,6 +13407,7 @@ mod tests {
                         ty: Type::Number,
                     }],
                     return_type: Type::Result(Box::new(Type::Number), Box::new(Type::Text)),
+                    effect_set: None,
                     body: vec![
                         Spanned::unknown(Stmt::Let {
                             name: "d".to_string(),
@@ -13475,6 +13477,7 @@ mod tests {
                         ty: Type::Number,
                     }],
                     return_type: rnt.clone(),
+                    effect_set: None,
                     body: vec![Spanned::unknown(Stmt::Expr(Expr::Err(Box::new(
                         Expr::Literal(Literal::Text("deep".to_string())),
                     ))))],
@@ -13488,6 +13491,7 @@ mod tests {
                         ty: Type::Number,
                     }],
                     return_type: rnt.clone(),
+                    effect_set: None,
                     body: unwrap_body("c"),
                     span: Span::UNKNOWN,
                 },
@@ -13499,6 +13503,7 @@ mod tests {
                         ty: Type::Number,
                     }],
                     return_type: rnt,
+                    effect_set: None,
                     body: unwrap_body("b"),
                     span: Span::UNKNOWN,
                 },

--- a/src/main.rs
+++ b/src/main.rs
@@ -3253,6 +3253,7 @@ fn rename_decl_with_alias(decl: ast::Decl, alias: &str) -> ast::Decl {
             body,
             span,
             type_params,
+            effect_set,
         } => ast::Decl::Function {
             name: format!("{}-{}", alias, name),
             params,
@@ -3260,6 +3261,7 @@ fn rename_decl_with_alias(decl: ast::Decl, alias: &str) -> ast::Decl {
             body,
             span,
             type_params,
+            effect_set,
         },
         ast::Decl::Tool {
             name,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4175,7 +4175,13 @@ fn resolve_engine_func_name<'a>(
 /// out rather than reused so a future verify-only invocation path
 /// (e.g. an `--check-only` flag on `run`) can call into the same logic
 /// without disturbing the run hot path.
-fn check_cmd(source_arg: &str, mode: OutputMode, _explicit_json: bool, strict: bool, show_effects: bool) -> i32 {
+fn check_cmd(
+    source_arg: &str,
+    mode: OutputMode,
+    _explicit_json: bool,
+    strict: bool,
+    show_effects: bool,
+) -> i32 {
     // Read source from file or treat as inline code.
     let (source, is_file) = if std::path::Path::new(source_arg).is_file() {
         match std::fs::read_to_string(source_arg) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3612,7 +3612,7 @@ fn dispatch_cli(cli: cli::Cli, bare_has_bin: bool) -> i32 {
         Some(cli::Cmd::Check(c)) => {
             let mode = cli.global.output_mode();
             let explicit_json = cli.global.explicit_json();
-            check_cmd(&c.source, mode, explicit_json, c.strict)
+            check_cmd(&c.source, mode, explicit_json, c.strict, c.show_effects)
         }
         Some(cli::Cmd::Explain(e)) => {
             let as_json = cli.global.explicit_json();
@@ -4175,7 +4175,7 @@ fn resolve_engine_func_name<'a>(
 /// out rather than reused so a future verify-only invocation path
 /// (e.g. an `--check-only` flag on `run`) can call into the same logic
 /// without disturbing the run hot path.
-fn check_cmd(source_arg: &str, mode: OutputMode, _explicit_json: bool, strict: bool) -> i32 {
+fn check_cmd(source_arg: &str, mode: OutputMode, _explicit_json: bool, strict: bool, show_effects: bool) -> i32 {
     // Read source from file or treat as inline code.
     let (source, is_file) = if std::path::Path::new(source_arg).is_file() {
         match std::fs::read_to_string(source_arg) {
@@ -4281,7 +4281,7 @@ fn check_cmd(source_arg: &str, mode: OutputMode, _explicit_json: bool, strict: b
     // cumulative so the caller sees every issue in one pass, not a
     // fix-one-rerun-find-next loop. Verifier itself is robust to
     // partially-broken ASTs.
-    let verify_result = verify::verify(&program);
+    let verify_result = verify::verify_with_effects(&program, show_effects);
     for w in &verify_result.warnings {
         report_diagnostic(&enrich(Diagnostic::from(w)), mode);
         had_warnings = true;
@@ -4291,6 +4291,24 @@ fn check_cmd(source_arg: &str, mode: OutputMode, _explicit_json: bool, strict: b
             report_diagnostic(&enrich(Diagnostic::from(e)), mode);
         }
         had_errors = true;
+    }
+
+    // Print effect sets when --show-effects is requested.
+    if show_effects && !verify_result.effects.is_empty() {
+        println!("Effect sets:");
+        for fx in &verify_result.effects {
+            let declared_str = match &fx.declared {
+                None => String::new(),
+                Some(v) if v.is_empty() => " (declared: ^)".to_string(),
+                Some(v) => format!(" (declared: ^{})", v.join("|")),
+            };
+            let inferred_str = if fx.inferred.is_empty() {
+                "none".to_string()
+            } else {
+                fx.inferred.join("|")
+            };
+            println!("  {}: {}{}", fx.name, inferred_str, declared_str);
+        }
     }
 
     if had_errors || (strict && had_warnings) {
@@ -7189,6 +7207,7 @@ mod tests {
             name: "myfunc".into(),
             params: vec![],
             return_type: ast::Type::Number,
+            effect_set: None,
             body: vec![],
             span: ast::Span { start: 0, end: 0 },
         };
@@ -7596,6 +7615,7 @@ mod tests {
             name: "f".into(),
             params: vec![],
             return_type: ast::Type::Number,
+            effect_set: None,
             body: vec![],
             span: ast::Span { start: 0, end: 0 },
         };
@@ -9533,6 +9553,7 @@ mod tests {
                     ty: Type::Number,
                 }],
                 return_type: Type::Number,
+                effect_set: None,
                 body: vec![],
                 span: Span::UNKNOWN,
             },

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -307,6 +307,21 @@ impl Parser {
         }
     }
 
+    /// Return the next token's text as an effect-variant name if it looks like
+    /// an identifier or a keyword that can serve as a variant name in an effect
+    /// set clause (e.g. `timeout`, `retry`). Returns `None` for tokens that
+    /// cannot be variant names (operators, type constructors, etc).
+    fn peek_as_effect_variant(&self) -> Option<String> {
+        match self.peek() {
+            Some(Token::Ident(s)) => Some(s.clone()),
+            // Keywords that are valid as variant names
+            Some(Token::Timeout) => Some("timeout".to_string()),
+            Some(Token::Retry) => Some("retry".to_string()),
+            Some(Token::With) => Some("with".to_string()),
+            _ => None,
+        }
+    }
+
     fn advance(&mut self) -> Option<&Token> {
         let tok = self.tokens.get(self.pos).map(|(t, _)| t);
         if tok.is_some() {
@@ -1448,6 +1463,36 @@ statement boundary; bind the chain to a local first. For example, split \
         // against `f2`, not against whatever ident starts the next line.
         self.check_fn_header_boundary_or_record(&name, start)?;
         let return_type = self.parse_type_or_record_fail(&name)?;
+        // Optional effect-set clause: `^variant|variant|...` after the return type.
+        // Declares which error variants may propagate out of this function.
+        // `^` is used to mirror match-arm error syntax (`^e` catches errors).
+        // Example: `process order:order > R order t ^invalid|timeout`
+        let effect_set = if self.peek() == Some(&Token::Caret) {
+            self.advance();
+            let mut variants = Vec::new();
+            // Consume: word (|word)* — word can be an Ident or any keyword token
+            // that is valid as a variant name (e.g. `timeout`, `retry`).
+            if let Some(v) = self.peek_as_effect_variant() {
+                variants.push(v);
+                self.advance();
+                while self.peek() == Some(&Token::Pipe) {
+                    self.advance();
+                    if let Some(v) = self.peek_as_effect_variant() {
+                        variants.push(v);
+                        self.advance();
+                    } else {
+                        break;
+                    }
+                }
+            }
+            if variants.is_empty() {
+                Some(vec![]) // `^` with no variants = empty effect set (pure)
+            } else {
+                Some(variants)
+            }
+        } else {
+            None
+        };
         // The header/body boundary is normally a `;`, but a newline (filtered
         // out before parsing) leaves no separator. Accept either: consume a
         // `;` if present, otherwise fall straight into the body.
@@ -1480,6 +1525,7 @@ statement boundary; bind the chain to a local first. For example, split \
             type_params,
             params,
             return_type,
+            effect_set,
             body,
             span: start.merge(end),
         })
@@ -5666,6 +5712,7 @@ For variable-position list indexing bind the head first: \
             type_params: vec![],
             params: lifted_params,
             return_type,
+            effect_set: None,
             body,
             span,
         });
@@ -12576,5 +12623,32 @@ mod tests {
             "should not fire multi-line hint here; hint: {:?}",
             e.hint
         );
+    }
+
+    // ── Effect sets (ILO-361) ──────────────────────────────────────────────────
+
+    #[test]
+    fn parse_effect_set_single_variant() {
+        // `f a:n>R n t ^zero;...` — single declared variant
+        let prog = parse_str(r#"f a:n>R n t ^zero;=a 0 ^"zero";~a"#);
+        let Decl::Function { effect_set, .. } = &prog.declarations[0] else { panic!() };
+        assert_eq!(effect_set.as_deref(), Some(["zero".to_string()].as_slice()));
+    }
+
+    #[test]
+    fn parse_effect_set_multiple_variants() {
+        // `f a:n>R n t ^invalid|timeout;...`
+        let prog = parse_str(r#"f a:n>R n t ^invalid|timeout;=a 0 ^"invalid";~a"#);
+        let Decl::Function { effect_set, .. } = &prog.declarations[0] else { panic!() };
+        let set = effect_set.as_ref().expect("expected Some");
+        assert_eq!(set, &["invalid".to_string(), "timeout".to_string()]);
+    }
+
+    #[test]
+    fn parse_no_effect_set_is_none() {
+        // No `^` clause → effect_set is None
+        let prog = parse_str("f x:n>n;x");
+        let Decl::Function { effect_set, .. } = &prog.declarations[0] else { panic!() };
+        assert!(effect_set.is_none());
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -12631,7 +12631,9 @@ mod tests {
     fn parse_effect_set_single_variant() {
         // `f a:n>R n t ^zero;...` — single declared variant
         let prog = parse_str(r#"f a:n>R n t ^zero;=a 0 ^"zero";~a"#);
-        let Decl::Function { effect_set, .. } = &prog.declarations[0] else { panic!() };
+        let Decl::Function { effect_set, .. } = &prog.declarations[0] else {
+            panic!()
+        };
         assert_eq!(effect_set.as_deref(), Some(["zero".to_string()].as_slice()));
     }
 
@@ -12639,7 +12641,9 @@ mod tests {
     fn parse_effect_set_multiple_variants() {
         // `f a:n>R n t ^invalid|timeout;...`
         let prog = parse_str(r#"f a:n>R n t ^invalid|timeout;=a 0 ^"invalid";~a"#);
-        let Decl::Function { effect_set, .. } = &prog.declarations[0] else { panic!() };
+        let Decl::Function { effect_set, .. } = &prog.declarations[0] else {
+            panic!()
+        };
         let set = effect_set.as_ref().expect("expected Some");
         assert_eq!(set, &["invalid".to_string(), "timeout".to_string()]);
     }
@@ -12648,7 +12652,9 @@ mod tests {
     fn parse_no_effect_set_is_none() {
         // No `^` clause → effect_set is None
         let prog = parse_str("f x:n>n;x");
-        let Decl::Function { effect_set, .. } = &prog.declarations[0] else { panic!() };
+        let Decl::Function { effect_set, .. } = &prog.declarations[0] else {
+            panic!()
+        };
         assert!(effect_set.is_none());
     }
 }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -11806,6 +11806,8 @@ mod tests {
             parse_and_verify("f x:n>n;?=x 0(todo \"zero case\")(+x 1)").is_ok(),
             "todo in ternary branch should typecheck"
         );
+    }
+
     // ── Effect sets (ILO-361) ──────────────────────────────────────────────────
 
     #[test]

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -7078,6 +7078,8 @@ fn collect_err_literals_expr(expr: &Expr, out: &mut std::collections::BTreeSet<S
             }
         }
         Expr::MakeClosure { .. } | Expr::Literal(_) | Expr::Ref(_) => {}
+        Expr::Todo(inner) => collect_err_literals_expr(inner, out),
+        Expr::Panic(inner) => collect_err_literals_expr(inner, out),
         Expr::Ternary {
             condition,
             then_expr,

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -4735,10 +4735,8 @@ impl VerifyContext {
                 inferred.remove("<dynamic>");
                 let declared_set: std::collections::BTreeSet<String> =
                     declared.iter().cloned().collect();
-                let mut undeclared: Vec<String> = inferred
-                    .difference(&declared_set)
-                    .cloned()
-                    .collect();
+                let mut undeclared: Vec<String> =
+                    inferred.difference(&declared_set).cloned().collect();
                 undeclared.sort();
                 if !undeclared.is_empty() {
                     let last_span = body.last().map(|s| s.span);
@@ -6971,7 +6969,12 @@ fn collect_err_literals_stmt(stmt: &Stmt, out: &mut std::collections::BTreeSet<S
         Stmt::Expr(e) | Stmt::Return(e) => collect_err_literals_expr(e, out),
         Stmt::Let { value, .. } => collect_err_literals_expr(value, out),
         Stmt::Destructure { value, .. } => collect_err_literals_expr(value, out),
-        Stmt::Guard { condition, body, else_body, .. } => {
+        Stmt::Guard {
+            condition,
+            body,
+            else_body,
+            ..
+        } => {
             collect_err_literals_expr(condition, out);
             collect_err_literals(body, out);
             if let Some(eb) = else_body {
@@ -6982,11 +6985,19 @@ fn collect_err_literals_stmt(stmt: &Stmt, out: &mut std::collections::BTreeSet<S
             collect_err_literals_expr(condition, out);
             collect_err_literals(body, out);
         }
-        Stmt::ForEach { collection, body, .. } => {
+        Stmt::ForEach {
+            collection, body, ..
+        } => {
             collect_err_literals_expr(collection, out);
             collect_err_literals(body, out);
         }
-        Stmt::ForRange { start, end, step, body, .. } => {
+        Stmt::ForRange {
+            start,
+            end,
+            step,
+            body,
+            ..
+        } => {
             collect_err_literals_expr(start, out);
             collect_err_literals_expr(end, out);
             if let Some(s) = step {
@@ -7067,7 +7078,11 @@ fn collect_err_literals_expr(expr: &Expr, out: &mut std::collections::BTreeSet<S
             }
         }
         Expr::MakeClosure { .. } | Expr::Literal(_) | Expr::Ref(_) => {}
-        Expr::Ternary { condition, then_expr, else_expr } => {
+        Expr::Ternary {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
             collect_err_literals_expr(condition, out);
             collect_err_literals_expr(then_expr, out);
             collect_err_literals_expr(else_expr, out);
@@ -7133,7 +7148,11 @@ pub fn verify_with_effects(program: &Program, show_effects: bool) -> VerifyResul
     };
 
     let (warnings, errors) = ctx.errors.into_iter().partition(|e| e.is_warning);
-    VerifyResult { errors, warnings, effects }
+    VerifyResult {
+        errors,
+        warnings,
+        effects,
+    }
 }
 
 #[cfg(test)]
@@ -11797,7 +11816,15 @@ mod tests {
             let tokens = crate::lexer::lex(code).expect("lex");
             let token_spans: Vec<(crate::lexer::Token, crate::ast::Span)> = tokens
                 .into_iter()
-                .map(|(t, r)| (t, crate::ast::Span { start: r.start, end: r.end }))
+                .map(|(t, r)| {
+                    (
+                        t,
+                        crate::ast::Span {
+                            start: r.start,
+                            end: r.end,
+                        },
+                    )
+                })
                 .collect();
             let (program, _) = crate::parser::parse(token_spans);
             infer_effects(&program)
@@ -11812,28 +11839,41 @@ mod tests {
     fn effect_set_declared_matches_inferred_no_warning() {
         // No warning when declared set matches inferred
         let result = parse_and_verify_full(r#"f a:n>R n t ^zero;=a 0 ^"zero";~a"#);
-        let effect_warnings: Vec<_> = result.warnings.iter()
+        let effect_warnings: Vec<_> = result
+            .warnings
+            .iter()
             .filter(|w| w.code == "ILO-E001")
             .collect();
-        assert!(effect_warnings.is_empty(), "should have no effect mismatch warning: {:?}", effect_warnings);
+        assert!(
+            effect_warnings.is_empty(),
+            "should have no effect mismatch warning: {:?}",
+            effect_warnings
+        );
     }
 
     #[test]
     fn effect_set_declared_mismatch_emits_warning() {
         // Warning when declared set misses an inferred variant
         let result = parse_and_verify_full(r#"f a:n>R n t ^other;=a 0 ^"zero";~a"#);
-        let effect_warnings: Vec<_> = result.warnings.iter()
+        let effect_warnings: Vec<_> = result
+            .warnings
+            .iter()
             .filter(|w| w.code == "ILO-E001")
             .collect();
         assert_eq!(effect_warnings.len(), 1, "expected 1 ILO-E001 warning");
-        assert!(effect_warnings[0].message.contains("zero"), "should mention 'zero'");
+        assert!(
+            effect_warnings[0].message.contains("zero"),
+            "should mention 'zero'"
+        );
     }
 
     #[test]
     fn effect_set_no_annotation_no_warning() {
         // Without annotation, no effect mismatch warning is emitted
         let result = parse_and_verify_full(r#"f a:n>R n t;=a 0 ^"zero";~a"#);
-        let effect_warnings: Vec<_> = result.warnings.iter()
+        let effect_warnings: Vec<_> = result
+            .warnings
+            .iter()
             .filter(|w| w.code == "ILO-E001")
             .collect();
         assert!(effect_warnings.is_empty());
@@ -11846,7 +11886,15 @@ mod tests {
         let tokens = crate::lexer::lex(code).expect("lex");
         let token_spans: Vec<(crate::lexer::Token, crate::ast::Span)> = tokens
             .into_iter()
-            .map(|(t, r)| (t, crate::ast::Span { start: r.start, end: r.end }))
+            .map(|(t, r)| {
+                (
+                    t,
+                    crate::ast::Span {
+                        start: r.start,
+                        end: r.end,
+                    },
+                )
+            })
             .collect();
         let (program, _) = crate::parser::parse(token_spans);
         let effects = infer_effects(&program);

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -4708,6 +4708,66 @@ impl VerifyContext {
         }
     }
 
+    /// Like `verify_bodies` but also checks declared effect sets against inferred ones.
+    fn verify_bodies_with_effects(&mut self, program: &Program) {
+        self.verify_bodies(program);
+        // Effect-set mismatch check: for functions with a declared `^variant|...`
+        // clause, warn if the inferred body effects contain variants not in the set.
+        for decl in &program.declarations {
+            if let Decl::Function {
+                name,
+                body,
+                effect_set: Some(declared),
+                return_type,
+                ..
+            } = decl
+            {
+                if self.parse_failed_fns.contains_key(name) {
+                    continue;
+                }
+                // Only check Result-returning functions.
+                if !matches!(return_type, Type::Result(_, _)) {
+                    continue;
+                }
+                let mut inferred = std::collections::BTreeSet::new();
+                collect_err_literals(body, &mut inferred);
+                // Remove <dynamic> from comparison — we can't statically verify those.
+                inferred.remove("<dynamic>");
+                let declared_set: std::collections::BTreeSet<String> =
+                    declared.iter().cloned().collect();
+                let mut undeclared: Vec<String> = inferred
+                    .difference(&declared_set)
+                    .cloned()
+                    .collect();
+                undeclared.sort();
+                if !undeclared.is_empty() {
+                    let last_span = body.last().map(|s| s.span);
+                    let declared_str = if declared.is_empty() {
+                        "empty".to_string()
+                    } else {
+                        declared.join("|")
+                    };
+                    self.warn(
+                        "ILO-E001",
+                        name,
+                        format!(
+                            "effect set mismatch: declared `^{}` but body may raise `{}`",
+                            declared_str,
+                            undeclared.join("|")
+                        ),
+                        Some(format!(
+                            "add `{}` to the effect set: `^{}|{}`",
+                            undeclared.join("|"),
+                            declared_str,
+                            undeclared.join("|")
+                        )),
+                        last_span,
+                    );
+                }
+            }
+        }
+    }
+
     fn verify_body(&mut self, func: &str, scope: &mut Scope, stmts: &[Spanned<Stmt>]) -> Ty {
         let mut last_ty = Ty::Nil;
         for (i, spanned) in stmts.iter().enumerate() {
@@ -6878,26 +6938,202 @@ ilo has no tuple type."
     }
 }
 
+/// Inferred effect set for a single function: the error variants that may
+/// propagate out of the function body.
+#[derive(Debug, Clone)]
+pub struct FnEffects {
+    /// Function name.
+    pub name: String,
+    /// Declared effect set from signature (`^v1|v2`), if any.
+    pub declared: Option<Vec<String>>,
+    /// Inferred effect set from body analysis.
+    pub inferred: Vec<String>,
+}
+
 #[derive(Debug)]
 pub struct VerifyResult {
     pub errors: Vec<VerifyError>,
     pub warnings: Vec<VerifyError>,
+    /// Effect sets per function (populated when `show_effects` is requested).
+    pub effects: Vec<FnEffects>,
+}
+
+/// Collect all string literals that appear directly in `^expr` (Err constructor)
+/// positions within the given statements, recursively.
+fn collect_err_literals(stmts: &[Spanned<Stmt>], out: &mut std::collections::BTreeSet<String>) {
+    for spanned in stmts {
+        collect_err_literals_stmt(&spanned.node, out);
+    }
+}
+
+fn collect_err_literals_stmt(stmt: &Stmt, out: &mut std::collections::BTreeSet<String>) {
+    match stmt {
+        Stmt::Expr(e) | Stmt::Return(e) => collect_err_literals_expr(e, out),
+        Stmt::Let { value, .. } => collect_err_literals_expr(value, out),
+        Stmt::Destructure { value, .. } => collect_err_literals_expr(value, out),
+        Stmt::Guard { condition, body, else_body, .. } => {
+            collect_err_literals_expr(condition, out);
+            collect_err_literals(body, out);
+            if let Some(eb) = else_body {
+                collect_err_literals(eb, out);
+            }
+        }
+        Stmt::While { condition, body } => {
+            collect_err_literals_expr(condition, out);
+            collect_err_literals(body, out);
+        }
+        Stmt::ForEach { collection, body, .. } => {
+            collect_err_literals_expr(collection, out);
+            collect_err_literals(body, out);
+        }
+        Stmt::ForRange { start, end, step, body, .. } => {
+            collect_err_literals_expr(start, out);
+            collect_err_literals_expr(end, out);
+            if let Some(s) = step {
+                collect_err_literals_expr(s, out);
+            }
+            collect_err_literals(body, out);
+        }
+        Stmt::Match { subject, arms } => {
+            if let Some(s) = subject {
+                collect_err_literals_expr(s, out);
+            }
+            for arm in arms {
+                collect_err_literals(&arm.body, out);
+            }
+        }
+        Stmt::Break(Some(e)) => collect_err_literals_expr(e, out),
+        Stmt::Break(None) | Stmt::Continue => {}
+    }
+}
+
+fn collect_err_literals_expr(expr: &Expr, out: &mut std::collections::BTreeSet<String>) {
+    match expr {
+        Expr::Err(inner) => {
+            // Direct error return: `^"variant"` or `^varname`
+            match inner.as_ref() {
+                Expr::Literal(Literal::Text(s)) => {
+                    out.insert(s.clone());
+                }
+                Expr::Ref(name) => {
+                    out.insert(name.clone());
+                }
+                _ => {
+                    // Complex expression — mark as unknown/dynamic
+                    out.insert("<dynamic>".to_string());
+                }
+            }
+            collect_err_literals_expr(inner, out);
+        }
+        Expr::Call { args, .. } => {
+            for a in args {
+                collect_err_literals_expr(a, out);
+            }
+        }
+        Expr::BinOp { left, right, .. } => {
+            collect_err_literals_expr(left, out);
+            collect_err_literals_expr(right, out);
+        }
+        Expr::UnaryOp { operand, .. } => collect_err_literals_expr(operand, out),
+        Expr::Ok(inner) => collect_err_literals_expr(inner, out),
+        Expr::Field { object, .. } => collect_err_literals_expr(object, out),
+        Expr::Index { object, .. } => collect_err_literals_expr(object, out),
+        Expr::List(items) => {
+            for i in items {
+                collect_err_literals_expr(i, out);
+            }
+        }
+        Expr::Record { fields, .. } | Expr::AnonRecord { fields } => {
+            for (_, v) in fields {
+                collect_err_literals_expr(v, out);
+            }
+        }
+        Expr::Match { subject, arms } => {
+            if let Some(s) = subject {
+                collect_err_literals_expr(s, out);
+            }
+            for arm in arms {
+                collect_err_literals(&arm.body, out);
+            }
+        }
+        Expr::NilCoalesce { value, default } => {
+            collect_err_literals_expr(value, out);
+            collect_err_literals_expr(default, out);
+        }
+        Expr::With { object, updates } => {
+            collect_err_literals_expr(object, out);
+            for (_, v) in updates {
+                collect_err_literals_expr(v, out);
+            }
+        }
+        Expr::MakeClosure { .. } | Expr::Literal(_) | Expr::Ref(_) => {}
+        Expr::Ternary { condition, then_expr, else_expr } => {
+            collect_err_literals_expr(condition, out);
+            collect_err_literals_expr(then_expr, out);
+            collect_err_literals_expr(else_expr, out);
+        }
+    }
+}
+
+/// Infer the effect set for all functions in the program.
+pub fn infer_effects(program: &Program) -> Vec<FnEffects> {
+    let mut result = Vec::new();
+    for decl in &program.declarations {
+        if let Decl::Function {
+            name,
+            body,
+            effect_set,
+            return_type,
+            ..
+        } = decl
+        {
+            // Only analyse Result-returning functions — others don't propagate errors.
+            let is_result = matches!(return_type, Type::Result(_, _));
+            if !is_result {
+                result.push(FnEffects {
+                    name: name.clone(),
+                    declared: effect_set.clone(),
+                    inferred: vec![],
+                });
+                continue;
+            }
+            let mut inferred_set = std::collections::BTreeSet::new();
+            collect_err_literals(body, &mut inferred_set);
+            result.push(FnEffects {
+                name: name.clone(),
+                declared: effect_set.clone(),
+                inferred: inferred_set.into_iter().collect(),
+            });
+        }
+    }
+    result
 }
 
 /// Run static verification on a parsed program.
 /// Returns errors and warnings separately.
 pub fn verify(program: &Program) -> VerifyResult {
+    verify_with_effects(program, false)
+}
+
+/// Run static verification; optionally populate `VerifyResult::effects`.
+pub fn verify_with_effects(program: &Program, show_effects: bool) -> VerifyResult {
     let mut ctx = VerifyContext::new();
     ctx.parse_failed_fns = program.parse_failed_fns.clone();
 
     // Phase 1: collect declarations
     ctx.collect_declarations(program);
 
-    // Phase 2: verify function bodies
-    ctx.verify_bodies(program);
+    // Phase 2: verify function bodies (includes effect-set mismatch warnings)
+    ctx.verify_bodies_with_effects(program);
+
+    let effects = if show_effects {
+        infer_effects(program)
+    } else {
+        vec![]
+    };
 
     let (warnings, errors) = ctx.errors.into_iter().partition(|e| e.is_warning);
-    VerifyResult { errors, warnings }
+    VerifyResult { errors, warnings, effects }
 }
 
 #[cfg(test)]
@@ -8276,6 +8512,7 @@ mod tests {
                         ty: Type::Number,
                     }],
                     return_type: rnt.clone(),
+                    effect_set: None,
                     body: vec![Spanned::unknown(Stmt::Expr(Expr::Ok(Box::new(Expr::Ref(
                         "x".to_string(),
                     )))))],
@@ -8289,6 +8526,7 @@ mod tests {
                         ty: Type::Number,
                     }],
                     return_type: rnt,
+                    effect_set: None,
                     body: vec![
                         Spanned::unknown(Stmt::Let {
                             name: "d".to_string(),
@@ -8330,6 +8568,7 @@ mod tests {
                         ty: Type::Number,
                     }],
                     return_type: Type::Number,
+                    effect_set: None,
                     body: vec![Spanned::unknown(Stmt::Expr(Expr::Ref("x".to_string())))],
                     span: Span::UNKNOWN,
                 },
@@ -8341,6 +8580,7 @@ mod tests {
                         ty: Type::Number,
                     }],
                     return_type: Type::Result(Box::new(Type::Number), Box::new(Type::Text)),
+                    effect_set: None,
                     body: vec![Spanned::unknown(Stmt::Expr(Expr::Call {
                         function: "inner".to_string(),
                         args: vec![Expr::Ref("x".to_string())],
@@ -8375,6 +8615,7 @@ mod tests {
                         ty: Type::Number,
                     }],
                     return_type: rnt,
+                    effect_set: None,
                     body: vec![Spanned::unknown(Stmt::Expr(Expr::Ok(Box::new(Expr::Ref(
                         "x".to_string(),
                     )))))],
@@ -8388,6 +8629,7 @@ mod tests {
                         ty: Type::Number,
                     }],
                     return_type: Type::Number,
+                    effect_set: None,
                     body: vec![Spanned::unknown(Stmt::Expr(Expr::Call {
                         function: "inner".to_string(),
                         args: vec![Expr::Ref("x".to_string())],
@@ -10657,6 +10899,7 @@ mod tests {
                     ty: Type::List(Box::new(Type::Text)),
                 }],
                 return_type: Type::Text,
+                effect_set: None,
                 body: vec![Spanned::unknown(Stmt::Match {
                     subject: Some(Expr::Ref("x".to_string())),
                     arms: vec![arm_list, arm_wild],
@@ -10890,6 +11133,7 @@ mod tests {
                     ty: Type::Number,
                 }],
                 return_type: Type::Number,
+                effect_set: None,
                 body: vec![Spanned::unknown(Stmt::Match {
                     subject: Some(Expr::Ref("x".to_string())),
                     arms: vec![
@@ -10932,6 +11176,7 @@ mod tests {
                 name: "f".to_string(),
                 params: vec![],
                 return_type: Type::Any,
+                effect_set: None,
                 body: vec![Spanned::unknown(Stmt::Expr(Expr::Literal(Literal::Nil)))],
                 span: Span::UNKNOWN,
             }],
@@ -10962,6 +11207,7 @@ mod tests {
                     ty: Type::Number,
                 }],
                 return_type: Type::Text,
+                effect_set: None,
                 body: vec![Spanned::unknown(Stmt::Expr(Expr::Ternary {
                     condition: Box::new(Expr::BinOp {
                         op: BinOp::Equals,
@@ -11541,6 +11787,71 @@ mod tests {
             parse_and_verify("f x:n>n;?=x 0(todo \"zero case\")(+x 1)").is_ok(),
             "todo in ternary branch should typecheck"
         );
+    // ── Effect sets (ILO-361) ──────────────────────────────────────────────────
+
+    #[test]
+    fn effect_set_infer_err_literal() {
+        // infer_effects extracts string literal from ^"variant"
+        let code = r#"safe-div a:n b:n>R n t;=b 0 ^"zero";~/a b"#;
+        let effects = {
+            let tokens = crate::lexer::lex(code).expect("lex");
+            let token_spans: Vec<(crate::lexer::Token, crate::ast::Span)> = tokens
+                .into_iter()
+                .map(|(t, r)| (t, crate::ast::Span { start: r.start, end: r.end }))
+                .collect();
+            let (program, _) = crate::parser::parse(token_spans);
+            infer_effects(&program)
+        };
+        assert_eq!(effects.len(), 1);
+        assert_eq!(effects[0].name, "safe-div");
+        assert_eq!(effects[0].inferred, vec!["zero".to_string()]);
+        assert!(effects[0].declared.is_none());
+    }
+
+    #[test]
+    fn effect_set_declared_matches_inferred_no_warning() {
+        // No warning when declared set matches inferred
+        let result = parse_and_verify_full(r#"f a:n>R n t ^zero;=a 0 ^"zero";~a"#);
+        let effect_warnings: Vec<_> = result.warnings.iter()
+            .filter(|w| w.code == "ILO-E001")
+            .collect();
+        assert!(effect_warnings.is_empty(), "should have no effect mismatch warning: {:?}", effect_warnings);
+    }
+
+    #[test]
+    fn effect_set_declared_mismatch_emits_warning() {
+        // Warning when declared set misses an inferred variant
+        let result = parse_and_verify_full(r#"f a:n>R n t ^other;=a 0 ^"zero";~a"#);
+        let effect_warnings: Vec<_> = result.warnings.iter()
+            .filter(|w| w.code == "ILO-E001")
+            .collect();
+        assert_eq!(effect_warnings.len(), 1, "expected 1 ILO-E001 warning");
+        assert!(effect_warnings[0].message.contains("zero"), "should mention 'zero'");
+    }
+
+    #[test]
+    fn effect_set_no_annotation_no_warning() {
+        // Without annotation, no effect mismatch warning is emitted
+        let result = parse_and_verify_full(r#"f a:n>R n t;=a 0 ^"zero";~a"#);
+        let effect_warnings: Vec<_> = result.warnings.iter()
+            .filter(|w| w.code == "ILO-E001")
+            .collect();
+        assert!(effect_warnings.is_empty());
+    }
+
+    #[test]
+    fn effect_set_non_result_fn_ignored() {
+        // Non-Result functions get empty inferred set
+        let code = "f x:n>n;x";
+        let tokens = crate::lexer::lex(code).expect("lex");
+        let token_spans: Vec<(crate::lexer::Token, crate::ast::Span)> = tokens
+            .into_iter()
+            .map(|(t, r)| (t, crate::ast::Span { start: r.start, end: r.end }))
+            .collect();
+        let (program, _) = crate::parser::parse(token_spans);
+        let effects = infer_effects(&program);
+        assert_eq!(effects.len(), 1);
+        assert!(effects[0].inferred.is_empty());
     }
 
     // ── ILO-402: Generic sum types ────────────────────────────────────────────

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -23672,6 +23672,7 @@ mod tests {
                 params,
                 body: vec![],
                 return_type: Type::Number,
+                effect_set: None,
                 span: Span::UNKNOWN,
             }],
             source: None,


### PR DESCRIPTION
## Summary

- Adds optional `^variant|variant` effect-set clause to function signatures, written after the return type: `process order:order > R order t ^invalid|timeout`
- Verifier infers which error string literals appear in `^expr` positions in Result-returning function bodies and emits `ILO-E001` warning when the declared set is narrower than the inferred set
- New `ilo check --show-effects` flag prints inferred (and declared) effect sets for every function in a file

## MVP shape

This is the inference + annotation surface only. Full enforcement (superset check at call sites, integration with Phase 2 fix plans) is filed as follow-up per the ticket scope.

- Syntax: `f x:n>R n t ^invalid|timeout;body`
- `^` sigil mirrors existing `^err` match-arm syntax
- No annotation = existing behaviour unchanged (backwards compatible)
- `ILO-E001` warning when declared set misses an inferred variant
- `--show-effects` CLI flag for auditing and annotation authoring
- 8 new targeted tests (3 parser, 5 verifier)

## Test plan

- [x] `cargo test` — all 4,773 tests pass, 0 failures
- [x] `ilo check examples/effect-sets.ilo --show-effects` — shows correct inferred sets
- [x] Mismatch warning fires with actionable hint
- [x] Unannotated functions unchanged (no warnings)

Closes ILO-361

🤖 Generated with [Claude Code](https://claude.com/claude-code)