### PR TITLE
Provenance matrix + golden-file diagnostics (ILO-363 Phase 4)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,54 @@ Key source files:
 
 See [SPEC.md](SPEC.md) for the full language specification. Changes to language syntax or semantics should update the spec.
 
+## Golden-file diagnostics
+
+ilo pins the JSON shape of its diagnostic output with golden snapshot files
+stored under `conformance/diagnostics/`. When you change a diagnostic message,
+add a `phase` field, or add a new error code, CI will fail on a diff unless
+you also update the matching snapshot.
+
+### Running the golden tests
+
+```
+cargo test --features golden
+```
+
+### Updating (blessing) snapshots
+
+If you intentionally changed a diagnostic's JSON shape, re-bless the affected
+golden files:
+
+```
+cargo test --features golden -- --bless
+```
+
+This rewrites every `conformance/diagnostics/<CODE>.expected.json` whose
+content has changed. Review the diff with `git diff conformance/` before
+committing — the snapshot is part of the stability contract.
+
+You can also bless a single code by running the specific test:
+
+```
+ILO_GOLDEN_BLESS=1 cargo test --features golden golden_ilo_t004
+```
+
+### Adding a new error code
+
+1. Add the entry to `src/diagnostic/registry.rs` with a `phase` field set to
+   the correct `Phase::*` variant.
+2. Run `cargo test --features golden -- --bless` to generate the initial
+   golden file.
+3. Commit both the registry change and the new `.expected.json` file.
+
+### Provenance surface
+
+`conformance/provenance-surface.json` maps every language feature to the
+compiler function that owns it and the fixture that exercises it. When you add
+a new feature or move code to a different function, update this file to keep
+the map accurate. The `provenance_surface_is_valid` golden test will catch
+structural problems.
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ http = ["dep:minreq"]
 cranelift = ["dep:cranelift-codegen", "dep:cranelift-frontend", "dep:cranelift-jit", "dep:cranelift-module", "dep:cranelift-native", "dep:cranelift-object", "dep:target-lexicon", "dep:postcard"]
 llvm = ["dep:inkwell"]
 tools = ["dep:tokio", "dep:reqwest"]
+# golden — enable golden-file diagnostic snapshot tests.
+# Run:  cargo test --features golden
+# Bless: cargo test --features golden -- --bless  (see CONTRIBUTING.md)
+golden = []
 
 [dependencies]
 logos = "0.16.1"

--- a/conformance/diagnostics/ILO-L001.expected.json
+++ b/conformance/diagnostics/ILO-L001.expected.json
@@ -1,0 +1,7 @@
+{
+  "code": "ILO-L001",
+  "long": "## ILO-L001: unexpected character\n\nA character was encountered that is not part of the ilo language.\n\n**Example:**\n\n    f x:n>n; $x\n\nThe `$` character is not valid in ilo source. Remove it or replace it\nwith a valid operator or identifier.\n",
+  "phase": "lex",
+  "schemaVersion": 1,
+  "short": "unexpected character"
+}

--- a/conformance/diagnostics/ILO-L002.expected.json
+++ b/conformance/diagnostics/ILO-L002.expected.json
@@ -1,0 +1,7 @@
+{
+  "code": "ILO-L002",
+  "long": "## ILO-L002: underscore in identifier\n\nilo uses hyphens as word separators in identifiers, not underscores.\n\n**Example that triggers this:**\n\n    my_func x:n>n;x\n\n**Fix:**\n\n    my-func x:n>n;x\n",
+  "phase": "lex",
+  "schemaVersion": 1,
+  "short": "underscore in identifier — use hyphens"
+}

--- a/conformance/diagnostics/ILO-L003.expected.json
+++ b/conformance/diagnostics/ILO-L003.expected.json
@@ -1,0 +1,7 @@
+{
+  "code": "ILO-L003",
+  "long": "## ILO-L003: uppercase identifier\n\nilo identifiers must be lowercase. Single uppercase letters (`L`, `R`)\nare reserved for the built-in `List` and `Result` type constructors.\n\n**Example that triggers this:**\n\n    MyFunc x:n>n;x\n\n**Fix:**\n\n    my-func x:n>n;x\n",
+  "phase": "lex",
+  "schemaVersion": 1,
+  "short": "uppercase identifier — use lowercase"
+}

--- a/conformance/diagnostics/ILO-P001.expected.json
+++ b/conformance/diagnostics/ILO-P001.expected.json
@@ -1,0 +1,7 @@
+{
+  "code": "ILO-P001",
+  "long": "## ILO-P001: unexpected token at top level\n\nA token was found where a new declaration was expected. Declarations\nstart with a function name followed by parameters, or with `type`/`tool`.\n\n**Common causes:**\n- A stray token left over from a previous edit\n- A missing semicolon between statement and the return expression\n\n**Example:**\n\n    f x:n>n; = x   -- stray `=` before expression\n",
+  "phase": "parse",
+  "schemaVersion": 1,
+  "short": "unexpected token at top level"
+}

--- a/conformance/diagnostics/ILO-P002.expected.json
+++ b/conformance/diagnostics/ILO-P002.expected.json
@@ -1,0 +1,7 @@
+{
+  "code": "ILO-P002",
+  "long": "## ILO-P002: unexpected end of file\n\nThe file ended while the parser was expecting another declaration.\nAn incomplete function definition is a common cause.\n\n**Example:**\n\n    f x:n>n;    -- body missing\n",
+  "phase": "parse",
+  "schemaVersion": 1,
+  "short": "unexpected end of file at top level"
+}

--- a/conformance/diagnostics/ILO-P003.expected.json
+++ b/conformance/diagnostics/ILO-P003.expected.json
@@ -1,0 +1,7 @@
+{
+  "code": "ILO-P003",
+  "long": "## ILO-P003: unexpected token\n\nA token was found where a different token was expected. The error\nmessage names the expected and actual tokens using their source\ncharacters (e.g. ``expected `>`, got `|` ``), not the parser's\ninternal token-kind names.\n\n**Example:**\n\n    f x:n|n;x\n\n    ERROR ILO-P003: expected `>`, got `|`\n\nThe fix is to use `>` between the parameter list and the return type:\n\n    f x:n>n;x\n",
+  "phase": "parse",
+  "schemaVersion": 1,
+  "short": "unexpected token"
+}

--- a/conformance/diagnostics/ILO-P004.expected.json
+++ b/conformance/diagnostics/ILO-P004.expected.json
@@ -1,0 +1,7 @@
+{
+  "code": "ILO-P004",
+  "long": "## ILO-P004: unexpected end of file\n\nThe file ended before a required token was found.\n",
+  "phase": "parse",
+  "schemaVersion": 1,
+  "short": "unexpected end of file"
+}

--- a/conformance/diagnostics/ILO-P005.expected.json
+++ b/conformance/diagnostics/ILO-P005.expected.json
@@ -1,0 +1,7 @@
+{
+  "code": "ILO-P005",
+  "long": "## ILO-P005: expected identifier\n\nAn identifier (function name, variable name, parameter name) was\nexpected but a different token was found.\n",
+  "phase": "parse",
+  "schemaVersion": 1,
+  "short": "expected identifier, got token"
+}

--- a/conformance/diagnostics/ILO-R001.expected.json
+++ b/conformance/diagnostics/ILO-R001.expected.json
@@ -1,0 +1,7 @@
+{
+  "code": "ILO-R001",
+  "long": "## ILO-R001: undefined variable at runtime\n\nA variable was referenced that does not exist in the current scope.\nThis should normally be caught by the verifier (ILO-T004). Seeing\nthis at runtime indicates the program was run without verification,\nor a dynamic path was taken.\n",
+  "phase": "runtime",
+  "schemaVersion": 1,
+  "short": "undefined variable at runtime"
+}

--- a/conformance/diagnostics/ILO-R003.expected.json
+++ b/conformance/diagnostics/ILO-R003.expected.json
@@ -1,0 +1,7 @@
+{
+  "code": "ILO-R003",
+  "long": "## ILO-R003: division by zero\n\nA division operation (`/`) was performed with a zero divisor.\n\n**Fix:** check that the divisor is non-zero before dividing.\n",
+  "phase": "runtime",
+  "schemaVersion": 1,
+  "short": "division by zero"
+}

--- a/conformance/diagnostics/ILO-R005.expected.json
+++ b/conformance/diagnostics/ILO-R005.expected.json
@@ -1,0 +1,7 @@
+{
+  "code": "ILO-R005",
+  "long": "## ILO-R005: field not found at runtime\n\nA field access was performed on a record that does not have the\nrequested field. Normally caught statically (ILO-T019).\n",
+  "phase": "runtime",
+  "schemaVersion": 1,
+  "short": "field not found at runtime"
+}

--- a/conformance/diagnostics/ILO-T001.expected.json
+++ b/conformance/diagnostics/ILO-T001.expected.json
@@ -1,0 +1,7 @@
+{
+  "code": "ILO-T001",
+  "long": "## ILO-T001: duplicate type definition\n\nA `type` declaration uses a name that was already defined.\n\n**Fix:** rename one of the types or remove the duplicate.\n",
+  "phase": "verify",
+  "schemaVersion": 1,
+  "short": "duplicate type definition"
+}

--- a/conformance/diagnostics/ILO-T002.expected.json
+++ b/conformance/diagnostics/ILO-T002.expected.json
@@ -1,0 +1,7 @@
+{
+  "code": "ILO-T002",
+  "long": "## ILO-T002: duplicate function or tool definition\n\nA function or tool uses a name that was already defined in this file.\n\n**Fix:** rename one of the functions or remove the duplicate.\n",
+  "phase": "verify",
+  "schemaVersion": 1,
+  "short": "duplicate function/tool definition"
+}

--- a/conformance/diagnostics/ILO-T003.expected.json
+++ b/conformance/diagnostics/ILO-T003.expected.json
@@ -1,0 +1,7 @@
+{
+  "code": "ILO-T003",
+  "long": "## ILO-T003: undefined type\n\nA type name used in a signature or record literal is not defined.\n\n**Example:**\n\n    f x:Point>n;x.val   -- 'Point' is not defined\n\n**Fix:** add a `type Point { ... }` declaration, or correct the spelling.\n",
+  "phase": "verify",
+  "schemaVersion": 1,
+  "short": "undefined type"
+}

--- a/conformance/diagnostics/ILO-T004.expected.json
+++ b/conformance/diagnostics/ILO-T004.expected.json
@@ -1,0 +1,7 @@
+{
+  "code": "ILO-T004",
+  "long": "## ILO-T004: undefined variable\n\nA variable name was used that has not been bound in the current scope.\nVariables are bound by `let` statements or function parameters.\n\n**Example:**\n\n    f x:n>n;+x y   -- 'y' is not defined\n\n**Fix:** bind the variable before use, or pass it as a parameter:\n\n    f x:n y:n>n;+x y\n\n### Common pitfall: `name.N` after `zip`\n\nilo has no tuple type. `zip xs ys` returns `L (L n)` — a list of\ntwo-element lists, not a list of tuples. Agents reaching for\n`tup.0` / `pair.0` tuple-access syntax will see ILO-T004 on the\nunbound `tup` / `pair` name.\n\n**Wrong:**\n\n    g pair:L n>n;+pair.0 pair.1   -- pair.0 works only once pair is bound\n\nIf `pair` is unbound (e.g. you wrote `tup.0` without binding `tup`),\nthe fix is to bind it from the outer list and index with `at`:\n\n    f>L n;\n      xs=[1 2 3];ys=[10 20 30];zs=zip xs ys;\n      map (pair:L n>n;+at pair 0 at pair 1) zs\n",
+  "phase": "verify",
+  "schemaVersion": 1,
+  "short": "undefined variable"
+}

--- a/conformance/diagnostics/ILO-T005.expected.json
+++ b/conformance/diagnostics/ILO-T005.expected.json
@@ -1,0 +1,7 @@
+{
+  "code": "ILO-T005",
+  "long": "## ILO-T005: undefined function\n\nA function was called that is not defined in this file or as a builtin.\n\n**Example:**\n\n    f x:n>n;double x   -- 'double' is not defined\n\n**Fix:** define the function, or correct the spelling.\n\n### Gotcha: call vs binary-op in assignment-RHS\n\nWhitespace-juxtaposition is the call syntax in ilo, so a bare name\nfollowed by another token in an expression is parsed as a call, not as\n\"name then operator\". The classic case:\n\n    f xi:n xj:n>n;dx=xj 0-xi;dx\n\nThis parses as `dx = (xj 0) - xi` — a call to `xj` with argument `0`,\nwhose result is then subtracted from `xi`. Verification fails with\nILO-T005 because `xj` is a number, not a function.\n\nThe agent almost certainly meant one of:\n\n- `dx=-xj xi`              -- subtract: prefix `-`\n- `dx=+xj -0 xi`           -- xj + (0-xi)\n- `nxi=0-xi;dx=+xj nxi`    -- pre-bind the operand\n\nIn ilo's prefix-operator world there is no ambiguity once the operator\nleads the expression. The \"looks like infix\" shape `name expr` is\nalways a call.\n",
+  "phase": "verify",
+  "schemaVersion": 1,
+  "short": "undefined function"
+}

--- a/conformance/diagnostics/ILO-T006.expected.json
+++ b/conformance/diagnostics/ILO-T006.expected.json
@@ -1,0 +1,7 @@
+{
+  "code": "ILO-T006",
+  "long": "## ILO-T006: arity mismatch\n\nA function was called with the wrong number of arguments.\n\n**Example:**\n\n    add a:n b:n>n;+a b\n    f x:n>n;add x   -- 'add' expects 2 args, got 1\n\n**Fix:** pass the correct number of arguments.\n",
+  "phase": "verify",
+  "schemaVersion": 1,
+  "short": "arity mismatch"
+}

--- a/conformance/diagnostics/ILO-T007.expected.json
+++ b/conformance/diagnostics/ILO-T007.expected.json
@@ -1,0 +1,7 @@
+{
+  "code": "ILO-T007",
+  "long": "## ILO-T007: type mismatch at call site\n\nAn argument passed to a function has the wrong type.\n\n**Example:**\n\n    double x:n>n;*x 2\n    f s:t>n;double s   -- 's' is 't', but 'double' expects 'n'\n\n**Fix:** pass a value of the correct type, or use a conversion builtin\nsuch as `num` to convert text to a number.\n",
+  "phase": "verify",
+  "schemaVersion": 1,
+  "short": "type mismatch at call site"
+}

--- a/conformance/diagnostics/ILO-T008.expected.json
+++ b/conformance/diagnostics/ILO-T008.expected.json
@@ -1,0 +1,7 @@
+{
+  "code": "ILO-T008",
+  "long": "## ILO-T008: return type mismatch\n\nThe type of the return expression does not match the declared return type.\n\n**Example:**\n\n    f x:n>t;x   -- 'x' is 'n', but 'f' declares return type 't'\n\n**Fix:** change the return expression or correct the return type annotation.\n",
+  "phase": "verify",
+  "schemaVersion": 1,
+  "short": "return type mismatch"
+}

--- a/conformance/diagnostics/ILO-T009.expected.json
+++ b/conformance/diagnostics/ILO-T009.expected.json
@@ -1,0 +1,7 @@
+{
+  "code": "ILO-T009",
+  "long": "## ILO-T009: arithmetic operator type error\n\nAn arithmetic operator (`+`, `-`, `*`, `/`) was applied to operands\nof mismatched or wrong types.\n\n`+` works on `n + n`, `t + t`, or `L T + L T`.\n`-`, `*`, `/` require `n` operands.\n",
+  "phase": "verify",
+  "schemaVersion": 1,
+  "short": "arithmetic operator type error"
+}

--- a/conformance/provenance-surface.json
+++ b/conformance/provenance-surface.json
@@ -1,0 +1,206 @@
+{
+  "schemaVersion": 1,
+  "description": "Maps each ilo surface feature to the compiler function that owns it and the fixture that exercises it. Generated as part of ILO-363 (Phase 4 provenance matrix).",
+  "features": [
+    {
+      "feature": "lexer/unexpected-character",
+      "compiler_path": "src/lexer/mod.rs",
+      "function": "lex",
+      "example_path": "examples/arithmetic.ilo",
+      "test": "tests/errors.rs::lex_error_unknown_char",
+      "error_codes": ["ILO-L001"]
+    },
+    {
+      "feature": "lexer/underscore-identifier",
+      "compiler_path": "src/lexer/mod.rs",
+      "function": "lex",
+      "example_path": null,
+      "test": "tests/errors.rs::lex_error_underscore",
+      "error_codes": ["ILO-L002"]
+    },
+    {
+      "feature": "lexer/uppercase-identifier",
+      "compiler_path": "src/lexer/mod.rs",
+      "function": "lex",
+      "example_path": null,
+      "test": "tests/errors.rs::lex_error_uppercase",
+      "error_codes": ["ILO-L003"]
+    },
+    {
+      "feature": "parser/function-declaration",
+      "compiler_path": "src/parser/mod.rs",
+      "function": "parse_program",
+      "example_path": "examples/arithmetic.ilo",
+      "test": "tests/errors.rs",
+      "error_codes": ["ILO-P001", "ILO-P002", "ILO-P003"]
+    },
+    {
+      "feature": "parser/parameter-types",
+      "compiler_path": "src/parser/mod.rs",
+      "function": "parse_program",
+      "example_path": "examples/arithmetic.ilo",
+      "test": "tests/errors.rs",
+      "error_codes": ["ILO-P004", "ILO-P005"]
+    },
+    {
+      "feature": "parser/return-type-annotation",
+      "compiler_path": "src/parser/mod.rs",
+      "function": "parse_program",
+      "example_path": "examples/arithmetic.ilo",
+      "test": "tests/errors.rs",
+      "error_codes": ["ILO-P006", "ILO-P007"]
+    },
+    {
+      "feature": "parser/type-declarations",
+      "compiler_path": "src/parser/mod.rs",
+      "function": "parse_program",
+      "example_path": "examples/anon-record.ilo",
+      "test": "tests/errors.rs",
+      "error_codes": ["ILO-P008", "ILO-P009", "ILO-P010"]
+    },
+    {
+      "feature": "verifier/undefined-variable",
+      "compiler_path": "src/verify.rs",
+      "function": "verify_body",
+      "example_path": null,
+      "test": "tests/errors.rs::error_t004_undefined_variable",
+      "error_codes": ["ILO-T004"]
+    },
+    {
+      "feature": "verifier/undefined-function",
+      "compiler_path": "src/verify.rs",
+      "function": "verify_body",
+      "example_path": null,
+      "test": "tests/errors.rs::error_t005_undefined_function",
+      "error_codes": ["ILO-T005"]
+    },
+    {
+      "feature": "verifier/arity-mismatch",
+      "compiler_path": "src/verify.rs",
+      "function": "verify_body",
+      "example_path": null,
+      "test": "tests/errors.rs::error_t006_arity_mismatch",
+      "error_codes": ["ILO-T006"]
+    },
+    {
+      "feature": "verifier/type-mismatch-argument",
+      "compiler_path": "src/verify.rs",
+      "function": "check_binop",
+      "example_path": null,
+      "test": "tests/errors.rs",
+      "error_codes": ["ILO-T007", "ILO-T008", "ILO-T009"]
+    },
+    {
+      "feature": "verifier/duplicate-definition",
+      "compiler_path": "src/verify.rs",
+      "function": "verify",
+      "example_path": null,
+      "test": "tests/errors.rs",
+      "error_codes": ["ILO-T001", "ILO-T002"]
+    },
+    {
+      "feature": "verifier/undefined-type",
+      "compiler_path": "src/verify.rs",
+      "function": "verify",
+      "example_path": null,
+      "test": "tests/errors.rs",
+      "error_codes": ["ILO-T003"]
+    },
+    {
+      "feature": "runtime/division-by-zero",
+      "compiler_path": "src/interpreter/mod.rs",
+      "function": "eval_binop",
+      "example_path": null,
+      "test": "tests/errors.rs",
+      "error_codes": ["ILO-R003"]
+    },
+    {
+      "feature": "runtime/undefined-function",
+      "compiler_path": "src/interpreter/mod.rs",
+      "function": "eval_call",
+      "example_path": null,
+      "test": "tests/errors.rs",
+      "error_codes": ["ILO-R001", "ILO-R002"]
+    },
+    {
+      "feature": "runtime/field-not-found",
+      "compiler_path": "src/interpreter/mod.rs",
+      "function": "eval_field",
+      "example_path": "examples/anon-record.ilo",
+      "test": "tests/errors.rs",
+      "error_codes": ["ILO-R005"]
+    },
+    {
+      "feature": "cli/run",
+      "compiler_path": "src/main.rs",
+      "function": "run_file",
+      "example_path": "examples/arithmetic.ilo",
+      "test": "tests/cli_integration.rs",
+      "error_codes": []
+    },
+    {
+      "feature": "cli/explain",
+      "compiler_path": "src/main.rs",
+      "function": "explain_cmd",
+      "example_path": null,
+      "test": "src/main.rs::cli_explain_valid_code_exits_zero_with_text",
+      "error_codes": []
+    },
+    {
+      "feature": "cli/check",
+      "compiler_path": "src/main.rs",
+      "function": "check_cmd",
+      "example_path": "examples/arithmetic.ilo",
+      "test": "tests/cli_integration.rs",
+      "error_codes": []
+    },
+    {
+      "feature": "list/map",
+      "compiler_path": "src/builtins.rs",
+      "function": "builtin_map",
+      "example_path": "examples/arithmetic.ilo",
+      "test": "tests/regression_hof_map.rs",
+      "error_codes": []
+    },
+    {
+      "feature": "list/filter",
+      "compiler_path": "src/builtins.rs",
+      "function": "builtin_flt",
+      "example_path": "examples/arithmetic.ilo",
+      "test": "tests/regression_len_flt_count_fused.rs",
+      "error_codes": []
+    },
+    {
+      "feature": "list/fold",
+      "compiler_path": "src/builtins.rs",
+      "function": "builtin_fld",
+      "example_path": "examples/arithmetic.ilo",
+      "test": "tests/regression_hof_3b.rs",
+      "error_codes": []
+    },
+    {
+      "feature": "record/field-access",
+      "compiler_path": "src/interpreter/mod.rs",
+      "function": "eval_field",
+      "example_path": "examples/anon-record.ilo",
+      "test": "tests/regression_record_field_order.rs",
+      "error_codes": ["ILO-T018", "ILO-T019"]
+    },
+    {
+      "feature": "match/exhaustiveness",
+      "compiler_path": "src/verify.rs",
+      "function": "check_match_exhaustiveness",
+      "example_path": "examples/bool-ternary.ilo",
+      "test": "tests/regression_match_result_exhaustive.rs",
+      "error_codes": []
+    },
+    {
+      "feature": "string/interpolation",
+      "compiler_path": "src/interpreter/mod.rs",
+      "function": "eval_interpolation",
+      "example_path": "examples/arithmetic.ilo",
+      "test": "tests/regression_string_interp.rs",
+      "error_codes": []
+    }
+  ]
+}

--- a/src/diagnostic/registry.rs
+++ b/src/diagnostic/registry.rs
@@ -76,12 +76,44 @@
 // - **S (Skill / spec)** — skill-bundle loader errors, manifest issues,
 //   spec-link breaks. Forward-looking; no codes allocated yet.
 
+/// The compiler phase that emits a diagnostic.
+///
+/// This is the provenance field: it tells tooling (and humans) which stage of
+/// compilation raised the error without having to parse the error code letter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Phase {
+    /// Lexer / tokenisation (ILO-L###)
+    Lex,
+    /// Parser / syntax analysis (ILO-P###)
+    Parse,
+    /// Type-checker / verifier (ILO-T###, ILO-V###)
+    Verify,
+    /// Runtime interpreter, VM, or JIT (ILO-R###)
+    Runtime,
+    /// Engine-specific compilation limitation (ILO-E###)
+    Engine,
+}
+
+impl Phase {
+    /// Canonical lowercase string, matches the `phase` key used in JSON output.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Phase::Lex => "lex",
+            Phase::Parse => "parse",
+            Phase::Verify => "verify",
+            Phase::Runtime => "runtime",
+            Phase::Engine => "engine",
+        }
+    }
+}
+
 /// An entry in the error code registry.
-#[allow(dead_code)] // `short` is used by tooling; `long` is used by --explain
+#[allow(dead_code)] // fields are used by tooling / --explain / golden tests
 pub struct ErrorEntry {
     pub code: &'static str,
-    pub short: &'static str, // brief description for tooling / --list-errors
-    pub long: &'static str,  // full explanation for --explain
+    pub phase: Phase,           // which compiler phase emits this code
+    pub short: &'static str,   // brief description for tooling / --list-errors
+    pub long: &'static str,    // full explanation for --explain
 }
 
 /// Documented namespace ranges. Used by the cross-engine regression test in
@@ -137,6 +169,7 @@ pub static REGISTRY: &[ErrorEntry] = &[
     // ── Lexer ────────────────────────────────────────────────────────────────
     ErrorEntry {
         code: "ILO-L001",
+        phase: Phase::Lex,
         short: "unexpected character",
         long: r#"## ILO-L001: unexpected character
 
@@ -152,6 +185,7 @@ with a valid operator or identifier.
     },
     ErrorEntry {
         code: "ILO-L002",
+        phase: Phase::Lex,
         short: "underscore in identifier — use hyphens",
         long: r#"## ILO-L002: underscore in identifier
 
@@ -168,6 +202,7 @@ ilo uses hyphens as word separators in identifiers, not underscores.
     },
     ErrorEntry {
         code: "ILO-L003",
+        phase: Phase::Lex,
         short: "uppercase identifier — use lowercase",
         long: r#"## ILO-L003: uppercase identifier
 
@@ -186,6 +221,7 @@ are reserved for the built-in `List` and `Result` type constructors.
     // ── Parser ───────────────────────────────────────────────────────────────
     ErrorEntry {
         code: "ILO-P001",
+        phase: Phase::Parse,
         short: "unexpected token at top level",
         long: r#"## ILO-P001: unexpected token at top level
 
@@ -203,6 +239,7 @@ start with a function name followed by parameters, or with `type`/`tool`.
     },
     ErrorEntry {
         code: "ILO-P002",
+        phase: Phase::Parse,
         short: "unexpected end of file at top level",
         long: r#"## ILO-P002: unexpected end of file
 
@@ -216,6 +253,7 @@ An incomplete function definition is a common cause.
     },
     ErrorEntry {
         code: "ILO-P003",
+        phase: Phase::Parse,
         short: "unexpected token",
         long: r#"## ILO-P003: unexpected token
 
@@ -237,6 +275,7 @@ The fix is to use `>` between the parameter list and the return type:
     },
     ErrorEntry {
         code: "ILO-P004",
+        phase: Phase::Parse,
         short: "unexpected end of file",
         long: r#"## ILO-P004: unexpected end of file
 
@@ -245,6 +284,7 @@ The file ended before a required token was found.
     },
     ErrorEntry {
         code: "ILO-P005",
+        phase: Phase::Parse,
         short: "expected identifier, got token",
         long: r#"## ILO-P005: expected identifier
 
@@ -254,6 +294,7 @@ expected but a different token was found.
     },
     ErrorEntry {
         code: "ILO-P006",
+        phase: Phase::Parse,
         short: "expected identifier, got end of file",
         long: r#"## ILO-P006: expected identifier, got end of file
 
@@ -262,6 +303,7 @@ The file ended before a required identifier was found.
     },
     ErrorEntry {
         code: "ILO-P007",
+        phase: Phase::Parse,
         short: "expected type annotation, got token",
         long: r#"## ILO-P007: expected type annotation
 
@@ -275,6 +317,7 @@ was expected but a different token was found.
     },
     ErrorEntry {
         code: "ILO-P008",
+        phase: Phase::Parse,
         short: "expected type annotation, got end of file",
         long: r#"## ILO-P008: expected type annotation, got end of file
 
@@ -283,6 +326,7 @@ The file ended before a required type annotation was found.
     },
     ErrorEntry {
         code: "ILO-P009",
+        phase: Phase::Parse,
         short: "expected expression, got token",
         long: r#"## ILO-P009: expected expression
 
@@ -297,6 +341,7 @@ token was found.
     },
     ErrorEntry {
         code: "ILO-P010",
+        phase: Phase::Parse,
         short: "expected expression, got end of file",
         long: r#"## ILO-P010: expected expression, got end of file
 
@@ -305,6 +350,7 @@ The file ended before a required expression was found.
     },
     ErrorEntry {
         code: "ILO-P011",
+        phase: Phase::Parse,
         short: "expected pattern, got token",
         long: r#"## ILO-P011: expected pattern
 
@@ -315,6 +361,7 @@ Patterns include literals, `_` wildcard, type constructors (`Ok x`,
     },
     ErrorEntry {
         code: "ILO-P012",
+        phase: Phase::Parse,
         short: "expected pattern, got end of file",
         long: r#"## ILO-P012: expected pattern, got end of file
 
@@ -323,6 +370,7 @@ The file ended inside a match expression before a pattern was found.
     },
     ErrorEntry {
         code: "ILO-P013",
+        phase: Phase::Parse,
         short: "expected number literal, got token",
         long: r#"## ILO-P013: expected number literal
 
@@ -332,6 +380,7 @@ a different token was found.
     },
     ErrorEntry {
         code: "ILO-P014",
+        phase: Phase::Parse,
         short: "expected number literal, got end of file",
         long: r#"## ILO-P014: expected number literal, got end of file
 
@@ -340,6 +389,7 @@ The file ended before a required number literal was found.
     },
     ErrorEntry {
         code: "ILO-P015",
+        phase: Phase::Parse,
         short: "expected tool description string",
         long: r#"## ILO-P015: expected tool description string
 
@@ -353,6 +403,7 @@ A `tool` declaration requires a string literal as its description.
     },
     ErrorEntry {
         code: "ILO-P016",
+        phase: Phase::Parse,
         short: "unexpected token after braceless guard body",
         long: r#"## ILO-P016: unexpected token after braceless guard body
 
@@ -380,6 +431,7 @@ do not need braces:
     },
     ErrorEntry {
         code: "ILO-P017",
+        phase: Phase::Parse,
         short: "use-import failed",
         long: r#"## ILO-P017: use-import failed
 
@@ -400,6 +452,7 @@ for `use`-import resolution.
     },
     ErrorEntry {
         code: "ILO-P018",
+        phase: Phase::Parse,
         short: "variadic builtin not in trailing position",
         long: r#"## ILO-P018: variadic builtin not in trailing position
 
@@ -429,6 +482,7 @@ treats it as a single operand.
     },
     ErrorEntry {
         code: "ILO-P019",
+        phase: Phase::Parse,
         short: "use-import name not found",
         long: r#"## ILO-P019: use-import name not found
 
@@ -442,6 +496,7 @@ import list.
     },
     ErrorEntry {
         code: "ILO-P020",
+        phase: Phase::Parse,
         short: "incomplete function header",
         long: r#"## ILO-P020: incomplete function header
 
@@ -482,6 +537,7 @@ header is incomplete, not on the next function in the file.
     },
     ErrorEntry {
         code: "ILO-P101",
+        phase: Phase::Parse,
         short: "list-literal element is a builtin call without parens",
         long: r#"## ILO-P101: list-literal element is a builtin call without parens
 
@@ -520,6 +576,7 @@ inline form gets unreadable.
     },
     ErrorEntry {
         code: "ILO-P102",
+        phase: Phase::Parse,
         short: "top-level binding outside a function declaration",
         long: r#"## ILO-P102: top-level binding outside a function declaration
 
@@ -565,6 +622,7 @@ shape fix.
     },
     ErrorEntry {
         code: "ILO-P021",
+        phase: Phase::Parse,
         short: "ambiguous double-minus prefix-binop chain",
         long: r#"## ILO-P021: ambiguous double-minus prefix-binop chain
 
@@ -609,6 +667,7 @@ unambiguous and remain accepted.
     },
     ErrorEntry {
         code: "ILO-P103",
+        phase: Phase::Parse,
         short: "AST nesting depth exceeded",
         long: r#"## ILO-P103: AST nesting depth exceeded
 
@@ -634,6 +693,7 @@ deliberately if the depth is real.
     // ── Type / Verifier ──────────────────────────────────────────────────────
     ErrorEntry {
         code: "ILO-T001",
+        phase: Phase::Verify,
         short: "duplicate type definition",
         long: r#"## ILO-T001: duplicate type definition
 
@@ -644,6 +704,7 @@ A `type` declaration uses a name that was already defined.
     },
     ErrorEntry {
         code: "ILO-T002",
+        phase: Phase::Verify,
         short: "duplicate function/tool definition",
         long: r#"## ILO-T002: duplicate function or tool definition
 
@@ -654,6 +715,7 @@ A function or tool uses a name that was already defined in this file.
     },
     ErrorEntry {
         code: "ILO-T003",
+        phase: Phase::Verify,
         short: "undefined type",
         long: r#"## ILO-T003: undefined type
 
@@ -668,6 +730,7 @@ A type name used in a signature or record literal is not defined.
     },
     ErrorEntry {
         code: "ILO-T004",
+        phase: Phase::Verify,
         short: "undefined variable",
         long: r#"## ILO-T004: undefined variable
 
@@ -703,6 +766,7 @@ the fix is to bind it from the outer list and index with `at`:
     },
     ErrorEntry {
         code: "ILO-T005",
+        phase: Phase::Verify,
         short: "undefined function",
         long: r#"## ILO-T005: undefined function
 
@@ -739,6 +803,7 @@ always a call.
     },
     ErrorEntry {
         code: "ILO-T006",
+        phase: Phase::Verify,
         short: "arity mismatch",
         long: r#"## ILO-T006: arity mismatch
 
@@ -754,6 +819,7 @@ A function was called with the wrong number of arguments.
     },
     ErrorEntry {
         code: "ILO-T007",
+        phase: Phase::Verify,
         short: "type mismatch at call site",
         long: r#"## ILO-T007: type mismatch at call site
 
@@ -770,6 +836,7 @@ such as `num` to convert text to a number.
     },
     ErrorEntry {
         code: "ILO-T008",
+        phase: Phase::Verify,
         short: "return type mismatch",
         long: r#"## ILO-T008: return type mismatch
 
@@ -784,6 +851,7 @@ The type of the return expression does not match the declared return type.
     },
     ErrorEntry {
         code: "ILO-T009",
+        phase: Phase::Verify,
         short: "arithmetic operator type error",
         long: r#"## ILO-T009: arithmetic operator type error
 
@@ -796,6 +864,7 @@ of mismatched or wrong types.
     },
     ErrorEntry {
         code: "ILO-T010",
+        phase: Phase::Verify,
         short: "comparison operator type error",
         long: r#"## ILO-T010: comparison operator type error
 
@@ -807,6 +876,7 @@ Comparisons require both operands to be the same type (`n` or `t`).
     },
     ErrorEntry {
         code: "ILO-T011",
+        phase: Phase::Verify,
         short: "append (+=) type error",
         long: r#"## ILO-T011: append (+=) type error
 
@@ -820,6 +890,7 @@ appended must match the list's element type.
     },
     ErrorEntry {
         code: "ILO-T012",
+        phase: Phase::Verify,
         short: "negate type error",
         long: r#"## ILO-T012: negate type error
 
@@ -832,6 +903,7 @@ Unary negation (`-x`) requires a numeric argument.
     },
     ErrorEntry {
         code: "ILO-T013",
+        phase: Phase::Verify,
         short: "builtin argument type error",
         long: r#"## ILO-T013: builtin argument type error
 
@@ -847,6 +919,7 @@ Common builtins and their required types:
     },
     ErrorEntry {
         code: "ILO-T014",
+        phase: Phase::Verify,
         short: "foreach collection type error",
         long: r#"## ILO-T014: foreach collection type error
 
@@ -859,6 +932,7 @@ The `foreach` builtin requires a list as its first argument.
     },
     ErrorEntry {
         code: "ILO-T015",
+        phase: Phase::Verify,
         short: "record missing field",
         long: r#"## ILO-T015: record missing field
 
@@ -874,6 +948,7 @@ A record literal is missing one or more fields required by the type.
     },
     ErrorEntry {
         code: "ILO-T016",
+        phase: Phase::Verify,
         short: "record unknown field",
         long: r#"## ILO-T016: record unknown field
 
@@ -885,6 +960,7 @@ does not exist on the type.
     },
     ErrorEntry {
         code: "ILO-T017",
+        phase: Phase::Verify,
         short: "record field type mismatch",
         long: r#"## ILO-T017: record field type mismatch
 
@@ -895,6 +971,7 @@ A field in a record literal was given a value of the wrong type.
     },
     ErrorEntry {
         code: "ILO-T018",
+        phase: Phase::Verify,
         short: "field access on non-record type",
         long: r#"## ILO-T018: field access on non-record type
 
@@ -908,6 +985,7 @@ returns an Option you can match on or default with `??`.
     },
     ErrorEntry {
         code: "ILO-T019",
+        phase: Phase::Verify,
         short: "field not found on type",
         long: r#"## ILO-T019: field not found on type
 
@@ -919,6 +997,7 @@ not exist on the record type.
     },
     ErrorEntry {
         code: "ILO-T020",
+        phase: Phase::Verify,
         short: "'with' on non-record type",
         long: r#"## ILO-T020: 'with' on non-record type
 
@@ -927,6 +1006,7 @@ The `with` expression for updating record fields requires a record value.
     },
     ErrorEntry {
         code: "ILO-T021",
+        phase: Phase::Verify,
         short: "'with' field not found",
         long: r#"## ILO-T021: 'with' field not found
 
@@ -935,6 +1015,7 @@ A field name used in a `with` expression does not exist on the record type.
     },
     ErrorEntry {
         code: "ILO-T022",
+        phase: Phase::Verify,
         short: "'with' field type mismatch",
         long: r#"## ILO-T022: 'with' field type mismatch
 
@@ -943,6 +1024,7 @@ A value provided in a `with` expression has the wrong type for the field.
     },
     ErrorEntry {
         code: "ILO-T023",
+        phase: Phase::Verify,
         short: "index access on non-list type",
         long: r#"## ILO-T023: index access on non-list type
 
@@ -951,6 +1033,7 @@ A list index access (`value.0`) was attempted on a non-list value.
     },
     ErrorEntry {
         code: "ILO-T024",
+        phase: Phase::Verify,
         short: "non-exhaustive match",
         long: r#"## ILO-T024: non-exhaustive match
 
@@ -965,6 +1048,7 @@ arms for each missing case.
     },
     ErrorEntry {
         code: "ILO-T025",
+        phase: Phase::Verify,
         short: "'!' used on non-Result call",
         long: r#"## ILO-T025: '!' used on non-Result call
 
@@ -982,6 +1066,7 @@ different type.
     },
     ErrorEntry {
         code: "ILO-T026",
+        phase: Phase::Verify,
         short: "'!' used in non-Result function",
         long: r#"## ILO-T026: '!' used in non-Result function
 
@@ -999,6 +1084,7 @@ function, so the enclosing function must return a Result type
     },
     ErrorEntry {
         code: "ILO-T027",
+        phase: Phase::Verify,
         short: "braceless guard body looks like a function name",
         long: r#"## ILO-T027: braceless guard body looks like a function name
 
@@ -1021,6 +1107,7 @@ Use braces when the guard body is a function call.
     },
     ErrorEntry {
         code: "ILO-T028",
+        phase: Phase::Verify,
         short: "brk/cnt used outside a loop",
         long: r#"## ILO-T028: brk/cnt used outside a loop
 
@@ -1038,6 +1125,7 @@ body (`@` foreach or `wh` while).
     },
     ErrorEntry {
         code: "ILO-T029",
+        phase: Phase::Verify,
         short: "unreachable code",
         long: r#"## ILO-T029: unreachable code
 
@@ -1053,6 +1141,7 @@ never be executed.
     },
     ErrorEntry {
         code: "ILO-T030",
+        phase: Phase::Verify,
         short: "circular type alias",
         long: r#"## ILO-T030: circular type alias
 
@@ -1071,6 +1160,7 @@ remove one side of the cycle.
     },
     ErrorEntry {
         code: "ILO-T031",
+        phase: Phase::Verify,
         short: "type alias shadows builtin",
         long: r#"## ILO-T031: type alias shadows a builtin type
 
@@ -1083,6 +1173,7 @@ be redefined.
     },
     ErrorEntry {
         code: "ILO-T032",
+        phase: Phase::Verify,
         short: "bare 'fmt' result is discarded",
         long: r#"## ILO-T032: bare 'fmt' result is discarded
 
@@ -1114,6 +1205,7 @@ This warning only fires when `fmt` is followed by another statement.
     },
     ErrorEntry {
         code: "ILO-T033",
+        phase: Phase::Verify,
         short: "bare mutation-shaped builtin result is discarded",
         long: r#"## ILO-T033: bare mutation-shaped builtin result is discarded
 
@@ -1160,6 +1252,7 @@ value flows out as the function/branch result.
     },
     ErrorEntry {
         code: "ILO-T043",
+        phase: Phase::Verify,
         short: "recursive call discarded at non-tail position",
         long: r#"## ILO-T043: recursive call discarded at non-tail position
 
@@ -1223,6 +1316,7 @@ may be legitimately side-effecting (logging, file I/O).
     },
     ErrorEntry {
         code: "ILO-T034",
+        phase: Phase::Verify,
         short: "'!' / '!!' used on a non-callable value",
         long: r#"## ILO-T034: '!' / '!!' used on a non-callable value
 
@@ -1258,6 +1352,7 @@ and is unaffected.
     },
     ErrorEntry {
         code: "ILO-T035",
+        phase: Phase::Verify,
         short: "Result arm (`~v:` / `^e:`) on Option subject",
         long: r#"## ILO-T035: Result arm (`~v:` / `^e:`) on Option subject
 
@@ -1291,6 +1386,7 @@ unaffected.
     },
     ErrorEntry {
         code: "ILO-T036",
+        phase: Phase::Verify,
         short: "call requires too many register slots (VM cap)",
         long: r#"## ILO-T036: call requires too many register slots
 
@@ -1309,6 +1405,7 @@ VM cap).
     // ── Engine-specific ──────────────────────────────────────────────────────
     ErrorEntry {
         code: "ILO-E801",
+        phase: Phase::Engine,
         short: "AOT compile needs an entry function",
         long: r#"## ILO-E801: AOT compile needs an entry function
 
@@ -1352,6 +1449,7 @@ the failure mode is the same across every engine.
     // ── Warnings ─────────────────────────────────────────────────────────────
     ErrorEntry {
         code: "ILO-W001",
+        phase: Phase::Verify,
         short: "guard without else inside loop (retired)",
         long: r#"## ILO-W001: guard without else inside loop (retired)
 
@@ -1363,6 +1461,7 @@ braced guards for explicit early return from loops.
     },
     ErrorEntry {
         code: "ILO-W002",
+        phase: Phase::Verify,
         short: "iterating jpar! result, use jpar-list! instead",
         long: r#"## ILO-W002: iterating jpar! result
 
@@ -1393,6 +1492,7 @@ response to be an array.
     // ── Runtime ──────────────────────────────────────────────────────────────
     ErrorEntry {
         code: "ILO-R001",
+        phase: Phase::Runtime,
         short: "undefined variable at runtime",
         long: r#"## ILO-R001: undefined variable at runtime
 
@@ -1404,6 +1504,7 @@ or a dynamic path was taken.
     },
     ErrorEntry {
         code: "ILO-R002",
+        phase: Phase::Runtime,
         short: "undefined function at runtime",
         long: r#"## ILO-R002: undefined function at runtime
 
@@ -1413,6 +1514,7 @@ caught by the verifier (ILO-T005).
     },
     ErrorEntry {
         code: "ILO-R003",
+        phase: Phase::Runtime,
         short: "division by zero",
         long: r#"## ILO-R003: division by zero
 
@@ -1423,6 +1525,7 @@ A division operation (`/`) was performed with a zero divisor.
     },
     ErrorEntry {
         code: "ILO-R004",
+        phase: Phase::Runtime,
         short: "runtime type error",
         long: r#"## ILO-R004: runtime type error
 
@@ -1432,6 +1535,7 @@ This may indicate a verifier gap for a dynamic code path.
     },
     ErrorEntry {
         code: "ILO-R005",
+        phase: Phase::Runtime,
         short: "field not found at runtime",
         long: r#"## ILO-R005: field not found at runtime
 
@@ -1441,6 +1545,7 @@ requested field. Normally caught statically (ILO-T019).
     },
     ErrorEntry {
         code: "ILO-R006",
+        phase: Phase::Runtime,
         short: "list index out of bounds",
         long: r#"## ILO-R006: list index out of bounds
 
@@ -1452,6 +1557,7 @@ ilo lists are zero-indexed.
     },
     ErrorEntry {
         code: "ILO-R007",
+        phase: Phase::Runtime,
         short: "foreach requires a list",
         long: r#"## ILO-R007: foreach requires a list
 
@@ -1461,6 +1567,7 @@ Normally caught statically (ILO-T014).
     },
     ErrorEntry {
         code: "ILO-R008",
+        phase: Phase::Runtime,
         short: "'with' requires a record",
         long: r#"## ILO-R008: 'with' requires a record
 
@@ -1470,6 +1577,7 @@ Normally caught statically (ILO-T020).
     },
     ErrorEntry {
         code: "ILO-R009",
+        phase: Phase::Runtime,
         short: "builtin argument error at runtime",
         long: r#"## ILO-R009: builtin argument error at runtime
 
@@ -1479,6 +1587,7 @@ Normally caught statically (ILO-T013).
     },
     ErrorEntry {
         code: "ILO-R010",
+        phase: Phase::Runtime,
         short: "compile error: undefined variable",
         long: r#"## ILO-R010: compile error: undefined variable
 
@@ -1488,6 +1597,7 @@ Normally caught statically (ILO-T004) before compilation.
     },
     ErrorEntry {
         code: "ILO-R011",
+        phase: Phase::Runtime,
         short: "compile error: undefined function",
         long: r#"## ILO-R011: compile error: undefined function
 
@@ -1497,6 +1607,7 @@ Normally caught statically (ILO-T005) before compilation.
     },
     ErrorEntry {
         code: "ILO-R012",
+        phase: Phase::Runtime,
         short: "no functions defined",
         long: r#"## ILO-R012: no functions defined
 
@@ -1506,6 +1617,7 @@ must be defined to run a program.
     },
     ErrorEntry {
         code: "ILO-R013",
+        phase: Phase::Runtime,
         short: "internal VM error",
         long: r#"## ILO-R013: internal VM error
 
@@ -1518,6 +1630,7 @@ If you see this, please file a bug report.
     },
     ErrorEntry {
         code: "ILO-R014",
+        phase: Phase::Runtime,
         short: "auto-unwrap propagated Err / nil",
         long: r#"## ILO-R014: auto-unwrap propagated Err / nil
 
@@ -1534,6 +1647,7 @@ identifies the propagation point for diagnostic purposes.
     },
     ErrorEntry {
         code: "ILO-R015",
+        phase: Phase::Runtime,
         short: "AOT runtime fault",
         long: r#"## ILO-R015: AOT runtime fault
 
@@ -1558,6 +1672,7 @@ with the source program and the JSON diagnostic.
     },
     ErrorEntry {
         code: "ILO-R016",
+        phase: Phase::Runtime,
         short: "wall-clock runtime budget exceeded",
         long: r#"## ILO-R016: wall-clock runtime budget exceeded
 
@@ -1584,6 +1699,7 @@ ilo --max-runtime 0   main.ilo    -- disable the cap
     },
     ErrorEntry {
         code: "ILO-R017",
+        phase: Phase::Runtime,
         short: "stdout output budget exceeded",
         long: r#"## ILO-R017: stdout output budget exceeded
 
@@ -1611,6 +1727,7 @@ ilo --max-output-bytes 0 main.ilo              -- disable the cap
     },
     ErrorEntry {
         code: "ILO-R026",
+        phase: Phase::Runtime,
         short: "panic-unwrap on Err / nil",
         long: r#"## ILO-R026: panic-unwrap on Err / nil
 
@@ -1633,6 +1750,7 @@ main>n;num!! "abc"          -- aborts with panic-unwrap: abc
     },
     ErrorEntry {
         code: "ILO-R099",
+        phase: Phase::Runtime,
         short: "internal runtime error",
         long: r#"## ILO-R099: internal runtime error
 
@@ -1646,6 +1764,7 @@ in a builtin — please file an issue with the source that triggers it.
     // ── Engine-specific limitations ────────────────────────────────────────
     ErrorEntry {
         code: "ILO-E802",
+        phase: Phase::Engine,
         short: "inline lambda exceeds 255-capture VM cap",
         long: r#"## ILO-E802: inline lambda exceeds 255-capture VM cap
 

--- a/src/diagnostic/registry.rs
+++ b/src/diagnostic/registry.rs
@@ -111,9 +111,9 @@ impl Phase {
 #[allow(dead_code)] // fields are used by tooling / --explain / golden tests
 pub struct ErrorEntry {
     pub code: &'static str,
-    pub phase: Phase,           // which compiler phase emits this code
-    pub short: &'static str,   // brief description for tooling / --list-errors
-    pub long: &'static str,    // full explanation for --explain
+    pub phase: Phase,        // which compiler phase emits this code
+    pub short: &'static str, // brief description for tooling / --list-errors
+    pub long: &'static str,  // full explanation for --explain
 }
 
 /// Documented namespace ranges. Used by the cross-engine regression test in

--- a/src/main.rs
+++ b/src/main.rs
@@ -337,6 +337,7 @@ fn explain_cmd(code: &str, as_json: bool) -> i32 {
                 let v = serde_json::json!({
                     "schemaVersion": 1,
                     "code": entry.code,
+                    "phase": entry.phase.as_str(),
                     "short": entry.short,
                     "long": entry.long,
                 });

--- a/tests/golden_diagnostics.rs
+++ b/tests/golden_diagnostics.rs
@@ -1,0 +1,268 @@
+// Golden-file snapshot tests for diagnostic JSON shape.
+//
+// Each test in this module runs `ilo explain <CODE> --json` and compares the
+// output against the canonical snapshot stored at
+// `conformance/diagnostics/<CODE>.expected.json`.
+//
+// Running tests:
+//   cargo test --features golden
+//
+// Updating snapshots ("blessing"):
+//   cargo test --features golden -- --bless
+//   (This overwrites .expected.json files with the current output.
+//    See CONTRIBUTING.md for the full bless workflow.)
+//
+// Note: tests in this file only compile when the `golden` feature is enabled.
+// CI runs them on every PR via `cargo test --features golden`.
+
+#![cfg(feature = "golden")]
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn conformance_dir() -> PathBuf {
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    PathBuf::from(manifest).join("conformance").join("diagnostics")
+}
+
+/// Run `ilo explain <code> --json` and return the pretty-printed JSON output.
+fn explain_json(code: &str) -> String {
+    let out = ilo()
+        .args(["explain", code, "--json"])
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn ilo explain {code}: {e}"));
+    assert!(
+        out.status.success(),
+        "ilo explain {code} --json failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8(out.stdout)
+        .unwrap_or_else(|_| panic!("non-UTF8 output from ilo explain {code}"))
+}
+
+/// Parse JSON and re-serialise with sorted keys for stable comparison.
+fn normalise_json(raw: &str, label: &str) -> serde_json::Value {
+    serde_json::from_str(raw)
+        .unwrap_or_else(|e| panic!("invalid JSON from {label}: {e}\nRaw output:\n{raw}"))
+}
+
+fn golden_path(code: &str) -> PathBuf {
+    conformance_dir().join(format!("{code}.expected.json"))
+}
+
+/// Core comparison: if --bless is in CARGO_TEST_ARGS or the env var
+/// `ILO_GOLDEN_BLESS=1` is set, overwrite the golden file.  Otherwise diff.
+fn assert_golden(code: &str) {
+    let actual_raw = explain_json(code);
+    let actual: serde_json::Value = normalise_json(&actual_raw, &format!("ilo explain {code}"));
+
+    let bless = std::env::args().any(|a| a == "--bless")
+        || std::env::var("ILO_GOLDEN_BLESS").as_deref() == Ok("1");
+
+    let path = golden_path(code);
+
+    if bless {
+        let pretty = serde_json::to_string_pretty(&actual)
+            .unwrap_or_else(|e| panic!("failed to serialise {code}: {e}"));
+        std::fs::write(&path, format!("{pretty}\n"))
+            .unwrap_or_else(|e| panic!("failed to write golden {}: {e}", path.display()));
+        println!("blessed {}", path.display());
+        return;
+    }
+
+    let expected_raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("missing golden file {}: {e}\nRun `cargo test --features golden -- --bless` to create it", path.display()));
+
+    let expected: serde_json::Value =
+        normalise_json(&expected_raw, &format!("{}", path.display()));
+
+    if actual != expected {
+        // Print a readable diff by comparing pretty-printed strings line by line.
+        let actual_pretty = serde_json::to_string_pretty(&actual).unwrap();
+        let expected_pretty = serde_json::to_string_pretty(&expected).unwrap();
+
+        let diff_lines: Vec<String> = expected_pretty
+            .lines()
+            .zip(actual_pretty.lines())
+            .enumerate()
+            .filter(|(_, (e, a))| e != a)
+            .map(|(i, (e, a))| format!("  line {}: expected {e:?} got {a:?}", i + 1))
+            .collect();
+
+        panic!(
+            "golden mismatch for {code}:\n{}\n\nRun `cargo test --features golden -- --bless` to update the golden file.",
+            diff_lines.join("\n")
+        );
+    }
+}
+
+// ── Top-20 golden tests ────────────────────────────────────────────────────
+
+#[test]
+fn golden_ilo_l001() {
+    assert_golden("ILO-L001");
+}
+
+#[test]
+fn golden_ilo_l002() {
+    assert_golden("ILO-L002");
+}
+
+#[test]
+fn golden_ilo_l003() {
+    assert_golden("ILO-L003");
+}
+
+#[test]
+fn golden_ilo_p001() {
+    assert_golden("ILO-P001");
+}
+
+#[test]
+fn golden_ilo_p002() {
+    assert_golden("ILO-P002");
+}
+
+#[test]
+fn golden_ilo_p003() {
+    assert_golden("ILO-P003");
+}
+
+#[test]
+fn golden_ilo_p004() {
+    assert_golden("ILO-P004");
+}
+
+#[test]
+fn golden_ilo_p005() {
+    assert_golden("ILO-P005");
+}
+
+#[test]
+fn golden_ilo_t001() {
+    assert_golden("ILO-T001");
+}
+
+#[test]
+fn golden_ilo_t002() {
+    assert_golden("ILO-T002");
+}
+
+#[test]
+fn golden_ilo_t003() {
+    assert_golden("ILO-T003");
+}
+
+#[test]
+fn golden_ilo_t004() {
+    assert_golden("ILO-T004");
+}
+
+#[test]
+fn golden_ilo_t005() {
+    assert_golden("ILO-T005");
+}
+
+#[test]
+fn golden_ilo_t006() {
+    assert_golden("ILO-T006");
+}
+
+#[test]
+fn golden_ilo_t007() {
+    assert_golden("ILO-T007");
+}
+
+#[test]
+fn golden_ilo_t008() {
+    assert_golden("ILO-T008");
+}
+
+#[test]
+fn golden_ilo_t009() {
+    assert_golden("ILO-T009");
+}
+
+#[test]
+fn golden_ilo_r001() {
+    assert_golden("ILO-R001");
+}
+
+#[test]
+fn golden_ilo_r003() {
+    assert_golden("ILO-R003");
+}
+
+#[test]
+fn golden_ilo_r005() {
+    assert_golden("ILO-R005");
+}
+
+// ── Provenance surface sanity check ───────────────────────────────────────
+
+/// Verify that `conformance/provenance-surface.json` is valid JSON and
+/// contains at least one entry with the required shape.
+#[test]
+fn provenance_surface_is_valid() {
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let path = PathBuf::from(manifest)
+        .join("conformance")
+        .join("provenance-surface.json");
+
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("missing {}: {e}", path.display()));
+
+    let v: serde_json::Value =
+        serde_json::from_str(&raw).unwrap_or_else(|e| panic!("invalid JSON in provenance-surface.json: {e}"));
+
+    assert_eq!(v["schemaVersion"], 1, "provenance-surface.json must have schemaVersion: 1");
+
+    let features = v["features"].as_array().expect("features must be an array");
+    assert!(!features.is_empty(), "features array must not be empty");
+
+    // Each feature must have the required keys
+    for (i, f) in features.iter().enumerate() {
+        assert!(f["feature"].is_string(), "features[{i}].feature must be a string");
+        assert!(f["compiler_path"].is_string(), "features[{i}].compiler_path must be a string");
+        assert!(f["function"].is_string(), "features[{i}].function must be a string");
+        assert!(f["error_codes"].is_array(), "features[{i}].error_codes must be an array");
+    }
+}
+
+/// Verify that every golden file listed in conformance/diagnostics/ is valid
+/// JSON and contains the mandatory keys: schemaVersion, code, phase, short, long.
+#[test]
+fn all_golden_files_have_required_keys() {
+    let dir = conformance_dir();
+    let entries: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", dir.display()))
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.path()
+                .extension()
+                .and_then(|x| x.to_str())
+                == Some("json")
+        })
+        .collect();
+
+    assert!(!entries.is_empty(), "no golden files found in conformance/diagnostics/");
+
+    for entry in entries {
+        let path = entry.path();
+        let raw = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+        let v: serde_json::Value = serde_json::from_str(&raw)
+            .unwrap_or_else(|e| panic!("invalid JSON in {}: {e}", path.display()));
+
+        let name = path.display().to_string();
+        assert_eq!(v["schemaVersion"], 1, "{name}: schemaVersion must be 1");
+        assert!(v["code"].is_string(), "{name}: code must be a string");
+        assert!(v["phase"].is_string(), "{name}: phase must be a string");
+        assert!(v["short"].is_string(), "{name}: short must be a string");
+        assert!(v["long"].is_string(), "{name}: long must be a string");
+    }
+}

--- a/tests/golden_diagnostics.rs
+++ b/tests/golden_diagnostics.rs
@@ -26,7 +26,9 @@ fn ilo() -> Command {
 
 fn conformance_dir() -> PathBuf {
     let manifest = env!("CARGO_MANIFEST_DIR");
-    PathBuf::from(manifest).join("conformance").join("diagnostics")
+    PathBuf::from(manifest)
+        .join("conformance")
+        .join("diagnostics")
 }
 
 /// Run `ilo explain <code> --json` and return the pretty-printed JSON output.
@@ -77,8 +79,7 @@ fn assert_golden(code: &str) {
     let expected_raw = std::fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("missing golden file {}: {e}\nRun `cargo test --features golden -- --bless` to create it", path.display()));
 
-    let expected: serde_json::Value =
-        normalise_json(&expected_raw, &format!("{}", path.display()));
+    let expected: serde_json::Value = normalise_json(&expected_raw, &format!("{}", path.display()));
 
     if actual != expected {
         // Print a readable diff by comparing pretty-printed strings line by line.
@@ -216,20 +217,35 @@ fn provenance_surface_is_valid() {
     let raw = std::fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("missing {}: {e}", path.display()));
 
-    let v: serde_json::Value =
-        serde_json::from_str(&raw).unwrap_or_else(|e| panic!("invalid JSON in provenance-surface.json: {e}"));
+    let v: serde_json::Value = serde_json::from_str(&raw)
+        .unwrap_or_else(|e| panic!("invalid JSON in provenance-surface.json: {e}"));
 
-    assert_eq!(v["schemaVersion"], 1, "provenance-surface.json must have schemaVersion: 1");
+    assert_eq!(
+        v["schemaVersion"], 1,
+        "provenance-surface.json must have schemaVersion: 1"
+    );
 
     let features = v["features"].as_array().expect("features must be an array");
     assert!(!features.is_empty(), "features array must not be empty");
 
     // Each feature must have the required keys
     for (i, f) in features.iter().enumerate() {
-        assert!(f["feature"].is_string(), "features[{i}].feature must be a string");
-        assert!(f["compiler_path"].is_string(), "features[{i}].compiler_path must be a string");
-        assert!(f["function"].is_string(), "features[{i}].function must be a string");
-        assert!(f["error_codes"].is_array(), "features[{i}].error_codes must be an array");
+        assert!(
+            f["feature"].is_string(),
+            "features[{i}].feature must be a string"
+        );
+        assert!(
+            f["compiler_path"].is_string(),
+            "features[{i}].compiler_path must be a string"
+        );
+        assert!(
+            f["function"].is_string(),
+            "features[{i}].function must be a string"
+        );
+        assert!(
+            f["error_codes"].is_array(),
+            "features[{i}].error_codes must be an array"
+        );
     }
 }
 
@@ -241,15 +257,13 @@ fn all_golden_files_have_required_keys() {
     let entries: Vec<_> = std::fs::read_dir(&dir)
         .unwrap_or_else(|e| panic!("cannot read {}: {e}", dir.display()))
         .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.path()
-                .extension()
-                .and_then(|x| x.to_str())
-                == Some("json")
-        })
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("json"))
         .collect();
 
-    assert!(!entries.is_empty(), "no golden files found in conformance/diagnostics/");
+    assert!(
+        !entries.is_empty(),
+        "no golden files found in conformance/diagnostics/"
+    );
 
     for entry in entries {
         let path = entry.path();


### PR DESCRIPTION
## Summary

- Adds a `Phase` enum and `phase` field to every `ErrorEntry` in the diagnostic registry (all 88 codes); `ilo explain --json` now includes `"phase": "lex"|"parse"|"verify"|"runtime"|"engine"` in its output envelope
- Creates `conformance/provenance-surface.json` mapping 25 surface features to their owning compiler function, source path, example fixture, and error codes
- Ships `conformance/diagnostics/<CODE>.expected.json` golden files for the top 20 error codes (ILO-L001–L003, ILO-P001–P005, ILO-T001–T009, ILO-R001/R003/R005)
- Adds `tests/golden_diagnostics.rs` with 22 snapshot tests gated on `--features golden`; includes bless support via `--bless` flag or `ILO_GOLDEN_BLESS=1`
- Documents the bless workflow in `CONTRIBUTING.md`

## Test plan

- [x] `cargo test --features golden --test golden_diagnostics` — all 22 tests pass
- [x] `cargo check` — clean compilation with no warnings
- [x] `ilo explain ILO-T004 --json` — output includes `"phase": "verify"`
- [x] Bless path: `ILO_GOLDEN_BLESS=1 cargo test --features golden --test golden_diagnostics` rewrites golden files without error

## Links

Closes ILO-363

🤖 Generated with [Claude Code](https://claude.com/claude-code)