### PR TITLE
feat(caps): ILO-345 --allow-env flag for env-read capability

### DIFF
--- a/examples/allow-env-cap.ilo
+++ b/examples/allow-env-cap.ilo
@@ -1,0 +1,29 @@
+-- allow-env-cap.ilo: demonstrates --allow-env capability flag (ILO-345).
+--
+-- Run with PATH and HOME allowed:
+--   ilo run --allow-env=PATH,HOME examples/allow-env-cap.ilo main
+--
+-- Run with all env blocked (empty allowlist):
+--   ilo run --allow-env= examples/allow-env-cap.ilo blocked-demo
+--
+-- Run without any --allow-env flag (permissive / legacy mode):
+--   ilo run examples/allow-env-cap.ilo main
+
+-- read-path: reads the PATH variable using the single-var `env` builtin.
+-- Requires: --allow-env=PATH (or permissive mode, or --allow-env=*)
+read-path>R t t
+  env "PATH"
+
+-- blocked-demo: reads PATH with an empty allowlist; returns the Err message.
+-- Expected: the Err branch fires when --allow-env= is set.
+blocked-demo>R t t
+  env "PATH"
+
+-- main: reads PATH and HOME, then prints a summary of whether each succeeded.
+main>_
+  r-path=read-path()
+  ?{r-path|er: prnt +"PATH blocked: " er
+           ~v:  prnt +"PATH ok, len=" lnt v}
+  r-home=env "HOME"
+  ?{r-home|er: prnt +"HOME blocked: " er
+           ~v:  prnt +"HOME=" v}

--- a/src/caps.rs
+++ b/src/caps.rs
@@ -23,6 +23,7 @@
 ///     read:  Policy::All,
 ///     write: Policy::All,
 ///     run:   Policy::All,
+///     env:   Policy::All,
 /// };
 /// assert!(caps.check_net("evil.example").is_err());
 /// assert!(caps.check_net("good.example").is_err()); // still blocked — list is empty
@@ -48,6 +49,8 @@ pub enum Caps {
         read: Policy,
         write: Policy,
         run: Policy,
+        /// Controls access to environment variables via `env` / `env-all`.
+        env: Policy,
     },
 }
 
@@ -150,6 +153,28 @@ impl Caps {
                 } else {
                     Err(format!(
                         "ILO-CAP-001 blocked by --allow-run policy: cmd={cmd} is not in the allowlist"
+                    ))
+                }
+            }
+        }
+    }
+
+    /// Returns `Ok(())` if reading environment variable `name` is allowed.
+    ///
+    /// For `env-all` (no specific name), pass `"*"` — the list policy blocks
+    /// the bulk snapshot unless the allowlist explicitly contains `"*"`.
+    pub fn check_env(&self, name: &str) -> Result<(), String> {
+        let Caps::Restricted { env, .. } = self else {
+            return Ok(());
+        };
+        match env {
+            Policy::All => Ok(()),
+            Policy::List(allowed) => {
+                if allowed.iter().any(|n| n == name) {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "ILO-CAP-001 blocked by --allow-env policy: var={name} is not in the allowlist"
                     ))
                 }
             }
@@ -286,6 +311,7 @@ mod tests {
             read: Policy::List(vec![]),
             write: Policy::List(vec![]),
             run: Policy::List(vec![]),
+            env: Policy::All,
         };
         assert!(caps.check_net("https://evil.example").is_ok());
     }
@@ -297,6 +323,7 @@ mod tests {
             read: Policy::All,
             write: Policy::All,
             run: Policy::All,
+            env: Policy::All,
         };
         let err = caps.check_net("https://example.com").unwrap_err();
         assert!(err.contains("--allow-net"), "msg={err}");
@@ -310,6 +337,7 @@ mod tests {
             read: Policy::All,
             write: Policy::All,
             run: Policy::All,
+            env: Policy::All,
         };
         assert!(caps.check_net("https://example.com/api").is_ok());
     }
@@ -321,6 +349,7 @@ mod tests {
             read: Policy::All,
             write: Policy::All,
             run: Policy::All,
+            env: Policy::All,
         };
         let err = caps.check_net("https://evil.example").unwrap_err();
         assert!(err.contains("--allow-net"), "msg={err}");
@@ -333,6 +362,7 @@ mod tests {
             read: Policy::All,
             write: Policy::All,
             run: Policy::All,
+            env: Policy::All,
         };
         assert!(caps.check_net("https://api.example.com/data").is_ok());
         assert!(caps.check_net("https://example.com/data").is_ok());
@@ -348,6 +378,7 @@ mod tests {
             read: Policy::List(vec![]),
             write: Policy::All,
             run: Policy::All,
+            env: Policy::All,
         };
         assert!(caps.check_read("/etc/passwd").is_err());
     }
@@ -359,6 +390,7 @@ mod tests {
             read: Policy::List(vec!["/tmp".to_owned()]),
             write: Policy::All,
             run: Policy::All,
+            env: Policy::All,
         };
         assert!(caps.check_read("/tmp/foo.txt").is_ok());
         assert!(caps.check_read("/tmp").is_ok());
@@ -371,6 +403,7 @@ mod tests {
             read: Policy::List(vec!["/tmp".to_owned()]),
             write: Policy::All,
             run: Policy::All,
+            env: Policy::All,
         };
         assert!(caps.check_read("/tmpfoo").is_err());
         assert!(caps.check_read("/etc/passwd").is_err());
@@ -385,6 +418,7 @@ mod tests {
             read: Policy::All,
             write: Policy::List(vec!["/tmp".to_owned()]),
             run: Policy::All,
+            env: Policy::All,
         };
         assert!(caps.check_write("/tmp/out.txt").is_ok());
         assert!(caps.check_write("/etc/passwd").is_err());
@@ -399,6 +433,7 @@ mod tests {
             read: Policy::All,
             write: Policy::All,
             run: Policy::List(vec![]),
+            env: Policy::All,
         };
         assert!(caps.check_run("ls").is_err());
     }
@@ -410,6 +445,7 @@ mod tests {
             read: Policy::All,
             write: Policy::All,
             run: Policy::List(vec!["ls".to_owned()]),
+            env: Policy::All,
         };
         assert!(caps.check_run("ls").is_ok());
         assert!(caps.check_run("/usr/bin/ls").is_ok()); // basename match
@@ -458,5 +494,80 @@ mod tests {
     #[test]
     fn path_matches_trailing_slash_prefix() {
         assert!(path_matches("/tmp/", "/tmp/foo"));
+    }
+
+    // ── check_env ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn env_permissive_allows_any() {
+        let caps = Caps::default();
+        assert!(caps.check_env("PATH").is_ok());
+        assert!(caps.check_env("SECRET_TOKEN").is_ok());
+    }
+
+    #[test]
+    fn env_all_policy_allows_any() {
+        let caps = Caps::Restricted {
+            net: Policy::All,
+            read: Policy::All,
+            write: Policy::All,
+            run: Policy::All,
+            env: Policy::All,
+        };
+        assert!(caps.check_env("PATH").is_ok());
+    }
+
+    #[test]
+    fn env_empty_list_blocks_all() {
+        let caps = Caps::Restricted {
+            net: Policy::All,
+            read: Policy::All,
+            write: Policy::All,
+            run: Policy::All,
+            env: Policy::List(vec![]),
+        };
+        let err = caps.check_env("PATH").unwrap_err();
+        assert!(err.contains("--allow-env"), "msg={err}");
+        assert!(err.contains("PATH"), "msg={err}");
+    }
+
+    #[test]
+    fn env_allowlisted_var_passes() {
+        let caps = Caps::Restricted {
+            net: Policy::All,
+            read: Policy::All,
+            write: Policy::All,
+            run: Policy::All,
+            env: Policy::List(vec!["PATH".to_owned(), "HOME".to_owned()]),
+        };
+        assert!(caps.check_env("PATH").is_ok());
+        assert!(caps.check_env("HOME").is_ok());
+        assert!(caps.check_env("SECRET_TOKEN").is_err());
+    }
+
+    #[test]
+    fn env_bulk_snapshot_blocked_by_empty_list() {
+        // env-all passes "*" as the name; an empty list blocks it.
+        let caps = Caps::Restricted {
+            net: Policy::All,
+            read: Policy::All,
+            write: Policy::All,
+            run: Policy::All,
+            env: Policy::List(vec![]),
+        };
+        assert!(caps.check_env("*").is_err());
+    }
+
+    #[test]
+    fn env_bulk_snapshot_allowed_by_star_in_list() {
+        // Explicit "*" in the allowlist permits env-all.
+        let caps = Caps::Restricted {
+            net: Policy::All,
+            read: Policy::All,
+            write: Policy::All,
+            run: Policy::All,
+            env: Policy::List(vec!["*".to_owned()]),
+        };
+        assert!(caps.check_env("*").is_ok());
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -212,6 +212,13 @@ pub struct RunArgs {
     #[arg(long = "allow-run", value_name = "CMDS")]
     pub allow_run: Option<String>,
 
+    /// Allow environment variable access. Comma-separated variable name list,
+    /// or `*` for all. Omitting leaves behaviour unchanged (permissive).
+    /// `--allow-env=` (empty value) blocks all env reads. `--allow-env=PATH,HOME`
+    /// permits only those variables. `env-all` requires `*` in the allowlist.
+    #[arg(long = "allow-env", value_name = "VARS")]
+    pub allow_env: Option<String>,
+
     /// Remaining positional args: optional function name + call arguments.
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub rest: Vec<String>,
@@ -936,6 +943,7 @@ mod tests {
             allow_read: None,
             allow_write: None,
             allow_run: None,
+            allow_env: None,
             rest: vec![],
         };
         assert_eq!(r.effective_engine(), Engine::Default);

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -5966,13 +5966,18 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
 
     if builtin == Some(Builtin::Env) && args.len() == 1 {
         return match &args[0] {
-            Value::Text(key) => match std::env::var(key.as_str()) {
-                Ok(val) => Ok(Value::Ok(Box::new(Value::Text(Arc::new(val))))),
-                Err(_) => Ok(Value::Err(Box::new(Value::Text(Arc::new(format!(
-                    "env var '{}' not set",
-                    key
-                )))))),
-            },
+            Value::Text(key) => {
+                if let Err(msg) = env.caps.check_env(key.as_str()) {
+                    return Ok(Value::Err(Box::new(Value::Text(Arc::new(msg)))));
+                }
+                match std::env::var(key.as_str()) {
+                    Ok(val) => Ok(Value::Ok(Box::new(Value::Text(Arc::new(val))))),
+                    Err(_) => Ok(Value::Err(Box::new(Value::Text(Arc::new(format!(
+                        "env var '{}' not set",
+                        key
+                    )))))),
+                }
+            }
             other => Err(RuntimeError::new(
                 "ILO-R009",
                 format!("env requires text, got {:?}", other),
@@ -5986,6 +5991,10 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
     // for future failure modes (non-UTF-8 vars, sandboxed envs). std::env::vars()
     // silently skips non-UTF-8 entries today, so the snapshot is always Ok.
     if builtin == Some(Builtin::EnvAll) && args.is_empty() {
+        // env-all reads the entire environment; check capability using "*" sentinel.
+        if let Err(msg) = env.caps.check_env("*") {
+            return Ok(Value::Err(Box::new(Value::Text(Arc::new(msg)))));
+        }
         let map: std::collections::HashMap<MapKey, Value> = std::env::vars()
             .map(|(k, v)| (MapKey::Text(k), Value::Text(Arc::new(v))))
             .collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -3010,6 +3010,7 @@ fn dispatch_bare_args(raw_args: Vec<String>, global: &cli::Global) -> i32 {
                     allow_read: None,
                     allow_write: None,
                     allow_run: None,
+                    allow_env: None,
                     rest: args[m + 1..].to_vec(),
                 };
                 return dispatch_run(run_args, mode, explicit_json, no_hints, silent);
@@ -3035,6 +3036,7 @@ fn dispatch_bare_args(raw_args: Vec<String>, global: &cli::Global) -> i32 {
                     allow_read: None,
                     allow_write: None,
                     allow_run: None,
+                    allow_env: None,
                     rest: vec![],
                 };
                 return dispatch_run(run_args, mode, explicit_json, no_hints, silent);
@@ -3065,6 +3067,7 @@ fn dispatch_bare_args(raw_args: Vec<String>, global: &cli::Global) -> i32 {
                     allow_read: None,
                     allow_write: None,
                     allow_run: None,
+                    allow_env: None,
                     rest: vec![],
                 };
                 return dispatch_run(run_args, mode, explicit_json, no_hints, silent);
@@ -3090,6 +3093,7 @@ fn dispatch_bare_args(raw_args: Vec<String>, global: &cli::Global) -> i32 {
                     allow_read: None,
                     allow_write: None,
                     allow_run: None,
+                    allow_env: None,
                     rest: vec![],
                 };
                 return dispatch_run(run_args, mode, explicit_json, no_hints, silent);
@@ -3115,6 +3119,7 @@ fn dispatch_bare_args(raw_args: Vec<String>, global: &cli::Global) -> i32 {
                     allow_read: None,
                     allow_write: None,
                     allow_run: None,
+                    allow_env: None,
                     rest: vec![],
                 };
                 return dispatch_run(run_args, mode, explicit_json, no_hints, silent);
@@ -3152,6 +3157,7 @@ fn dispatch_bare_args(raw_args: Vec<String>, global: &cli::Global) -> i32 {
         allow_read: None,
         allow_write: None,
         allow_run: None,
+        allow_env: None,
         rest,
     };
     dispatch_run(run_args, mode, explicit_json, no_hints, silent)
@@ -3347,7 +3353,8 @@ fn build_caps(r: &cli::RunArgs) -> Arc<Caps> {
     let any = r.allow_net.is_some()
         || r.allow_read.is_some()
         || r.allow_write.is_some()
-        || r.allow_run.is_some();
+        || r.allow_run.is_some()
+        || r.allow_env.is_some();
     if !any {
         return Arc::new(Caps::Permissive);
     }
@@ -3369,6 +3376,11 @@ fn build_caps(r: &cli::RunArgs) -> Arc<Caps> {
             .unwrap_or(Policy::All),
         run: r
             .allow_run
+            .as_deref()
+            .map(Caps::parse_allow)
+            .unwrap_or(Policy::All),
+        env: r
+            .allow_env
             .as_deref()
             .map(Caps::parse_allow)
             .unwrap_or(Policy::All),
@@ -9513,6 +9525,7 @@ mod tests {
             allow_read: None,
             allow_write: None,
             allow_run: None,
+            allow_env: None,
             rest: vec![],
         };
         let code = dispatch_run(run_args, OutputMode::Text, false, false, false);
@@ -9543,6 +9556,7 @@ mod tests {
             allow_read: None,
             allow_write: None,
             allow_run: None,
+            allow_env: None,
             rest: vec![],
         };
         let code = dispatch_run(run_args, OutputMode::Text, false, false, false);
@@ -9577,6 +9591,7 @@ mod tests {
             allow_read: None,
             allow_write: None,
             allow_run: None,
+            allow_env: None,
             rest: vec![],
         };
         let code = dispatch_run(run_args, OutputMode::Text, false, false, false);
@@ -9608,6 +9623,7 @@ mod tests {
             allow_read: None,
             allow_write: None,
             allow_run: None,
+            allow_env: None,
             rest: vec!["f".to_string(), "1".to_string()],
         };
         // no_hints = false → hints emitted (to stderr, so just verify no panic)
@@ -9637,6 +9653,7 @@ mod tests {
             allow_read: None,
             allow_write: None,
             allow_run: None,
+            allow_env: None,
             rest: vec!["f".to_string(), "1".to_string()],
         };
         // no_hints = true → hints suppressed
@@ -9668,6 +9685,7 @@ mod tests {
             allow_read: None,
             allow_write: None,
             allow_run: None,
+            allow_env: None,
             rest: vec![],
         };
         let code = dispatch_run(run_args, OutputMode::Text, false, false, false);
@@ -9699,6 +9717,7 @@ mod tests {
             allow_read: None,
             allow_write: None,
             allow_run: None,
+            allow_env: None,
             rest: vec!["f".to_string(), "1".to_string()],
         };
         let code = dispatch_run(run_args, OutputMode::Text, false, false, false);
@@ -10178,6 +10197,104 @@ mod tests {
             ],
             &global,
         );
+        assert_eq!(code, 0);
+    }
+
+    // ── --allow-env ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn allow_env_permissive_mode_reads_path() {
+        // No --allow-env flag → permissive mode → env reads succeed.
+        let run_args = cli::RunArgs {
+            source: "f k:t>R t t;env k".to_string(),
+            engine: cli::Engine::Default,
+            run_tree: false,
+            run: false,
+            run_vm: false,
+            jit: false,
+            run_llvm: false,
+            bench: false,
+            emit: None,
+            explain: false,
+            dense: false,
+            expanded: false,
+            ast: false,
+            tools_path: None,
+            mcp_path: None,
+            allow_net: None,
+            allow_read: None,
+            allow_write: None,
+            allow_run: None,
+            allow_env: None,
+            rest: vec!["f".to_string(), "PATH".to_string()],
+        };
+        let code = dispatch_run(run_args, OutputMode::Text, false, false, false);
+        assert_eq!(code, 0);
+    }
+
+    #[test]
+    fn allow_env_empty_list_blocks_reads() {
+        // --allow-env= (empty) → restricted mode → env returns Err value.
+        // The function signature is R t t; returning an Err is valid — the
+        // runner exits 1 only because the top-level result is Err, which is
+        // ilo's standard non-zero exit convention for unhandled Err results.
+        // The key assertion is that it doesn't panic and the message is printed.
+        let run_args = cli::RunArgs {
+            source: "f k:t>R t t;env k".to_string(),
+            engine: cli::Engine::Default,
+            run_tree: false,
+            run: false,
+            run_vm: false,
+            jit: false,
+            run_llvm: false,
+            bench: false,
+            emit: None,
+            explain: false,
+            dense: false,
+            expanded: false,
+            ast: false,
+            tools_path: None,
+            mcp_path: None,
+            allow_net: None,
+            allow_read: None,
+            allow_write: None,
+            allow_run: None,
+            allow_env: Some(String::new()),
+            rest: vec!["f".to_string(), "PATH".to_string()],
+        };
+        // Exits 1 because the top-level Err value is ilo's non-zero exit convention,
+        // NOT because the program crashed — it correctly returned the blocked Err.
+        let code = dispatch_run(run_args, OutputMode::Text, false, false, false);
+        assert_eq!(code, 1);
+    }
+
+    #[test]
+    fn allow_env_specific_var_allowed() {
+        // --allow-env=PATH → PATH read succeeds.
+        let run_args = cli::RunArgs {
+            source: "f k:t>R t t;env k".to_string(),
+            engine: cli::Engine::Default,
+            run_tree: false,
+            run: false,
+            run_vm: false,
+            jit: false,
+            run_llvm: false,
+            bench: false,
+            emit: None,
+            explain: false,
+            dense: false,
+            expanded: false,
+            ast: false,
+            tools_path: None,
+            mcp_path: None,
+            allow_net: None,
+            allow_read: None,
+            allow_write: None,
+            allow_run: None,
+            allow_env: Some("PATH".to_string()),
+            rest: vec!["f".to_string(), "PATH".to_string()],
+        };
+        let code = dispatch_run(run_args, OutputMode::Text, false, false, false);
         assert_eq!(code, 0);
     }
 }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -11089,6 +11089,10 @@ impl<'a> VM<'a> {
                             _ => unreachable!(),
                         }
                     };
+                    if let Err(msg) = self.caps.check_env(&key_str) {
+                        reg_set!(a, NanVal::heap_err(NanVal::heap_string(msg)));
+                        continue;
+                    }
                     let result = match std::env::var(&key_str) {
                         Ok(val) => NanVal::heap_ok(NanVal::heap_string(val)),
                         Err(_) => NanVal::heap_err(NanVal::heap_string(format!(

--- a/tests/capability_flags.rs
+++ b/tests/capability_flags.rs
@@ -85,6 +85,7 @@ fn allow_net_empty_blocks_get() {
         read: Policy::All,
         write: Policy::All,
         run: Policy::All,
+        env: Policy::All,
     };
     let src = "f>R t t;get \"https://example.com\"";
     let (tree, vm_val) = run_both(src, caps);
@@ -112,6 +113,7 @@ fn allow_net_empty_blocks_get_vm_message() {
         read: Policy::All,
         write: Policy::All,
         run: Policy::All,
+        env: Policy::All,
     };
     let src = "f>R t t;get \"https://example.com\"";
     let program = make_program(src);
@@ -133,6 +135,7 @@ fn allow_net_blocks_non_allowlisted_host() {
         read: Policy::All,
         write: Policy::All,
         run: Policy::All,
+        env: Policy::All,
     };
     let src = "f>R t t;get \"https://evil.example\"";
     let (tree, vm_val) = run_both(src, caps);
@@ -156,6 +159,7 @@ fn allow_read_blocks_outside_prefix() {
         read: Policy::List(vec!["/tmp".to_owned()]),
         write: Policy::All,
         run: Policy::All,
+        env: Policy::All,
     };
     let src = "f>R t t;rd \"/etc/passwd\"";
     let (tree, vm_val) = run_both(src, caps);
@@ -187,6 +191,7 @@ fn allow_read_permits_inside_prefix() {
         read: Policy::List(vec!["/tmp".to_owned()]),
         write: Policy::All,
         run: Policy::All,
+        env: Policy::All,
     };
     let src = format!("f>R t t;rd \"{path}\"");
     let (tree, vm_val) = run_both(&src, caps);
@@ -210,6 +215,7 @@ fn allow_write_blocks_outside_prefix() {
         read: Policy::All,
         write: Policy::List(vec!["/tmp/ilo_allowed".to_owned()]),
         run: Policy::All,
+        env: Policy::All,
     };
     let src = "f>R t t;wr \"/etc/evil.txt\" \"data\"";
     let (tree, vm_val) = run_both(src, caps);
@@ -241,6 +247,7 @@ fn allow_run_empty_blocks_run() {
         read: Policy::All,
         write: Policy::All,
         run: Policy::List(vec![]),
+        env: Policy::All,
     };
     let src = "f>R (M t t) t;run \"echo\" [\"hello\"]";
     // Only test via tree interpreter (run goes through tree-bridge in VM).
@@ -268,6 +275,7 @@ fn allow_run_permits_allowlisted_cmd() {
         read: Policy::All,
         write: Policy::All,
         run: Policy::List(vec!["echo".to_owned()]),
+        env: Policy::All,
     };
     let src = "f>R (M t t) t;run \"echo\" [\"hello\"]";
     let program = make_program(src);
@@ -337,6 +345,7 @@ fn one_flag_restricts_only_that_dimension() {
         read: Policy::All,         // read unrestricted
         write: Policy::All,        // write unrestricted
         run: Policy::All,          // run unrestricted
+        env: Policy::All,          // env unrestricted
     };
     assert!(
         caps.check_net("https://any.host").is_err(),


### PR DESCRIPTION
## Summary

- Adds `--allow-env=VARS` CLI flag gating the `env` and `env-all` builtins, following the existing `--allow-net/read/write/run` pattern from ILO-59 (#606)
- `Caps::Restricted` gains an `env: Policy` field; new `check_env(name)` method uses exact-name matching (env-all passes `"*"` sentinel, which the `Policy::All` default always permits)
- Both the tree-walking interpreter and the VM's `OP_ENV` handler are guarded; `env-all` routes through the interpreter bridge so its guard is also covered
- Blocked calls return a soft `Err` value (consistent with `--allow-net` behaviour) rather than a hard crash

## Test plan

- [ ] `cargo test --lib caps` — 32 unit tests for `Caps` including 6 new `check_env` cases
- [ ] `cargo test --bin ilo allow_env` — 3 dispatch-level integration tests (permissive, empty-list blocks, specific-var allowed)
- [ ] `cargo test` — full suite clean (pre-existing `verify.rs` doctest failure unrelated)
- [ ] `ilo run --allow-env=PATH,HOME examples/allow-env-cap.ilo main` — manual smoke test

Closes ILO-345. Extends ILO-59 (#606).

🤖 Generated with [Claude Code](https://claude.com/claude-code)