### PR TITLE
Add long-form map-op aliases (map-get/map-set/etc)

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -535,6 +535,18 @@ const BUILTIN_ALIASES: &[(&str, &str)] = &[
     ("readbuf", "rdb"),
     ("write", "wr"),
     ("writelines", "wrl"),
+    // Map ops — long-form hyphen aliases for the canonical short names.
+    // ilo identifiers use hyphens, not underscores, so only hyphen forms
+    // are valid surface syntax.
+    ("map-get", "mget"),
+    ("map-set", "mset"),
+    ("map-has", "mhas"),
+    ("map-del", "mdel"),
+    // Alias-of-alias: map-keys / map-values resolve to the canonical
+    // short forms `mkeys` / `mvals` directly (no two-hop needed since
+    // resolve_alias is a single table lookup).
+    ("map-keys", "mkeys"),
+    ("map-values", "mvals"),
 ];
 
 /// If `name` is a long-form alias, return the canonical short form.

--- a/tests/regression_map_op_aliases.rs
+++ b/tests/regression_map_op_aliases.rs
@@ -90,7 +90,8 @@ fn map_values_alias() {
 fn map_aliases_mixed_with_canonical() {
     // Uses map-set to build, mhas to check, map-del to remove,
     // then confirms key is gone with mhas.
-    let src = "main>b;m=mmap;m=map-set m \"hi\" 1;ok=mhas m \"hi\";m=map-del m \"hi\";mhas m \"hi\"";
+    let src =
+        "main>b;m=mmap;m=map-set m \"hi\" 1;ok=mhas m \"hi\";m=map-del m \"hi\";mhas m \"hi\"";
     assert_eq!(run(src, "main"), "false");
 }
 

--- a/tests/regression_map_op_aliases.rs
+++ b/tests/regression_map_op_aliases.rs
@@ -1,0 +1,103 @@
+// Regression tests for long-form map-op aliases (ILO-82).
+//
+// Adds discoverability aliases so users can write `map-get`, `map-set`,
+// `map-has`, `map-del`, `map-keys`, and `map-values` in addition to the
+// canonical short forms `mget`, `mset`, `mhas`, `mdel`, `mkeys`, and `mvals`.
+//
+// ilo identifiers use hyphens (not underscores), so only hyphen forms are
+// valid surface syntax. All aliases resolve to the canonical short form at
+// the AST level, so every engine (tree, VM, Cranelift) executes identical
+// bytecode. Tests here exercise the VM engine; alias resolution itself is
+// engine-independent.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(src: &str, entry: &str) -> String {
+    let out = ilo()
+        .args([src, "--vm", entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo --vm failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+// ── map-get ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn map_get_alias() {
+    let src = "main>n;m=mmap;m=mset m \"k\" 42;map-get m \"k\"";
+    assert_eq!(run(src, "main"), "42");
+}
+
+// ── map-set ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn map_set_alias() {
+    let src = "main>n;m=mmap;m=map-set m \"x\" 99;mget m \"x\"";
+    assert_eq!(run(src, "main"), "99");
+}
+
+// ── map-has ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn map_has_alias_present() {
+    let src = "main>b;m=mmap;m=mset m \"a\" 1;map-has m \"a\"";
+    assert_eq!(run(src, "main"), "true");
+}
+
+#[test]
+fn map_has_alias_absent() {
+    let src = "main>b;m=mmap;map-has m \"z\"";
+    assert_eq!(run(src, "main"), "false");
+}
+
+// ── map-del ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn map_del_alias() {
+    let src = "main>n;m=mmap;m=mset m \"a\" 1;m=mset m \"b\" 2;m=map-del m \"a\";len m";
+    assert_eq!(run(src, "main"), "1");
+}
+
+// ── map-keys ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn map_keys_alias() {
+    // Single key so output is deterministic without sorting.
+    let src = "main>t;m=mmap;m=mset m \"only\" 1;ks=map-keys m;at ks 0";
+    assert_eq!(run(src, "main"), "only");
+}
+
+// ── map-values ────────────────────────────────────────────────────────────────
+
+#[test]
+fn map_values_alias() {
+    let src = "main>n;m=mmap;m=mset m \"k\" 77;vs=map-values m;at vs 0";
+    assert_eq!(run(src, "main"), "77");
+}
+
+// ── Combined: mix long and short forms in one program ─────────────────────────
+
+#[test]
+fn map_aliases_mixed_with_canonical() {
+    // Uses map-set to build, mhas to check, map-del to remove,
+    // then confirms key is gone with mhas.
+    let src = "main>b;m=mmap;m=map-set m \"hi\" 1;ok=mhas m \"hi\";m=map-del m \"hi\";mhas m \"hi\"";
+    assert_eq!(run(src, "main"), "false");
+}
+
+// ── map-get used with map-set (all long-form, no canonical) ──────────────────
+
+#[test]
+fn all_long_form_roundtrip() {
+    let src = "main>n;m=mmap;m=map-set m \"v\" 5;map-get m \"v\"";
+    assert_eq!(run(src, "main"), "5");
+}


### PR DESCRIPTION
## Summary

- Adds hyphen-form discoverability aliases for all six map builtins to `BUILTIN_ALIASES` in `src/ast/mod.rs`
- Aliases: `map-get`→`mget`, `map-set`→mset`, `map-has`→`mhas`, `map-del`→`mdel`, `map-keys`→`mkeys`, `map-values`→`mvals`
- Regression tests in `tests/regression_map_op_aliases.rs` (9 tests, all passing)

Note: ilo identifiers use hyphens not underscores, so only hyphen forms are valid surface syntax (the ticket listed underscore forms but the lexer rejects them with ILO-L002).

Closes ILO-82.

## Test plan

- [x] `cargo test --test regression_map_op_aliases` — 9/9 pass
- [ ] Full CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)