### PR TITLE
feat(jit/aot): native OP_PARMAP Cranelift path (ILO-353)

### DIFF
--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -244,6 +244,8 @@ struct HelperFuncs {
     solve: FuncId,
     inv: FuncId,
     det: FuncId,
+    // Parallel map (ILO-353): native AOT path for OP_PARMAP.
+    parmap: FuncId,
 }
 
 fn declare_helper(
@@ -449,6 +451,8 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         solve: declare_helper(module, "jit_solve", 3, 1),
         inv: declare_helper(module, "jit_inv", 2, 1),
         det: declare_helper(module, "jit_det", 2, 1),
+        // jit_parmap(fn_bits, xs_bits, concurrency_or_sentinel) -> result_bits
+        parmap: declare_helper(module, "jit_parmap", 3, 1),
     }
 }
 
@@ -1207,6 +1211,16 @@ fn compile_function_body(
                 i += 1 + n_words;
                 continue;
             }
+            // OP_PARMAP is a 2-word instruction; skip the data word so its
+            // register-index bytes aren't mis-classified as opcode writes.
+            if op == OP_PARMAP {
+                if a < reg_count {
+                    non_num_write[a] = true;
+                    non_bool_write[a] = true;
+                }
+                i += 2; // skip OP_PARMAP + data word
+                continue;
+            }
             i += 1;
             if a >= reg_count {
                 continue;
@@ -1258,7 +1272,8 @@ fn compile_function_body(
                 | OP_ENUMERATE | OP_RANGE | OP_WINDOW | OP_WINDOW_VIEW | OP_CHUNKS | OP_CUMSUM
                 | OP_CPROD | OP_SETUNION | OP_SETINTER | OP_SETDIFF | OP_FFT | OP_IFFT
                 | OP_TRANSPOSE | OP_MATMUL | OP_INV | OP_SOLVE | OP_DTFMT | OP_DTPARSE
-                | OP_FLAT | OP_CALL_BUILTIN_TREE | OP_LOADFN | OP_CALL_DYN | OP_SEED => {
+                | OP_FLAT | OP_CALL_BUILTIN_TREE | OP_LOADFN | OP_CALL_DYN | OP_SEED
+                | OP_PARMAP => {
                     non_num_write[a] = true;
                     non_bool_write[a] = true;
                 }
@@ -1302,6 +1317,11 @@ fn compile_function_body(
                 if op == OP_MAKE_CLOSURE {
                     let n = (inst & 0xFF) as usize;
                     i += 1 + n.div_ceil(4);
+                    continue;
+                }
+                // OP_PARMAP: 2-word instruction; skip data word.
+                if op == OP_PARMAP {
+                    i += 2;
                     continue;
                 }
                 i += 1;
@@ -4366,6 +4386,31 @@ fn compile_function_body(
                 let dv = builder.use_var(vars[d_idx]);
                 let fref = get_func_ref(&mut builder, module, helpers.posth);
                 let call_inst = builder.ins().call(fref, &[bv, cv, dv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            // ── OP_PARMAP: parallel fan-out via jit_parmap helper (ILO-353) ──
+            // Two-instruction sequence:
+            //   OP_PARMAP  A=result  B=fn_reg  C=xs_reg
+            //   data word: bits[23:16] = n_reg  (0xFF = use default concurrency)
+            // We consume the data word at compile time and lower the whole
+            // sequence to a single call to `jit_parmap(fn, xs, concurrency)`.
+            OP_PARMAP => {
+                let fn_val = builder.use_var(vars[b_idx]);
+                let xs_val = builder.use_var(vars[c_idx]);
+                // Consume the next instruction (data word) at compile time.
+                let data_inst = chunk.code[ip + 1];
+                skip_next = true;
+                let n_reg_byte = ((data_inst >> 16) & 0xFF) as u8;
+                let concurrency_val = if n_reg_byte == 0xFF {
+                    // sentinel: use par_map_default_concurrency inside the helper
+                    builder.ins().iconst(I64, 0xFF_i64)
+                } else {
+                    // explicit register holds the concurrency value at runtime
+                    builder.use_var(vars[n_reg_byte as usize])
+                };
+                let fref = get_func_ref(&mut builder, module, helpers.parmap);
+                let call_inst = builder.ins().call(fref, &[fn_val, xs_val, concurrency_val]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -218,6 +218,8 @@ struct HelperFuncs {
     // Per-thread call-stack tracking for cross-engine error parity.
     push_call_frame: FuncId,
     pop_call_frame: FuncId,
+    // Parallel map (ILO-353): native JIT path for OP_PARMAP.
+    parmap: FuncId,
 }
 
 /// Pack a `Span { start, end }` into a single i64 immediate for passing to
@@ -427,6 +429,7 @@ fn register_helpers(builder: &mut JITBuilder) {
         ("jit_call_builtin_tree", jit_call_builtin_tree as *const u8),
         ("jit_call_dyn", jit_call_dyn as *const u8),
         ("jit_make_closure", jit_make_closure as *const u8),
+        ("jit_parmap", jit_parmap as *const u8),
         // Call-stack tracking for VmRuntimeError.call_stack parity with
         // VM/tree. See `jit_push_call_frame` / `jit_pop_call_frame` in
         // src/vm/mod.rs for the rationale.
@@ -626,6 +629,8 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         make_closure: declare_helper(module, "jit_make_closure", 3, 1),
         push_call_frame: declare_helper(module, "jit_push_call_frame", 2, 1),
         pop_call_frame: declare_helper(module, "jit_pop_call_frame", 0, 1),
+        // jit_parmap(fn_bits, xs_bits, concurrency_or_sentinel) -> result_bits
+        parmap: declare_helper(module, "jit_parmap", 3, 1),
     }
 }
 
@@ -1172,6 +1177,15 @@ fn compile_function_body(
                 i += 1 + n_words;
                 continue;
             }
+            // OP_PARMAP: 2-word instruction; skip data word.
+            if op == OP_PARMAP {
+                if a < reg_count {
+                    non_num_write[a] = true;
+                    non_bool_write[a] = true;
+                }
+                i += 2;
+                continue;
+            }
             i += 1;
             if a >= reg_count {
                 continue;
@@ -1231,7 +1245,8 @@ fn compile_function_body(
                 | OP_PADL | OP_PADR | OP_PADLC | OP_PADRC | OP_CHR | OP_CHARS | OP_UNQ | OP_UNIQBY | OP_PARTITION | OP_FRQ | OP_NUM
                 | OP_SRT_BY_KEY | OP_GRP_BY_KEY | OP_UNIQ_BY_KEY
                 | OP_RGXSUB | OP_TRANSPOSE | OP_MATMUL | OP_DTFMT | OP_DTPARSE
-                | OP_FLAT | OP_CALL_BUILTIN_TREE | OP_LOADFN | OP_CALL_DYN | OP_SEED => {
+                | OP_FLAT | OP_CALL_BUILTIN_TREE | OP_LOADFN | OP_CALL_DYN | OP_SEED
+                | OP_PARMAP => {
                     non_num_write[a] = true;
                     non_bool_write[a] = true;
                 }
@@ -1278,6 +1293,11 @@ fn compile_function_body(
                 if op == OP_MAKE_CLOSURE {
                     let n = (inst & 0xFF) as usize;
                     i += 1 + n.div_ceil(4);
+                    continue;
+                }
+                // OP_PARMAP: 2-word instruction; skip data word.
+                if op == OP_PARMAP {
+                    i += 2;
                     continue;
                 }
                 i += 1;
@@ -5025,6 +5045,28 @@ fn compile_function_body(
                 let dv = builder.use_var(vars[d_idx]);
                 let fref = get_func_ref(&mut builder, module, helpers.posth);
                 let call_inst = builder.ins().call(fref, &[bv, cv, dv]);
+                let result = builder.inst_results(call_inst)[0];
+                builder.def_var(vars[a_idx], result);
+            }
+            // ── OP_PARMAP: parallel fan-out via jit_parmap helper (ILO-353) ──
+            // Two-instruction sequence:
+            //   OP_PARMAP  A=result  B=fn_reg  C=xs_reg
+            //   data word: bits[23:16] = n_reg  (0xFF = use default concurrency)
+            // Consume the data word at compile time and emit a single call to
+            // `jit_parmap(fn_bits, xs_bits, concurrency_or_sentinel)`.
+            OP_PARMAP => {
+                let fn_val = builder.use_var(vars[b_idx]);
+                let xs_val = builder.use_var(vars[c_idx]);
+                let data_inst = chunk.code[ip + 1];
+                skip_next = true;
+                let n_reg_byte = ((data_inst >> 16) & 0xFF) as u8;
+                let concurrency_val = if n_reg_byte == 0xFF {
+                    builder.ins().iconst(I64, 0xFF_i64)
+                } else {
+                    builder.use_var(vars[n_reg_byte as usize])
+                };
+                let fref = get_func_ref(&mut builder, module, helpers.parmap);
+                let call_inst = builder.ins().call(fref, &[fn_val, xs_val, concurrency_val]);
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -19848,6 +19848,180 @@ pub(crate) extern "C" fn jit_posth(url_v: u64, body_v: u64, headers_v: u64) -> u
     }
 }
 
+/// Cranelift JIT/AOT helper for OP_PARMAP (ILO-353).
+///
+/// Executes `par-map fn xs` from native code. Mirrors the VM's OP_PARMAP
+/// dispatch arm exactly, re-using the ACTIVE_PROGRAM TLS slot (set by
+/// `with_active_registry`) so user-fn callees can re-enter the VM.
+///
+/// Args:
+///   fn_bits:              NanVal bits of the function (FnRef or closure).
+///   xs_bits:              NanVal bits of the input list.
+///   concurrency_or_sentinel: requested concurrency level as a u64 integer,
+///                             or 0xFF (the sentinel) to use
+///                             `par_map_default_concurrency()`.
+///
+/// Returns NanVal bits of `L (R _ t)` — a list of `Ok(_)` / `Err(_)` values
+/// in input order, matching tree/VM semantics.  Returns TAG_NIL and sets the
+/// JIT runtime-error channel on type mismatch or missing program.
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_parmap(fn_bits: u64, xs_bits: u64, concurrency_or_sentinel: u64) -> u64 {
+    let mut callee = NanVal(fn_bits);
+
+    // Unwrap closure: extract fn ref + captures.
+    let mut closure_captures: Vec<Value> = Vec::new();
+    if callee.is_heap() && (callee.0 & TAG_MASK) == TAG_LIST {
+        let heap = unsafe { callee.as_heap_ref() };
+        if let HeapObj::Closure { kind, id, captures } = heap {
+            closure_captures = captures.iter().map(|v| v.to_value()).collect();
+            callee = NanVal::fnref(*kind, *id);
+        }
+    }
+
+    // Text callee — resolve through the active program's func_names.
+    if callee.is_string() && !callee.is_fnref() {
+        let prog_ptr = ACTIVE_PROGRAM.with(|cell| cell.get());
+        if !prog_ptr.is_null() {
+            let program: &CompiledProgram = unsafe { &*prog_ptr };
+            let name_val = callee.to_value_with_program(&program.func_names);
+            if let Value::Text(name) = name_val {
+                if let Some(idx) = program.func_names.iter().position(|n| n == &*name) {
+                    callee = NanVal::fnref(FnRefKind::User, idx as u32);
+                } else if let Some(b) = crate::builtins::Builtin::from_name(&name) {
+                    callee = NanVal::fnref(FnRefKind::Builtin, b.tag() as u32);
+                }
+            }
+        }
+    }
+
+    if !callee.is_fnref() {
+        jit_set_runtime_error_with_span(
+            VmError::Type("par-map: first arg must be a function reference"),
+            0,
+        );
+        return TAG_NIL;
+    }
+
+    let xs_nv = NanVal(xs_bits);
+    if !xs_nv.is_heap() || (xs_nv.0 & TAG_MASK) != TAG_LIST {
+        jit_set_runtime_error_with_span(
+            VmError::Type("par-map: second arg must be a list"),
+            0,
+        );
+        return TAG_NIL;
+    }
+
+    let items_nan: Vec<NanVal> = {
+        let slice: &[NanVal] = slice_of(unsafe { xs_nv.as_heap_ref() });
+        slice.to_vec()
+    };
+    let items: Vec<Value> = items_nan.iter().map(|v| v.to_value()).collect();
+
+    let concurrency: usize = if concurrency_or_sentinel == 0xFF {
+        crate::interpreter::par_map_default_concurrency_pub()
+    } else {
+        let n = concurrency_or_sentinel as usize;
+        if n == 0 {
+            jit_set_runtime_error_with_span(
+                VmError::Type("par-map: concurrency must be > 0"),
+                0,
+            );
+            return TAG_NIL;
+        }
+        n
+    };
+
+    // Resolve callee to a dispatchable form.
+    let (fn_kind, fn_id) = callee.fnref_parts();
+    enum ParmapCallee { User(u16), Builtin(String) }
+    let callee_kind = match fn_kind {
+        FnRefKind::User => ParmapCallee::User(fn_id as u16),
+        FnRefKind::Builtin => {
+            let name = crate::builtins::Builtin::from_tag(fn_id as u8)
+                .map(|b| b.name().to_owned())
+                .unwrap_or_default();
+            ParmapCallee::Builtin(name)
+        }
+    };
+
+    // Look up the active program for User callees.
+    let prog_ptr = ACTIVE_PROGRAM.with(|cell| cell.get());
+    if matches!(callee_kind, ParmapCallee::User(_)) && prog_ptr.is_null() {
+        jit_set_runtime_error_with_span(
+            VmError::Type("par-map: no active program (user-fn callee from AOT/JIT)"),
+            0,
+        );
+        return TAG_NIL;
+    }
+    // Cast to usize so the address is trivially Send; reconstructed inside each
+    // scoped thread. SAFETY: CompiledProgram is read-only after compilation;
+    // scoped threads cannot outlive this stack frame.
+    let program_addr: usize = prog_ptr as usize;
+
+    let concurrency = concurrency.max(1);
+    let chunk_size = crate::interpreter::par_map_chunk_size_pub(items.len(), concurrency);
+    let mut results: Vec<Value> = (0..items.len()).map(|_| Value::Nil).collect();
+
+    std::thread::scope(|s| {
+        let item_chunks: Vec<&[Value]> = items.chunks(chunk_size).collect();
+        let mut handles = Vec::with_capacity(item_chunks.len());
+        for chunk in item_chunks.iter() {
+            let chunk_items: Vec<Value> = chunk.to_vec();
+            let captures_t = closure_captures.clone();
+            let program_addr_t = program_addr;
+            let callee_ref: ParmapCallee = match &callee_kind {
+                ParmapCallee::User(idx) => ParmapCallee::User(*idx),
+                ParmapCallee::Builtin(name) => ParmapCallee::Builtin(name.clone()),
+            };
+            handles.push(s.spawn(move || -> Vec<Value> {
+                let mut chunk_results = Vec::with_capacity(chunk_items.len());
+                for item in chunk_items {
+                    let mut call_args = vec![item];
+                    call_args.extend(captures_t.iter().cloned());
+                    let result = match &callee_ref {
+                        ParmapCallee::User(func_idx) => {
+                            let program: &CompiledProgram =
+                                unsafe { &*(program_addr_t as *const CompiledProgram) };
+                            let mut sub_vm = VM::new(program);
+                            sub_vm.call(*func_idx, call_args)
+                                .map(|v| Value::Ok(Box::new(v)))
+                                .unwrap_or_else(|e| {
+                                    Value::Err(Box::new(Value::Text(
+                                        Arc::new(e.error.to_string()),
+                                    )))
+                                })
+                        }
+                        ParmapCallee::Builtin(name) => {
+                            match crate::interpreter::call_builtin_for_bridge(name, call_args) {
+                                Ok(v) => Value::Ok(Box::new(v)),
+                                Err(e) => Value::Err(Box::new(Value::Text(Arc::new(e.message)))),
+                            }
+                        }
+                    };
+                    chunk_results.push(result);
+                }
+                chunk_results
+            }));
+        }
+        let mut result_off = 0usize;
+        for handle in handles {
+            let chunk_results = handle.join().unwrap_or_else(|_| {
+                vec![Value::Err(Box::new(Value::Text(Arc::new(
+                    "par-map worker thread panicked".to_string(),
+                ))))]
+            });
+            for v in chunk_results {
+                results[result_off] = v;
+                result_off += 1;
+            }
+        }
+    });
+
+    let nan_items: Vec<NanVal> = results.iter().map(NanVal::from_value).collect();
+    NanVal::heap_list(nan_items).0
+}
+
 // ── AOT runtime init/fini and arena/registry pointer helpers ─────────
 
 /// Async-signal-safe handler installed by `ilo_aot_init`. Writes a single
@@ -20206,7 +20380,7 @@ pub(crate) fn find_block_leaders(code: &[u32]) -> Vec<usize> {
                 leaders.insert(i + 3);
             }
             OP_SLC | OP_LST | OP_MSET | OP_POSTH | OP_RGXSUB | OP_CLAMP | OP_PADLC | OP_PADRC
-            | OP_WINDOW_VIEW | OP_LEN_HAS_K_COUNT => {
+            | OP_WINDOW_VIEW | OP_LEN_HAS_K_COUNT | OP_PARMAP => {
                 // 2-word instructions: the following word is data, not an instruction.
                 // Skip it so its bits aren't mis-decoded as an opcode that might mark
                 // bogus leaders. The instruction after the data word is a normal leader


### PR DESCRIPTION
## Summary

- Adds `jit_parmap` extern \"C\" helper that mirrors the VM's `OP_PARMAP` dispatch arm: resolves FnRef/closure/text callees, fans out over `std::thread::scope` workers, returns `L(R _ t)` in input order
- Wires `OP_PARMAP` into both Cranelift backends (JIT: `jit_cranelift.rs`, AOT: `compile_cranelift.rs`) — par-map no longer falls through to the interpreter on these paths
- Data word consumed at compile time via `skip_next = true` (same pattern as `OP_POSTH`); `find_block_leaders` updated to skip it as a 2-word instruction; prepass/fixpoint classification loops guarded accordingly

## Test plan

- [ ] All 8 `op_parmap_*` unit tests pass (`cargo test --features cranelift op_parmap`)
- [ ] Full test suite passes with `--features cranelift`
- [ ] Builds cleanly: `cargo build --features cranelift`

Extends ILO-352 (#688) / ILO-67 (#610).

🤖 Generated with [Claude Code](https://claude.com/claude-code)