### PR TITLE
feat: mget-or builtin (ILO-42)

### DIFF
--- a/examples/mget-or.ilo
+++ b/examples/mget-or.ilo
@@ -1,0 +1,30 @@
+-- mget-or m k default: value at key k, or default if missing.
+--
+-- Unlike `mget m k ?? default`, which returns `O v` and requires the
+-- nil-coalesce operator, `mget-or` returns the value type directly — no
+-- `??` ceremony, no optional wrapper. The default type must match the map
+-- value type (enforced at verify time).
+
+-- Key present — returns the stored value, not the default.
+hit>n;m=mset mmap "alice" 99;mget-or m "alice" 0
+
+-- Key absent — returns the caller-supplied default.
+miss>n;m=mset mmap "alice" 99;mget-or m "carol" 0
+
+-- Text-valued map: absent key falls back to a text default.
+label>t;m=mset mmap "x" "found";mget-or m "y" "unknown"
+
+-- Numeric key map: integer key lookup with default.
+bynum>t;idx=mset mmap 7 "seven";mget-or idx 7 "none"
+bynum-miss>t;idx=mset mmap 7 "seven";mget-or idx 8 "none"
+
+-- run: hit
+-- out: 99
+-- run: miss
+-- out: 0
+-- run: label
+-- out: unknown
+-- run: bynum
+-- out: seven
+-- run: bynum-miss
+-- out: none

--- a/tests/regression_mget_or.rs
+++ b/tests/regression_mget_or.rs
@@ -21,11 +21,7 @@ fn ilo() -> Command {
 fn run_inline(engine: &str, src: &str, entry: &str) -> String {
     static COUNTER: AtomicU64 = AtomicU64::new(0);
     let seq = COUNTER.fetch_add(1, Ordering::SeqCst);
-    let path = std::env::temp_dir().join(format!(
-        "ilo_mget_or_{}_{}.ilo",
-        std::process::id(),
-        seq
-    ));
+    let path = std::env::temp_dir().join(format!("ilo_mget_or_{}_{}.ilo", std::process::id(), seq));
     std::fs::write(&path, src).unwrap();
     let out = ilo()
         .args([path.to_str().unwrap(), engine, entry])
@@ -80,13 +76,21 @@ fn check(engine: &str) {
     );
     // Numeric-key map: hit
     assert_eq!(
-        run_inline(engine, r#"f>t;m=mset mmap 7 "seven";mget-or m 7 "default""#, "f"),
+        run_inline(
+            engine,
+            r#"f>t;m=mset mmap 7 "seven";mget-or m 7 "default""#,
+            "f"
+        ),
         "seven",
         "mget-or num-key hit [{engine}]"
     );
     // Numeric-key map: miss
     assert_eq!(
-        run_inline(engine, r#"f>t;m=mset mmap 7 "seven";mget-or m 8 "default""#, "f"),
+        run_inline(
+            engine,
+            r#"f>t;m=mset mmap 7 "seven";mget-or m 8 "default""#,
+            "f"
+        ),
         "default",
         "mget-or num-key miss [{engine}]"
     );

--- a/tests/regression_mget_or.rs
+++ b/tests/regression_mget_or.rs
@@ -1,0 +1,120 @@
+// Regression tests for the `mget-or m k default` builtin (ILO-42).
+//
+// `mget-or` is the defaulted map-lookup counterpart to `mget`. It returns
+// the value at key `k`, or `default` if the key is absent — never nil.
+// The default's type must match the map's value type (verifier ILO-T013).
+//
+// Coverage:
+//   - text-key map: hit and miss paths
+//   - numeric-key map: hit and miss paths
+//   - text-valued map with text default
+//   - default-type mismatch rejected at verify time (ILO-T013)
+//   - tree-bridge dispatch consistent with interpreter (--run-vm)
+
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_inline(engine: &str, src: &str, entry: &str) -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let seq = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let path = std::env::temp_dir().join(format!(
+        "ilo_mget_or_{}_{}.ilo",
+        std::process::id(),
+        seq
+    ));
+    std::fs::write(&path, src).unwrap();
+    let out = ilo()
+        .args([path.to_str().unwrap(), engine, entry])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}`: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn run_inline_expect_err(engine: &str, src: &str) -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let seq = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let path = std::env::temp_dir().join(format!(
+        "ilo_mget_or_err_{}_{}.ilo",
+        std::process::id(),
+        seq
+    ));
+    std::fs::write(&path, src).unwrap();
+    let out = ilo()
+        .args([path.to_str().unwrap(), engine])
+        .output()
+        .expect("failed to run ilo");
+    assert!(
+        !out.status.success(),
+        "expected failure but ilo {engine} succeeded for `{src}`"
+    );
+    String::from_utf8_lossy(&out.stderr).to_string()
+}
+
+fn check(engine: &str) {
+    // Text-key numeric-value map: hit
+    assert_eq!(
+        run_inline(engine, r#"f>n;m=mset mmap "k" 5;mget-or m "k" 0"#, "f"),
+        "5",
+        "mget-or text-key hit [{engine}]"
+    );
+    // Text-key numeric-value map: miss
+    assert_eq!(
+        run_inline(engine, r#"f>n;m=mmap;mget-or m "missing" 99"#, "f"),
+        "99",
+        "mget-or text-key miss [{engine}]"
+    );
+    // Text-key text-value map: miss returns text default
+    assert_eq!(
+        run_inline(engine, r#"f>t;m=mmap;mget-or m "k" "fallback""#, "f"),
+        "fallback",
+        "mget-or text-val miss [{engine}]"
+    );
+    // Numeric-key map: hit
+    assert_eq!(
+        run_inline(engine, r#"f>t;m=mset mmap 7 "seven";mget-or m 7 "default""#, "f"),
+        "seven",
+        "mget-or num-key hit [{engine}]"
+    );
+    // Numeric-key map: miss
+    assert_eq!(
+        run_inline(engine, r#"f>t;m=mset mmap 7 "seven";mget-or m 8 "default""#, "f"),
+        "default",
+        "mget-or num-key miss [{engine}]"
+    );
+}
+
+#[test]
+fn mget_or_vm() {
+    check("--run-vm");
+}
+
+#[cfg(feature = "cranelift")]
+#[test]
+fn mget_or_cranelift() {
+    check("--jit");
+}
+
+// Default type must match map value type — verifier must reject with ILO-T013.
+#[test]
+fn mget_or_default_type_mismatch_rejected() {
+    // Map is M t n (value=n); default "x" is text — mismatch.
+    let src = r#"f>n;m=mset mmap "k" 5;mget-or m "k" "x""#;
+    let stderr = run_inline_expect_err("--run-vm", src);
+    assert!(
+        stderr.contains("ILO-T013"),
+        "expected ILO-T013 for mget-or default type mismatch, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("mget-or"),
+        "expected message to mention mget-or, got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `examples/mget-or.ilo` demonstrating `mget-or m k default` across text-key, numeric-key, and text-value maps with annotated run/out blocks
- Adds `tests/regression_mget_or.rs` with 3 tests: VM hit/miss across key types, Cranelift parity, and verifier rejection of default-type mismatch (ILO-T013)
- Core implementation (builtins.rs enum, interpreter dispatch, verify.rs signature `M t a a > a`, vm tree-bridge, SPEC.md, ai.txt) was already in place on `main`

## Test plan

- [ ] `cargo test --test regression_mget_or` — 3 tests pass (VM + Cranelift + type-mismatch rejection)
- [ ] `cargo test --test regression_mget_or_lget_or` — 5 existing tests still pass
- [ ] `examples/mget-or.ilo` run/out blocks verify manually with `ilo examples/mget-or.ilo --run-vm <entry>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)