### PR TITLE
ILO-41: Filesystem-metadata builtins (fsize/mtime/isfile/isdir)

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -6437,6 +6437,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 ));
             }
         };
+        if let Err(msg) = env.caps.check_read(path.as_str()) {
+            return Ok(Value::Err(Box::new(Value::Text(Arc::new(msg)))));
+        }
         return match std::fs::metadata(path.as_str()) {
             Err(e) => Ok(Value::Err(Box::new(Value::Text(Arc::new(e.to_string()))))),
             Ok(md) if md.is_dir() => Ok(Value::Err(Box::new(Value::Text(Arc::new(format!(
@@ -6461,6 +6464,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 ));
             }
         };
+        if let Err(msg) = env.caps.check_read(path.as_str()) {
+            return Ok(Value::Err(Box::new(Value::Text(Arc::new(msg)))));
+        }
         return match std::fs::metadata(path.as_str()) {
             Err(e) => Ok(Value::Err(Box::new(Value::Text(Arc::new(e.to_string()))))),
             Ok(md) => match md.modified() {
@@ -6487,6 +6493,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 ));
             }
         };
+        if env.caps.check_read(path.as_str()).is_err() {
+            return Ok(Value::Bool(false));
+        }
         let is = std::fs::metadata(path.as_str())
             .map(|m| m.is_file())
             .unwrap_or(false);
@@ -6504,6 +6513,9 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
                 ));
             }
         };
+        if env.caps.check_read(path.as_str()).is_err() {
+            return Ok(Value::Bool(false));
+        }
         let is = std::fs::metadata(path.as_str())
             .map(|m| m.is_dir())
             .unwrap_or(false);

--- a/tests/capability_flags.rs
+++ b/tests/capability_flags.rs
@@ -337,6 +337,82 @@ fn permissive_caps_allow_everything() {
     assert!(caps.check_run("rm").is_ok());
 }
 
+// ── --allow-read: fs-metadata builtins (fsize/mtime/isfile/isdir) ─────────────
+
+/// `fsize` blocked by --allow-read → returns Err containing ILO-CAP-001.
+#[test]
+fn allow_read_blocks_fsize() {
+    let path = "/tmp/ilo_cap_fsize.txt";
+    std::fs::write(path, "hello").unwrap();
+    let caps = Caps::Restricted {
+        net: Policy::All,
+        read: Policy::List(vec![]),
+        write: Policy::All,
+        run: Policy::All,
+    };
+    let src = format!("f>R n t;fsize \"{path}\"");
+    let (tree, _vm_val) = run_both(&src, caps);
+    assert!(is_err_value(&tree), "tree: fsize should be blocked by read cap");
+    let msg = err_text(&tree);
+    assert!(msg.contains("ILO-CAP-001"), "expected ILO-CAP-001, got: {msg}");
+}
+
+/// `mtime` blocked by --allow-read → returns Err containing ILO-CAP-001.
+#[test]
+fn allow_read_blocks_mtime() {
+    let path = "/tmp/ilo_cap_mtime.txt";
+    std::fs::write(path, "hello").unwrap();
+    let caps = Caps::Restricted {
+        net: Policy::All,
+        read: Policy::List(vec![]),
+        write: Policy::All,
+        run: Policy::All,
+    };
+    let src = format!("f>R n t;mtime \"{path}\"");
+    let (tree, _vm_val) = run_both(&src, caps);
+    assert!(is_err_value(&tree), "tree: mtime should be blocked by read cap");
+    let msg = err_text(&tree);
+    assert!(msg.contains("ILO-CAP-001"), "expected ILO-CAP-001, got: {msg}");
+}
+
+/// `isfile` blocked by --allow-read → returns false (collapses to bool false).
+#[test]
+fn allow_read_blocks_isfile_returns_false() {
+    let path = "/tmp/ilo_cap_isfile.txt";
+    std::fs::write(path, "hello").unwrap();
+    let caps = Caps::Restricted {
+        net: Policy::All,
+        read: Policy::List(vec![]),
+        write: Policy::All,
+        run: Policy::All,
+    };
+    let src = format!("f>b;isfile \"{path}\"");
+    let (tree, _vm_val) = run_both(&src, caps);
+    assert_eq!(
+        tree,
+        Value::Bool(false),
+        "isfile should return false when blocked by read cap"
+    );
+}
+
+/// `isdir` blocked by --allow-read → returns false.
+#[test]
+fn allow_read_blocks_isdir_returns_false() {
+    let caps = Caps::Restricted {
+        net: Policy::All,
+        read: Policy::List(vec![]),
+        write: Policy::All,
+        run: Policy::All,
+    };
+    let src = "f>b;isdir \"/tmp\"";
+    let (tree, _vm_val) = run_both(src, caps);
+    assert_eq!(
+        tree,
+        Value::Bool(false),
+        "isdir should return false when blocked by read cap"
+    );
+}
+
 /// When any --allow-* flag is set, undefined dimensions default to Policy::All.
 #[test]
 fn one_flag_restricts_only_that_dimension() {

--- a/tests/capability_flags.rs
+++ b/tests/capability_flags.rs
@@ -352,9 +352,15 @@ fn allow_read_blocks_fsize() {
     };
     let src = format!("f>R n t;fsize \"{path}\"");
     let (tree, _vm_val) = run_both(&src, caps);
-    assert!(is_err_value(&tree), "tree: fsize should be blocked by read cap");
+    assert!(
+        is_err_value(&tree),
+        "tree: fsize should be blocked by read cap"
+    );
     let msg = err_text(&tree);
-    assert!(msg.contains("ILO-CAP-001"), "expected ILO-CAP-001, got: {msg}");
+    assert!(
+        msg.contains("ILO-CAP-001"),
+        "expected ILO-CAP-001, got: {msg}"
+    );
 }
 
 /// `mtime` blocked by --allow-read → returns Err containing ILO-CAP-001.
@@ -370,9 +376,15 @@ fn allow_read_blocks_mtime() {
     };
     let src = format!("f>R n t;mtime \"{path}\"");
     let (tree, _vm_val) = run_both(&src, caps);
-    assert!(is_err_value(&tree), "tree: mtime should be blocked by read cap");
+    assert!(
+        is_err_value(&tree),
+        "tree: mtime should be blocked by read cap"
+    );
     let msg = err_text(&tree);
-    assert!(msg.contains("ILO-CAP-001"), "expected ILO-CAP-001, got: {msg}");
+    assert!(
+        msg.contains("ILO-CAP-001"),
+        "expected ILO-CAP-001, got: {msg}"
+    );
 }
 
 /// `isfile` blocked by --allow-read → returns false (collapses to bool false).


### PR DESCRIPTION
## Summary

- All four fs-metadata builtins (`fsize`, `mtime`, `isfile`, `isdir`) were already fully implemented across builtins, verify, interpreter, VM, and Python codegen
- Added missing `--allow-read` cap enforcement: `fsize`/`mtime` return `Err(ILO-CAP-001 ...)` on blocked paths; `isfile`/`isdir` return `false` (consistent with their missing/perm-denied contract)
- Added 4 new cap integration tests in `tests/capability_flags.rs`

## What already existed

All four builtins were present on `main` with full cross-engine coverage (15 regression tests passing). The only gap was cap enforcement in the interpreter tree-bridge path.

## Test plan

- [x] `cargo test --test regression_fs_metadata` — 15/15 pass
- [x] `cargo test --test capability_flags` — 19/19 pass (4 new tests added)

Closes ILO-41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)