### PR TITLE
feat(ILO-407): JIT (Cranelift) trace path — wire OP_STMT into JIT/AOT codegen

### DIFF
--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -244,6 +244,8 @@ struct HelperFuncs {
     solve: FuncId,
     inv: FuncId,
     det: FuncId,
+    // ILO-407: OP_STMT trace trampoline — (result_bits, chunk_idx, debug_idx, span_bits) -> 0
+    stmt_trace: FuncId,
 }
 
 fn declare_helper(
@@ -449,6 +451,8 @@ fn declare_all_helpers(module: &mut ObjectModule) -> HelperFuncs {
         solve: declare_helper(module, "jit_solve", 3, 1),
         inv: declare_helper(module, "jit_inv", 2, 1),
         det: declare_helper(module, "jit_det", 2, 1),
+        // ILO-407: OP_STMT trace trampoline
+        stmt_trace: declare_helper(module, "jit_stmt_trace", 4, 1),
     }
 }
 
@@ -655,6 +659,7 @@ pub fn compile_to_binary(
             &helpers,
             Some(&func_ids),
             Some(program),
+            i,
         )?;
     }
 
@@ -1028,6 +1033,7 @@ fn compile_function_body(
     helpers: &HelperFuncs,
     all_func_ids: Option<&[FuncId]>,
     program: Option<&CompiledProgram>,
+    chunk_idx: usize,
 ) -> Result<(), String> {
     let mut sig = module.make_signature();
     for _ in 0..chunk.param_count {
@@ -4426,11 +4432,28 @@ fn compile_function_body(
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
-            // ILO-343: OP_STMT is a VM-only trace instruction; JIT trace
-            // is deferred to a follow-up ticket. Emit nothing here so
-            // existing Cranelift tests continue to pass.
+            // ILO-407: OP_STMT — emit a call to jit_stmt_trace so `ilo trace`
+            // produces output on the AOT path.
+            //
+            // Encoding: A = result register (255 = void/nil), Bx = debug_idx.
             crate::vm::OP_STMT => {
-                // no-op in JIT codegen
+                let debug_idx = (inst & 0xFFFF) as u64;
+                let result_bits = if a_idx == 255 {
+                    builder.ins().iconst(I64, TAG_NIL as i64)
+                } else {
+                    builder.use_var(vars[a_idx])
+                };
+                let chunk_idx_val = builder.ins().iconst(I64, chunk_idx as i64);
+                let debug_idx_val = builder.ins().iconst(I64, debug_idx as i64);
+                let span = chunk.spans.get(ip).copied().unwrap_or(crate::ast::Span::UNKNOWN);
+                let span_bits = {
+                    let start = span.start.min(u32::MAX as usize) as u64;
+                    let end = span.end.min(u32::MAX as usize) as u64;
+                    ((start << 32) | end) as i64
+                };
+                let span_arg = builder.ins().iconst(I64, span_bits);
+                let fref = get_func_ref(&mut builder, module, helpers.stmt_trace);
+                builder.ins().call(fref, &[result_bits, chunk_idx_val, debug_idx_val, span_arg]);
             }
             _ => {
                 return Err(format!("unsupported opcode {} at instruction {}", op, ip));
@@ -4855,6 +4878,7 @@ pub fn compile_to_bench_binary(
             &helpers,
             Some(&func_ids),
             Some(program),
+            i,
         )?;
     }
 
@@ -5259,6 +5283,7 @@ mod tests {
                 &helpers,
                 Some(&func_ids),
                 Some(&compiled),
+                i,
             )?;
         }
 
@@ -6359,6 +6384,7 @@ f a:t b:t>t;join a b"#,
                     &helpers,
                     Some(&func_ids),
                     Some(&compiled),
+                    i,
                 );
                 if result.is_err() {
                     break;
@@ -7014,6 +7040,7 @@ f a:t b:t>t;join a b"#,
             &helpers,
             Some(&all_func_ids),
             None, // <-- program=None exercises lines 911-914
+            f_idx,
         );
         assert!(
             result.is_ok(),
@@ -7079,6 +7106,7 @@ f a:t b:t>t;join a b"#,
             &helpers,
             None, // <-- all_func_ids=None exercises lines 2547-2580
             None,
+            0,
         );
         assert!(
             result.is_ok(),
@@ -7118,6 +7146,7 @@ f a:t b:t>t;join a b"#,
             &helpers,
             None, // <-- all_func_ids=None, zero args → exercises lines 2569-2580
             None,
+            f_idx,
         );
         assert!(
             result.is_ok(),

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -218,6 +218,8 @@ struct HelperFuncs {
     // Per-thread call-stack tracking for cross-engine error parity.
     push_call_frame: FuncId,
     pop_call_frame: FuncId,
+    // ILO-407: OP_STMT trace trampoline for the JIT path.
+    stmt_trace: FuncId,
 }
 
 /// Pack a `Span { start, end }` into a single i64 immediate for passing to
@@ -438,6 +440,11 @@ fn register_helpers(builder: &mut JITBuilder) {
             "jit_pop_call_frame",
             crate::vm::jit_pop_call_frame as *const u8,
         ),
+        // ILO-407: OP_STMT trace trampoline.
+        (
+            "jit_stmt_trace",
+            crate::vm::jit_stmt_trace as *const u8,
+        ),
     ];
     for &(name, ptr) in helpers {
         builder.symbol(name, ptr);
@@ -626,6 +633,8 @@ fn declare_all_helpers(module: &mut JITModule) -> HelperFuncs {
         make_closure: declare_helper(module, "jit_make_closure", 3, 1),
         push_call_frame: declare_helper(module, "jit_push_call_frame", 2, 1),
         pop_call_frame: declare_helper(module, "jit_pop_call_frame", 0, 1),
+        // ILO-407: OP_STMT trace trampoline — (result_bits, chunk_idx, debug_idx, span_bits) -> 0
+        stmt_trace: declare_helper(module, "jit_stmt_trace", 4, 1),
     }
 }
 
@@ -927,6 +936,7 @@ fn compile_function_body(
     helpers: &HelperFuncs,
     all_func_ids: &[FuncId],
     program: &CompiledProgram,
+    chunk_idx: usize,
 ) -> Option<()> {
     // Build function signature: (i64, i64, ...) -> i64
     let mut sig = module.make_signature();
@@ -5086,10 +5096,26 @@ fn compile_function_body(
                 let result = builder.inst_results(call_inst)[0];
                 builder.def_var(vars[a_idx], result);
             }
-            // ILO-343: OP_STMT is a VM-only trace boundary; JIT trace is a
-            // follow-up. Treat it as a no-op so JIT compilation proceeds.
+            // ILO-407: OP_STMT — emit a call to jit_stmt_trace so `ilo trace`
+            // produces output on the JIT path.
+            //
+            // Encoding: A = result register (255 = void/nil), Bx = debug_idx.
+            // The trampoline checks trace_hook_active() internally and is a
+            // fast no-op (single branch) when no hook is installed.
             crate::vm::OP_STMT => {
-                // no-op in JIT codegen
+                let debug_idx = (inst & 0xFFFF) as u64;
+                // Result value: use TAG_NIL when A == 255 (void statement).
+                let result_bits = if a_idx == 255 {
+                    builder.ins().iconst(I64, TAG_NIL as i64)
+                } else {
+                    builder.use_var(vars[a_idx])
+                };
+                let chunk_idx_val = builder.ins().iconst(I64, chunk_idx as i64);
+                let debug_idx_val = builder.ins().iconst(I64, debug_idx as i64);
+                let span_bits = pack_span_bits(chunk.spans.get(ip).copied().unwrap_or(crate::ast::Span::UNKNOWN));
+                let span_arg = builder.ins().iconst(I64, span_bits);
+                let fref = get_func_ref(&mut builder, module, helpers.stmt_trace);
+                builder.ins().call(fref, &[result_bits, chunk_idx_val, debug_idx_val, span_arg]);
             }
             _ => {
                 // Unknown opcode — bail out
@@ -5168,6 +5194,7 @@ fn compile_program(program: &CompiledProgram, entry_idx: usize) -> Option<JitFun
             &helpers,
             &func_ids,
             program,
+            i,
         )?;
     }
 

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -6825,6 +6825,92 @@ pub(crate) fn jit_clear_call_stack() {
     JIT_CALL_STACK.with(|cell| cell.borrow_mut().clear());
 }
 
+/// JIT-to-Rust trampoline for `OP_STMT` trace events (ILO-407).
+///
+/// Emitted by Cranelift codegen at every `OP_STMT` boundary when a trace
+/// hook is active.  The four arguments are all `i64` so Cranelift can call
+/// this with `builder.ins().call(fref, &[result_bits, chunk_idx, debug_idx,
+/// span_bits])`.
+///
+/// * `result_bits` — the NanVal bit pattern of the statement's result
+///   register (`TAG_NIL` when `A == 255`).
+/// * `chunk_idx`   — index of the currently executing chunk inside
+///   `ACTIVE_PROGRAM.chunks`; used to look up `stmt_debug` and `spans`.
+/// * `debug_idx`   — `Bx` field of the `OP_STMT` instruction; indexes
+///   `chunk.stmt_debug` for the name→register snapshot.
+/// * `span_bits`   — packed span (`pack_span_bits`): high 32 = start,
+///   low 32 = end byte offset.
+///
+/// Bindings are reported with `Value::Nil` for every variable because the
+/// JIT trampoline does not have access to the live register file.  Line and
+/// statement text are resolved from `TRACE_SOURCE` exactly as the VM does.
+#[cfg(feature = "cranelift")]
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn jit_stmt_trace(
+    result_bits: u64,
+    chunk_idx: u64,
+    debug_idx: u64,
+    span_bits: u64,
+) -> u64 {
+    if !crate::interpreter::trace_hook_active() {
+        return 0;
+    }
+
+    // Resolve variable names from the active program's stmt_debug table.
+    let bindings: Vec<(String, crate::interpreter::Value)> = ACTIVE_PROGRAM.with(|cell| {
+        let ptr = cell.get();
+        if ptr.is_null() {
+            return Vec::new();
+        }
+        // SAFETY: pointer is set by `with_active_registry` for the duration of
+        // the JIT dispatch and cleared before the program is dropped.
+        let program: &CompiledProgram = unsafe { &*ptr };
+        let ci = chunk_idx as usize;
+        let di = debug_idx as usize;
+        if let Some(chunk) = program.chunks.get(ci) {
+            if let Some(locals) = chunk.stmt_debug.get(di) {
+                return locals
+                    .iter()
+                    .map(|(name, _reg)| (name.clone(), crate::interpreter::Value::Nil))
+                    .collect();
+            }
+        }
+        Vec::new()
+    });
+
+    // Decode result NanVal → Value.
+    let result = NanVal(result_bits).to_value();
+
+    // Decode span_bits → (line, stmt_text) using TRACE_SOURCE.
+    let start = (span_bits >> 32) as usize;
+    let end = (span_bits & 0xFFFF_FFFF) as usize;
+    let span = crate::ast::Span { start, end };
+
+    let (line, stmt_text) = crate::interpreter::TRACE_SOURCE.with(|s| {
+        if let Some(ref source) = *s.borrow() {
+            if span != crate::ast::Span::UNKNOWN {
+                let sm = crate::ast::SourceMap::new(source);
+                let (ln, _) = sm.lookup(span.start);
+                let text = sm.line_text(source, ln).trim().to_string();
+                (ln, text)
+            } else {
+                (0usize, String::new())
+            }
+        } else {
+            (0usize, String::new())
+        }
+    });
+
+    crate::interpreter::fire_trace_hook(crate::interpreter::TraceEvent {
+        line,
+        stmt: stmt_text,
+        bindings,
+        result,
+    });
+
+    0
+}
+
 // Why a separate tag for ListView
 // ───────────────────────────────
 // Both `HeapObj::List` and `HeapObj::ListView` live in the same `HeapObj` enum,
@@ -36169,6 +36255,103 @@ main>n
         // Running without trace hook must not panic or error.
         let src = "f>n;x=10;+x 1";
         let result = vm_run(src, Some("f"), vec![]);
+        assert_eq!(result, Value::Number(11.0));
+    }
+}
+
+// ── ILO-407: JIT (Cranelift) trace tests ──────────────────────────────────────
+#[cfg(all(test, feature = "cranelift"))]
+mod jit_trace_tests {
+    //! Verify that OP_STMT fires `TraceEvent`s through the Cranelift JIT path.
+
+    use super::*;
+    use crate::interpreter::{TraceEvent, Value};
+    use std::sync::{Arc, Mutex};
+
+    fn parse_and_compile(src: &str) -> CompiledProgram {
+        let tokens = crate::lexer::lex(src).expect("lex");
+        let token_spans: Vec<_> = tokens
+            .into_iter()
+            .map(|(t, r)| {
+                (
+                    t,
+                    crate::ast::Span {
+                        start: r.start,
+                        end: r.end,
+                    },
+                )
+            })
+            .collect();
+        let (mut prog, errors) = crate::parser::parse(token_spans);
+        assert!(errors.is_empty(), "parse errors: {:?}", errors);
+        crate::ast::resolve_aliases(&mut prog);
+        prog.source = Some(src.to_string());
+        compile(&prog).expect("compile")
+    }
+
+    /// Smoke test: the JIT trace path fires one event per statement.
+    #[test]
+    fn jit_trace_fires_events() {
+        let src = "f>n;a=1;b=2;+a b";
+        let compiled = parse_and_compile(src);
+
+        let events: Arc<Mutex<Vec<TraceEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_clone = events.clone();
+
+        let f_idx = compiled.func_index("f").expect("f not found") as usize;
+        let jit_fn = crate::vm::jit_cranelift::compile(
+            &compiled.chunks[f_idx],
+            &compiled.nan_constants[f_idx],
+            &compiled,
+        )
+        .expect("JIT compile");
+
+        // Install trace hook and source text.
+        use crate::interpreter::{TRACE_HOOK, TRACE_SOURCE};
+        TRACE_HOOK.with(|h| {
+            *h.borrow_mut() = Some(Box::new(move |ev: TraceEvent| {
+                events_clone.lock().unwrap().push(ev);
+            }));
+        });
+        TRACE_SOURCE.with(|s| {
+            *s.borrow_mut() = Some(src.to_string());
+        });
+
+        // Execute via with_active_registry so ACTIVE_PROGRAM is set for the trampoline.
+        let _result = with_active_registry(&compiled, || {
+            crate::vm::jit_cranelift::call(&jit_fn, &[], Some("f"))
+        });
+
+        TRACE_HOOK.with(|h| *h.borrow_mut() = None);
+        TRACE_SOURCE.with(|s| *s.borrow_mut() = None);
+
+        let evs = events.lock().unwrap();
+        // Three statements: a=1, b=2, +a b
+        assert!(
+            !evs.is_empty(),
+            "expected trace events from JIT path, got none"
+        );
+        // The last event should be the result of +a b = 3.0
+        let last = evs.last().unwrap();
+        assert_eq!(last.result, Value::Number(3.0), "last event result mismatch: {evs:?}");
+    }
+
+    /// No-hook path must not panic.
+    #[test]
+    fn jit_trace_no_hook_no_panic() {
+        let src = "f>n;x=10;+x 1";
+        let compiled = parse_and_compile(src);
+        let f_idx = compiled.func_index("f").expect("f") as usize;
+        let jit_fn = crate::vm::jit_cranelift::compile(
+            &compiled.chunks[f_idx],
+            &compiled.nan_constants[f_idx],
+            &compiled,
+        )
+        .expect("JIT compile");
+        let result_bits = with_active_registry(&compiled, || {
+            crate::vm::jit_cranelift::call(&jit_fn, &[], Some("f")).unwrap()
+        });
+        let result = NanVal(result_bits).to_value();
         assert_eq!(result, Value::Number(11.0));
     }
 }


### PR DESCRIPTION
## Summary

- Adds `jit_stmt_trace` extern C trampoline in `src/vm/mod.rs` that fires `TraceEvent` via the existing `fire_trace_hook` / `TRACE_HOOK` thread-local
- Replaces the OP_STMT no-op in `jit_cranelift.rs` and `compile_cranelift.rs` with a call to the trampoline, passing `(result_bits, chunk_idx, debug_idx, span_bits)` as i64 arguments
- Trampoline is a zero-cost no-op when no trace hook is installed (single `trace_hook_active()` branch)
- Variable names from `chunk.stmt_debug` are reported; values are Nil (register file not available in trampoline without full spill)
- Two new tests in `jit_trace_tests`: `jit_trace_fires_events` and `jit_trace_no_hook_no_panic`

Closes ILO-407. Extends ILO-343 (#686).

## Test plan

- [x] `cargo test --features cranelift -- jit_trace` — both new tests pass
- [x] `cargo test --features cranelift` — full suite passes
- [x] No-hook fast path verified (no panics, correct return value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)