### PR TITLE
feat(builtins): numeric-pipeline primitives for 0.13.0 (ILO-38)

### DIFF
--- a/examples/list-mutation.ilo
+++ b/examples/list-mutation.ilo
@@ -5,9 +5,9 @@
 -- This replaces user-space rebuild loops for "increment bin i" patterns that
 -- previously rebuilt the entire list on every update.
 
-hist samples:L n bins:L n>L n;@s samples{c=at bins s;bins=lst bins s +c 1};bins
+bin-count samples:L n bins:L n>L n;@s samples{c=at bins s;bins=lst bins s +c 1};bins
 
--- run: hist [0,2,1,2,3,1,2,0] [0,0,0,0]
+-- run: bin-count [0,2,1,2,3,1,2,0] [0,0,0,0]
 -- out: [2, 2, 3, 1]
--- run: hist [1,1,1] [0,0]
+-- run: bin-count [1,1,1] [0,0]
 -- out: [0, 3]

--- a/examples/lset-alias.ilo
+++ b/examples/lset-alias.ilo
@@ -4,9 +4,9 @@
 -- it from the M↔L parallelism don't fall back to slice-rebuild patterns.
 -- Resolved at the AST level; bytecode is identical to `lst` across engines.
 
-hist samples:L n bins:L n>L n;@s samples{c=at bins s;bins=lset bins s +c 1};bins
+bin-count samples:L n bins:L n>L n;@s samples{c=at bins s;bins=lset bins s +c 1};bins
 
--- run: hist [0,2,1,2,3,1,2,0] [0,0,0,0]
+-- run: bin-count [0,2,1,2,3,1,2,0] [0,0,0,0]
 -- out: [2, 2, 3, 1]
--- run: hist [1,1,1] [0,0]
+-- run: bin-count [1,1,1] [0,0]
 -- out: [0, 3]

--- a/examples/numeric-map-keys.ilo
+++ b/examples/numeric-map-keys.ilo
@@ -6,8 +6,8 @@
 -- Floats floor to i64 at the builtin boundary, matching `at xs i`. Text and
 -- number keys are distinct: Int(1) and Text("1") never collide.
 
--- Build a small histogram by writing through numeric keys.
-hist>n;m=mmap;m=mset m 1 10;m=mset m 2 20;m=mset m 3 30;r=mget m 2;?r{n v:v;_:-1}
+-- Build a small map-histogram by writing through numeric keys.
+map-hist>n;m=mmap;m=mset m 1 10;m=mset m 2 20;m=mset m 3 30;r=mget m 2;?r{n v:v;_:-1}
 
 -- mhas works with numeric keys.
 has-key>b;m=mmap;m=mset m 42 "answer";mhas m 42
@@ -21,7 +21,7 @@ key-count>n;m=mmap;m=mset m 1 0;m=mset m 2 0;m=mset m 3 0;ks=mkeys m;len ks
 -- Iteration is deterministic via sorted mkeys.
 sorted-keys>t;m=mmap;m=mset m 3 0;m=mset m 1 0;m=mset m 2 0;ks=srt (mkeys m);fmt "{};{};{}" (str (at ks 0)) (str (at ks 1)) (str (at ks 2))
 
--- run: hist
+-- run: map-hist
 -- out: 20
 -- run: has-key
 -- out: true

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -475,6 +475,42 @@ pub enum Builtin {
     Bshl64,
     Bshr64,
     Brot64,
+
+    // Numeric-pipeline constructors and stack combinators (0.13.0).
+    // All are tree-bridge eligible: pure numeric/list ops, no FnRef args,
+    // no I/O. Appended last to preserve every existing on-wire tag.
+    //
+    // `arange start:n stop:n step:n > L n` — evenly-spaced values in
+    //   [start, stop) with the given step (numpy `arange` semantics).
+    //   step > 0 required; empty list when start >= stop.
+    //
+    // `zeros n:n > L n` — list of n 0.0 values. Mirror of `ones`.
+    //
+    // `vstack matrices:L > L` — vertical stack: concatenate a list of
+    //   row-lists, i.e., `flat` on a list of matrices. Each inner list
+    //   must be a list of rows (lists). Equivalent to numpy `vstack` for
+    //   2-d inputs. Returns a flat list of rows.
+    //
+    // `hstack matrices:L > L` — horizontal stack: concatenate the rows of
+    //   corresponding row-lists column-wise. All inner matrices must have
+    //   the same number of rows; output rows are the pairwise `cat` of
+    //   corresponding rows. Equivalent to numpy `hstack` for 2-d inputs.
+    //
+    // `column-stack vecs:L > L` — treat each element (a 1-d vector or
+    //   single-column matrix) as a column and return a 2-d matrix (list of
+    //   rows). Equivalent to numpy `column_stack`. All vectors must have
+    //   the same length.
+    //
+    // `hist xs:L n_bins:n > L n` — fixed-width histogram over the numeric
+    //   list `xs` into `n_bins` equal-width bins spanning [min, max].
+    //   Returns a list of n_bins integer counts. Empty xs → all-zero bins.
+    //   n_bins must be a positive integer (≤ 1_000_000).
+    Arange,
+    Zeros,
+    Vstack,
+    Hstack,
+    ColumnStack,
+    Hist,
 }
 
 impl Builtin {
@@ -698,6 +734,12 @@ impl Builtin {
             "bshl64" => Some(Builtin::Bshl64),
             "bshr64" => Some(Builtin::Bshr64),
             "brot64" => Some(Builtin::Brot64),
+            "arange" => Some(Builtin::Arange),
+            "zeros" => Some(Builtin::Zeros),
+            "vstack" => Some(Builtin::Vstack),
+            "hstack" => Some(Builtin::Hstack),
+            "column-stack" => Some(Builtin::ColumnStack),
+            "hist" => Some(Builtin::Hist),
             _ => None,
         }
     }
@@ -918,6 +960,12 @@ impl Builtin {
             Builtin::Bshl64 => "bshl64",
             Builtin::Bshr64 => "bshr64",
             Builtin::Brot64 => "brot64",
+            Builtin::Arange => "arange",
+            Builtin::Zeros => "zeros",
+            Builtin::Vstack => "vstack",
+            Builtin::Hstack => "hstack",
+            Builtin::ColumnStack => "column-stack",
+            Builtin::Hist => "hist",
         }
     }
 
@@ -1314,6 +1362,14 @@ impl Builtin {
         Builtin::Bshl64,
         Builtin::Bshr64,
         Builtin::Brot64,
+        // Numeric-pipeline primitives (0.13.0). Appended last; tree-bridge
+        // eligible. Preserves all existing on-wire tags.
+        Builtin::Arange,
+        Builtin::Zeros,
+        Builtin::Vstack,
+        Builtin::Hstack,
+        Builtin::ColumnStack,
+        Builtin::Hist,
     ];
 
     /// Stability tier for this builtin, sourced from `STABILITY.md`.
@@ -1342,7 +1398,14 @@ impl Builtin {
             | Builtin::DurFmt
             | Builtin::Idxof
             | Builtin::HexRev
-            | Builtin::Tokcount => "experimental",
+            | Builtin::Tokcount
+            // Numeric-pipeline primitives (0.13.0) — experimental.
+            | Builtin::Arange
+            | Builtin::Zeros
+            | Builtin::Vstack
+            | Builtin::Hstack
+            | Builtin::ColumnStack
+            | Builtin::Hist => "experimental",
 
             // Everything else shipped in 0.12.1 or earlier → provisional.
             _ => "provisional",
@@ -1723,6 +1786,12 @@ mod tests {
             "bshl64",
             "bshr64",
             "brot64",
+            "arange",
+            "zeros",
+            "vstack",
+            "hstack",
+            "column-stack",
+            "hist",
         ];
         for name in &all {
             let b = Builtin::from_name(name).unwrap_or_else(|| panic!("missing builtin: {name}"));
@@ -1995,6 +2064,12 @@ mod tests {
             "idxof",
             "hex-rev",
             "tokcount",
+            "arange",
+            "zeros",
+            "vstack",
+            "hstack",
+            "column-stack",
+            "hist",
         ] {
             let b = Builtin::from_name(name).unwrap_or_else(|| panic!("no builtin: {name}"));
             let t = b.tag();

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -5637,6 +5637,295 @@ fn call_function(env: &mut Env, name: &str, args: Vec<Value>) -> Result<Value> {
         let out = vec![v.clone(); n as usize];
         return Ok(Value::List(Arc::new(out)));
     }
+    // ----- zeros -----
+    if builtin == Some(Builtin::Zeros) && args.len() == 1 {
+        let n_raw = match &args[0] {
+            Value::Number(n) => *n,
+            other => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!("zeros: count must be a number, got {:?}", other),
+                ));
+            }
+        };
+        if n_raw.fract() != 0.0 || n_raw < 0.0 {
+            return Err(RuntimeError::new(
+                "ILO-R009",
+                format!("zeros: count must be a non-negative integer, got {n_raw}"),
+            ));
+        }
+        let n = n_raw as u64;
+        if n > 1_000_000 {
+            return Err(RuntimeError::new(
+                "ILO-R009",
+                format!("zeros too large: {n} elements (max 1000000)"),
+            ));
+        }
+        let out = vec![Value::Number(0.0); n as usize];
+        return Ok(Value::List(Arc::new(out)));
+    }
+    // ----- arange -----
+    if builtin == Some(Builtin::Arange) && args.len() == 3 {
+        let (start, stop, step) = match (&args[0], &args[1], &args[2]) {
+            (Value::Number(a), Value::Number(b), Value::Number(s)) => (*a, *b, *s),
+            _ => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    "arange requires three numbers (start stop step)".to_string(),
+                ));
+            }
+        };
+        if step <= 0.0 {
+            return Err(RuntimeError::new(
+                "ILO-R009",
+                format!("arange: step must be positive, got {step}"),
+            ));
+        }
+        if start >= stop {
+            return Ok(Value::List(Arc::new(Vec::new())));
+        }
+        let n = ((stop - start) / step).ceil() as u64;
+        if n > 1_000_000 {
+            return Err(RuntimeError::new(
+                "ILO-R009",
+                format!("arange too large: {n} elements (max 1000000)"),
+            ));
+        }
+        let mut out = Vec::with_capacity(n as usize);
+        let mut i = 0u64;
+        loop {
+            let v = start + step * (i as f64);
+            if v >= stop {
+                break;
+            }
+            out.push(Value::Number(v));
+            i += 1;
+            if i > 1_000_000 {
+                break;
+            }
+        }
+        return Ok(Value::List(Arc::new(out)));
+    }
+    // ----- vstack -----
+    // vstack matrices:L > L — vertical concatenation of a list of row-lists.
+    // Equivalent to flat on a list of matrices: [[r0,r1],[r2,r3]] → [r0,r1,r2,r3].
+    #[inline(never)]
+    fn vstack_run(matrices_val: &Value) -> Result<Value> {
+        let matrices = match matrices_val {
+            Value::List(xs) => xs.clone(),
+            _ => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    "vstack: argument must be a list of matrices".to_string(),
+                ));
+            }
+        };
+        let mut out: Vec<Value> = Vec::new();
+        for item in matrices.iter() {
+            match item {
+                Value::List(rows) => {
+                    for row in rows.iter() {
+                        out.push(row.clone());
+                    }
+                }
+                _ => {
+                    return Err(RuntimeError::new(
+                        "ILO-R009",
+                        "vstack: each element must be a list (matrix or vector)".to_string(),
+                    ));
+                }
+            }
+        }
+        Ok(Value::List(Arc::new(out)))
+    }
+    if builtin == Some(Builtin::Vstack) && args.len() == 1 {
+        return vstack_run(&args[0]);
+    }
+    // ----- hstack -----
+    // hstack matrices:L > L — horizontal concatenation: cat corresponding rows.
+    // All matrices must have the same number of rows; each output row is the
+    // concatenation of the corresponding input rows.
+    #[inline(never)]
+    fn hstack_run(matrices_val: &Value) -> Result<Value> {
+        let matrices = match matrices_val {
+            Value::List(xs) => xs.clone(),
+            _ => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    "hstack: argument must be a list of matrices".to_string(),
+                ));
+            }
+        };
+        if matrices.is_empty() {
+            return Ok(Value::List(Arc::new(Vec::new())));
+        }
+        // Collect as Vec<Vec<&Value>> — each element is a list of rows.
+        let mut mats: Vec<Arc<Vec<Value>>> = Vec::with_capacity(matrices.len());
+        for item in matrices.iter() {
+            match item {
+                Value::List(rows) => mats.push(rows.clone()),
+                _ => {
+                    return Err(RuntimeError::new(
+                        "ILO-R009",
+                        "hstack: each element must be a list (matrix)".to_string(),
+                    ));
+                }
+            }
+        }
+        let n_rows = mats[0].len();
+        for m in &mats {
+            if m.len() != n_rows {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!(
+                        "hstack: all matrices must have the same number of rows; expected {n_rows}, got {}",
+                        m.len()
+                    ),
+                ));
+            }
+        }
+        let mut out = Vec::with_capacity(n_rows);
+        for r in 0..n_rows {
+            let mut row: Vec<Value> = Vec::new();
+            for m in &mats {
+                match &m[r] {
+                    Value::List(cols) => {
+                        for col in cols.iter() {
+                            row.push(col.clone());
+                        }
+                    }
+                    other => row.push(other.clone()),
+                }
+            }
+            out.push(Value::List(Arc::new(row)));
+        }
+        Ok(Value::List(Arc::new(out)))
+    }
+    if builtin == Some(Builtin::Hstack) && args.len() == 1 {
+        return hstack_run(&args[0]);
+    }
+    // ----- column-stack -----
+    // column-stack vecs:L > L — treat each vector (1-d list) as a column,
+    // return a 2-d matrix (list of rows). All vectors must have the same length.
+    #[inline(never)]
+    fn column_stack_run(vecs_val: &Value) -> Result<Value> {
+        let vecs = match vecs_val {
+            Value::List(xs) => xs.clone(),
+            _ => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    "column-stack: argument must be a list of vectors".to_string(),
+                ));
+            }
+        };
+        if vecs.is_empty() {
+            return Ok(Value::List(Arc::new(Vec::new())));
+        }
+        let mut cols: Vec<Arc<Vec<Value>>> = Vec::with_capacity(vecs.len());
+        for item in vecs.iter() {
+            match item {
+                Value::List(col) => cols.push(col.clone()),
+                _ => {
+                    return Err(RuntimeError::new(
+                        "ILO-R009",
+                        "column-stack: each element must be a list (vector)".to_string(),
+                    ));
+                }
+            }
+        }
+        let n_rows = cols[0].len();
+        for col in &cols {
+            if col.len() != n_rows {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    format!(
+                        "column-stack: all vectors must have the same length; expected {n_rows}, got {}",
+                        col.len()
+                    ),
+                ));
+            }
+        }
+        let mut out = Vec::with_capacity(n_rows);
+        for r in 0..n_rows {
+            let row: Vec<Value> = cols.iter().map(|col| col[r].clone()).collect();
+            out.push(Value::List(Arc::new(row)));
+        }
+        Ok(Value::List(Arc::new(out)))
+    }
+    if builtin == Some(Builtin::ColumnStack) && args.len() == 1 {
+        return column_stack_run(&args[0]);
+    }
+    // ----- hist -----
+    // hist xs:L n_bins:n > L n — fixed-width histogram.
+    // Returns a list of n_bins integer counts for equal-width bins over [min,max].
+    #[inline(never)]
+    fn hist_run(xs_val: &Value, n_bins_val: &Value) -> Result<Value> {
+        let xs = match xs_val {
+            Value::List(xs) => xs.clone(),
+            _ => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    "hist: first argument must be a numeric list".to_string(),
+                ));
+            }
+        };
+        let n_bins_raw = match n_bins_val {
+            Value::Number(n) => *n,
+            _ => {
+                return Err(RuntimeError::new(
+                    "ILO-R009",
+                    "hist: n_bins must be a number".to_string(),
+                ));
+            }
+        };
+        if n_bins_raw.fract() != 0.0 || n_bins_raw <= 0.0 {
+            return Err(RuntimeError::new(
+                "ILO-R009",
+                format!("hist: n_bins must be a positive integer, got {n_bins_raw}"),
+            ));
+        }
+        let n_bins = n_bins_raw as usize;
+        if n_bins > 1_000_000 {
+            return Err(RuntimeError::new(
+                "ILO-R009",
+                format!("hist: n_bins too large: {n_bins} (max 1000000)"),
+            ));
+        }
+        let mut counts = vec![Value::Number(0.0); n_bins];
+        if xs.is_empty() {
+            return Ok(Value::List(Arc::new(counts)));
+        }
+        let mut vals: Vec<f64> = Vec::with_capacity(xs.len());
+        for v in xs.iter() {
+            match v {
+                Value::Number(n) => vals.push(*n),
+                _ => {
+                    return Err(RuntimeError::new(
+                        "ILO-R009",
+                        "hist: list elements must all be numbers".to_string(),
+                    ));
+                }
+            }
+        }
+        let mn = vals.iter().cloned().fold(f64::INFINITY, f64::min);
+        let mx = vals.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+        let range = mx - mn;
+        for &v in &vals {
+            let bin = if range == 0.0 {
+                0
+            } else {
+                let b = ((v - mn) / range * (n_bins as f64)).floor() as usize;
+                b.min(n_bins - 1)
+            };
+            if let Value::Number(ref mut c) = counts[bin] {
+                *c += 1.0;
+            }
+        }
+        Ok(Value::List(Arc::new(counts)))
+    }
+    if builtin == Some(Builtin::Hist) && args.len() == 2 {
+        return hist_run(&args[0], &args[1]);
+    }
     if builtin == Some(Builtin::Chunks) && args.len() == 2 {
         let n_raw = match &args[0] {
             Value::Number(n) => *n,

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -939,6 +939,21 @@ const BUILTINS: &[(&str, &[&str], &str)] = &[
     ("bshl64", &["n", "n"], "n"),
     ("bshr64", &["n", "n"], "n"),
     ("brot64", &["n", "n"], "n"),
+    // Numeric-pipeline primitives (0.13.0). All tree-bridge eligible; pure
+    // constructors and stack combinators, no FnRef args, no I/O.
+    //
+    // zeros n > L n — list of n zeros (mirror of `ones`).
+    // arange start stop step > L n — half-open range [start, stop) with step.
+    // vstack matrices > L — vertical concat (flat list of rows from each matrix).
+    // hstack matrices > L — horizontal concat (row-wise cat of corresponding rows).
+    // column-stack vecs > L — treat each vector as a column; return a 2-d matrix.
+    // hist xs n_bins > L n — fixed-width histogram; returns list of n_bins counts.
+    ("zeros", &["n"], "L n"),
+    ("arange", &["n", "n", "n"], "L n"),
+    ("vstack", &["list"], "list"),
+    ("hstack", &["list"], "list"),
+    ("column-stack", &["list"], "list"),
+    ("hist", &["list", "n"], "L n"),
 ];
 
 fn builtin_arity(name: &str) -> Option<usize> {

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -917,6 +917,14 @@ pub(crate) fn is_tree_bridge_eligible(b: crate::builtins::Builtin, argc: usize) 
         (Builtin::Bshl64, 2) => true,
         (Builtin::Bshr64, 2) => true,
         (Builtin::Brot64, 2) => true,
+        // Numeric-pipeline primitives (0.13.0). Pure constructors and stack
+        // combinators; no FnRef args, no I/O, no Result wrapper.
+        (Builtin::Zeros, 1) => true,
+        (Builtin::Arange, 3) => true,
+        (Builtin::Vstack, 1) => true,
+        (Builtin::Hstack, 1) => true,
+        (Builtin::ColumnStack, 1) => true,
+        (Builtin::Hist, 2) => true,
         _ => false,
     }
 }
@@ -18089,6 +18097,14 @@ pub(crate) fn tree_bridge_propagates_error(b: crate::builtins::Builtin) -> bool 
             // tokcount: raises ILO-R009 on non-text input. Surface on
             // Cranelift in lockstep rather than degenerating silently to nil.
             | Builtin::Tokcount
+            // Numeric-pipeline primitives (0.13.0). Raise ILO-R009 on bad
+            // inputs; surface on Cranelift in lockstep rather than silently nil.
+            | Builtin::Zeros
+            | Builtin::Arange
+            | Builtin::Vstack
+            | Builtin::Hstack
+            | Builtin::ColumnStack
+            | Builtin::Hist
     )
 }
 

--- a/tests/regression_lset_alias.rs
+++ b/tests/regression_lset_alias.rs
@@ -253,8 +253,8 @@ fn lset_preserves_original_cranelift() {
 // in a foreach loop to in-place-rebuild bins. This is the example program
 // shipped in examples/lset-alias.ilo, exercised here at the harness level
 // across all three engines.
-const HIST_SRC: &str = "hist samples:L n bins:L n>L n;@s samples{c=at bins s;bins=lset bins s +c 1};bins;\
-     main>L n;hist [0,2,1,2,3,1,2,0] [0,0,0,0]";
+const HIST_SRC: &str = "bin-count samples:L n bins:L n>L n;@s samples{c=at bins s;bins=lset bins s +c 1};bins;\
+     main>L n;bin-count [0,2,1,2,3,1,2,0] [0,0,0,0]";
 
 #[test]
 fn lset_histogram_tree() {

--- a/tests/regression_numeric_pipeline.rs
+++ b/tests/regression_numeric_pipeline.rs
@@ -1,0 +1,370 @@
+// Cross-engine regression tests for the numeric-pipeline primitives added in
+// 0.13.0: `arange`, `zeros`, `vstack`, `hstack`, `column-stack`, `hist`.
+//
+// These builtins close the gap between ilo's linear-algebra core and the
+// constructive inputs needed to feed it: OLS ~2.25x compression, histogram
+// ~3x versus the hand-rolled equivalents.
+//
+// All six lower through `is_tree_bridge_eligible`, so the bridge is the same
+// path on every engine; the test fans across tree / register VM / JIT
+// (when built with --features cranelift) anyway to catch any future drift.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn engines() -> Vec<&'static str> {
+    let mut v = vec!["tree", "--vm"];
+    if cfg!(feature = "cranelift") {
+        v.push("--jit");
+    }
+    v
+}
+
+fn run_ok(engine: &str, src: &str, fn_name: &str) -> String {
+    let out = match engine {
+        "tree" => ilo()
+            .args(["run", src, fn_name])
+            .output()
+            .expect("failed to run ilo"),
+        _ => ilo()
+            .args([src, engine, fn_name])
+            .output()
+            .expect("failed to run ilo"),
+    };
+    assert!(
+        out.status.success(),
+        "ilo {engine} failed for `{src}` fn={fn_name}: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn run_err(engine: &str, src: &str, fn_name: &str) -> String {
+    let out = match engine {
+        "tree" => ilo()
+            .args(["run", src, fn_name])
+            .output()
+            .expect("failed to run ilo"),
+        _ => ilo()
+            .args([src, engine, fn_name])
+            .output()
+            .expect("failed to run ilo"),
+    };
+    assert!(
+        !out.status.success(),
+        "ilo {engine} unexpectedly succeeded for `{src}`: stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    String::from_utf8_lossy(&out.stderr).to_string()
+}
+
+// ---------- zeros ----------
+
+#[test]
+fn zeros_basic() {
+    let src = "f>L n;zeros 4";
+    for e in engines() {
+        assert_eq!(run_ok(e, src, "f"), "[0, 0, 0, 0]", "engine={e}");
+    }
+}
+
+#[test]
+fn zeros_empty() {
+    let src = "f>L n;zeros 0";
+    for e in engines() {
+        assert_eq!(run_ok(e, src, "f"), "[]", "engine={e}");
+    }
+}
+
+#[test]
+fn zeros_sums_to_zero() {
+    let src = "f>n;sum (zeros 10)";
+    for e in engines() {
+        assert_eq!(run_ok(e, src, "f"), "0", "engine={e}");
+    }
+}
+
+#[test]
+fn zeros_rejects_negative() {
+    let src = "f>L n;zeros -1";
+    for e in engines() {
+        let err = run_err(e, src, "f");
+        assert!(err.contains("zeros"), "engine={e} err missing 'zeros': {err}");
+    }
+}
+
+#[test]
+fn zeros_rejects_fractional() {
+    let src = "f>L n;zeros 2.5";
+    for e in engines() {
+        let err = run_err(e, src, "f");
+        assert!(
+            err.contains("non-negative integer"),
+            "engine={e} err missing 'non-negative integer': {err}"
+        );
+    }
+}
+
+// ---------- arange ----------
+
+#[test]
+fn arange_basic() {
+    let src = "f>L n;arange 0 5 1";
+    for e in engines() {
+        assert_eq!(run_ok(e, src, "f"), "[0, 1, 2, 3, 4]", "engine={e}");
+    }
+}
+
+#[test]
+fn arange_float_step() {
+    let src = "f>n;len (arange 0 1 0.1)";
+    for e in engines() {
+        assert_eq!(run_ok(e, src, "f"), "10", "engine={e}");
+    }
+}
+
+#[test]
+fn arange_start_ge_stop_empty() {
+    let src = "f>L n;arange 5 5 1";
+    for e in engines() {
+        assert_eq!(run_ok(e, src, "f"), "[]", "engine={e}");
+    }
+}
+
+#[test]
+fn arange_start_gt_stop_empty() {
+    let src = "f>L n;arange 10 5 1";
+    for e in engines() {
+        assert_eq!(run_ok(e, src, "f"), "[]", "engine={e}");
+    }
+}
+
+#[test]
+fn arange_rejects_nonpositive_step() {
+    let src = "f>L n;arange 0 10 0";
+    for e in engines() {
+        let err = run_err(e, src, "f");
+        assert!(
+            err.contains("step must be positive"),
+            "engine={e} err missing 'step must be positive': {err}"
+        );
+    }
+}
+
+#[test]
+fn arange_rejects_negative_step() {
+    let src = "f>L n;arange 0 10 -1";
+    for e in engines() {
+        let err = run_err(e, src, "f");
+        assert!(
+            err.contains("step must be positive"),
+            "engine={e} err missing 'step must be positive': {err}"
+        );
+    }
+}
+
+// ---------- vstack ----------
+
+#[test]
+fn vstack_two_matrices() {
+    // vstack [[1,2],[3,4]] [[5,6]] → 3 rows
+    let src = "f>n;ms=[[1,2],[3,4],[5,6]];a=slc ms 0 2;b=slc ms 2 3;len (vstack [a,b])";
+    for e in engines() {
+        assert_eq!(run_ok(e, src, "f"), "3", "engine={e}");
+    }
+}
+
+#[test]
+fn vstack_single() {
+    let src = "f>L n;vstack [[[1,2],[3,4]]]";
+    for e in engines() {
+        let got = run_ok(e, src, "f");
+        assert_eq!(got, "[[1, 2], [3, 4]]", "engine={e}");
+    }
+}
+
+#[test]
+fn vstack_empty_outer() {
+    let src = "f>L n;vstack []";
+    for e in engines() {
+        assert_eq!(run_ok(e, src, "f"), "[]", "engine={e}");
+    }
+}
+
+#[test]
+fn vstack_rejects_non_list_element() {
+    let src = "f>L n;vstack [42]";
+    for e in engines() {
+        let err = run_err(e, src, "f");
+        assert!(
+            err.contains("vstack"),
+            "engine={e} err missing 'vstack': {err}"
+        );
+    }
+}
+
+// ---------- hstack ----------
+
+#[test]
+fn hstack_two_row_matrices() {
+    // hstack [[[1,2],[3,4]], [[5],[6]]] → [[1,2,5],[3,4,6]]
+    let src = "f>n;a=[[1,2],[3,4]];b=[[5],[6]];m=hstack [a,b];len m";
+    for e in engines() {
+        assert_eq!(run_ok(e, src, "f"), "2", "engine={e}");
+    }
+}
+
+#[test]
+fn hstack_row_width() {
+    let src = "f>n;a=[[1,2],[3,4]];b=[[5],[6]];m=hstack [a,b];len (at m 0)";
+    for e in engines() {
+        assert_eq!(run_ok(e, src, "f"), "3", "engine={e}");
+    }
+}
+
+#[test]
+fn hstack_empty_outer() {
+    let src = "f>L n;hstack []";
+    for e in engines() {
+        assert_eq!(run_ok(e, src, "f"), "[]", "engine={e}");
+    }
+}
+
+#[test]
+fn hstack_rejects_row_count_mismatch() {
+    let src = "f>L n;a=[[1],[2]];b=[[3]];hstack [a,b]";
+    for e in engines() {
+        let err = run_err(e, src, "f");
+        assert!(
+            err.contains("hstack"),
+            "engine={e} err missing 'hstack': {err}"
+        );
+    }
+}
+
+// ---------- column-stack ----------
+
+#[test]
+fn column_stack_two_vectors() {
+    // column-stack [[1,2,3],[4,5,6]] → [[1,4],[2,5],[3,6]]
+    let src = "f>n;m=column-stack [[1,2,3],[4,5,6]];len m";
+    for e in engines() {
+        assert_eq!(run_ok(e, src, "f"), "3", "engine={e}");
+    }
+}
+
+#[test]
+fn column_stack_row_width() {
+    let src = "f>n;m=column-stack [[1,2,3],[4,5,6]];len (at m 0)";
+    for e in engines() {
+        assert_eq!(run_ok(e, src, "f"), "2", "engine={e}");
+    }
+}
+
+#[test]
+fn column_stack_first_element() {
+    let src = "f>n;m=column-stack [[1,2,3],[4,5,6]];at (at m 0) 0";
+    for e in engines() {
+        assert_eq!(run_ok(e, src, "f"), "1", "engine={e}");
+    }
+}
+
+#[test]
+fn column_stack_empty_outer() {
+    let src = "f>L n;column-stack []";
+    for e in engines() {
+        assert_eq!(run_ok(e, src, "f"), "[]", "engine={e}");
+    }
+}
+
+#[test]
+fn column_stack_rejects_length_mismatch() {
+    let src = "f>L n;column-stack [[1,2],[3,4,5]]";
+    for e in engines() {
+        let err = run_err(e, src, "f");
+        assert!(
+            err.contains("column-stack"),
+            "engine={e} err missing 'column-stack': {err}"
+        );
+    }
+}
+
+// ---------- hist ----------
+
+#[test]
+fn hist_basic_counts() {
+    // xs=[0,1,2,3,4], 5 bins of width 1 → each bin has count 1
+    let src = "f>n;sum (hist [0,1,2,3,4] 5)";
+    for e in engines() {
+        assert_eq!(run_ok(e, src, "f"), "5", "engine={e}");
+    }
+}
+
+#[test]
+fn hist_all_same_value() {
+    // All values equal → everything lands in one bin.
+    let src = "f>n;xs=rep 10 5;counts=hist xs 4;at counts 0";
+    for e in engines() {
+        assert_eq!(run_ok(e, src, "f"), "10", "engine={e}");
+    }
+}
+
+#[test]
+fn hist_empty_input() {
+    let src = "f>n;len (hist [] 3)";
+    for e in engines() {
+        assert_eq!(run_ok(e, src, "f"), "3", "engine={e}");
+    }
+}
+
+#[test]
+fn hist_empty_all_zero() {
+    let src = "f>n;sum (hist [] 5)";
+    for e in engines() {
+        assert_eq!(run_ok(e, src, "f"), "0", "engine={e}");
+    }
+}
+
+#[test]
+fn hist_bin_count() {
+    let src = "f>n;len (hist [1,2,3,4,5] 3)";
+    for e in engines() {
+        assert_eq!(run_ok(e, src, "f"), "3", "engine={e}");
+    }
+}
+
+#[test]
+fn hist_rejects_zero_bins() {
+    let src = "f>L n;hist [1,2,3] 0";
+    for e in engines() {
+        let err = run_err(e, src, "f");
+        assert!(
+            err.contains("hist"),
+            "engine={e} err missing 'hist': {err}"
+        );
+    }
+}
+
+#[test]
+fn hist_rejects_negative_bins() {
+    let src = "f>L n;hist [1,2,3] -1";
+    for e in engines() {
+        let err = run_err(e, src, "f");
+        assert!(
+            err.contains("positive integer"),
+            "engine={e} err missing 'positive integer': {err}"
+        );
+    }
+}
+
+#[test]
+fn hist_total_counts_match_input_len() {
+    // Sum of histogram bins must equal len of input.
+    let src = "f>n;xs=arange 0 100 1;sum (hist xs 10)";
+    for e in engines() {
+        assert_eq!(run_ok(e, src, "f"), "100", "engine={e}");
+    }
+}

--- a/tests/regression_numeric_pipeline.rs
+++ b/tests/regression_numeric_pipeline.rs
@@ -92,7 +92,10 @@ fn zeros_rejects_negative() {
     let src = "f>L n;zeros -1";
     for e in engines() {
         let err = run_err(e, src, "f");
-        assert!(err.contains("zeros"), "engine={e} err missing 'zeros': {err}");
+        assert!(
+            err.contains("zeros"),
+            "engine={e} err missing 'zeros': {err}"
+        );
     }
 }
 
@@ -341,10 +344,7 @@ fn hist_rejects_zero_bins() {
     let src = "f>L n;hist [1,2,3] 0";
     for e in engines() {
         let err = run_err(e, src, "f");
-        assert!(
-            err.contains("hist"),
-            "engine={e} err missing 'hist': {err}"
-        );
+        assert!(err.contains("hist"), "engine={e} err missing 'hist': {err}");
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds 6 constructive numeric-pipeline builtins: `zeros`, `arange`, `vstack`, `hstack`, `column-stack`, `hist`
- Closes the numpy-parity gap surfaced by linear-regression, histogram-bin, and monte-carlo personas (~2-3x token compression for OLS and histogram workflows)
- All 6 are tree-bridge eligible; added to `Builtin::ALL` (on-wire stable), `verify.rs` BUILTINS table (arity checked), and Cranelift error-propagation allow-list
- Renames 3 example `hist` user-functions that collide with the new builtin (`bin-count` / `map-hist`)
- 32 new cross-engine regression tests, all green on tree / VM / JIT

## Builtins shipped

| Builtin | Signature | Notes |
|---|---|---|
| `zeros` | `n > L n` | Mirror of `ones` with 0.0 fill |
| `arange` | `start stop step > L n` | Half-open `[start,stop)`, step > 0 |
| `vstack` | `L > L` | Vertical concat (flat list of rows) |
| `hstack` | `L > L` | Horizontal concat (row-wise cat) |
| `column-stack` | `L > L` | Vectors as columns → 2-d matrix |
| `hist` | `L n > L n` | Fixed-width histogram, n_bins counts |

## Test plan

- [x] `cargo test --tests` — all green (pre-existing doctest failure in `verify.rs` is unrelated)
- [x] 32 new tests in `tests/regression_numeric_pipeline.rs` covering happy path, edge cases, and error paths per engine
- [x] Example files updated and examples test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)