### PR TITLE
TCO: emit return_call for OP_TAILCALL in Cranelift JIT and AOT (ILO-15)

### DIFF
--- a/examples/tco-deep.ilo
+++ b/examples/tco-deep.ilo
@@ -1,0 +1,17 @@
+-- Guaranteed-depth tail-call elimination: 1 000 000 recursive steps without
+-- host-stack growth on every engine (tree, VM, JIT, AOT).
+--
+-- Tree:      trampolines tail calls in the interpreter.
+-- VM:        OP_TAILCALL reuses the current CallFrame.
+-- JIT/AOT:   `return_call` (CallConv::Tail) eliminates the stack frame.
+--
+-- A default ulimit stack (8 MiB) holds roughly 8–80 k ordinary frames
+-- depending on frame size. Without TCO, `count-down 1000000` would overflow.
+-- With TCO the depth is O(1) in host-stack space.
+
+count-down n:n>n;=n 0 0;count-down -n 1
+
+main >n;count-down 1000000
+
+-- run: main
+-- out: 0

--- a/examples/tco-vm-deep.ilo
+++ b/examples/tco-vm-deep.ilo
@@ -1,19 +1,13 @@
--- Deep tail-call elimination on the bytecode VM. Pre-OP_TAILCALL the VM
--- pushed a fresh CallFrame on every user-fn call, so a 1M-deep count-down
--- allocated 1M frame entries plus the register windows that go with them.
--- With OP_TAILCALL the runtime reuses the current frame: a recursion that
--- only calls in tail position runs in constant frame memory regardless of
--- depth.
---
--- The Cranelift JIT/AOT path will gain matching `return_call` lowering in
--- the next PR; until then this example skips those engines and runs on
--- the tree interpreter (trampolined) and the VM (OP_TAILCALL).
+-- Deep tail-call elimination across all four engines. The VM uses
+-- OP_TAILCALL (frame reuse); the Cranelift JIT/AOT backend emits
+-- `return_call` with CallConv::Tail so the host stack does not grow.
+-- Both self-recursion and mutual tail recursion are exercised.
 
 count-down n:n>n;=n 0 0;count-down -n 1
 
 -- Mutual tail recursion: ev tail-calls od tail-calls ev forever. Exercises
--- OP_TAILCALL's chunk_idx switch, the reused frame's chunk pointer flips
--- between the two functions every iteration.
+-- OP_TAILCALL's chunk_idx switch on the VM and cross-function `return_call`
+-- on Cranelift.
 ev n:n>n;=n 0 1;od -n 1
 od n:n>n;=n 0 0;ev -n 1
 
@@ -21,8 +15,6 @@ main >n;count-down 200000
 
 ev-200k >n;ev 200000
 
--- engine-skip: jit
--- engine-skip: cranelift
 -- run: main
 -- out: 0
 -- run: ev-200k

--- a/src/vm/compile_cranelift.rs
+++ b/src/vm/compile_cranelift.rs
@@ -12,6 +12,7 @@ use super::*;
 use cranelift_codegen::Context;
 use cranelift_codegen::ir::types::{F64, I32, I64};
 use cranelift_codegen::ir::{AbiParam, InstBuilder, MemFlags};
+use cranelift_codegen::isa::CallConv;
 use cranelift_codegen::settings::{self, Configurable};
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext, Variable};
 use cranelift_module::{FuncId, Linkage, Module, default_libcall_names};
@@ -606,6 +607,10 @@ pub fn compile_to_binary(
     flag_builder
         .set("is_pic", "true")
         .map_err(|e| e.to_string())?;
+    // CallConv::Tail requires frame pointers to be preserved.
+    flag_builder
+        .set("preserve_frame_pointers", "true")
+        .map_err(|e| e.to_string())?;
     let isa_builder = cranelift_native::builder().map_err(|e| e.to_string())?;
     let isa = isa_builder
         .finish(settings::Flags::new(flag_builder))
@@ -623,11 +628,14 @@ pub fn compile_to_binary(
     // Declare all runtime helpers as imports (resolved at link time from libilo.a)
     let helpers = declare_all_helpers(&mut module);
 
-    // First pass: declare all functions to get FuncIds
+    // First pass: declare all functions to get FuncIds.
+    // All ilo functions use CallConv::Tail so that OP_TAILCALL can emit
+    // `return_call` for true stack-growth-free tail-call elimination.
     let mut func_ids: Vec<FuncId> = Vec::with_capacity(program.chunks.len());
     for (i, chunk) in program.chunks.iter().enumerate() {
         let name = format!("ilo_{}", program.func_names[i]);
         let mut sig = module.make_signature();
+        sig.call_conv = CallConv::Tail;
         for _ in 0..chunk.param_count {
             sig.params.push(AbiParam::new(I64));
         }
@@ -658,8 +666,51 @@ pub fn compile_to_binary(
         )?;
     }
 
-    let entry_func_id = func_ids[entry_idx];
+    // Emit a thin SystemV trampoline for the entry ilo function.
+    // All ilo functions use CallConv::Tail, but `main` (and the C runtime) calls
+    // them using the SystemV ABI.  The trampoline converts SystemV arguments to the
+    // Tail calling convention by forwarding them with a regular `call`.
     let entry_chunk = &program.chunks[entry_idx];
+    let entry_param_count = entry_chunk.param_count as usize;
+    let entry_func_id = {
+        let tramp_name = format!("ilo_{}_entry", program.func_names[entry_idx]);
+        let mut sig = module.make_signature();
+        // Default call_conv is SystemV — matches `extern "C"` / OS calling convention
+        for _ in 0..entry_param_count {
+            sig.params.push(AbiParam::new(I64));
+        }
+        sig.returns.push(AbiParam::new(I64));
+        let tramp_id = module
+            .declare_function(&tramp_name, Linkage::Local, &sig)
+            .map_err(|e| e.to_string())?;
+
+        let mut ctx = Context::new();
+        ctx.func.signature = sig;
+        let mut fn_builder_ctx = FunctionBuilderContext::new();
+        let mut builder = FunctionBuilder::new(&mut ctx.func, &mut fn_builder_ctx);
+
+        let entry_block = builder.create_block();
+        builder.append_block_params_for_function_params(entry_block);
+        builder.switch_to_block(entry_block);
+        builder.seal_block(entry_block);
+
+        let args: Vec<_> = (0..entry_param_count)
+            .map(|i| builder.block_params(entry_block)[i])
+            .collect();
+
+        let target_fref = module.declare_func_in_func(func_ids[entry_idx], builder.func);
+        let call_inst = builder.ins().call(target_fref, &args);
+        let result = builder.inst_results(call_inst)[0];
+        builder.ins().return_(&[result]);
+
+        builder.seal_all_blocks();
+        builder.finalize();
+
+        module
+            .define_function(tramp_id, &mut ctx)
+            .map_err(|e| e.to_string())?;
+        tramp_id
+    };
 
     // Serialize the type registry for embedding in the binary
     let registry_bytes = serialize_type_registry(&program.type_registry);
@@ -1030,6 +1081,7 @@ fn compile_function_body(
     program: Option<&CompiledProgram>,
 ) -> Result<(), String> {
     let mut sig = module.make_signature();
+    sig.call_conv = CallConv::Tail;
     for _ in 0..chunk.param_count {
         sig.params.push(AbiParam::new(I64));
     }
@@ -3804,13 +3856,10 @@ fn compile_function_body(
                 // fast path in the OP_MSET handler.
                 //
                 // OP_TAILCALL: emitted by the VM compiler when a call sits
-                // in tail position. The bytecode VM reuses the current call
-                // frame (no stack growth); the Cranelift backend lowers it
-                // as a regular call here — semantically equivalent (same
-                // return value flows back through the next OP_RET) but the
-                // host stack grows by one frame per tail call. PR3 of the
-                // TCO series will switch this to Cranelift's `return_call`
-                // for true tail-call elimination under the JIT/AOT path.
+                // in tail position. The Cranelift backend lowers it as
+                // `return_call` — a terminator that reuses the current stack
+                // frame for true TCO. Both caller and callee use CallConv::Tail,
+                // satisfying the ABI requirement for `return_call`.
                 let a = ((inst >> 16) & 0xFF) as u8;
                 let bx = (inst & 0xFFFF) as usize;
                 let func_idx = bx >> 8;
@@ -3894,16 +3943,23 @@ fn compile_function_body(
                             builder.def_var(result_var, result);
                         }
                     } else {
-                        // Direct call: the target function is compiled in this module
+                        // Direct call: the target function is compiled in this module.
+                        // For OP_TAILCALL emit `return_call` (a Cranelift terminator)
+                        // so the callee reuses this frame — true TCO with no stack growth.
                         let target_fid = fids[func_idx];
                         let target_fref = get_func_ref(&mut builder, module, target_fid);
                         let mut call_args = Vec::with_capacity(n_args);
                         for i in 0..n_args {
                             call_args.push(builder.use_var(vars[a_idx_call + 1 + i]));
                         }
-                        let call_inst = builder.ins().call(target_fref, &call_args);
-                        let result = builder.inst_results(call_inst)[0];
-                        builder.def_var(vars[a_idx_call], result);
+                        if op == OP_TAILCALL {
+                            builder.ins().return_call(target_fref, &call_args);
+                            block_terminated = true;
+                        } else {
+                            let call_inst = builder.ins().call(target_fref, &call_args);
+                            let result = builder.inst_results(call_inst)[0];
+                            builder.def_var(vars[a_idx_call], result);
+                        }
                     }
                 } else {
                     // Fallback: use jit_call helper (should not happen if all_func_ids is provided)
@@ -3943,8 +3999,9 @@ fn compile_function_body(
                     }
                 }
                 // Update F64 shadow so arithmetic ops can skip bitcast when using this
-                // register as input.
-                if a_idx_call < reg_count && reg_always_num[a_idx_call] {
+                // register as input.  Skip when the block was terminated by a
+                // `return_call` (OP_TAILCALL path) — no further IR is allowed.
+                if !block_terminated && a_idx_call < reg_count && reg_always_num[a_idx_call] {
                     let rv = builder.use_var(vars[a_idx_call]);
                     let rf = builder.ins().bitcast(F64, mf, rv);
                     builder.def_var(f64_vars[a_idx_call], rf);
@@ -4809,6 +4866,10 @@ pub fn compile_to_bench_binary(
     flag_builder
         .set("is_pic", "true")
         .map_err(|e| e.to_string())?;
+    // CallConv::Tail requires frame pointers to be preserved.
+    flag_builder
+        .set("preserve_frame_pointers", "true")
+        .map_err(|e| e.to_string())?;
     let isa_builder = cranelift_native::builder().map_err(|e| e.to_string())?;
     let isa = isa_builder
         .finish(settings::Flags::new(flag_builder))
@@ -4820,22 +4881,21 @@ pub fn compile_to_bench_binary(
 
     let helpers = declare_all_helpers(&mut module);
 
-    // First pass: declare all functions to get FuncIds
+    // First pass: declare all functions to get FuncIds.
+    // All ilo functions use CallConv::Tail for `return_call` TCO support.
+    // Use `ilo_{name}_inner` to avoid a name clash with the SystemV trampoline
+    // that will be exported as `ilo_{name}` in the third pass below.
     let mut func_ids: Vec<FuncId> = Vec::with_capacity(program.chunks.len());
     for (i, chunk) in program.chunks.iter().enumerate() {
-        let name = format!("ilo_{}", program.func_names[i]);
-        let linkage = if i == entry_idx {
-            Linkage::Export
-        } else {
-            Linkage::Local
-        };
+        let name = format!("ilo_{}_inner", program.func_names[i]);
         let mut sig = module.make_signature();
+        sig.call_conv = CallConv::Tail;
         for _ in 0..chunk.param_count {
             sig.params.push(AbiParam::new(I64));
         }
         sig.returns.push(AbiParam::new(I64));
         let fid = module
-            .declare_function(&name, linkage, &sig)
+            .declare_function(&name, Linkage::Local, &sig)
             .map_err(|e| e.to_string())?;
         func_ids.push(fid);
     }
@@ -4847,7 +4907,7 @@ pub fn compile_to_bench_binary(
         .zip(program.nan_constants.iter())
         .enumerate()
     {
-        let name = format!("ilo_{}", program.func_names[i]);
+        let name = format!("ilo_{}_inner", program.func_names[i]);
         compile_function_body(
             &mut module,
             chunk,
@@ -4860,17 +4920,55 @@ pub fn compile_to_bench_binary(
         )?;
     }
 
+    // Third pass: emit a SystemV trampoline exported under `ilo_{name}` so the
+    // C bench harness can call it with the standard C ABI.
+    let entry_chunk = &program.chunks[entry_idx];
+    let param_count = entry_chunk.param_count as usize;
+    let func_name = format!("ilo_{}", entry_func);
+    {
+        let mut sig = module.make_signature();
+        // Default call_conv is SystemV
+        for _ in 0..param_count {
+            sig.params.push(AbiParam::new(I64));
+        }
+        sig.returns.push(AbiParam::new(I64));
+        let tramp_id = module
+            .declare_function(&func_name, Linkage::Export, &sig)
+            .map_err(|e| e.to_string())?;
+
+        let mut ctx = Context::new();
+        ctx.func.signature = sig;
+        let mut fn_builder_ctx = FunctionBuilderContext::new();
+        let mut builder = FunctionBuilder::new(&mut ctx.func, &mut fn_builder_ctx);
+
+        let entry_block = builder.create_block();
+        builder.append_block_params_for_function_params(entry_block);
+        builder.switch_to_block(entry_block);
+        builder.seal_block(entry_block);
+
+        let args: Vec<_> = (0..param_count)
+            .map(|i| builder.block_params(entry_block)[i])
+            .collect();
+
+        let target_fref = module.declare_func_in_func(func_ids[entry_idx], builder.func);
+        let call_inst = builder.ins().call(target_fref, &args);
+        let result = builder.inst_results(call_inst)[0];
+        builder.ins().return_(&[result]);
+
+        builder.seal_all_blocks();
+        builder.finalize();
+
+        module
+            .define_function(tramp_id, &mut ctx)
+            .map_err(|e| e.to_string())?;
+    }
+
     // Emit object file
     let obj_product = module.finish();
     let obj_bytes = obj_product.emit().map_err(|e| e.to_string())?;
     let obj_path = format!("{}.o", output_path);
     std::fs::write(&obj_path, &obj_bytes)
         .map_err(|e| format!("failed to write object file: {}", e))?;
-
-    // Generate C bench harness
-    let entry_chunk = &program.chunks[entry_idx];
-    let param_count = entry_chunk.param_count as usize;
-    let func_name = format!("ilo_{}", entry_func);
     let bench_c_path = format!("{}_bench.c", output_path);
     // Serialize registry for embedding in C harness
     let registry_bytes = serialize_type_registry(&program.type_registry);
@@ -5209,6 +5307,8 @@ mod tests {
         let mut flag_builder = settings::builder();
         flag_builder.set("opt_level", "speed").unwrap();
         flag_builder.set("is_pic", "true").unwrap();
+        // CallConv::Tail requires frame pointers to be preserved.
+        flag_builder.set("preserve_frame_pointers", "true").unwrap();
         let isa_builder = cranelift_native::builder().unwrap();
         let isa = isa_builder
             .finish(settings::Flags::new(flag_builder))
@@ -5225,11 +5325,12 @@ mod tests {
         let mut module = make_module();
         let helpers = declare_all_helpers(&mut module);
 
-        // First pass: declare all functions
+        // First pass: declare all functions (with CallConv::Tail to match compile_function_body)
         let mut func_ids: Vec<FuncId> = Vec::with_capacity(compiled.chunks.len());
         for (i, chunk) in compiled.chunks.iter().enumerate() {
             let name = format!("ilo_{}", compiled.func_names[i]);
             let mut sig = module.make_signature();
+            sig.call_conv = CallConv::Tail;
             for _ in 0..chunk.param_count {
                 sig.params.push(cranelift_codegen::ir::AbiParam::new(
                     cranelift_codegen::ir::types::I64,
@@ -6330,6 +6431,7 @@ f a:t b:t>t;join a b"#,
             for (i, chunk) in compiled.chunks.iter().enumerate() {
                 let name = format!("ilo_{}", compiled.func_names[i]);
                 let mut sig = module.make_signature();
+                sig.call_conv = CallConv::Tail;
                 for _ in 0..chunk.param_count {
                     sig.params.push(cranelift_codegen::ir::AbiParam::new(
                         cranelift_codegen::ir::types::I64,
@@ -6988,12 +7090,13 @@ f a:t b:t>t;join a b"#,
         let mut module = make_module();
         let helpers = declare_all_helpers(&mut module);
 
-        // Declare the helper function so OP_CALL can reference it
+        // Declare the helper function so OP_CALL can reference it (CallConv::Tail to match body)
         let mut all_func_ids = Vec::new();
         for (i, c) in compiled.chunks.iter().enumerate() {
             let name = format!("ilo_{}", compiled.func_names[i]);
             let linkage = cranelift_module::Linkage::Local;
             let mut sig = module.make_signature();
+            sig.call_conv = CallConv::Tail;
             for _ in 0..c.param_count {
                 sig.params.push(cranelift_codegen::ir::AbiParam::new(
                     cranelift_codegen::ir::types::I64,
@@ -7039,8 +7142,9 @@ f a:t b:t>t;join a b"#,
         let mut module = make_module();
         let helpers = declare_all_helpers(&mut module);
 
-        // Declare only f's func_id (need to declare it to get a FuncId)
+        // Declare only f's func_id (need to declare it to get a FuncId, CallConv::Tail)
         let mut sig = module.make_signature();
+        sig.call_conv = CallConv::Tail;
         for _ in 0..chunk.param_count {
             sig.params.push(cranelift_codegen::ir::AbiParam::new(
                 cranelift_codegen::ir::types::I64,
@@ -7056,6 +7160,7 @@ f a:t b:t>t;join a b"#,
             .position(|n| n == "helper")
             .unwrap();
         let mut helper_sig = module.make_signature();
+        helper_sig.call_conv = CallConv::Tail;
         for _ in 0..compiled.chunks[helper_idx].param_count {
             helper_sig.params.push(cranelift_codegen::ir::AbiParam::new(
                 cranelift_codegen::ir::types::I64,
@@ -7104,6 +7209,7 @@ f a:t b:t>t;join a b"#,
         let helpers = declare_all_helpers(&mut module);
 
         let mut sig = module.make_signature();
+        sig.call_conv = CallConv::Tail;
         sig.returns.push(cranelift_codegen::ir::AbiParam::new(
             cranelift_codegen::ir::types::I64,
         ));

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -4552,24 +4552,19 @@ fn compile_function_body(
                             // (the inliner mirrors what the tree walker
                             // would have called the caller, not the
                             // callee).
-                            let push_call_emitted =
-                                if let Some(name) = program.func_names.get(func_idx)
-                                    && !name.is_empty()
-                                {
-                                    let name_ptr =
-                                        builder.ins().iconst(I64, name.as_ptr() as i64);
-                                    let name_len =
-                                        builder.ins().iconst(I64, name.len() as i64);
-                                    let push_fref = get_func_ref(
-                                        &mut builder,
-                                        module,
-                                        helpers.push_call_frame,
-                                    );
-                                    builder.ins().call(push_fref, &[name_ptr, name_len]);
-                                    true
-                                } else {
-                                    false
-                                };
+                            let push_call_emitted = if let Some(name) =
+                                program.func_names.get(func_idx)
+                                && !name.is_empty()
+                            {
+                                let name_ptr = builder.ins().iconst(I64, name.as_ptr() as i64);
+                                let name_len = builder.ins().iconst(I64, name.len() as i64);
+                                let push_fref =
+                                    get_func_ref(&mut builder, module, helpers.push_call_frame);
+                                builder.ins().call(push_fref, &[name_ptr, name_len]);
+                                true
+                            } else {
+                                false
+                            };
 
                             let call_inst = builder.ins().call(target_fref, &call_args);
                             call_result = builder.inst_results(call_inst)[0];
@@ -4583,11 +4578,8 @@ fn compile_function_body(
                             // is the *caller's* responsibility to propagate
                             // via its own RET sequence.)
                             if push_call_emitted {
-                                let pop_fref = get_func_ref(
-                                    &mut builder,
-                                    module,
-                                    helpers.pop_call_frame,
-                                );
+                                let pop_fref =
+                                    get_func_ref(&mut builder, module, helpers.pop_call_frame);
                                 builder.ins().call(pop_fref, &[]);
                             }
                         }
@@ -5205,10 +5197,7 @@ fn compile_program(program: &CompiledProgram, entry_idx: usize) -> Option<JitFun
     // to the real ilo entry function using a regular `call`, then returns the result.
     let entry_param_count = program.chunks[entry_idx].param_count as usize;
     let trampoline_fid = {
-        let tramp_name = format!(
-            "ilo_{}_trampoline",
-            program.func_names[entry_idx]
-        );
+        let tramp_name = format!("ilo_{}_trampoline", program.func_names[entry_idx]);
         let mut sig = module.make_signature();
         // sig.call_conv defaults to SystemV — the ABI Rust uses for extern "C"
         for _ in 0..entry_param_count {

--- a/src/vm/jit_cranelift.rs
+++ b/src/vm/jit_cranelift.rs
@@ -9,6 +9,7 @@ use super::*;
 use cranelift_codegen::Context;
 use cranelift_codegen::ir::types::{F64, I64};
 use cranelift_codegen::ir::{AbiParam, InstBuilder};
+use cranelift_codegen::isa::CallConv;
 use cranelift_codegen::settings::{self, Configurable};
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext, Variable};
 use cranelift_jit::{JITBuilder, JITModule};
@@ -928,8 +929,11 @@ fn compile_function_body(
     all_func_ids: &[FuncId],
     program: &CompiledProgram,
 ) -> Option<()> {
-    // Build function signature: (i64, i64, ...) -> i64
+    // Build function signature: (i64, i64, ...) -> i64 with CallConv::Tail so that
+    // OP_TAILCALL sites can emit `return_call` (which requires both caller and callee
+    // to use the Tail calling convention).
     let mut sig = module.make_signature();
+    sig.call_conv = CallConv::Tail;
     for _ in 0..chunk.param_count {
         sig.params.push(AbiParam::new(I64));
     }
@@ -4427,13 +4431,14 @@ fn compile_function_body(
                 // referenced again.
                 //
                 // OP_TAILCALL: bytecode-VM tail-call elimination opcode.
-                // For Cranelift we lower it identically to OP_CALL for
-                // now — semantically correct (the callee's return value
-                // flows back to be returned by the next OP_RET), but the
-                // host stack still grows by one frame per call. PR3 of
-                // the TCO series will switch this to Cranelift's
-                // `return_call` for true tail-call elimination, lifting
-                // the JIT/AOT host-stack bound to match the VM.
+                // For Cranelift we emit `return_call` (a terminator) so the
+                // callee reuses the caller's stack frame — true TCO with no
+                // host-stack growth. Both caller and callee use CallConv::Tail,
+                // which is required for `return_call`. Inlinable callees skip
+                // this path (they are inlined directly, so TCO is automatic).
+                // The `jit_call` fallback path cannot use `return_call` because
+                // the helper uses SystemV; that path is only hit for out-of-range
+                // func indices which should not occur in well-formed programs.
                 let a = ((inst >> 16) & 0xFF) as u8;
                 let bx = (inst & 0xFFFF) as usize;
                 let func_idx = bx >> 8;
@@ -4527,44 +4532,64 @@ fn compile_function_body(
                             call_args.push(builder.use_var(vars[a_idx_call + 1 + i]));
                         }
 
-                        // Push the callee's name onto the per-thread JIT
-                        // call stack so a runtime error surfaced from
-                        // inside the callee carries call_stack notes
-                        // matching VM/tree output. We only push for
-                        // non-inlined calls because inlined callees fuse
-                        // into the caller's IR — they do not constitute
-                        // a separate frame in the VM/tree model either
-                        // (the inliner mirrors what the tree walker
-                        // would have called the caller, not the
-                        // callee).
-                        let push_call_emitted = if let Some(name) = program.func_names.get(func_idx)
-                            && !name.is_empty()
-                        {
-                            let name_ptr = builder.ins().iconst(I64, name.as_ptr() as i64);
-                            let name_len = builder.ins().iconst(I64, name.len() as i64);
-                            let push_fref =
-                                get_func_ref(&mut builder, module, helpers.push_call_frame);
-                            builder.ins().call(push_fref, &[name_ptr, name_len]);
-                            true
+                        if op == OP_TAILCALL {
+                            // True tail-call elimination: emit `return_call` which is a
+                            // Cranelift terminator that reuses the current stack frame.
+                            // Both caller and callee use CallConv::Tail, satisfying the
+                            // ABI requirement. The call-stack push/pop is omitted because
+                            // the frame is replaced, not nested — there is no "return to
+                            // caller" so no pop is needed.
+                            builder.ins().return_call(target_fref, &call_args);
+                            block_terminated = true;
                         } else {
-                            false
-                        };
+                            // Push the callee's name onto the per-thread JIT
+                            // call stack so a runtime error surfaced from
+                            // inside the callee carries call_stack notes
+                            // matching VM/tree output. We only push for
+                            // non-inlined calls because inlined callees fuse
+                            // into the caller's IR — they do not constitute
+                            // a separate frame in the VM/tree model either
+                            // (the inliner mirrors what the tree walker
+                            // would have called the caller, not the
+                            // callee).
+                            let push_call_emitted =
+                                if let Some(name) = program.func_names.get(func_idx)
+                                    && !name.is_empty()
+                                {
+                                    let name_ptr =
+                                        builder.ins().iconst(I64, name.as_ptr() as i64);
+                                    let name_len =
+                                        builder.ins().iconst(I64, name.len() as i64);
+                                    let push_fref = get_func_ref(
+                                        &mut builder,
+                                        module,
+                                        helpers.push_call_frame,
+                                    );
+                                    builder.ins().call(push_fref, &[name_ptr, name_len]);
+                                    true
+                                } else {
+                                    false
+                                };
 
-                        let call_inst = builder.ins().call(target_fref, &call_args);
-                        call_result = builder.inst_results(call_inst)[0];
-                        builder.def_var(vars[a_idx_call], call_result);
+                            let call_inst = builder.ins().call(target_fref, &call_args);
+                            call_result = builder.inst_results(call_inst)[0];
+                            builder.def_var(vars[a_idx_call], call_result);
 
-                        // Pop on the success path. On the error path the
-                        // post-call check in `jit_cranelift::call` will
-                        // snapshot the stack before unwinding, so we do
-                        // not need to pop in that case. (The callee
-                        // returned normally here: any helper-set error
-                        // is the *caller's* responsibility to propagate
-                        // via its own RET sequence.)
-                        if push_call_emitted {
-                            let pop_fref =
-                                get_func_ref(&mut builder, module, helpers.pop_call_frame);
-                            builder.ins().call(pop_fref, &[]);
+                            // Pop on the success path. On the error path the
+                            // post-call check in `jit_cranelift::call` will
+                            // snapshot the stack before unwinding, so we do
+                            // not need to pop in that case. (The callee
+                            // returned normally here: any helper-set error
+                            // is the *caller's* responsibility to propagate
+                            // via its own RET sequence.)
+                            if push_call_emitted {
+                                let pop_fref = get_func_ref(
+                                    &mut builder,
+                                    module,
+                                    helpers.pop_call_frame,
+                                );
+                                builder.ins().call(pop_fref, &[]);
+                            }
                         }
                     } // end else (not inlined)
                 } else {
@@ -4605,8 +4630,9 @@ fn compile_function_body(
                     }
                 }
                 // Update F64 shadow so arithmetic ops can skip bitcast when using this
-                // register as input.
-                if a_idx_call < reg_count && reg_always_num[a_idx_call] {
+                // register as input.  Skip when the block was terminated by a
+                // `return_call` (OP_TAILCALL path) — no further IR is allowed.
+                if !block_terminated && a_idx_call < reg_count && reg_always_num[a_idx_call] {
                     let mf = cranelift_codegen::ir::MemFlags::new();
                     let rv = builder.use_var(vars[a_idx_call]);
                     let rf = builder.ins().bitcast(F64, mf, rv);
@@ -5125,6 +5151,9 @@ pub fn compile(
 fn compile_program(program: &CompiledProgram, entry_idx: usize) -> Option<JitFunction> {
     let mut flag_builder = settings::builder();
     flag_builder.set("opt_level", "speed").ok()?;
+    // CallConv::Tail requires frame pointers to be preserved so that the
+    // backend can construct the tail-call frame correctly.
+    flag_builder.set("preserve_frame_pointers", "true").ok()?;
     let isa_builder = cranelift_native::builder().ok()?;
     let isa = isa_builder
         .finish(settings::Flags::new(flag_builder))
@@ -5135,11 +5164,14 @@ fn compile_program(program: &CompiledProgram, entry_idx: usize) -> Option<JitFun
     let mut module = JITModule::new(jit_builder);
     let helpers = declare_all_helpers(&mut module);
 
-    // First pass: declare ALL functions in the module
+    // First pass: declare ALL functions in the module.
+    // All ilo functions use CallConv::Tail so that OP_TAILCALL sites can emit
+    // `return_call` for true stack-growth-free tail-call elimination.
     let mut func_ids = Vec::with_capacity(program.chunks.len());
     for (i, chunk) in program.chunks.iter().enumerate() {
         let name = format!("ilo_{}", program.func_names[i]);
         let mut sig = module.make_signature();
+        sig.call_conv = CallConv::Tail;
         for _ in 0..chunk.param_count {
             sig.params.push(AbiParam::new(I64));
         }
@@ -5166,11 +5198,57 @@ fn compile_program(program: &CompiledProgram, entry_idx: usize) -> Option<JitFun
         )?;
     }
 
+    // Third pass: emit a thin SystemV ("extern C") trampoline for the entry function.
+    // All ilo functions above use CallConv::Tail, which uses different parameter
+    // registers than SystemV.  Rust calls into JIT code via `extern "C"` fn pointers
+    // (SystemV), so we need this bridge.  The trampoline simply forwards all arguments
+    // to the real ilo entry function using a regular `call`, then returns the result.
+    let entry_param_count = program.chunks[entry_idx].param_count as usize;
+    let trampoline_fid = {
+        let tramp_name = format!(
+            "ilo_{}_trampoline",
+            program.func_names[entry_idx]
+        );
+        let mut sig = module.make_signature();
+        // sig.call_conv defaults to SystemV — the ABI Rust uses for extern "C"
+        for _ in 0..entry_param_count {
+            sig.params.push(AbiParam::new(I64));
+        }
+        sig.returns.push(AbiParam::new(I64));
+        let fid = module
+            .declare_function(&tramp_name, Linkage::Local, &sig)
+            .ok()?;
+
+        let mut ctx = Context::new();
+        ctx.func.signature = sig;
+        let mut fn_builder_ctx = FunctionBuilderContext::new();
+        let mut builder = FunctionBuilder::new(&mut ctx.func, &mut fn_builder_ctx);
+
+        let entry_block = builder.create_block();
+        builder.append_block_params_for_function_params(entry_block);
+        builder.switch_to_block(entry_block);
+        builder.seal_block(entry_block);
+
+        let args: Vec<_> = (0..entry_param_count)
+            .map(|i| builder.block_params(entry_block)[i])
+            .collect();
+
+        let target_fref = module.declare_func_in_func(func_ids[entry_idx], builder.func);
+        let call_inst = builder.ins().call(target_fref, &args);
+        let result = builder.inst_results(call_inst)[0];
+        builder.ins().return_(&[result]);
+
+        builder.seal_all_blocks();
+        builder.finalize();
+
+        module.define_function(fid, &mut ctx).ok()?;
+        fid
+    };
+
     module.finalize_definitions().ok()?;
 
-    let entry_func_id = func_ids[entry_idx];
-    let func_ptr = module.get_finalized_function(entry_func_id);
-    let param_count = program.chunks[entry_idx].param_count as usize;
+    let func_ptr = module.get_finalized_function(trampoline_fid);
+    let param_count = entry_param_count;
 
     Some(JitFunction {
         _module: module,
@@ -5184,8 +5262,9 @@ fn compile_program(program: &CompiledProgram, entry_idx: usize) -> Option<JitFun
 /// # Safety (internal)
 /// Each `transmute` casts the JIT function pointer to a typed `extern "C"` fn.
 /// This is sound because:
-/// 1. `compile()` generates code using the SystemV/Win64 C calling convention
-///    (Cranelift's `CallConv::SystemV` / platform default).
+/// 1. `compile()` generates a SystemV trampoline as the entry point; all ilo
+///    functions use `CallConv::Tail` internally, but the exported function
+///    pointer points to the trampoline which uses the SystemV/Win64 C ABI.
 /// 2. All parameters and the return value are `u64` (NanVal bit patterns),
 ///    matching the `I64` Cranelift type used for every parameter and return.
 /// 3. The function pointer is obtained from `module.get_finalized_function()`

--- a/tests/regression_tco_jit.rs
+++ b/tests/regression_tco_jit.rs
@@ -20,7 +20,11 @@ fn run_jit(src: &str, entry: &str, args: &[&str]) -> String {
         cmd.arg(a);
     }
     let out = cmd.output().expect("ilo --jit failed to spawn");
-    assert!(out.status.success(), "jit exited non-zero: {:?}", out.status);
+    assert!(
+        out.status.success(),
+        "jit exited non-zero: {:?}",
+        out.status
+    );
     String::from_utf8_lossy(&out.stdout).trim().to_string()
 }
 

--- a/tests/regression_tco_jit.rs
+++ b/tests/regression_tco_jit.rs
@@ -1,0 +1,54 @@
+//! Regression tests for Cranelift JIT tail-call elimination via `return_call`.
+//!
+//! PR3 of the TCO series migrates all JIT-compiled ilo functions to
+//! `CallConv::Tail` and emits `return_call` at every `OP_TAILCALL` site.
+//! These tests confirm that deep tail-recursive programs run to completion
+//! on the JIT engine without stack overflow.
+
+#![cfg(feature = "cranelift")]
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run_jit(src: &str, entry: &str, args: &[&str]) -> String {
+    let mut cmd = ilo();
+    cmd.args(["--jit", src, entry]);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("ilo --jit failed to spawn");
+    assert!(out.status.success(), "jit exited non-zero: {:?}", out.status);
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Self-recursive tail call, 200 000 deep — would overflow stack without TCO.
+#[test]
+fn tco_jit_countdown_200k() {
+    let src = "count-down n:n>n;=n 0 0;count-down -n 1\nmain>n;count-down 200000";
+    assert_eq!(run_jit(src, "main", &[]), "0");
+}
+
+/// Self-recursive tail call, 1 000 000 deep.
+#[test]
+fn tco_jit_countdown_1m() {
+    let src = "count-down n:n>n;=n 0 0;count-down -n 1\nmain>n;count-down 1000000";
+    assert_eq!(run_jit(src, "main", &[]), "0");
+}
+
+/// Mutual tail recursion (ev ↔ od), 200 000 steps.
+#[test]
+fn tco_jit_mutual_200k() {
+    let src = "ev n:n>n;=n 0 1;od -n 1\nod n:n>n;=n 0 0;ev -n 1\nev200k>n;ev 200000";
+    assert_eq!(run_jit(src, "ev200k", &[]), "1");
+}
+
+/// Self-recursive accumulator (mysum), exercises a numeric arg pair.
+#[test]
+fn tco_jit_sum_accumulator_100k() {
+    // sum from 1 to 100000 = 5000050000; tail-recursive accumulator pattern.
+    let src = "mysum n:n acc:n>n;=n 0 acc;mysum -n 1 +acc n\nmain>n;mysum 100000 0";
+    assert_eq!(run_jit(src, "main", &[]), "5000050000");
+}


### PR DESCRIPTION
## Summary

- Migrates all JIT/AOT-compiled ilo functions to `CallConv::Tail` so that `return_call` can be emitted at every `OP_TAILCALL` site — the Cranelift counterpart to the VM's `OP_TAILCALL` frame-reuse
- Adds `preserve_frame_pointers` to the Cranelift settings (required by `CallConv::Tail` in 0.116)
- Adds `extern "C"` / SystemV trampolines at each JIT/AOT entry point so Rust and C callers continue to use stable ABI; the trampolines bridge SystemV → Tail with a regular `call`, then return the result
- Removes `engine-skip: jit` / `engine-skip: cranelift` from `tco-vm-deep.ilo` — deep mutual and self-recursive tail calls now pass on all four engines
- Adds `examples/tco-deep.ilo`: 1 000 000-deep self-recursive countdown, all engines
- Adds `tests/regression_tco_jit.rs`: 200k countdown, 1M countdown, mutual 200k, accumulator 100k on `--jit`

Resolves ILO-15.

## Test plan

- [ ] `cargo test --features cranelift` passes (3342 lib + all integration tests)
- [ ] `regression_tco_jit`: 4 new JIT TCO regression tests pass
- [ ] `examples/tco-deep.ilo` runs to completion on all engines
- [ ] No stack overflow at 1M depth with `--jit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)