### PR TITLE
hotfix(parser): brace-lambda detection requires param ident before `>`

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5126,6 +5126,12 @@ For variable-position list indexing bind the head first: \
         }
         let mut depth = 1usize;
         let mut i = self.pos + 1;
+        // A brace-lambda needs at least one ident-shaped token (a param name)
+        // before the `>` separator. Without this check, a braced guard body
+        // whose first statement is a comparison/prefix-op guard (e.g.
+        // `@x a{>x 0{m=x}}`) misparses as `a` calling a brace-lambda, with
+        // the `>` mistaken for the lambda's param separator.
+        let mut saw_param_ident = false;
         while let Some(tok) = self.token_at(i) {
             match tok {
                 Token::LParen | Token::LBracket | Token::LBrace => depth += 1,
@@ -5140,8 +5146,10 @@ For variable-position list indexing bind the head first: \
                 }
                 // A `;` at depth 1 before any `>` means destructure, not lambda.
                 Token::Semi if depth == 1 => return false,
-                // A `>` at depth 1 signals brace-lambda params separator.
-                Token::Greater if depth == 1 => return true,
+                // A `>` at depth 1 signals brace-lambda params separator —
+                // but only if at least one param ident appeared first.
+                Token::Greater if depth == 1 => return saw_param_ident,
+                Token::Ident(_) if depth == 1 => saw_param_ident = true,
                 _ => {}
             }
             i += 1;

--- a/tests/regression_brace_lambda_vs_guard.rs
+++ b/tests/regression_brace_lambda_vs_guard.rs
@@ -1,0 +1,48 @@
+// Regression: `looks_like_brace_lambda` must NOT mistake a braced
+// guard body whose first statement starts with a prefix-op `>` for a
+// brace-lambda. Before this fix, `@x a{>x 0{m=x}}` was misparsed as
+// `@x` collection `a{>x 0{...}}`, where `a{...}` looked like a call to
+// `a` with a brace-lambda arg because the parser only scanned for a `>`
+// at depth 1 and ignored whether any param ident preceded it.
+//
+// Test names live across interpreter and VM (the failing tests after
+// PR #706/#709/#713 landed); this test asserts the canonical
+// find-max-with-braced-guard idiom parses and runs.
+
+use std::process::Command;
+
+fn ilo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ilo"))
+}
+
+fn run(engine: &str, src: &str, args: &[&str]) -> String {
+    let mut cmd = ilo();
+    cmd.arg(src).arg(engine);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("run");
+    assert!(
+        out.status.success(),
+        "{engine}: stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8(out.stdout).unwrap().trim().to_string()
+}
+
+#[test]
+fn braced_guard_inside_foreach_parses_across_engines() {
+    let src = "mx xs:L n>n;m=xs.0;@x xs{>x m{m=x}};+m 0";
+    for engine in ["--vm", "--jit"] {
+        let got = run(engine, src, &["mx", "1,2,5,3"]);
+        assert_eq!(got, "5", "{engine}: find-max failed");
+    }
+}
+
+#[test]
+fn brace_lambda_still_works_with_param_idents() {
+    // Make sure the brace-lambda shape `{x > body}` is unaffected.
+    let src = "main>n;ys=map {x>*x 2} [1 2 3];ys.0";
+    let got = run("--vm", src, &[]);
+    assert_eq!(got, "2");
+}


### PR DESCRIPTION
## Summary

Follow-up to #720. Restores the 2 pre-existing test failures on main:

- `interpreter::tests::interpret_braced_guard_in_loop_no_early_return`
- `vm::tests::vm_braced_guard_in_loop_no_early_return`

The canonical find-max idiom

```
mx xs:L n>n;m=xs.0;@x xs{>x m{m=x}};+m 0
```

was misparsing with `ILO-P003: expected `{`, got `;``. `looks_like_brace_lambda` only checked for a `>` at depth 1 inside a brace block before classifying it as a brace-lambda. A braced guard body whose first statement starts with a prefix-op `>x m` (greater-than) tripped that signal, so `xs{>x m{m=x}}` was parsed as `xs` calling a brace-lambda `{>x m{m=x}}`.

## Fix

Require at least one ident-shaped token between the opening `{` and the depth-1 `>` before classifying as a brace-lambda. Real brace-lambdas always have a param name before the separator (`{x > body}`, `{x:n y:n > body}`); braced guard bodies starting with a comparison do not.

## Test plan

- [x] New regression: `tests/regression_brace_lambda_vs_guard.rs` covers the failing find-max shape across VM + JIT and confirms `{x > body}` brace-lambdas still classify correctly
- [x] `cargo test --release --features cranelift` — lib + 396 doctests pass; only `aot_binary_size_under_threshold` fails (env-dependent, pre-existing)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

## Result

After #720 + this PR, main builds, lints, and the full test suite is green except for the env-dependent AOT binary-size test. The 38 PRs sitting behind these blockers should now be re-mergeable on rebase.