### PR TITLE
hotfix: fix examples_engines failures blocking all open PR CI

### DIFF
--- a/examples/mpairs.ilo
+++ b/examples/mpairs.ilo
@@ -14,7 +14,7 @@ nums>L (L _);m=mset (mset (mset mmap 10 "a") 2 "b") 5 "c";mpairs m
 -- Common pattern replacing: map (k:t>L _;[k (mget m k)]) (mkeys m)
 iter>_
   m=mset (mset (mset mmap "x" 10) "y" 20) "z" 30
-  fld (acc:L _; pair:L _;cat acc [[pair.0, pair.1]]) [] (mpairs m)
+  fld {acc pair > [acc, pair]} [] (mpairs m)
 
 -- run: pairs
 -- out: [[a, 1], [b, 2], [c, 3]]

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -1129,6 +1129,8 @@ impl Builtin {
         Builtin::B64Dec,
         Builtin::HexEnc,
         Builtin::CtEq,
+        Builtin::Sha256Hex,
+        Builtin::Sha256d,
         // getx / pstx — HTTP variants that surface response status, headers,
         // and body as a Map[Text, _] wrapped in Ok. Additive — the existing
         // `get` / `pst` body-only signatures stay intact for token-cheap GETs


### PR DESCRIPTION
## Summary

- **`examples/mpairs.ilo` line 17** — labelled-arg inline lambda (`acc:L _; pair:L _;…`) inside `fld` now fails ILO-P003 since `:` is parsed as a type-ascription delimiter. Rewritten as `{acc pair > [acc, pair]}` using brace-lambda syntax (ILO-404). The `cat` call is also dropped — comma-spread in a list literal achieves the same append without the `L (L _)` type error.

- **`src/builtins.rs`** — `Sha256Hex` and `Sha256d` variants were defined, tree-bridge-registered, and interpreter-dispatched (ILO-383) but missing from `Builtin::ALL`. Every call panicked with `Builtin::ALL must include every variant` at builtins.rs:1198. Added after `CtEq` in the crypto-primitives cluster, preserving all prior on-wire tags. Fixes `examples/sha256-hex.ilo` (4 test cases) and `examples/sha256d-bitcoin.ilo` (1 test case).

9/1236 test cases were failing; all pass after these two changes.

## Test plan

- [x] `cargo test --test examples_engines` — was 9 failures, now 0
- [x] Two focused commits, one per root cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)