### PR TITLE
hotfix: clippy errors blocking PR lint

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -105,6 +105,7 @@ pub enum UsePredicate {
 }
 
 impl UsePredicate {
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Option<Self> {
         match s {
             "wasm" => Some(Self::Wasm),

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -220,6 +220,9 @@ pub fn map_key_to_value(k: &MapKey) -> Value {
     }
 }
 
+type StdinLinesInner =
+    Arc<Mutex<Box<dyn Iterator<Item = std::result::Result<String, std::io::Error>> + Send>>>;
+
 /// A lazy handle to stdin's line iterator.
 ///
 /// Wraps a `BufRead::lines()` iterator behind `Arc<Mutex<>>` so that
@@ -232,7 +235,7 @@ pub fn map_key_to_value(k: &MapKey) -> Value {
 /// On WASM the variant is never constructed (the builtin returns Err early).
 /// The `Debug` impl shows `<stdin-lines>` to keep output readable.
 pub struct StdinLinesHandle {
-    inner: Arc<Mutex<Box<dyn Iterator<Item = std::result::Result<String, std::io::Error>> + Send>>>,
+    inner: StdinLinesInner,
 }
 
 impl std::fmt::Debug for StdinLinesHandle {
@@ -252,6 +255,13 @@ impl Clone for StdinLinesHandle {
 impl PartialEq for StdinLinesHandle {
     fn eq(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.inner, &other.inner)
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl Default for StdinLinesHandle {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2271,12 +2271,12 @@ impl BuildTarget {
     /// Evaluate a `UsePredicate` against this target: returns `true` when
     /// the predicate matches (i.e. the "true" branch should be imported).
     pub fn eval(self, pred: ast::UsePredicate) -> bool {
-        match (self, pred) {
-            (BuildTarget::Wasm, ast::UsePredicate::Wasm) => true,
-            (BuildTarget::Native, ast::UsePredicate::Native) => true,
-            (BuildTarget::Test, ast::UsePredicate::Test) => true,
-            _ => false,
-        }
+        matches!(
+            (self, pred),
+            (BuildTarget::Wasm, ast::UsePredicate::Wasm)
+                | (BuildTarget::Native, ast::UsePredicate::Native)
+                | (BuildTarget::Test, ast::UsePredicate::Test)
+        )
     }
 }
 
@@ -7110,6 +7110,7 @@ mod tests {
     #[test]
     fn resolve_imports_conditional_wasm_true_branch() {
         // `use ?wasm "wasm.ilo" : "native.ilo"` with BuildTarget::Wasm → loads wasm.ilo
+        #[allow(unused_imports)]
         use std::io::Write;
         let wasm_path = "/tmp/ilo_cond_wasm_ILO399.ilo";
         let native_path = "/tmp/ilo_cond_native_ILO399.ilo";

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -9659,7 +9659,6 @@ impl<'a> VM<'a> {
                             | HeapObj::Record { .. }
                             | HeapObj::OkVal(_)
                             | HeapObj::ErrVal(_)
-                            | HeapObj::LazyStdinLines(_)
                             | HeapObj::Closure { .. } => {
                                 vm_err!(VmError::Type("foreach requires a list"))
                             }
@@ -9722,7 +9721,6 @@ impl<'a> VM<'a> {
                             | HeapObj::Record { .. }
                             | HeapObj::OkVal(_)
                             | HeapObj::ErrVal(_)
-                            | HeapObj::LazyStdinLines(_)
                             | HeapObj::Closure { .. } => {
                                 // Should never happen: list was validated by FOREACHPREP.
                                 vm_err!(VmError::Type("foreach requires a list"))


### PR DESCRIPTION
## Summary

- Removes unreachable `HeapObj::LazyStdinLines` arms in `FOREACHPREP`/`FOREACHNEXT` match blocks (`vm/mod.rs`)
- Adds `#[allow(clippy::should_implement_trait)]` to `UsePredicate::from_str` (`ast/mod.rs`)
- Extracts `StdinLinesInner` type alias to resolve complex-type lint (`interpreter/mod.rs`)
- Adds `Default` impl for `StdinLinesHandle` (`interpreter/mod.rs`)
- Converts match-to-bool to `matches!` macro in `BuildTarget::eval` (`main.rs`)
- Suppresses spurious unused-import warning in test (`main.rs`)

Blocks every open PR's lint job. `cargo clippy --workspace --all-targets -- -D warnings` is now clean.

## Test plan

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes with no errors
- [ ] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)