### PR TITLE
chore: bump ilo-language token cap to 1800

### DIFF
--- a/scripts/check-skill-tokens.py
+++ b/scripts/check-skill-tokens.py
@@ -54,7 +54,7 @@ PER_MODULE_LIMIT = 1000
 #   ilo-builtins-math:  1409  ilo-builtins-io:    1947
 #   ilo-builtins-text:  1140  ilo-agent:          1219
 PER_MODULE_OVERRIDES = {
-    "ilo-language": 1700,
+    "ilo-language": 1800,
     "ilo-builtins-core": 1125,
     "ilo-builtins-math": 1460,
     "ilo-builtins-io": 2000,


### PR DESCRIPTION
Lint blocker: `ilo-language.md` drifted past the 1700-token cap (now 1746) after the post-#722 docs landed. Every PR's CI lint job has been red since. Bumps the cap to 1800 with the same ~50-token headroom the other modules use.