### PR TITLE
fix(builtins): add Idxof to Builtin::ALL

### DIFF
--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -1158,6 +1158,9 @@ impl Builtin {
         // Returns a LazyStdinLines handle that ForEach drains one line at a time,
         // enabling processing of unbounded piped input without buffering.
         Builtin::ForLine,
+        // `idxof s sub > O n` — text-search builtin (0.13.0). Appended last
+        // to preserve every existing on-wire tag.
+        Builtin::Idxof,
     ];
 
     /// Stability tier for this builtin, sourced from `STABILITY.md`.


### PR DESCRIPTION
Build blocker: `Builtin::Idxof` was declared in the enum but never appended to `Builtin::ALL`. Calling `idxof` panics with `Builtin::ALL must include every variant` on every engine, failing `tests/regression_idxof.rs::idxof_empty_haystack_not_found` and `::idxof_both_empty_returns_zero` on every PR's CI. Appended last to preserve every existing on-wire tag.