### PR TITLE
hotfix: bump ilo-builtins-io token cap

### DIFF
--- a/scripts/check-skill-tokens.py
+++ b/scripts/check-skill-tokens.py
@@ -57,7 +57,7 @@ PER_MODULE_OVERRIDES = {
     "ilo-language": 1800,
     "ilo-builtins-core": 1125,
     "ilo-builtins-math": 1460,
-    "ilo-builtins-io": 2000,
+    "ilo-builtins-io": 2200,
     "ilo-builtins-text": 1190,
     "ilo-agent": 1270,
 }


### PR DESCRIPTION
ilo-builtins-io.md grew to 2098 tokens past 2000 cap. Bump to 2200 for headroom. Blocks PRs.