### PR TITLE
hotfix: pkg.rs build break + resolve_imports arity (ILO-63 followup)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2467,6 +2467,7 @@ fn resolve_imports(
                         imported_dir.as_deref(),
                         visited,
                         diagnostics,
+                        build_target,
                     );
                     visited.remove(&canonical);
                     let filtered =

--- a/src/pkg.rs
+++ b/src/pkg.rs
@@ -250,8 +250,6 @@ fn add_recursive(spec: &str, visited: &mut HashSet<String>, stack: &mut Vec<Stri
         return 0;
     }
 
-    let git_ref = git_ref.unwrap_or("HEAD");
-
     let url = format!("https://github.com/{owner}/{repo}.git");
 
     // Resolve semver constraints to a concrete tag before cloning.


### PR DESCRIPTION
Build blocker. PR #614 (ilo add) merged with two compile errors that fail the build/coverage/cross-platform jobs on every PR's CI:

1. `src/pkg.rs:253` unwraps `git_ref` to `&str`, then line 260 matches it as `Option<_>` — type error. Remove the early unwrap; the later match at 273-276 already handles the `Option` correctly.
2. `src/main.rs:2465` calls `resolve_imports` with 4 args but it takes 5 (the `build_target` arg was added by #643 conditional imports). Add the missing arg.

Restores main to clean build. Lint + clippy + fmt clean.