### PR TITLE
fix(ci): persona-smoke uses correct ensure-ilo.sh path

### DIFF
--- a/.github/workflows/persona-smoke.yml
+++ b/.github/workflows/persona-smoke.yml
@@ -45,7 +45,7 @@ jobs:
         run: pip install tiktoken
 
       - name: Install ilo binary
-        run: bash scripts/ensure-ilo.sh
+        run: bash skills/ilo/scripts/ensure-ilo.sh
 
       - name: Print skill-module token sizes
         # Always emit the token report in CI so cap progress is visible in the


### PR DESCRIPTION
The script lives at `skills/ilo/scripts/ensure-ilo.sh` (inside the skill bundle), not at `scripts/ensure-ilo.sh`. The workflow has been failing with exit code 127 (command not found) on every PR since the persona-smoke job was added.

After this lands, the Persona corpus smoke run job will actually execute the smoke regression on PRs that touch `skills/` or `ai.txt` instead of failing in the install step.