### PR TITLE
chore: bump ilo-language tokcount cap to 1500

### DIFF
--- a/scripts/check-skill-tokens.ilo
+++ b/scripts/check-skill-tokens.ilo
@@ -22,7 +22,7 @@
 --   ilo-language:1410  ilo-builtins-core:995  ilo-builtins-math:1323
 --   ilo-builtins-io:1834  ilo-builtins-text:1114  ilo-agent:1330
 limit-for name:t>n
-  ?name{"ilo-language":1475
+  ?name{"ilo-language":1500
         "ilo-builtins-core":1060
         "ilo-builtins-math":1390
         "ilo-builtins-io":1900


### PR DESCRIPTION
Lint blocker. `scripts/check-skill-tokens.ilo` has `ilo-language` cap at 1475 but measured size is 1488 — fails on every PR. Bump to 1500 (~12-token headroom).