### PR TITLE
feat: canonical pagination idiom (supersedes ILO-88)

### DIFF
--- a/examples/pagination.ilo
+++ b/examples/pagination.ilo
@@ -1,0 +1,88 @@
+-- Canonical pagination idiom (ILO-421, supersedes ILO-88).
+--
+-- Pattern: tail-recursive accumulator + empty-token termination + Result chain.
+--
+-- Shape:
+--   fetch-all url token acc
+--     token="" → ~acc              (done: wrap and return)
+--     page,next = fetch-page url token
+--     fetch-all url next (+acc page)  (tail position — no stack growth)
+--
+-- `fld` threads the accumulator for in-memory aggregation once all pages
+-- are collected.  The Result chain (`!` propagation) means any HTTP or
+-- parse Err bubbles up from `fetch-page` without explicit match arms.
+
+-- ---------------------------------------------------------------------------
+-- Simulated paged data source.
+-- Real code would call `get!` / `pst!` here; we return hardcoded pages so
+-- the example runs without network access and passes on every engine.
+-- Tokens: "0"→page0 (next "1"), "1"→page1 (next "2"), "2"→page2 (next ""),
+-- where "" signals end-of-pages.  In a real API the server supplies tokens.
+-- ---------------------------------------------------------------------------
+
+-- page-data: returns [items, next-token] for a given 0-based page index n.
+page-data idx:n>L _
+  ?idx{
+    0:[[1 2] "1"]
+    1:[[3 4] "2"]
+    2:[[5 6] ""]
+    _:[[]]
+  }
+
+-- fetch-page: simulates a network call returning a Result-wrapped record.
+-- Returns ~[items next-token] (Ok) or ^"out of range" (Err).
+-- In a real program: b=get! url; items=jpar-list! b; nxt=default-on-err (jpth b "next") ""; ~[items nxt]
+fetch-page url:t token:t>R (L _) t
+  idx=default-on-err (num token) 0
+  r=page-data idx
+  =len r 0 ^"out of range"
+  items=at r 0
+  nxt=at r 1
+  ~[items nxt]
+
+-- ---------------------------------------------------------------------------
+-- Core idiom: tail-recursive paginator.
+-- Empty string token signals the last page has been consumed.
+-- ---------------------------------------------------------------------------
+
+fetch-all url:t token:t acc:L n>R (L n) t
+  -- termination: empty next-token means we have collected all pages
+  =token "" ~acc
+  -- fetch this page (! propagates Err out of fetch-all)
+  r=fetch-page! url token
+  page=at r 0
+  nxt=at r 1
+  -- tail call with extended accumulator (no stack frame consumed)
+  fetch-all url nxt +acc page
+
+-- Entry points -----------------------------------------------------------
+
+-- all-items: collect every item across pages, return as list.
+all-items>R (L n) t
+  fetch-all "https://api.example.com/items" "0" []
+
+-- sum-pages: collect then fold to a sum (fld threads accumulator over result).
+sum-pages>R n t
+  xs=fetch-all! "https://api.example.com/items" "0" []
+  ~fld (a:n x:n>n;+a x) xs 0
+
+-- count-pages: count total items without keeping them all in memory.
+-- Uses a dedicated tail-recursive counter to show the streaming variant.
+count-all url:t token:t n:n>R n t
+  =token "" ~n
+  r=fetch-page! url token
+  page=at r 0
+  nxt=at r 1
+  count-all url nxt +n len page
+
+total-count>R n t
+  count-all "https://api.example.com/items" "0" 0
+
+-- run: all-items
+-- out: [1, 2, 3, 4, 5, 6]
+
+-- run: sum-pages
+-- out: 21
+
+-- run: total-count
+-- out: 6

--- a/skills/ilo/ilo-builtins-io.md
+++ b/skills/ilo/ilo-builtins-io.md
@@ -52,10 +52,40 @@ ilo has no globals. Thread state through function args (in-run) or persist to a 
 
 **Closure-threading** (in-run cache, paginated fetch, rate-limit window). Pass state in, return state out:
 
+**Canonical pagination idiom** (ILO-421): empty-token termination + tail-recursive accumulator + `!` Result propagation. See `examples/pagination.ilo` for the fully-tested, multi-case reference.
+
 ```
--- Paginated fetch: cursor + accumulator thread through recursion.
-fetch-page url:t cur:t acc:L _>R (L _) t;u=fmt "{}?cursor={}" url cur;b=get! u;page=jpar-list! b;acc=+acc page;nxt=default-on-err (jpth b "next") "";=nxt "" ~acc;fetch-page url nxt acc
+-- fetch-page: one HTTP page → Result-wrapped [items, next-token].
+-- next-token="" signals end-of-pages (server convention).
+fetch-page url:t token:t>R (L _) t
+  b=get! (fmt "{}?cursor={}" url token)
+  items=jpar-list! b
+  nxt=default-on-err (jpth b "next") ""
+  ~[items nxt]
+
+-- fetch-all: tail-recursive accumulator.  Empty token = done.
+-- `!` on fetch-page propagates Err without a match arm.
+fetch-all url:t token:t acc:L n>R (L n) t
+  =token "" ~acc
+  r=fetch-page! url token
+  page=at r 0
+  nxt=at r 1
+  fetch-all url nxt +acc page
+
+-- Entry: seed with first-page token (often "0", "1", or "" per API).
+all-items url:t>R (L n) t;fetch-all url "0" []
+
+-- Streaming count variant (no accumulator growth):
+count-all url:t token:t n:n>R n t
+  =token "" ~n
+  r=fetch-page! url token
+  fetch-all url (at r 1) +n len (at r 0)
+
+-- Post-collection fold (fld threads acc over the gathered list):
+sum-all url:t>R n t;xs=fetch-all! url "0" [];~fld (a:n x:n>n;+a x) xs 0
 ```
+
+Key rules: (1) termination guard (`=token "" ~acc`) must be the **first** statement so the recursive call stays in tail position; (2) use `fetch-page!` not `fetch-page` so Err propagates through `fetch-all` without explicit match arms; (3) `nxt` comes from `at r 1`, not from re-parsing the response — `jpth` already typed it.
 
 **File-backed** (cross-run OAuth token, refresh on expiry). Read cached value, do work, write refreshed value back. `wr`/`rd` survive across runs; `now-ms` gives a TTL stamp.
 


### PR DESCRIPTION
## Summary

- Adds `examples/pagination.ilo`: fully-tested multi-case reference for paginated stateful loops covering `all-items` (collect), `sum-pages` (collect + fld), and `total-count` (streaming counter)
- Empty-token termination + tail-recursive accumulator + `!` Result propagation — all three cases pass on the VM engine
- Expands `skills/ilo/ilo-builtins-io.md` with the canonical multi-line idiom (termination guard, fetch+unwrap, tail call, fld post-fold, streaming variant), replacing the previous one-liner

## Test plan

- [ ] `cargo test --test examples_engines` passes (only pre-existing `effect-sets.ilo` failure, unrelated to this PR)
- [ ] `all-items` → `[1, 2, 3, 4, 5, 6]`
- [ ] `sum-pages` → `21`
- [ ] `total-count` → `6`

Closes ILO-421

🤖 Generated with [Claude Code](https://claude.com/claude-code)