### PR TITLE
docs: wire ilo-example-package into examples (ILO-425)

### DIFF
--- a/examples/pkg-registry.ilo
+++ b/examples/pkg-registry.ilo
@@ -1,21 +1,23 @@
 -- pkg-registry.ilo
--- Demonstrates `use "owner/repo"` package import syntax.
+-- End-to-end demo of `ilo add` / `use "owner/repo"` package import.
 --
--- Before running:
---   ilo add ilo-lang/ilo-std
+-- Step 1 — install the example package (one-time, writes ilo.lock):
+--   ilo add ilo-lang/ilo-example-package
 --
--- Then:
+-- Step 2 — run this file:
 --   ilo run examples/pkg-registry.ilo
 --
--- This file won't run standalone (the package won't exist on your machine
--- unless you `ilo add` it), but it serves as a usage reference.
---
--- use "ilo-lang/ilo-std"         -- import index.ilo from cached package
--- use "ilo-lang/ilo-std" [greet] -- selective import
---
--- main>_;
---   prnt greet "agent"
+-- Expected output:
+--   hello, agent
+--   QUIET
+--   5
+--   10
 
--- Minimal standalone demo that works without a network package:
-main>_;
-  prnt "run `ilo add owner/repo` to install a package, then `use \"owner/repo\"` to import it"
+use "ilo-lang/ilo-example-package" [greet shout safe-div clamp]
+
+main>_
+  prnt greet "agent"
+  prnt shout "quiet"
+  r = safe-div 10 2
+  ?r{ok(v):prnt str v;err(e):prnt e}
+  prnt str clamp 15 0 10

--- a/skills/ilo/ilo-agent.md
+++ b/skills/ilo/ilo-agent.md
@@ -70,6 +70,29 @@ Parser nesting is capped at 256 by default — guards `ilo serv` and any other c
 
 `ilo run`: wall-clock 60 s (`ILO-R016`), stdout ~100 MB (`ILO-R017`). Override: `--max-runtime SECS` / `--max-output-bytes BYTES` (0 disables). Hitting either = missing loop increment or no base case.
 
+## Packages
+
+GitHub-based registry; no central server.
+
+```
+ilo add ilo-lang/ilo-example-package        -- shallow-clone into ~/.ilo/pkgs/, write ilo.lock
+ilo add owner/repo@v1.2                     -- pin to tag / branch / SHA
+ilo update                                  -- re-fetch all locked packages
+```
+
+After `ilo add`, import with `use`:
+
+```
+use "ilo-lang/ilo-example-package"               -- all public symbols from index.ilo
+use "ilo-lang/ilo-example-package" [greet clamp] -- selective import
+
+main>_
+  prnt greet "agent"      -- hello, agent
+  prnt str clamp 15 0 10  -- 10
+```
+
+`ilo.lock` records slug, SHA, and URL — commit it to source control. A path whose first component has no `.` is always a package reference; use `"./local.ilo"` for local files.
+
 ## Branching
 
 Failures / repair: `ilo-edit-loop`. Runnable patterns: `ilo-examples`. Tools: `ilo-tools`. Engine pick: `ilo-engines`.


### PR DESCRIPTION
## Summary

- `examples/pkg-registry.ilo`: replaced stub with a fully-runnable end-to-end demo using `ilo-lang/ilo-example-package` (greet, shout, safe-div, clamp)
- `skills/ilo/ilo-agent.md`: added **Packages** section documenting `ilo add`, `ilo update`, lockfile behaviour, and `use "owner/repo"` selective import with a working code snippet

Closes ILO-425.

## Test plan

- [ ] `ilo add ilo-lang/ilo-example-package && ilo run examples/pkg-registry.ilo` produces the four expected lines
- [ ] `ilo skill get ilo-agent` includes the new Packages section

🤖 Generated with [Claude Code](https://claude.com/claude-code)