### PR TITLE
release: run gitleaks via CLI instead of the licensed action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,10 +44,15 @@ jobs:
         with:
           fetch-depth: 0
       - name: gitleaks
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_CONFIG: .github/gitleaks.toml
+        # Use the gitleaks CLI directly rather than gitleaks-action, which now
+        # requires a paid licence key for organisation repos (GITLEAKS_LICENSE).
+        # The CLI binary is the same scanner, free for orgs, and keeps the
+        # release pipeline unblocked. Scans full git history (fetch-depth: 0).
+        run: |
+          GITLEAKS_VERSION=8.21.2
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz gitleaks
+          ./gitleaks detect --source . --config .github/gitleaks.toml --redact --no-banner --exit-code 1
 
   build:
     needs: secret-scan


### PR DESCRIPTION
## Why

The Release workflow gates every downstream job behind `secret-scan`, which uses `gitleaks/gitleaks-action`. That action now requires a paid `GITLEAKS_LICENSE` secret for **organisation** repos. Both `v26.5` tag pushes (2026-05-23) died in this job within seconds:

```
[ilo-lang] is an organization. License key is required.
🛑 missing gitleaks license. Go grab one at gitleaks.io ...
```

So no 26.5 release was ever published. GitHub still shows v0.12.0 as Latest, and ilo-lang.ai (which reads the latest release tag) shows v0.12.0 too.

## What's in the diff

Replace the licensed action with the gitleaks **CLI binary** (v8.21.2), run directly against full git history with the existing `.github/gitleaks.toml` config. Same scanner, free for orgs, no licence secret needed.

```
./gitleaks detect --source . --config .github/gitleaks.toml --redact --no-banner --exit-code 1
```

## Test plan

- [ ] Release workflow's secret-scan job passes on the next tag push (verified by re-cutting v26.5 after merge)
- [ ] No regression in scanning: gitleaks.toml still applied, full history scanned (fetch-depth: 0)

## Follow-up

After merge, re-cut `v26.5` at current main so the release pipeline runs end to end (binaries + GitHub release + crates + npm), which restores the version label on ilo-lang.ai.