### PR TITLE
release: allow same-version npm publish so 26.5 ships

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,7 +200,11 @@ jobs:
 
       - name: Set npm version from tag
         working-directory: npm
-        run: npm version ${{ needs.validate-tag.outputs.semver }} --no-git-tag-version
+        # --allow-same-version: the in-repo package.json is already bumped to the
+        # release version (e.g. 26.5.0), so a plain `npm version` aborts with
+        # "Version not changed" and blocks the publish. This makes the step a
+        # no-op when already at the target version rather than failing.
+        run: npm version ${{ needs.validate-tag.outputs.semver }} --no-git-tag-version --allow-same-version
 
       - name: Publish to npm
         working-directory: npm
@@ -237,7 +241,11 @@ jobs:
 
       - name: Set npm version from tag
         working-directory: pi
-        run: npm version ${{ needs.validate-tag.outputs.semver }} --no-git-tag-version
+        # --allow-same-version: the in-repo package.json is already bumped to the
+        # release version (e.g. 26.5.0), so a plain `npm version` aborts with
+        # "Version not changed" and blocks the publish. This makes the step a
+        # no-op when already at the target version rather than failing.
+        run: npm version ${{ needs.validate-tag.outputs.semver }} --no-git-tag-version --allow-same-version
 
       - name: Publish to npm
         working-directory: pi


### PR DESCRIPTION
## Why

The v26.5 release reached GitHub and crates.io, but **npm + pi never published** (npm registry is still on 0.12.0). Both `publish-npm` and `publish-pi` failed at the same step:

```
npm error Version not changed
```

`npm/package.json` and `pi/package.json` are already at `26.5.0` in the repo, so `npm version 26.5.0` aborts before the publish step runs.

## Fix

Add `--allow-same-version` to both `npm version` steps so they no-op when the package is already at the target version instead of failing.

## Test plan

- [ ] Re-cut v26.5 after merge; publish-npm and publish-pi go green and 26.5.0 lands on npm.

## Context

Separate from the gitleaks/secret-scan question (that moves to a local pre-push hook; release CI keeps it dropped per ILO-502).